### PR TITLE
Add needs tags for `database_cremona_(mini_)ellcurve`

### DIFF
--- a/src/doc/de/tutorial/introduction.rst
+++ b/src/doc/de/tutorial/introduction.rst
@@ -39,6 +39,7 @@ Tutorial der richtige Ort um damit anzufangen. Zum Beispiel:
     [-3  1]
     [ 2  3]
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve([1,2,3,4,5]);
     sage: E
     Elliptic Curve defined by y^2 + x*y + 3*y = x^3 + 2*x^2 + 4*x + 5

--- a/src/doc/de/tutorial/tour_advanced.rst
+++ b/src/doc/de/tutorial/tour_advanced.rst
@@ -128,6 +128,7 @@ Wir veranschaulichen jede dieser Konstruktionen:
     sage: EllipticCurve([1,2])
     Elliptic Curve defined by y^2  = x^3 + x + 2 over Rational Field
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: EllipticCurve('37a')
     Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field
 
@@ -227,6 +228,7 @@ Tamagawa Zahlen, Regulatoren, usw..
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve("37b2")
     sage: E
     Elliptic Curve defined by y^2 + y = x^3 + x^2 - 1873*x - 31833 over Rational
@@ -244,6 +246,7 @@ Wir können auch direkt auf die Cremona-Datenbank zugreifen.
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: db = sage.databases.cremona.CremonaDatabase()
     sage: db.curves(37)
     {'a1': [[0, 0, 1, -1, 0], 1, 1], 'b1': [[0, 1, 1, -23, -50], 0, 3]}

--- a/src/doc/en/reference/coercion/index.rst
+++ b/src/doc/en/reference/coercion/index.rst
@@ -46,6 +46,7 @@ members. Parents are first-class objects.  Most things in Sage are
 either parents or have a parent. Typically whenever one sees the word
 *Parent* one can think *Set*. Here are some examples::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: parent(1)
     Integer Ring
     sage: parent(1) is ZZ

--- a/src/doc/en/thematic_tutorials/explicit_methods_in_number_theory/elliptic_curves.rst
+++ b/src/doc/en/thematic_tutorials/explicit_methods_in_number_theory/elliptic_curves.rst
@@ -17,6 +17,7 @@ To use the database, just create a curve by giving
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: EllipticCurve('5077a1')
     Elliptic Curve defined by y^2 + y = x^3 - 7*x + 6 over Rational Field
     sage: C = CremonaDatabase()
@@ -46,6 +47,7 @@ single graphics object.
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: v = cremona_optimal_curves([11..37])
     sage: w = [E.plot(thickness=10,rgbcolor=(random(),random(),random())) for E in v]
     sage: graphics_array(w, 4, 5).show(axes=False)
@@ -138,6 +140,7 @@ the :math:`5`-adic and :math:`997`-adic regulators of this curve.
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve('389a')
     sage: E.padic_regulator(5, 10)
     5^2 + 2*5^3 + 2*5^4 + 4*5^5 + 3*5^6 + 4*5^7 + 3*5^8 + 5^9 + O(5^11)
@@ -176,6 +179,7 @@ rank :math:`2`.
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve('389a')
     sage: L = E.padic_lseries(5)
     sage: L
@@ -195,6 +199,7 @@ unpublished papers of Wuthrich and me.
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve('11a1')
     sage: E.sha().bound()            # so only 2 could divide sha
     [2]
@@ -223,6 +228,7 @@ and :math:`7` do not divide the Shafarevich-Tate group of our rank
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve('389a1')
     sage: sha = E.sha()
     sage: sha.p_primary_bound(5)  # iwasawa theory ==> 5 doesn't divide sha
@@ -254,6 +260,7 @@ GP scripts for computing Mordell-Weil groups of elliptic curves.
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve([1,2,5,17,159])
     sage: E.conductor()       # not in the Tables
     10272987
@@ -274,6 +281,7 @@ the only free open source implementation available.
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve([1,2,5,7,17])
     sage: E.integral_points(both_signs=True)
     [(1 : -9 : 1), (1 : 3 : 1)]
@@ -326,6 +334,7 @@ on the complex plane using Sage (via code of Tim Dokchitser).
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve('389a1')
     sage: L = E.lseries(); L
     Complex L-series of the Elliptic Curve defined by
@@ -342,6 +351,7 @@ Taylor Series
 
 We can also compute the Taylor series of :math:`L` about any point::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve('389a1')
     sage: L = E.lseries()
     sage: Ld = L.dokchitser()

--- a/src/doc/en/tutorial/introduction.rst
+++ b/src/doc/en/tutorial/introduction.rst
@@ -36,6 +36,7 @@ tutorial is the place to start. For example:
     [-3  1]
     [ 2  3]
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve([1,2,3,4,5]);
     sage: E
     Elliptic Curve defined by y^2 + x*y + 3*y = x^3 + 2*x^2 + 4*x + 5

--- a/src/doc/en/tutorial/tour_advanced.rst
+++ b/src/doc/en/tutorial/tour_advanced.rst
@@ -126,6 +126,7 @@ We illustrate each of these constructors:
     sage: EllipticCurve([1,2])
     Elliptic Curve defined by y^2  = x^3 + x + 2 over Rational Field
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: EllipticCurve('37a')
     Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field
 
@@ -226,6 +227,7 @@ Tamagawa numbers, regulator, etc.
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve("37b2")
     sage: E
     Elliptic Curve defined by y^2 + y = x^3 + x^2 - 1873*x - 31833 over Rational
@@ -243,6 +245,7 @@ We can also access the Cremona database directly.
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: db = sage.databases.cremona.CremonaDatabase()
     sage: db.curves(37)
     {'a1': [[0, 0, 1, -1, 0], 1, 1], 'b1': [[0, 1, 1, -23, -50], 0, 3]}

--- a/src/doc/es/tutorial/introduction.rst
+++ b/src/doc/es/tutorial/introduction.rst
@@ -35,6 +35,7 @@ lugar justo para empezar. Por ejemplo:
     [-3  1]
     [ 2  3]
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve([1,2,3,4,5]);
     sage: E
     Elliptic Curve defined by y^2 + x*y + 3*y = x^3 + 2*x^2 + 4*x + 5

--- a/src/doc/fr/tutorial/introduction.rst
+++ b/src/doc/fr/tutorial/introduction.rst
@@ -38,6 +38,7 @@ tutoriel est le bon endroit où commencer. Voici quelques exemples :
     [-3  1]
     [ 2  3]
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve([1,2,3,4,5]);
     sage: E
     Elliptic Curve defined by y^2 + x*y + 3*y = x^3 + 2*x^2 + 4*x + 5

--- a/src/doc/fr/tutorial/tour_advanced.rst
+++ b/src/doc/fr/tutorial/tour_advanced.rst
@@ -127,6 +127,7 @@ Illustrons chacune de ces constructions :
     sage: EllipticCurve([1,2])
     Elliptic Curve defined by y^2  = x^3 + x + 2 over Rational Field
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: EllipticCurve('37a')
     Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field
 
@@ -227,6 +228,7 @@ nombre de Tamagawa, son régulateur, etc.
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve("37b2")
     sage: E
     Elliptic Curve defined by y^2 + y = x^3 + x^2 - 1873*x - 31833 over Rational
@@ -244,6 +246,7 @@ On peut aussi accéder à la base de données de Cremona directement.
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: db = sage.databases.cremona.CremonaDatabase()
     sage: db.curves(37)
     {'a1': [[0, 0, 1, -1, 0], 1, 1], 'b1': [[0, 1, 1, -23, -50], 0, 3]}

--- a/src/doc/it/tutorial/introduction.rst
+++ b/src/doc/it/tutorial/introduction.rst
@@ -33,7 +33,8 @@ Per esempio:
     [-3  1]
     [ 2  3]
     
-    sage: E = EllipticCurve([1,2,3,4,5]); 
+    sage: # needs database_cremona_mini_ellcurve
+    sage: E = EllipticCurve([1,2,3,4,5]);
     sage: E
     Elliptic Curve defined by y^2 + x*y + 3*y = x^3 + 2*x^2 + 4*x + 5 
     over Rational Field

--- a/src/doc/ja/tutorial/introduction.rst
+++ b/src/doc/ja/tutorial/introduction.rst
@@ -32,6 +32,7 @@ Sageのかなりの部分がPythonを使って実装されているものの，�
     [-3  1]
     [ 2  3]
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve([1,2,3,4,5]);
     sage: E
     Elliptic Curve defined by y^2 + x*y + 3*y = x^3 + 2*x^2 + 4*x + 5

--- a/src/doc/ja/tutorial/tour_advanced.rst
+++ b/src/doc/ja/tutorial/tour_advanced.rst
@@ -121,6 +121,7 @@ Sageの楕円曲線部門にはPARIの楕円曲線機能の大部分が取り込
     sage: EllipticCurve([1,2])
     Elliptic Curve defined by y^2  = x^3 + x + 2 over Rational Field
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: EllipticCurve('37a')
     Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field
 
@@ -214,6 +215,7 @@ Sageでは， :math:`j` -不変量を以下のようにして計算する:
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve("37b2")
     sage: E
     Elliptic Curve defined by y^2 + y = x^3 + x^2 - 1873*x - 31833 over Rational
@@ -232,6 +234,7 @@ Cremonaのデータベースへ直接にアクセスすることも可能だ．
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: db = sage.databases.cremona.CremonaDatabase()
     sage: db.curves(37)
     {'a1': [[0, 0, 1, -1, 0], 1, 1], 'b1': [[0, 1, 1, -23, -50], 0, 3]}

--- a/src/doc/pt/tutorial/introduction.rst
+++ b/src/doc/pt/tutorial/introduction.rst
@@ -37,6 +37,7 @@ certo para começar. Por exemplo:
     [-3  1]
     [ 2  3]
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve([1,2,3,4,5]);
     sage: E
     Elliptic Curve defined by y^2 + x*y + 3*y = x^3 + 2*x^2 + 4*x + 5

--- a/src/doc/pt/tutorial/tour_advanced.rst
+++ b/src/doc/pt/tutorial/tour_advanced.rst
@@ -128,6 +128,7 @@ Agora ilustramos cada uma dessas construções:
     sage: EllipticCurve([1,2])
     Elliptic Curve defined by y^2  = x^3 + x + 2 over Rational Field
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: EllipticCurve('37a')
     Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field
 
@@ -227,6 +228,7 @@ sobre o seu posto, números de Tomagawa, regulador, etc.
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve("37b2")
     sage: E
     Elliptic Curve defined by y^2 + y = x^3 + x^2 - 1873*x - 31833 over Rational
@@ -244,6 +246,7 @@ Nós também podemos acessar a base de dados Cremona diretamente.
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: db = sage.databases.cremona.CremonaDatabase()
     sage: db.curves(37)
     {'a1': [[0, 0, 1, -1, 0], 1, 1], 'b1': [[0, 1, 1, -23, -50], 0, 3]}

--- a/src/doc/ru/tutorial/introduction.rst
+++ b/src/doc/ru/tutorial/introduction.rst
@@ -38,6 +38,7 @@
     [-3  1]
     [ 2  3]
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve([1,2,3,4,5]);
     sage: E
     Elliptic Curve defined by y^2 + x*y + 3*y = x^3 + 2*x^2 + 4*x + 5

--- a/src/doc/ru/tutorial/tour_advanced.rst
+++ b/src/doc/ru/tutorial/tour_advanced.rst
@@ -109,6 +109,7 @@ Sage может вычислить тороидальный идеал непл�
     sage: EllipticCurve([1,2])
     Elliptic Curve defined by y^2  = x^3 + x + 2 over Rational Field
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: EllipticCurve('37a')
     Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field
 
@@ -198,6 +199,7 @@ Sage может вычислить тороидальный идеал непл�
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve("37b2")
     sage: E
     Elliptic Curve defined by y^2 + y = x^3 + x^2 - 1873*x - 31833 over Rational
@@ -215,6 +217,7 @@ Sage может вычислить тороидальный идеал непл�
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: db = sage.databases.cremona.CremonaDatabase()
     sage: db.curves(37)
     {'a1': [[0, 0, 1, -1, 0], 1, 1], 'b1': [[0, 1, 1, -23, -50], 0, 3]}

--- a/src/doc/zh/tutorial/introduction.rst
+++ b/src/doc/zh/tutorial/introduction.rst
@@ -31,6 +31,7 @@ Python 初学者指南 [PyB]_ 列出了许多选择。如果你只是想快速�
     [-3  1]
     [ 2  3]
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve([1,2,3,4,5]);
     sage: E
     Elliptic Curve defined by y^2 + x*y + 3*y = x^3 + 2*x^2 + 4*x + 5

--- a/src/doc/zh/tutorial/tour_advanced.rst
+++ b/src/doc/zh/tutorial/tour_advanced.rst
@@ -112,6 +112,7 @@ SEA 算法、计算所有同源、许多关于 `\QQ` 上曲线的新代码，
     sage: EllipticCurve([1,2])
     Elliptic Curve defined by y^2  = x^3 + x + 2 over Rational Field
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: EllipticCurve('37a')
     Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field
 
@@ -199,6 +200,7 @@ SEA 算法、计算所有同源、许多关于 `\QQ` 上曲线的新代码，
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve("37b2")
     sage: E
     Elliptic Curve defined by y^2 + y = x^3 + x^2 - 1873*x - 31833 over Rational
@@ -216,6 +218,7 @@ SEA 算法、计算所有同源、许多关于 `\QQ` 上曲线的新代码，
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: db = sage.databases.cremona.CremonaDatabase()
     sage: db.curves(37)
     {'a1': [[0, 0, 1, -1, 0], 1, 1], 'b1': [[0, 1, 1, -23, -50], 0, 3]}

--- a/src/sage/calculus/expr.py
+++ b/src/sage/calculus/expr.py
@@ -43,7 +43,7 @@ def symbolic_expression(x):
 
     Note that equations exist in the symbolic ring::
 
-        sage: # needs sage.schemes
+        sage: # needs database_cremona_mini_ellcurve sage.schemes
         sage: E = EllipticCurve('15a'); E
         Elliptic Curve defined by y^2 + x*y + y = x^3 + x^2 - 10*x - 10 over Rational Field
         sage: symbolic_expression(E)
@@ -53,6 +53,7 @@ def symbolic_expression(x):
 
     If ``x`` is a list or tuple, create a vector of symbolic expressions::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: v = symbolic_expression([x,1]); v
         (x, 1)
         sage: v.base_ring()
@@ -184,7 +185,7 @@ def symbolic_expression(x):
         rows = [symbolic_expression(row) for row in x.rows()]
         return matrix(rows)
     if callable(x):
-        from inspect import signature, Parameter
+        from inspect import Parameter, signature
         try:
             s = signature(x)
         except ValueError:

--- a/src/sage/categories/homset.py
+++ b/src/sage/categories/homset.py
@@ -773,10 +773,11 @@ class Homset[DomainElementT: Parent, CodomainElementT: Parent](Set_generic):
             sage: hash(Hom(QQ, ZZ)) == hash((QQ, ZZ, QQ))
             True
 
-            sage: E = EllipticCurve('37a')                                              # needs sage.schemes
-            sage: H = E(0).parent(); H                                                  # needs sage.schemes
+            sage: # needs database_cremona_mini_ellcurve
+            sage: E = EllipticCurve('37a')  # needs sage.schemes
+            sage: H = E(0).parent(); H  # needs sage.schemes
             Abelian group of points on Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field
-            sage: hash(H) == hash((H.domain(), H.codomain(), H.base()))                 # needs sage.schemes
+            sage: hash(H) == hash((H.domain(), H.codomain(), H.base()))  # needs sage.schemes
             True
         """
         return hash((self._domain, self._codomain, self.base()))

--- a/src/sage/databases/all.py
+++ b/src/sage/databases/all.py
@@ -25,6 +25,7 @@ EXAMPLES::
     sage: ConwayPolynomials()
     Frank Lübeck's database of Conway polynomials
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: CremonaDatabase()
     Cremona's database of elliptic curves with conductor...
 

--- a/src/sage/databases/cremona.py
+++ b/src/sage/databases/cremona.py
@@ -546,6 +546,7 @@ def cremona_to_lmfdb(cremona_label, CDB=None):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.databases.cremona import cremona_to_lmfdb, lmfdb_to_cremona
         sage: cremona_to_lmfdb('990j1')
         '990.h3'
@@ -554,6 +555,7 @@ def cremona_to_lmfdb(cremona_label, CDB=None):
 
     TESTS::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: for label in ['5077a1','66a3','102b','420c2']:
         ....:     assert(lmfdb_to_cremona(cremona_to_lmfdb(label)) == label)
         sage: for label in ['438.c2','306.b','462.f3']:
@@ -602,6 +604,7 @@ def lmfdb_to_cremona(lmfdb_label, CDB=None):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.databases.cremona import cremona_to_lmfdb, lmfdb_to_cremona
         sage: lmfdb_to_cremona('990.h3')
         '990j1'
@@ -638,6 +641,7 @@ class MiniCremonaDatabase(SQLDatabase):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: c = CremonaDatabase()
         sage: c.allcurves(11)
         {'a1': [[0, -1, 1, -10, -20], 0, 5],
@@ -652,6 +656,7 @@ class MiniCremonaDatabase(SQLDatabase):
 
         TESTS::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: c = CremonaDatabase('cremona mini')
             sage: c.name
             'cremona mini'
@@ -680,6 +685,7 @@ class MiniCremonaDatabase(SQLDatabase):
 
         TESTS::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: it = CremonaDatabase().__iter__()
             sage: next(it).label()
             '11a1'
@@ -712,6 +718,7 @@ class MiniCremonaDatabase(SQLDatabase):
 
         TESTS::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: c = CremonaDatabase()
             sage: c[11]['allcurves']['a2']
             [[0, -1, 1, -7820, -263580], 0, 1]
@@ -744,6 +751,7 @@ class MiniCremonaDatabase(SQLDatabase):
 
         TESTS::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: c = CremonaDatabase('cremona mini')
             sage: c.__repr__()
             "Cremona's database of elliptic curves with conductor at most 9999"
@@ -763,6 +771,7 @@ class MiniCremonaDatabase(SQLDatabase):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: c = CremonaDatabase()
             sage: c.allcurves(11)['a3']
             [[0, -1, 1, 0, 0], 0, 5]
@@ -793,17 +802,20 @@ class MiniCremonaDatabase(SQLDatabase):
 
         Optimal curves of conductor 37::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: CremonaDatabase().curves(37)
             {'a1': [[0, 0, 1, -1, 0], 1, 1], 'b1': [[0, 1, 1, -23, -50], 0, 3]}
 
         Note the 'h3', which is the unique case in the tables where
         the optimal curve doesn't have label ending in 1::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: sorted(CremonaDatabase().curves(990))
             ['a1', 'b1', 'c1', 'd1', 'e1', 'f1', 'g1', 'h3', 'i1', 'j1', 'k1', 'l1']
 
         TESTS::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: c = CremonaDatabase()
             sage: c.curves(12001)['a1']   # optional - database_cremona_ellcurve
             [[1, 0, 0, -101, 382], 1, 1]
@@ -826,6 +838,7 @@ class MiniCremonaDatabase(SQLDatabase):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: c, d = CremonaDatabase().coefficients_and_data('144b1')
             sage: c
             [0, 0, 0, 6, 7]
@@ -896,6 +909,7 @@ class MiniCremonaDatabase(SQLDatabase):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: d = CremonaDatabase().data_from_coefficients([1, -1, 1, 31, 128])
             sage: d['conductor']
             1953
@@ -955,6 +969,7 @@ class MiniCremonaDatabase(SQLDatabase):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: c = CremonaDatabase()
             sage: c.elliptic_curve_from_ainvs([0, -1, 1, -10, -20])
             Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
@@ -993,6 +1008,7 @@ class MiniCremonaDatabase(SQLDatabase):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: c = CremonaDatabase()
             sage: c.elliptic_curve('11a1')
             Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
@@ -1024,6 +1040,7 @@ class MiniCremonaDatabase(SQLDatabase):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: [e.cremona_label() for e in CremonaDatabase().iter([11..15])]
             ['11a1', '11a2', '11a3', '14a1', '14a2', '14a3', '14a4', '14a5',
              '14a6', '15a1', '15a2', '15a3', '15a4', '15a5', '15a6', '15a7', '15a8']
@@ -1043,6 +1060,7 @@ class MiniCremonaDatabase(SQLDatabase):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: c = CremonaDatabase()
             sage: c.isogeny_classes(11)
             [[[[0, -1, 1, -10, -20], 0, 5],
@@ -1080,6 +1098,7 @@ class MiniCremonaDatabase(SQLDatabase):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: c = CremonaDatabase()
             sage: c.isogeny_class('11a1')
             [Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field,
@@ -1108,11 +1127,13 @@ class MiniCremonaDatabase(SQLDatabase):
 
         We list optimal curves with conductor up to 20::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: [e.cremona_label() for e in CremonaDatabase().iter_optimal([11..20])]
             ['11a1', '14a1', '15a1', '17a1', '19a1', '20a1']
 
         Note the unfortunate 990h3 special case::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: [e.cremona_label() for e in CremonaDatabase().iter_optimal([990])]
             ['990a1', '990b1', '990c1', '990d1', '990e1', '990f1', '990g1', '990h3', '990i1', '990j1', '990k1', '990l1']
         """
@@ -1142,6 +1163,7 @@ class MiniCremonaDatabase(SQLDatabase):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: CremonaDatabase().list([37])
             [Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field,
              Elliptic Curve defined by y^2 + y = x^3 + x^2 - 23*x - 50 over Rational Field,
@@ -1163,6 +1185,7 @@ class MiniCremonaDatabase(SQLDatabase):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: CremonaDatabase().list_optimal([37])
             [Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field,
              Elliptic Curve defined by y^2 + y = x^3 + x^2 - 23*x - 50 over Rational Field]
@@ -1177,6 +1200,7 @@ class MiniCremonaDatabase(SQLDatabase):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: c = CremonaDatabase('cremona mini')
             sage: c.largest_conductor()
             9999
@@ -1203,6 +1227,7 @@ class MiniCremonaDatabase(SQLDatabase):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: CremonaDatabase().smallest_conductor()
             1
         """
@@ -1217,6 +1242,7 @@ class MiniCremonaDatabase(SQLDatabase):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: c = CremonaDatabase('cremona mini')
             sage: c.conductor_range()
             (1, 10000)
@@ -1241,6 +1267,7 @@ class MiniCremonaDatabase(SQLDatabase):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: c = CremonaDatabase()
             sage: c.number_of_curves(11)
             3
@@ -1282,6 +1309,7 @@ class MiniCremonaDatabase(SQLDatabase):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: c = CremonaDatabase()
             sage: c.number_of_isogeny_classes(11)
             1
@@ -1306,6 +1334,7 @@ class MiniCremonaDatabase(SQLDatabase):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: CremonaDatabase().random() # random -- depends on database installed
             Elliptic Curve defined by y^2 + x*y  = x^3 - x^2 - 224*x + 3072 over Rational Field
         """
@@ -1465,6 +1494,7 @@ class LargeCremonaDatabase(MiniCremonaDatabase):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: c = CremonaDatabase()
             sage: c.allbsd(12)            # optional - database_cremona_ellcurve
             {}
@@ -1493,6 +1523,7 @@ class LargeCremonaDatabase(MiniCremonaDatabase):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: c = CremonaDatabase()
             sage: c.allgens(12)            # optional - database_cremona_ellcurve
             {}
@@ -1520,6 +1551,7 @@ class LargeCremonaDatabase(MiniCremonaDatabase):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: c = CremonaDatabase()
             sage: c.degphi(11)            # optional - database_cremona_ellcurve
             {'a1': 1}
@@ -1662,6 +1694,7 @@ def CremonaDatabase(name=None, mini=None):
 
     TESTS::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: c = CremonaDatabase()
         sage: isinstance(c, sage.databases.cremona.MiniCremonaDatabase)
         True

--- a/src/sage/groups/additive_abelian/additive_abelian_wrapper.py
+++ b/src/sage/groups/additive_abelian/additive_abelian_wrapper.py
@@ -10,7 +10,7 @@ EXAMPLES:
 
 We create a toy example based on the Mordell-Weil group of an elliptic curve over `\QQ`::
 
-    sage: # needs sage.schemes
+    sage: # needs database_cremona_mini_ellcurve sage.schemes
     sage: E = EllipticCurve('30a2')
     sage: pts = [E(4,-7,1), E(7/4, -11/8, 1), E(3, -2, 1)]
     sage: M = AdditiveAbelianGroupWrapper(pts[0].parent(), pts, [3, 2, 2]); M
@@ -68,13 +68,14 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from . import additive_abelian_group as addgp
-from sage.rings.integer_ring import ZZ
 from sage.categories.morphism import Morphism
-from sage.structure.element import parent
-from sage.structure.sequence import Sequence
-from sage.structure.richcmp import richcmp_method
 from sage.modules.free_module_element import vector
+from sage.rings.integer_ring import ZZ
+from sage.structure.element import parent
+from sage.structure.richcmp import richcmp_method
+from sage.structure.sequence import Sequence
+
+from . import additive_abelian_group as addgp
 
 
 class UnwrappingMorphism(Morphism):
@@ -100,7 +101,7 @@ class UnwrappingMorphism(Morphism):
         r"""
         TESTS::
 
-            sage: # needs sage.schemes
+            sage: # needs database_cremona_mini_ellcurve sage.schemes
             sage: E = EllipticCurve("65a1")
             sage: G = E.torsion_subgroup()
             sage: isinstance(G, sage.groups.additive_abelian.additive_abelian_wrapper.AdditiveAbelianGroupWrapper)
@@ -145,11 +146,12 @@ class AdditiveAbelianGroupWrapperElement(addgp.AdditiveAbelianGroupElement):
 
         EXAMPLES::
 
-            sage: T = EllipticCurve('65a').torsion_subgroup().gen(0)                    # needs sage.schemes
-            sage: T; type(T)                                                            # needs sage.schemes
+            sage: # needs database_cremona_mini_ellcurve
+            sage: T = EllipticCurve('65a').torsion_subgroup().gen(0)  # needs sage.schemes
+            sage: T; type(T)  # needs sage.schemes
             (0 : 0 : 1)
             <class 'sage.schemes.elliptic_curves.ell_torsion.EllipticCurveTorsionSubgroup_with_category.element_class'>
-            sage: T.element(); type(T.element())                                        # needs sage.schemes
+            sage: T.element(); type(T.element())  # needs sage.schemes
             (0 : 0 : 1)
             <class 'sage.schemes.elliptic_curves.ell_point.EllipticCurvePoint_number_field'>
         """
@@ -163,8 +165,9 @@ class AdditiveAbelianGroupWrapperElement(addgp.AdditiveAbelianGroupElement):
 
         EXAMPLES::
 
-            sage: T = EllipticCurve('65a').torsion_subgroup().gen(0)                    # needs sage.schemes
-            sage: repr(T)  # indirect doctest                                           # needs sage.schemes
+            sage: # needs database_cremona_mini_ellcurve
+            sage: T = EllipticCurve('65a').torsion_subgroup().gen(0)  # needs sage.schemes
+            sage: repr(T)  # indirect doctest  # needs sage.schemes
             '(0 : 0 : 1)'
         """
         return repr(self.element())
@@ -371,7 +374,7 @@ class AdditiveAbelianGroupWrapper(addgp.AdditiveAbelianGroup_fixed_gens):
             # test if generating set of G is contained in H
             return all(g.element() in H for g in G.gens())
 
-        from sage.structure.richcmp import op_LT, op_LE, op_EQ, op_NE, op_GE, op_GT
+        from sage.structure.richcmp import op_EQ, op_GE, op_GT, op_LE, op_LT, op_NE
         if op == op_LE:
             return leq(self, other)
         if op == op_GE:
@@ -532,7 +535,7 @@ class AdditiveAbelianGroupWrapper(addgp.AdditiveAbelianGroup_fixed_gens):
 
         ::
 
-            sage: # needs sage.schemes
+            sage: # needs database_cremona_mini_ellcurve sage.schemes
             sage: E = EllipticCurve('574i1')
             sage: pts = [E(103,172), E(61,18)]
             sage: assert pts[0].order() == 7 and pts[1].order() == infinity

--- a/src/sage/groups/generic.py
+++ b/src/sage/groups/generic.py
@@ -115,14 +115,14 @@ Some examples in the group of points of an elliptic curve over a finite field:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from copy import copy
 import operator
+from copy import copy
 
+import sage.rings.integer
 from sage.arith.misc import integer_ceil, integer_floor, xlcm
 from sage.arith.srange import xsrange
 from sage.misc.misc_c import prod
 from sage.rings import integer_ring
-import sage.rings.integer
 from sage.structure.element import parent
 
 #
@@ -186,7 +186,7 @@ def _parse_group_def(parent, operation, identity, inverse, op, *, check=True):
         sage: _parse_group_def(ZZ, 'other', 0, operator.neg, operator.add)
         ('other', 0, <built-in function neg>, <built-in function add>)
     """
-    from operator import inv, mul, neg, add
+    from operator import add, inv, mul, neg
 
     if operation in multiplication_names:
         if identity is not None or inverse is not None or op is not None:
@@ -210,10 +210,9 @@ def _parse_group_def(parent, operation, identity, inverse, op, *, check=True):
                 raise
         inverse = neg
         op = add
-    else:
-        if check and (identity is None or inverse is None or op is None):
-            raise ValueError("identity, inverse and operation must all be specified "
-                             "when operation is neither addition nor multiplication")
+    elif check and (identity is None or inverse is None or op is None):
+        raise ValueError("identity, inverse and operation must all be specified "
+                         "when operation is neither addition nor multiplication")
     return 'other', identity, inverse, op
 
 
@@ -315,7 +314,7 @@ def multiple(a, n, operation='*', identity=None, inverse=None, op=None):
         sage: multiple(1, 10^1000)
         1
 
-        sage: # needs sage.schemes
+        sage: # needs database_cremona_mini_ellcurve sage.schemes
         sage: E = EllipticCurve('389a1')
         sage: P = E(-1,1)
         sage: multiple(P, 10, '+')
@@ -399,9 +398,10 @@ class multiples:
         sage: list(multiples(1, 10, 100))
         [100, 101, 102, 103, 104, 105, 106, 107, 108, 109]
 
-        sage: E = EllipticCurve('389a1')                                                # needs sage.schemes
-        sage: P = E(-1,1)                                                               # needs sage.schemes
-        sage: for Q in multiples(P, 5): print((Q, Q.height()/P.height()))               # needs sage.schemes
+        sage: # needs database_cremona_mini_ellcurve
+        sage: E = EllipticCurve('389a1')  # needs sage.schemes
+        sage: P = E(-1,1)  # needs sage.schemes
+        sage: for Q in multiples(P, 5): print((Q, Q.height()/P.height()))  # needs sage.schemes
         ((0 : 1 : 0), 0.000000000000000)
         ((-1 : 1 : 1), 1.00000000000000)
         ((10/9 : -35/27 : 1), 4.00000000000000)
@@ -459,7 +459,7 @@ class multiples:
         if n < 0:
             raise ValueError('n cannot be negative in multiples')
 
-        from operator import mul, add
+        from operator import add, mul
 
         if operation in multiplication_names:
             if P0 is None:
@@ -743,8 +743,8 @@ def discrete_log_rho(a, base, ord=None, operation='*', identity=None, inverse=No
 
     - Yann Laigle-Chapuy (2009-09-05)
     """
-    from sage.rings.integer import Integer
     from sage.rings.finite_rings.integer_mod_ring import IntegerModRing
+    from sage.rings.integer import Integer
 
     operation, identity, inverse, op = _parse_group_def(parent(a), operation, identity, inverse, op)
 

--- a/src/sage/lfunctions/dokchitser.py
+++ b/src/sage/lfunctions/dokchitser.py
@@ -99,6 +99,7 @@ class Dokchitser(SageObject):
 
     We compute with the `L`-series of a rank `1` curve. ::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('37a')
         sage: L = E.lseries().dokchitser(algorithm='pari'); L
         PARI L-function associated to Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field
@@ -120,6 +121,7 @@ class Dokchitser(SageObject):
     We compute the leading coefficient and Taylor expansion of the
     `L`-series of a rank `2` elliptic curve. ::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('389a')
         sage: L = E.lseries().dokchitser(algorithm='pari')
         sage: L.cost()
@@ -343,6 +345,7 @@ class Dokchitser(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: L = E.lseries().dokchitser(algorithm='pari')
             sage: L.cost()
@@ -492,6 +495,7 @@ class Dokchitser(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('5077a')
             sage: L = E.lseries().dokchitser(100, algorithm='pari')
             sage: L(1)
@@ -540,6 +544,7 @@ class Dokchitser(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: L = E.lseries().dokchitser(algorithm='pari')
             sage: L.derivative(1,E.rank())
@@ -578,6 +583,7 @@ class Dokchitser(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: L = Dokchitser(conductor=1, gammaV=[0], weight=1, eps=1, poles=[1], residues=[-1], init='1')
             sage: L.taylor_series(2, 3)
             1.64493406684823 - 0.937548254315844*z + 0.994640117149451*z^2 + O(z^3)
@@ -589,6 +595,7 @@ class Dokchitser(SageObject):
         We compute a Taylor series where each coefficient is to high
         precision. ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: L = E.lseries().dokchitser(200, algorithm='pari')
             sage: L.taylor_series(1,3)

--- a/src/sage/lfunctions/lcalc.py
+++ b/src/sage/lfunctions/lcalc.py
@@ -234,6 +234,7 @@ class LCalc(SageObject):
         Sometimes warnings are printed (by lcalc) when this command is
         run::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: values = E.lseries().values_along_line(0.5, 3, 5)
             sage: values[0][0] # abs tol 1e-8
@@ -398,6 +399,7 @@ class LCalc(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: lcalc.analytic_rank(E)
             1

--- a/src/sage/lfunctions/pari.py
+++ b/src/sage/lfunctions/pari.py
@@ -342,6 +342,7 @@ def lfun_elliptic_curve(E):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.lfunctions.pari import lfun_elliptic_curve, LFunction
         sage: E = EllipticCurve('11a1')
         sage: L = LFunction(lfun_elliptic_curve(E))
@@ -568,6 +569,7 @@ class LFunction(SageObject):
 
     We compute with the `L`-series of a rank `1` curve. ::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('37a')
         sage: L = E.lseries().dokchitser(algorithm='pari'); L
         PARI L-function associated to Elliptic Curve defined by
@@ -591,6 +593,7 @@ class LFunction(SageObject):
     We compute the leading coefficient and Taylor expansion of the
     `L`-series of a rank `2` elliptic curve::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('389a')
         sage: L = E.lseries().dokchitser(algorithm='pari')
         sage: L.cost()
@@ -701,6 +704,7 @@ class LFunction(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.lfunctions.pari import *
             sage: L = LFunction(lfun_number_field(QQ)); L.conductor
             1
@@ -744,6 +748,7 @@ class LFunction(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: L = E.lseries().dokchitser(algorithm='pari')
             sage: L.cost()
@@ -855,6 +860,7 @@ class LFunction(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.lfunctions.pari import lfun_number_field, LFunction
             sage: lf = lfun_number_field(QQ)
             sage: L = LFunction(lf)
@@ -869,6 +875,7 @@ class LFunction(SageObject):
         We compute a Taylor series where each coefficient is to high
         precision::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: L = E.lseries().dokchitser(200,algorithm='pari')
             sage: L.taylor_series(1, 3)
@@ -876,12 +883,14 @@ class LFunction(SageObject):
 
         Check that :issue:`25402` is fixed::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: L = EllipticCurve("24a1").modular_form().lseries()
             sage: L.taylor_series(-1, 3)
             0.000000000000000 - 0.702565506265199*z + 0.638929001045535*z^2 + O(z^3)
 
         Check that :issue:`25965` is fixed::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: L2 = EllipticCurve("37a1").modular_form().lseries(); L2
             L-series associated to the cusp form q - 2*q^2 - 3*q^3 + 2*q^4 - 2*q^5 + O(q^6)
             sage: L2.taylor_series(0,3)
@@ -942,6 +951,7 @@ class LFunction(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('5077a')
             sage: L = E.lseries().dokchitser(100, algorithm='pari')
             sage: L(1)

--- a/src/sage/lfunctions/sympow.py
+++ b/src/sage/lfunctions/sympow.py
@@ -207,6 +207,7 @@ class Sympow(SageObject):
         EXAMPLES: We compute the modular degrees of the lowest known
         conductor curves of the first few ranks::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: sympow.modular_degree(EllipticCurve('11a'))
             1
             sage: sympow.modular_degree(EllipticCurve('37a'))
@@ -255,6 +256,7 @@ class Sympow(SageObject):
         EXAMPLES: We compute the analytic ranks of the lowest known
         conductor curves of the first few ranks::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: sympow.analytic_rank(EllipticCurve('11a'))
             (0, '2.53842e-01')
             sage: sympow.analytic_rank(EllipticCurve('37a'))

--- a/src/sage/lfunctions/zero_sums.pyx
+++ b/src/sage/lfunctions/zero_sums.pyx
@@ -71,6 +71,7 @@ cdef class LFunctionZeroSum_abstract(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: Z = LFunctionZeroSum(EllipticCurve("389a"))
             sage: Z.ncpus()
             1
@@ -106,6 +107,7 @@ cdef class LFunctionZeroSum_abstract(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("389a")
             sage: Z = LFunctionZeroSum(E)
             sage: Z.level()
@@ -122,6 +124,7 @@ cdef class LFunctionZeroSum_abstract(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("389a")
             sage: Z = LFunctionZeroSum(E)
             sage: Z.weight()
@@ -147,6 +150,7 @@ cdef class LFunctionZeroSum_abstract(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("389a")
             sage: Z = LFunctionZeroSum(E)
             sage: Z.C0() # tol 1.0e-13
@@ -185,6 +189,7 @@ cdef class LFunctionZeroSum_abstract(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("11a")
             sage: Z = LFunctionZeroSum(E)
             sage: cnlist = Z.cnlist(11)
@@ -234,6 +239,7 @@ cdef class LFunctionZeroSum_abstract(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: Z = LFunctionZeroSum(EllipticCurve("37a"))
             sage: Z.digamma(3.2) # tol 1.0e-13
             0.9988388912865993
@@ -525,6 +531,7 @@ cdef class LFunctionZeroSum_abstract(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("389a"); E.rank()
             2
             sage: Z = LFunctionZeroSum(E)
@@ -613,6 +620,7 @@ cdef class LFunctionZeroSum_abstract(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("37a"); E.rank()
             1
             sage: Z = LFunctionZeroSum(E)
@@ -727,6 +735,7 @@ cdef class LFunctionZeroSum_abstract(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("37a"); E.rank()
             1
             sage: Z = LFunctionZeroSum(E)
@@ -817,6 +826,7 @@ cdef class LFunctionZeroSum_abstract(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("11a")
             sage: zeros = E.lseries().zeros(2)
             sage: zeros[0] # abs tol 1e-8
@@ -913,6 +923,7 @@ cdef class LFunctionZeroSum_EllipticCurve(LFunctionZeroSum_abstract):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.lfunctions.zero_sums import LFunctionZeroSum_EllipticCurve
             sage: E = EllipticCurve([1,0,0,3,-4])
             sage: Z = LFunctionZeroSum_EllipticCurve(E); Z
@@ -951,6 +962,7 @@ cdef class LFunctionZeroSum_EllipticCurve(LFunctionZeroSum_abstract):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: Z = LFunctionZeroSum(EllipticCurve("37a")); Z
             Zero sum estimator for L-function attached to Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field
         """
@@ -1009,6 +1021,7 @@ cdef class LFunctionZeroSum_EllipticCurve(LFunctionZeroSum_abstract):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("11a")
             sage: Z = LFunctionZeroSum(E)
             sage: for n in range(12): print((n, Z.cn(n))) # tol 1.0e-13
@@ -1136,6 +1149,7 @@ cdef class LFunctionZeroSum_EllipticCurve(LFunctionZeroSum_abstract):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("37a")
             sage: Z = LFunctionZeroSum(E)
             sage: print((E.rank(),Z._zerosum_sincsquared_fast(Delta=1))) # tol 1.0e-13
@@ -1271,6 +1285,7 @@ cdef class LFunctionZeroSum_EllipticCurve(LFunctionZeroSum_abstract):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("37a"); Z = LFunctionZeroSum(E)
             sage: Z._get_residue_data(8)
             ([2, 3, 5, 7],
@@ -1418,6 +1433,7 @@ cdef class LFunctionZeroSum_EllipticCurve(LFunctionZeroSum_abstract):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("37a"); print(E.rank())
             1
             sage: Z = LFunctionZeroSum(E)
@@ -1616,6 +1632,7 @@ cdef class LFunctionZeroSum_EllipticCurve(LFunctionZeroSum_abstract):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("11a")
             sage: E.rank()
             0
@@ -1623,6 +1640,7 @@ cdef class LFunctionZeroSum_EllipticCurve(LFunctionZeroSum_abstract):
             sage: Z.analytic_rank_upper_bound(max_Delta=1,ncpus=1)
             0
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve([-39,123])
             sage: E.rank()
             1
@@ -1653,6 +1671,7 @@ cdef class LFunctionZeroSum_EllipticCurve(LFunctionZeroSum_abstract):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("974b1")
             sage: r = E.rank(); r
             0
@@ -1818,6 +1837,7 @@ def LFunctionZeroSum(X, *args, **kwds):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve("389a")
         sage: Z = LFunctionZeroSum(E); Z
         Zero sum estimator for L-function attached to Elliptic Curve defined by y^2 + y = x^3 + x^2 - 2*x over Rational Field

--- a/src/sage/libs/eclib/interface.py
+++ b/src/sage/libs/eclib/interface.py
@@ -18,6 +18,7 @@ TESTS:
 
 Check that ``eclib`` is imported as needed::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: [k for k in sys.modules if k.startswith("sage.libs.eclib")]
     []
     sage: EllipticCurve('11a1').mwrank_curve()

--- a/src/sage/libs/eclib/newforms.pyx
+++ b/src/sage/libs/eclib/newforms.pyx
@@ -27,6 +27,7 @@ cdef class ECModularSymbol:
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.libs.eclib.newforms import ECModularSymbol
         sage: E = EllipticCurve('11a')
         sage: M = ECModularSymbol(E,1); M
@@ -59,6 +60,7 @@ cdef class ECModularSymbol:
     tuple).  However it is more work to create the full modular
     symbol space::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('11a1')
         sage: M = ECModularSymbol(E,0); M
         Modular symbol with sign 0 over Rational Field attached to Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
@@ -81,6 +83,7 @@ cdef class ECModularSymbol:
 
     Non-optimal curves are handled correctly in eclib, by comparing the ratios of real and/or imaginary periods::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.libs.eclib.newforms import ECModularSymbol
         sage: E1 = EllipticCurve('11a1') # optimal
         sage: E1.period_lattice().basis()
@@ -93,6 +96,7 @@ cdef class ECModularSymbol:
 
     One non-optimal curve has real period 1/5 that of the optimal one, so plus symbols scale up by a factor of 5 while minus symbols are unchanged::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E2 = EllipticCurve('11a2') # not optimal
         sage: E2.period_lattice().basis()
         (0.253841860855911, 0.126920930427955 + 1.45881661693850*I)
@@ -108,6 +112,7 @@ cdef class ECModularSymbol:
 
     The other non-optimal curve has real period 5 times that of the optimal one, so plus symbols scale down by a factor of 5; again, minus symbols are unchanged::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E3 = EllipticCurve('11a3') # not optimal
         sage: E3.period_lattice().basis()
         (6.34604652139777, 3.17302326069888 + 1.45881661693850*I)
@@ -144,6 +149,7 @@ cdef class ECModularSymbol:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.libs.eclib.newforms import ECModularSymbol
             sage: E = EllipticCurve('11a')
             sage: M = ECModularSymbol(E, +1)
@@ -163,6 +169,7 @@ cdef class ECModularSymbol:
 
         This one is from :issue:`8042`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.libs.eclib.newforms import ECModularSymbol
             sage: E = EllipticCurve('858k2')
             sage: ECModularSymbol(E)
@@ -226,6 +233,7 @@ cdef class ECModularSymbol:
         """
         TESTS::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.libs.eclib.newforms import ECModularSymbol
             sage: E = EllipticCurve('11a')
             sage: M = ECModularSymbol(E); M
@@ -265,6 +273,7 @@ cdef class ECModularSymbol:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.libs.eclib.newforms import ECModularSymbol
             sage: E = EllipticCurve('11a')
             sage: M = ECModularSymbol(E)
@@ -283,6 +292,7 @@ cdef class ECModularSymbol:
 
         When the class is created with sign 0 we can ask for +1 or -1 symbols or (by default) both::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.libs.eclib.newforms import ECModularSymbol
             sage: E = EllipticCurve('11a1')
             sage: M = ECModularSymbol(E,0)
@@ -303,6 +313,7 @@ cdef class ECModularSymbol:
 
         When the class is created with sign +1 we can only ask for +1 symbols::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.libs.eclib.newforms import ECModularSymbol
             sage: E = EllipticCurve('11a1')
             sage: M = ECModularSymbol(E)
@@ -323,6 +334,7 @@ cdef class ECModularSymbol:
 
         See :issue:`11211`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.libs.eclib.newforms import ECModularSymbol
             sage: E = EllipticCurve('11a')
             sage: M = ECModularSymbol(E)
@@ -384,6 +396,7 @@ cdef class ECModularSymbol:
         """
         TESTS::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.libs.eclib.newforms import ECModularSymbol
             sage: E = EllipticCurve('11a')
             sage: M = ECModularSymbol(E)

--- a/src/sage/libs/lcalc/lcalc_Lfunction.pyx
+++ b/src/sage/libs/lcalc/lcalc_Lfunction.pyx
@@ -962,6 +962,7 @@ def Lfunction_from_elliptic_curve(E, number_of_coeffs=10000):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.libs.lcalc.lcalc_Lfunction import Lfunction_from_elliptic_curve
         sage: L = Lfunction_from_elliptic_curve(EllipticCurve('37'))
         sage: L

--- a/src/sage/libs/pari/tests.py
+++ b/src/sage/libs/pari/tests.py
@@ -139,8 +139,9 @@ Some more exotic examples::
     sage: pari(K)
     [y^3 - 2, [1, 1], -108, 1, [[1, 1.25992104989487, 1.58740105196820; 1, -0.629960524947437 + 1.09112363597172*I, -0.793700525984100 - 1.37472963699860*I], [1, 1.25992104989487, 1.58740105196820; 1, 0.461163111024285, -2.16843016298270; 1, -1.72108416091916, 0.581029111014503], [16, 20, 25; 16, 7, -35; 16, -28, 9], [3, 0, 0; 0, 0, 6; 0, 6, 0], [6, 0, 0; 0, 6, 0; 0, 0, 3], [2, 0, 0; 0, 0, 1; 0, 1, 0], [2, [0, 0, 2; 1, 0, 0; 0, 1, 0]], [2, 3]], [1.25992104989487, -0.629960524947437 + 1.09112363597172*I], [1, y, y^2], [1, 0, 0; 0, 1, 0; 0, 0, 1], [1, 0, 0, 0, 0, 2, 0, 2, 0; 0, 1, 0, 1, 0, 0, 0, 0, 2; 0, 0, 1, 0, 1, 0, 1, 0, 0]]
 
-    sage: E = EllipticCurve('37a1')                                                     # needs sage.schemes
-    sage: pari(E)                                                                       # needs sage.schemes
+    sage: # needs database_cremona_mini_ellcurve
+    sage: E = EllipticCurve('37a1')  # needs sage.schemes
+    sage: pari(E)  # needs sage.schemes
     [0, 0, 1, -1, 0, 0, -2, 1, -1, 48, -216, 37, 110592/37, Vecsmall([1]), [Vecsmall([64, 1])], [0, 0, 0, 0, 0, 0, 0, 0]]
 
 Deprecation checks::
@@ -1252,7 +1253,7 @@ Elliptic curves::
     sage: e.ellglobalred()
     [20144, [1, -2, 0, -1], 1, [2, 4; 1259, 1], [[4, 2, 0, 1], [1, 5, 0, 1]]]
 
-    sage: # needs sage.schemes
+    sage: # needs database_cremona_mini_ellcurve sage.schemes
     sage: e = pari(EllipticCurve('17a').a_invariants()).ellinit()
     sage: e.ellglobalred()
     [17, [1, 0, 0, 0], 4, Mat([17, 1]), [[1, 8, 0, 4]]]
@@ -1271,9 +1272,9 @@ Elliptic curves::
     sage: e.ellak(0)
     0
 
-    sage: # needs sage.schemes
+    sage: # needs database_cremona_mini_ellcurve sage.schemes
     sage: E = EllipticCurve('389a1')
-    sage: pari(E).ellanalyticrank()                                                     # needs sage.rings.number_field
+    sage: pari(E).ellanalyticrank()  # needs sage.rings.number_field
     [2, 1.51863300057685]
 
     sage: e = pari([0, -1, 1, -10, -20]).ellinit()
@@ -1312,7 +1313,7 @@ Elliptic curves::
     sage: om.elleisnum(100)
     2.15314248576078 E50
 
-    sage: # needs sage.schemes
+    sage: # needs database_cremona_mini_ellcurve sage.schemes
     sage: e = pari([0,0,0,0,1]).ellinit()
     sage: e.elllocalred(7)
     [0, 1, [1, 0, 0, 0], 1]
@@ -1353,7 +1354,7 @@ Elliptic curves::
     sage: e.elllocalred(3)
     [2, -10, [1, 0, 0, 0], 4]
 
-    sage: # needs sage.schemes
+    sage: # needs database_cremona_mini_ellcurve sage.schemes
     sage: e = pari(EllipticCurve('65a1').a_invariants()).ellinit()
     sage: e.ellorder([0,0])
     2

--- a/src/sage/matrix/special.py
+++ b/src/sage/matrix/special.py
@@ -1992,6 +1992,7 @@ def block_matrix(*args, **kwds):
 
     Error reporting when non-ring elements are passed in::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: matrix.block([
         ....:     ["abc"],
         ....:     ])

--- a/src/sage/misc/benchmark.py
+++ b/src/sage/misc/benchmark.py
@@ -221,6 +221,7 @@ def bench7() -> tuple[str, float]:
 
     BENCHMARK::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.misc.benchmark import *
         sage: print(bench7()[0])
         Compute the Mordell-Weil group of y^2 = x^3 + 37*x - 997.

--- a/src/sage/misc/functional.py
+++ b/src/sage/misc/functional.py
@@ -1655,8 +1655,9 @@ def rank(x):
 
     We compute the rank of an elliptic curve::
 
-        sage: E = EllipticCurve([0,0,1,-1,0])                                           # needs sage.schemes
-        sage: rank(E)                                                                   # needs sage.schemes
+        sage: # needs database_cremona_mini_ellcurve
+        sage: E = EllipticCurve([0,0,1,-1,0])  # needs sage.schemes
+        sage: rank(E)  # needs sage.schemes
         1
     """
     return x.rank()
@@ -1668,10 +1669,11 @@ def regulator(x):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: x = polygen(ZZ, 'x')
-        sage: regulator(NumberField(x^2 - 2, 'a'))                                      # needs sage.rings.number_field
+        sage: regulator(NumberField(x^2 - 2, 'a'))  # needs sage.rings.number_field
         0.881373587019543
-        sage: regulator(EllipticCurve('11a'))                                           # needs sage.schemes
+        sage: regulator(EllipticCurve('11a'))  # needs sage.schemes
         1.00000000000000
     """
     return x.regulator()

--- a/src/sage/misc/latex.py
+++ b/src/sage/misc/latex.py
@@ -2141,9 +2141,10 @@ def repr_lincomb(symbols, coeffs):
     Verify that :issue:`17299` (latex representation of modular symbols)
     is fixed::
 
-        sage: x = EllipticCurve('64a1').modular_symbol_space(sign=1).basis()[0]         # needs sage.schemes
+        sage: # needs database_cremona_mini_ellcurve
+        sage: x = EllipticCurve('64a1').modular_symbol_space(sign=1).basis()[0]  # needs sage.schemes
         sage: from sage.misc.latex import repr_lincomb
-        sage: latex(x.modular_symbol_rep())                                             # needs sage.schemes
+        sage: latex(x.modular_symbol_rep())  # needs sage.schemes
         \left\{\frac{-3}{11}, \frac{-1}{4}\right\} - \left\{\frac{3}{13}, \frac{1}{4}\right\}
 
     Verify that it works when the symbols are numbers::

--- a/src/sage/modular/abvar/abvar.py
+++ b/src/sage/modular/abvar/abvar.py
@@ -597,14 +597,17 @@ class ModularAbelianVariety_abstract(Parent):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: J = J0(11)
             sage: J.elliptic_curve()
             Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: J = J0(49)
             sage: J.elliptic_curve()
             Elliptic Curve defined by y^2 + x*y = x^3 - x^2 - 2*x - 1 over Rational Field
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: A = J0(37)[1]
             sage: E = A.elliptic_curve()
             sage: A.lseries()(1)
@@ -1747,6 +1750,7 @@ class ModularAbelianVariety_abstract(Parent):
             sage: A.conductor().factor()
             11^10
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: A = J0(33)[0]; A
             Simple abelian subvariety 11a(1,33) of dimension 1 of J0(33)
             sage: A.conductor()
@@ -2720,6 +2724,7 @@ class ModularAbelianVariety_abstract(Parent):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: J = J0(33)
             sage: A = J.new_subvariety()
             sage: A
@@ -3663,6 +3668,7 @@ class ModularAbelianVariety_abstract(Parent):
 
         By a theorem the modular degree must thus be `3`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('33a')
             sage: E.modular_degree()
             3

--- a/src/sage/modular/abvar/torsion_subgroup.py
+++ b/src/sage/modular/abvar/torsion_subgroup.py
@@ -18,6 +18,7 @@ AUTHORS:
 EXAMPLES: First we consider `J_0(50)` where everything
 works out nicely::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: J = J0(50)
     sage: T = J.rational_torsion_subgroup(); T
     Torsion subgroup of Abelian variety J0(50) of dimension 2
@@ -42,6 +43,7 @@ factor.
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: for N in range(1,38):
     ....:    for A in J0(N).new_subvariety().decomposition():
     ....:        T = A.rational_torsion_subgroup()
@@ -184,6 +186,7 @@ class RationalTorsionSubgroup(FiniteSubgroup):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: A = J0(11)
             sage: A.rational_torsion_subgroup().order()
             5
@@ -341,6 +344,7 @@ class RationalTorsionSubgroup(FiniteSubgroup):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: t = J0(37)[1].rational_torsion_subgroup()
             sage: t.divisor_of_order()
             3
@@ -409,6 +413,7 @@ class RationalTorsionSubgroup(FiniteSubgroup):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: J = J1(11); J
             Abelian variety J1(11) of dimension 1
             sage: J.rational_torsion_subgroup().multiple_of_order()

--- a/src/sage/modular/btquotients/btquotient.py
+++ b/src/sage/modular/btquotients/btquotient.py
@@ -3684,6 +3684,7 @@ class BruhatTitsQuotient(SageObject, UniqueRepresentation):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('21a1')
             sage: X = BruhatTitsQuotient(7,3)
             sage: f = X.harmonic_cocycle_from_elliptic_curve(E,10)

--- a/src/sage/modular/hecke/element.py
+++ b/src/sage/modular/hecke/element.py
@@ -215,6 +215,7 @@ class HeckeModuleElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: M = ModularForms(2, 22); M.0.is_cuspidal()
             True
             sage: (M.0 + M.4).is_cuspidal()
@@ -249,6 +250,7 @@ class HeckeModuleElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: CuspForms(2,8).0.is_eisenstein()
             False
             sage: M = ModularForms(2,8);(M.0  + M.1).is_eisenstein()

--- a/src/sage/modular/hecke/module.py
+++ b/src/sage/modular/hecke/module.py
@@ -1567,6 +1567,7 @@ class HeckeModule_free_module(HeckeModule_generic):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: e = EllipticCurve('34a')
             sage: m = ModularSymbols(34); s = m.cuspidal_submodule()
             sage: d = s.decomposition(7)

--- a/src/sage/modular/hecke/submodule.py
+++ b/src/sage/modular/hecke/submodule.py
@@ -314,6 +314,7 @@ class HeckeSubmodule(module.HeckeModule_free_module):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: M = ModularSymbols(15, 6).cuspidal_subspace()
             sage: M.complement()
             Modular Symbols subspace of dimension 4 of Modular Symbols space of dimension 20 for Gamma_0(15) of weight 6 with sign 0 over Rational Field
@@ -491,6 +492,7 @@ class HeckeSubmodule(module.HeckeModule_free_module):
 
         We test that :issue:`5080` is fixed::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('128a').congruence_number()
             32
         """

--- a/src/sage/modular/modform/element.py
+++ b/src/sage/modular/modform/element.py
@@ -853,6 +853,7 @@ class ModularForm_abstract(ModuleElement):
         associated to `E`, then the periods of `f` are in the period
         lattice of `E` up to an integer multiple::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a3')
             sage: f = E.newform()
             sage: g = Gamma0(11)([3, 1, 11, 4])
@@ -922,6 +923,7 @@ class ModularForm_abstract(ModuleElement):
             ...
             NotImplementedError: don't know how to compute Atkin-Lehner matrix acting on this space (try using a newform constructor instead)
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('19a1')
             sage: M = Gamma0(19)([10, 1, 19, 2])
             sage: E.newform().period(M)  # abs tol 1e-14
@@ -1069,6 +1071,7 @@ class ModularForm_abstract(ModuleElement):
 
         We check that :issue:`5262` is fixed::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37b2')
             sage: h = Newforms(37)[1]
             sage: Lh = h.lseries()
@@ -1432,6 +1435,7 @@ class ModularForm_abstract(ModuleElement):
 
         Here is a non-cm example coming from elliptic curves. ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: f = E.modular_form()
             sage: f.has_cm()
@@ -2580,6 +2584,7 @@ class ModularFormElement(ModularForm_abstract, element.HeckeModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: f = EllipticCurve('37a').modular_form()
             sage: f.q_expansion()  # indirect doctest
             q - 2*q^2 - 3*q^3 + 2*q^4 - 2*q^5 + O(q^6)
@@ -2921,6 +2926,7 @@ class ModularFormElement_elliptic_curve(Newform):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: f = E.modular_form()
             sage: f
@@ -2930,6 +2936,7 @@ class ModularFormElement_elliptic_curve(Newform):
             sage: f.parent()
             Modular Forms space of dimension 33 for Congruence Subgroup Gamma0(389) of weight 2 over Rational Field
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: f = E.modular_form() ; f
             q - 2*q^2 - 3*q^3 + 2*q^4 - 2*q^5 + O(q^6)
@@ -2945,6 +2952,7 @@ class ModularFormElement_elliptic_curve(Newform):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: f = E.modular_form()
             sage: f.elliptic_curve()
@@ -2961,6 +2969,7 @@ class ModularFormElement_elliptic_curve(Newform):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('11a1').modular_form()._compute_element()
             (1, 0)
             sage: EllipticCurve('389a1').modular_form()._compute_element()
@@ -2979,6 +2988,7 @@ class ModularFormElement_elliptic_curve(Newform):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a') ; f = E.modular_form()
             sage: f._compute_q_expansion(10)
             q - 2*q^2 - q^3 + 2*q^4 + q^5 + 2*q^6 - 2*q^7 - 2*q^9 + O(q^10)
@@ -3012,6 +3022,7 @@ class ModularFormElement_elliptic_curve(Newform):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('57a1').newform().atkin_lehner_eigenvalue()
             1
             sage: EllipticCurve('57b1').newform().atkin_lehner_eigenvalue()

--- a/src/sage/modular/modform/l_series_gross_zagier.py
+++ b/src/sage/modular/modform/l_series_gross_zagier.py
@@ -32,6 +32,7 @@ class GrossZagierLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.modular.modform.l_series_gross_zagier import GrossZagierLseries
             sage: e = EllipticCurve('37a')
             sage: K.<a> = QuadraticField(-40)
@@ -90,6 +91,7 @@ class GrossZagierLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: e = EllipticCurve('37a')
             sage: K.<a> = QuadraticField(-40)
             sage: A = K.class_group().gen(0)
@@ -114,6 +116,7 @@ class GrossZagierLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: e = EllipticCurve('37a')
             sage: K.<a> = QuadraticField(-40)
             sage: A = K.class_group().gen(0)

--- a/src/sage/modular/modform/l_series_gross_zagier_coeffs.pyx
+++ b/src/sage/modular/modform/l_series_gross_zagier_coeffs.pyx
@@ -116,6 +116,7 @@ def gross_zagier_L_series(an_list, Q, long N, long u, var=None):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.modular.modform.l_series_gross_zagier_coeffs import gross_zagier_L_series
         sage: E = EllipticCurve('37a')
         sage: N = 37

--- a/src/sage/modular/modsym/space.py
+++ b/src/sage/modular/modsym/space.py
@@ -2165,6 +2165,7 @@ class ModularSymbolsSpace(HeckeModule_free_module):
         where the torsion subgroup of the optimal quotients (which are
         all elliptic curves) are all cuspidal::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: M = ModularSymbols(37).cuspidal_subspace().new_subspace()
             sage: D = M.decomposition()
             sage: [(A.abvarquo_rational_cuspidal_subgroup().invariants(), A.T(19)[0,0]) for A in D]
@@ -2175,6 +2176,7 @@ class ModularSymbolsSpace(HeckeModule_free_module):
         Next we consider level 54, where the rational cuspidal
         subgroups of the quotients are also cuspidal::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: M = ModularSymbols(54).cuspidal_subspace().new_subspace()
             sage: D = M.decomposition()
             sage: [A.abvarquo_rational_cuspidal_subgroup().invariants() for A in D]
@@ -2188,6 +2190,7 @@ class ModularSymbolsSpace(HeckeModule_free_module):
         in the quotient is a nontrivial subgroup of `E(\QQ)_{tor}`.
         Thus not all torsion in the quotient is cuspidal!::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: M = ModularSymbols(66).cuspidal_subspace().new_subspace()
             sage: D = M.decomposition()
             sage: [(A.abvarquo_rational_cuspidal_subgroup().invariants(), A.T(19)[0,0]) for A in D]

--- a/src/sage/modular/pollack_stevens/fund_domain.py
+++ b/src/sage/modular/pollack_stevens/fund_domain.py
@@ -1445,6 +1445,7 @@ class ManinRelations(PollackStevensModularDomain):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -1515,6 +1516,7 @@ class ManinRelations(PollackStevensModularDomain):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()

--- a/src/sage/modular/pollack_stevens/manin_map.py
+++ b/src/sage/modular/pollack_stevens/manin_map.py
@@ -10,6 +10,7 @@ provides basic arithmetic and right action of matrices.
 
 EXAMPLES::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve('11a')
     sage: phi = E.pollack_stevens_modular_symbol()
     sage: phi
@@ -778,6 +779,7 @@ class ManinMap:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -829,6 +831,7 @@ class ManinMap:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: f = phi._map

--- a/src/sage/modular/pollack_stevens/modsym.py
+++ b/src/sage/modular/pollack_stevens/modsym.py
@@ -5,6 +5,7 @@ This is the class of elements in the spaces of Pollack-Steven's modular symbols 
 
 EXAMPLES::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve('11a')
     sage: phi = E.pollack_stevens_modular_symbol(); phi
     Modular symbol of level 11 with values in Sym^0 Q^2
@@ -81,6 +82,7 @@ def _iterate_Up(Phi, p, M, ap, q, aq, check):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('57a')
         sage: p = 5
         sage: prec = 4
@@ -121,6 +123,7 @@ class PSModSymAction(Action):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: g = phi._map._codomain._act._Sigma0(matrix(ZZ,2,2,[1,2,3,4]))
@@ -136,6 +139,7 @@ class PSModSymAction(Action):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: g = phi._map._codomain._act._Sigma0(matrix(ZZ,2,2,[2,1,5,-1]))
@@ -153,6 +157,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: phi = E.pollack_stevens_modular_symbol()
         """
@@ -168,6 +173,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi._repr_()
@@ -183,6 +189,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: Set([x.moment(0) for x in phi.dict().values()]) == Set([-1/5, 1, 0])
@@ -202,6 +209,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.weight()
@@ -217,6 +225,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -237,6 +246,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi._normalize()
@@ -256,6 +266,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi == phi
@@ -280,6 +291,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -297,6 +309,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -314,6 +327,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -331,6 +345,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -411,6 +426,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -433,6 +449,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -473,6 +490,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -507,6 +525,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+           sage: # needs database_cremona_mini_ellcurve
            sage: E = EllipticCurve('11a')
            sage: phi = E.pollack_stevens_modular_symbol()
            sage: phi.values()
@@ -547,6 +566,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -579,6 +599,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -625,6 +646,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.values()
@@ -692,6 +714,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi.is_ordinary(2)
@@ -752,12 +775,14 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('17a1')
             sage: L = E.padic_lseries(5, implementation='pollackstevens', precision=4) #long time
             sage: D = L.quadratic_twist()          # long time
             sage: L.symbol().evaluate_twisted(1,D) # long time
             (1 + 5 + 3*5^2 + 5^3 + O(5^4), 5^2 + O(5^3), 1 + O(5^2), 2 + O(5))
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('40a4')
             sage: L = E.padic_lseries(7, implementation='pollackstevens', precision=4) #long time
             sage: D = L.quadratic_twist()          # long time
@@ -768,6 +793,7 @@ class PSModularSymbolElement(ModuleElement):
 
         Check for :issue:`32878`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: L = E.padic_lseries(3, implementation='pollackstevens', precision=4)
             sage: D = 5
@@ -798,6 +824,7 @@ class PSModularSymbolElement(ModuleElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: phi._consistency_check()
@@ -882,6 +909,7 @@ class PSModularSymbolElement_symk(PSModularSymbolElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: p = 5
             sage: M = 10
@@ -992,6 +1020,7 @@ class PSModularSymbolElement_symk(PSModularSymbolElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: p = 5
             sage: prec = 4
@@ -1148,6 +1177,7 @@ class PSModularSymbolElement_symk(PSModularSymbolElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: f = E.pollack_stevens_modular_symbol()
             sage: g = f.lift(11,4,algorithm='stevens',eigensymbol=True)
@@ -1165,6 +1195,7 @@ class PSModularSymbolElement_symk(PSModularSymbolElement):
 
         Another example, which showed precision loss in an earlier version of the code::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: p = 5
             sage: prec = 4
@@ -1175,6 +1206,7 @@ class PSModularSymbolElement_symk(PSModularSymbolElement):
 
         Another example::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.modular.pollack_stevens.padic_lseries import pAdicLseries
             sage: E = EllipticCurve('37a')
             sage: p = 5
@@ -1187,6 +1219,7 @@ class PSModularSymbolElement_symk(PSModularSymbolElement):
 
         Examples using Greenberg's algorithm::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: Phi = phi.lift(11,8,algorithm='greenberg',eigensymbol=True)
@@ -1281,6 +1314,7 @@ class PSModularSymbolElement_symk(PSModularSymbolElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: f = E.pollack_stevens_modular_symbol()
             sage: f._lift_to_OMS(11,4,Qp(11,4))
@@ -1360,6 +1394,7 @@ class PSModularSymbolElement_symk(PSModularSymbolElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: f = E.pollack_stevens_modular_symbol()
             sage: f._find_aq(5,10,True)
@@ -1406,6 +1441,7 @@ class PSModularSymbolElement_symk(PSModularSymbolElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: p = 5
             sage: M = 10
@@ -1471,6 +1507,7 @@ class PSModularSymbolElement_symk(PSModularSymbolElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: f = E.pollack_stevens_modular_symbol()
             sage: g = f.p_stabilize_and_lift(3,10)  # long time
@@ -1575,6 +1612,7 @@ class PSModularSymbolElement_dist(PSModularSymbolElement):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: phi = E.pollack_stevens_modular_symbol()
             sage: L = phi.lift(37, M=6, eigensymbol=True).padic_lseries(); L  # long time

--- a/src/sage/modular/pollack_stevens/padic_lseries.py
+++ b/src/sage/modular/pollack_stevens/padic_lseries.py
@@ -46,6 +46,7 @@ class pAdicLseries(SageObject):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('37a')
         sage: p = 5
         sage: prec = 4
@@ -57,6 +58,7 @@ class pAdicLseries(SageObject):
 
     ::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.modular.pollack_stevens.padic_lseries import pAdicLseries
         sage: E = EllipticCurve('20a')
         sage: phi = E.pollack_stevens_modular_symbol()
@@ -92,6 +94,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.modular.pollack_stevens.padic_lseries import pAdicLseries
             sage: E = EllipticCurve('11a3')
             sage: phi = E.pollack_stevens_modular_symbol()
@@ -129,6 +132,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a5')
             sage: L = E.padic_lseries(7,implementation='pollackstevens',precision=5) # long time
             sage: L[0]                                   # long time
@@ -171,6 +175,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: L = E.padic_lseries(11,implementation='pollackstevens',precision=6) # long time
             sage: L == loads(dumps(L)) # indirect doctest, long time
@@ -190,6 +195,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: L = E.padic_lseries(11,implementation='pollackstevens',precision=6) # long time
             sage: L != L  # long time
@@ -203,6 +209,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.modular.pollack_stevens.padic_lseries import pAdicLseries
             sage: E = EllipticCurve('21a4')
             sage: phi = E.pollack_stevens_modular_symbol()
@@ -222,6 +229,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('19a')
             sage: L = E.padic_lseries(19, implementation='pollackstevens',precision=6) # long time
             sage: L.prime()                   # long time
@@ -235,6 +243,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.modular.pollack_stevens.padic_lseries import pAdicLseries
             sage: E = EllipticCurve('37a')
             sage: phi = E.pollack_stevens_modular_symbol()
@@ -251,6 +260,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a2')
             sage: L = E.padic_lseries(3, implementation='pollackstevens', precision=4)  # long time
             sage: L._repr_()                           # long time
@@ -271,6 +281,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a2')
             sage: p = 3
             sage: prec = 6
@@ -278,11 +289,13 @@ class pAdicLseries(SageObject):
             sage: L.series(4)          # long time
             2*3 + 3^4 + 3^5 + O(3^6) + (2*3 + 3^2 + O(3^4))*T + (2*3 + O(3^2))*T^2 + (3 + O(3^2))*T^3 + O(T^4)
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("15a3")
             sage: L = E.padic_lseries(5,implementation='pollackstevens',precision=15)  # long time
             sage: L.series(3)            # long time
             O(5^15) + (2 + 4*5^2 + 3*5^3 + 5^5 + 2*5^6 + 3*5^7 + 3*5^8 + 2*5^9 + 2*5^10 + 3*5^11 + 5^12 + O(5^13))*T + (4*5 + 4*5^3 + 3*5^4 + 4*5^5 + 3*5^6 + 2*5^7 + 5^8 + 4*5^9 + 3*5^10 + O(5^11))*T^2 + O(T^3)
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("79a1")
             sage: L = E.padic_lseries(2,implementation='pollackstevens',precision=10) # not tested
             sage: L.series(4)  # not tested
@@ -314,6 +327,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('19a2')
             sage: L = E.padic_lseries(3,implementation='pollackstevens',precision=6)  # long time
             sage: ap = E.ap(3)               # long time
@@ -356,6 +370,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.modular.pollack_stevens.padic_lseries import pAdicLseries
             sage: E = EllipticCurve('11a3')
             sage: L = E.padic_lseries(5, implementation='pollackstevens', precision=4) #long time

--- a/src/sage/modular/pollack_stevens/space.py
+++ b/src/sage/modular/pollack_stevens/space.py
@@ -48,6 +48,7 @@ classical modular symbols (or even elliptic curves) as follows::
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve('37a1')
     sage: phi = E.pollack_stevens_modular_symbol(); phi
     Modular symbol of level 37 with values in Sym^0 Q^2
@@ -857,6 +858,7 @@ def ps_modsym_from_elliptic_curve(E, sign=0, implementation='eclib'):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('113a1')
         sage: symb = E.pollack_stevens_modular_symbol() # indirect doctest
         sage: symb
@@ -972,6 +974,7 @@ def ps_modsym_from_simple_modsym_space(A, name='alpha'):
 
     A consistency check with :meth:`sage.modular.pollack_stevens.space.ps_modsym_from_simple_modsym_space`::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.modular.pollack_stevens.space import ps_modsym_from_simple_modsym_space
         sage: E = EllipticCurve('11a')
         sage: f_E = E.pollack_stevens_modular_symbol(); f_E.values()

--- a/src/sage/plot/animate.py
+++ b/src/sage/plot/animate.py
@@ -130,12 +130,13 @@ import shlex
 import struct
 import zlib
 
-from sage.misc.fast_methods import WithEqualityById
-from sage.structure.sage_object import SageObject
-from sage.misc.temporary_file import tmp_dir, tmp_filename
-from . import plot
 import sage.misc.misc
 import sage.misc.viewer
+from sage.misc.fast_methods import WithEqualityById
+from sage.misc.temporary_file import tmp_dir, tmp_filename
+from sage.structure.sage_object import SageObject
+
+from . import plot
 
 
 def animate(frames, **kwds):
@@ -515,7 +516,7 @@ class Animation(WithEqualityById, SageObject):
 
         EXAMPLES::
 
-            sage: # needs sage.schemes
+            sage: # needs database_cremona_mini_ellcurve sage.schemes
             sage: E = EllipticCurve('37a')
             sage: v = [E.change_ring(GF(p)).plot(pointsize=30)
             ....:      for p in [97, 101, 103]]
@@ -619,8 +620,8 @@ class Animation(WithEqualityById, SageObject):
 
               See www.imagemagick.org and www.ffmpeg.org for more information.
         """
-        from sage.features.imagemagick import ImageMagick
         from sage.features.ffmpeg import FFmpeg
+        from sage.features.imagemagick import ImageMagick
 
         if not ImageMagick().is_present() and not FFmpeg().is_present():
             raise OSError("Error: Neither ImageMagick nor ffmpeg appear to "
@@ -970,17 +971,15 @@ class Animation(WithEqualityById, SageObject):
         if savefile is None:
             if output_format is None:
                 output_format = '.mpg'
-            else:
-                if output_format[0] != '.':
-                    output_format = '.'+output_format
+            elif output_format[0] != '.':
+                output_format = '.'+output_format
             savefile = tmp_filename(ext=output_format)
-        else:
-            if output_format is None:
-                suffix = os.path.splitext(savefile)[1]
-                if len(suffix) > 0:
-                    output_format = suffix
-                else:
-                    output_format = '.mpg'
+        elif output_format is None:
+            suffix = os.path.splitext(savefile)[1]
+            if len(suffix) > 0:
+                output_format = suffix
+            else:
+                output_format = '.mpg'
         if not savefile.endswith(output_format):
             savefile += output_format
         early_options = ''
@@ -1020,7 +1019,7 @@ class Animation(WithEqualityById, SageObject):
         cmd = 'cd {}; {} -nostdin -y -f image2 {} -i {} {} {}'.format(
             shlex.quote(pngdir), shlex.quote(FFmpeg().absolute_filename()),
             early_options, shlex.quote(pngs), ffmpeg_options, shlex.quote(savefile))
-        from subprocess import check_call, CalledProcessError, PIPE
+        from subprocess import PIPE, CalledProcessError, check_call
         try:
             if sage.misc.verbose.get_verbose() > 0:
                 set_stderr = None
@@ -1452,9 +1451,8 @@ class APngAssembler:
                     if ref is None:
                         self._matchref[ctype] = cdata
                         self._copy()
-                    else:
-                        if cdata != ref:
-                            raise ValueError(f"Chunk {utype} mismatch")
+                    elif cdata != ref:
+                        raise ValueError(f"Chunk {utype} mismatch")
                 met = ("_first_" if self._first else "_next_") + utype
                 try:
                     met = getattr(self, met)
@@ -1784,8 +1782,9 @@ class APngAssembler:
             sage: from sage.plot.animate import APngAssembler
             sage: APngAssembler._testCase1()
         """
-        from sage.doctest.fixtures import trace_method
         from io import BytesIO
+
+        from sage.doctest.fixtures import trace_method
         buf = BytesIO()
         apng = cls(buf, 2)
         if methodToTrace is not None:

--- a/src/sage/plot/line.py
+++ b/src/sage/plot/line.py
@@ -18,9 +18,9 @@ Line plots
 #
 #                  http://www.gnu.org/licenses/
 # *****************************************************************************
-from sage.plot.primitive import GraphicPrimitive_xydata
 from sage.misc.decorators import options, rename_keyword
 from sage.plot.colors import to_mpl_color
+from sage.plot.primitive import GraphicPrimitive_xydata
 
 
 class Line(GraphicPrimitive_xydata):
@@ -131,8 +131,9 @@ class Line(GraphicPrimitive_xydata):
 
         EXAMPLES::
 
-            sage: E = EllipticCurve('37a').plot(thickness=5).plot3d()                   # needs sage.schemes
-            sage: F = EllipticCurve('37a').plot(thickness=5).plot3d(z=2)                # needs sage.schemes
+            sage: # needs database_cremona_mini_ellcurve
+            sage: E = EllipticCurve('37a').plot(thickness=5).plot3d()  # needs sage.schemes
+            sage: F = EllipticCurve('37a').plot(thickness=5).plot3d(z=2)  # needs sage.schemes
             sage: E + F                         # long time (5s on sage.math, 2012), needs sage.schemes
             Graphics3d Object
 
@@ -572,7 +573,7 @@ def line2d(points, **options):
 
     A purple plot of the Hasse-Weil `L`-function `L(E, 1 + it)`, `-1 < t < 10`::
 
-        sage: # needs sage.schemes
+        sage: # needs database_cremona_mini_ellcurve sage.schemes
         sage: E = EllipticCurve('37a')
         sage: vals = E.lseries().values_along_line(1-I, 1+10*I, 100)  # critical line
         sage: L = [(z[1].real(), z[1].imag()) for z in vals]

--- a/src/sage/plot/plot3d/tachyon.py
+++ b/src/sage/plot/plot3d/tachyon.py
@@ -158,19 +158,16 @@ AUTHOR:
 
     - clean up trianglefactory stuff
 """
-from .tri_plot import Triangle, SmoothTriangle, TriangleFactory, TrianglePlot
+# from sage.ext import fast_tachyon_routines
+from math import sqrt
 
 from sage.interfaces.tachyon import tachyon_rt
-
 from sage.misc.fast_methods import WithEqualityById
+from sage.misc.temporary_file import tmp_filename
+from sage.misc.verbose import get_verbose
 from sage.structure.sage_object import SageObject
 
-from sage.misc.verbose import get_verbose
-from sage.misc.temporary_file import tmp_filename
-
-# from sage.ext import fast_tachyon_routines
-
-from math import sqrt
+from .tri_plot import SmoothTriangle, Triangle, TriangleFactory, TrianglePlot
 
 
 class Tachyon(WithEqualityById, SageObject):
@@ -259,26 +256,26 @@ class Tachyon(WithEqualityById, SageObject):
     Points on an elliptic curve, their height indicated by their height
     above the axis::
 
-        sage: # needs sage.schemes
+        sage: # needs database_cremona_mini_ellcurve sage.schemes
         sage: t = Tachyon(camera_position=(5,2,2), look_at=(0,1,0))
         sage: t.light((10,3,2), 0.2, (1,1,1))
         sage: t.texture('t0', ambient=0.1, diffuse=0.9, specular=0.5, opacity=1.0, color=(1,0,0))
         sage: t.texture('t1', ambient=0.1, diffuse=0.9, specular=0.5, opacity=1.0, color=(0,1,0))
         sage: t.texture('t2', ambient=0.1, diffuse=0.9, specular=0.5, opacity=1.0, color=(0,0,1))
-        sage: E = EllipticCurve('37a')                                                  # needs sage.schemes
-        sage: P = E([0,0])                                                              # needs sage.schemes
-        sage: Q = P                                                                     # needs sage.schemes
+        sage: E = EllipticCurve('37a')  # needs sage.schemes
+        sage: P = E([0,0])  # needs sage.schemes
+        sage: Q = P  # needs sage.schemes
         sage: n = 100
-        sage: for i in range(n):   # increase 20 for a better plot                      # needs sage.schemes
+        sage: for i in range(n):   # increase 20 for a better plot  # needs sage.schemes
         ....:    Q = Q + P
         ....:    t.sphere((Q[1], Q[0], ZZ(i)/n), 0.1, 't%s'%(i%3))
-        sage: t.show()                                                                  # needs sage.schemes
+        sage: t.show()  # needs sage.schemes
 
     A beautiful picture of rational points on a rank 1 elliptic curve.
 
     ::
 
-        sage: # needs sage.schemes
+        sage: # needs database_cremona_mini_ellcurve sage.schemes
         sage: t = Tachyon(xres=1000, yres=800, camera_position=(2,7,4),
         ....:             look_at=(2,0,0), raydepth=4)
         sage: t.light((10,3,2), 1, (1,1,1))
@@ -289,16 +286,16 @@ class Tachyon(WithEqualityById, SageObject):
         sage: t.plane((0,0,0),(0,0,1),'grey')
         sage: t.cylinder((0,0,0),(1,0,0),.01,'black')
         sage: t.cylinder((0,0,0),(0,1,0),.01,'black')
-        sage: E = EllipticCurve('37a')                                                  # needs sage.schemes
-        sage: P = E([0,0])                                                              # needs sage.schemes
-        sage: Q = P                                                                     # needs sage.schemes
+        sage: E = EllipticCurve('37a')  # needs sage.schemes
+        sage: P = E([0,0])  # needs sage.schemes
+        sage: Q = P  # needs sage.schemes
         sage: n = 100
-        sage: for i in range(n):                                                        # needs sage.schemes
+        sage: for i in range(n):  # needs sage.schemes
         ....:    Q = Q + P
         ....:    c = i/n + .1
         ....:    t.texture('r%s'%i,color=(float(i/n),0,0))
         ....:    t.sphere((Q[0], -Q[1], .01), .04, 'r%s'%i)
-        sage: t.show()                          # long time                             # needs sage.schemes
+        sage: t.show()                          # long time  # needs sage.schemes
 
     A beautiful spiral.
 

--- a/src/sage/plot/point.py
+++ b/src/sage/plot/point.py
@@ -3,12 +3,13 @@ Points
 
 TESTS::
 
-    sage: E = EllipticCurve('37a')                                                      # needs sage.schemes
-    sage: P = E(0,0)                                                                    # needs sage.schemes
+    sage: # needs database_cremona_mini_ellcurve
+    sage: E = EllipticCurve('37a')  # needs sage.schemes
+    sage: P = E(0,0)  # needs sage.schemes
     sage: def get_points(n):
     ....:     return sum(point(list(i*P)[:2], size=3)
     ....:                for i in range(-n,n) if i != 0 and (i*P)[0] < 3)
-    sage: sum(get_points(15*n).plot3d(z=n) for n in range(1,10))                        # needs sage.schemes
+    sage: sum(get_points(15*n).plot3d(z=n) for n in range(1,10))  # needs sage.schemes
     Graphics3d Object
 """
 

--- a/src/sage/repl/ipython_kernel/widgets_sagenb.py
+++ b/src/sage/repl/ipython_kernel/widgets_sagenb.py
@@ -472,6 +472,7 @@ def selector(values, label=None, default=None, nrows=None, ncols=None, width=Non
 
     The values can be any kind of object::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: selector([sin(x^2), GF(29), EllipticCurve('37a1')])
         Dropdown(options=(sin(x^2), Finite Field of size 29, Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field), value=sin(x^2))
     """

--- a/src/sage/rings/number_field/number_field_ideal.py
+++ b/src/sage/rings/number_field/number_field_ideal.py
@@ -801,14 +801,15 @@ class NumberFieldIdeal(Ideal_generic):
 
         Make sure this works with large ideals (:issue:`11836`)::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: R.<x> = QQ['x']
             sage: L.<b> = NumberField(x^10 - 10*x^8 - 20*x^7 + 165*x^6 - 12*x^5 - 760*x^3 + 2220*x^2 + 5280*x + 7744)
             sage: z_x = -96698852571685/2145672615243325696*b^9 + 2472249905907/195061146840302336*b^8 + 916693155514421/2145672615243325696*b^7 + 1348520950997779/2145672615243325696*b^6 - 82344497086595/12191321677518896*b^5 + 2627122040194919/536418153810831424*b^4 - 452199105143745/48765286710075584*b^3 + 4317002771457621/536418153810831424*b^2 + 2050725777454935/67052269226353928*b + 3711967683469209/3047830419379724
-            sage: P = EllipticCurve(L, '57a1').lift_x(z_x) * 3                          # needs sage.schemes
-            sage: ideal = L.fractional_ideal(P[0], P[1])                                # needs sage.schemes
-            sage: ideal.is_principal(proof=False)                                       # needs sage.schemes
+            sage: P = EllipticCurve(L, '57a1').lift_x(z_x) * 3  # needs sage.schemes
+            sage: ideal = L.fractional_ideal(P[0], P[1])  # needs sage.schemes
+            sage: ideal.is_principal(proof=False)  # needs sage.schemes
             True
-            sage: len(ideal.gens_reduced(proof=False))                                  # needs sage.schemes
+            sage: len(ideal.gens_reduced(proof=False))  # needs sage.schemes
             1
         """
         if len(self.gens()) <= 1:

--- a/src/sage/rings/padics/padic_template_element.pxi
+++ b/src/sage/rings/padics/padic_template_element.pxi
@@ -536,6 +536,7 @@ cdef class pAdicTemplateElement(pAdicGenericElement):
 
         Check to see that :issue:`10292` is resolved::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: R = E.padic_regulator(7)
             sage: len(R.expansion())

--- a/src/sage/rings/polynomial/padics/polynomial_padic.py
+++ b/src/sage/rings/polynomial/padics/polynomial_padic.py
@@ -204,6 +204,7 @@ class Polynomial_padic(Polynomial):
 
         See :issue:`4038`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: K = Qp(7,10)
             sage: EK = E.base_extend(K)

--- a/src/sage/rings/qqbar.py
+++ b/src/sage/rings/qqbar.py
@@ -1524,6 +1524,7 @@ class AlgebraicRealField(Singleton, AlgebraicField_common, sage.rings.abc.Algebr
 
         TESTS::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: R.<x> = AA[]
             sage: AA._factor_univariate_polynomial(x)
             x
@@ -1539,7 +1540,7 @@ class AlgebraicRealField(Singleton, AlgebraicField_common, sage.rings.abc.Algebr
             (12) * (x - 0.5773502691896258?) * (x + 0.5773502691896258?)
             sage: AA._factor_univariate_polynomial(12*x^2 + 4)
             (12) * (x^2 + 0.3333333333333334?)
-            sage: AA._factor_univariate_polynomial(EllipticCurve('11a1').change_ring(AA).division_polynomial(5))        # needs sage.schemes
+            sage: AA._factor_univariate_polynomial(EllipticCurve('11a1').change_ring(AA).division_polynomial(5))  # needs sage.schemes
             (5) * (x - 16.00000000000000?) * (x - 5.000000000000000?) * (x - 1.959674775249769?) * (x + 2.959674775249769?) * (x^2 - 2.854101966249685?*x + 15.47213595499958?) * (x^2 + 1.909830056250526?*x + 1.660606461254312?) * (x^2 + 3.854101966249685?*x + 6.527864045000421?) * (x^2 + 13.09016994374948?*x + 93.33939353874569?)
         """
         rr = f.roots()
@@ -2070,6 +2071,7 @@ class AlgebraicField(Singleton, AlgebraicField_common, sage.rings.abc.AlgebraicF
 
         TESTS::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: R.<x> = QQbar[]
             sage: QQbar._factor_univariate_polynomial(x)
             x

--- a/src/sage/rings/rational_field.py
+++ b/src/sage/rings/rational_field.py
@@ -120,6 +120,7 @@ class RationalField(Singleton, number_field_base.NumberField):
 
     Here's a nice example involving elliptic curves::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('11a')
         sage: L = E.lseries().at1(300)[0]; L
         0.2538418608559106843377589233...

--- a/src/sage/schemes/curves/projective_curve.py
+++ b/src/sage/schemes/curves/projective_curve.py
@@ -798,7 +798,7 @@ class ProjectivePlaneCurve(ProjectiveCurve):
 
         An elliptic curve::
 
-            sage: # needs sage.plot
+            sage: # needs database_cremona_mini_ellcurve sage.plot
             sage: E = EllipticCurve('101a')
             sage: C = Curve(E)
             sage: C.plot()

--- a/src/sage/schemes/elliptic_curves/BSD.py
+++ b/src/sage/schemes/elliptic_curves/BSD.py
@@ -14,6 +14,7 @@ class BSD_data:
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.BSD import BSD_data
         sage: D = BSD_data()
         sage: D.Sha is None
@@ -46,6 +47,7 @@ class BSD_data:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.BSD import BSD_data
             sage: D = BSD_data()
             sage: D.Sha is None
@@ -86,6 +88,7 @@ def mwrank_two_descent_work(E, two_tor_rk) -> tuple:
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.BSD import mwrank_two_descent_work
         sage: E = EllipticCurve('14a')
         sage: mwrank_two_descent_work(E, E.two_torsion_rank())
@@ -125,6 +128,7 @@ def pari_two_descent_work(E) -> tuple:
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.BSD import pari_two_descent_work
         sage: E = EllipticCurve('14a')
         sage: pari_two_descent_work(E)
@@ -177,6 +181,7 @@ def native_two_isogeny_descent_work(E, two_tor_rk) -> tuple:
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.BSD import native_two_isogeny_descent_work
         sage: E = EllipticCurve('14a')
         sage: native_two_isogeny_descent_work(E, E.two_torsion_rank())
@@ -215,6 +220,7 @@ def heegner_index_work(E) -> tuple:
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.BSD import heegner_index_work
         sage: heegner_index_work(EllipticCurve('14a'))
         (1, -31)
@@ -298,6 +304,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: EllipticCurve('11a').prove_BSD(verbosity=2)
         p = 2: True by 2-descent
         True for p not in {2, 5} by Kolyvagin.
@@ -305,6 +312,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
         True for p = 5 by Kolyvagin bound
         []
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: EllipticCurve('14a').prove_BSD(verbosity=2)
         p = 2: True by 2-descent
         True for p not in {2, 3} by Kolyvagin.
@@ -312,6 +320,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
         True for p = 3 by Kolyvagin bound
         []
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve("20a1")
         sage: E.prove_BSD(verbosity=2)
         p = 2: True by 2-descent
@@ -319,6 +328,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
         Kato further implies that #Sha[3] is trivial.
         []
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve("50b1")
         sage: E.prove_BSD(verbosity=2)
         p = 2: True by 2-descent
@@ -333,6 +343,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
 
     A rank two curve::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('389a')
 
     We know nothing with proof=True::
@@ -347,6 +358,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
 
     A curve of rank 0 and prime conductor::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('19a')
         sage: E.prove_BSD(verbosity=2)
         p = 2: True by 2-descent
@@ -355,6 +367,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
         True for p = 3 by Kolyvagin bound
         []
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('37a')
         sage: E.rank()
         1
@@ -370,6 +383,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
 
     We test the consistency check for the 2-part of Sha::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('37a')
         sage: S = E.sha(); S
         Tate-Shafarevich group for the Elliptic Curve defined by y^2 + y = x^3 - x
@@ -384,6 +398,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
 
     An example with a Tamagawa number at 5::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('123a1')
         sage: E.prove_BSD(verbosity=2)
         p = 2: True by 2-descent
@@ -394,6 +409,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
 
     A curve for which 3 divides the order of the Tate-Shafarevich group::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('681b')
         sage: E.prove_BSD(verbosity=2)               # long time
         p = 2: True by 2-descent...
@@ -406,6 +422,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
 
     A curve for which we need to use ``heegner_index_bound``::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('198b')
         sage: E.prove_BSD(verbosity=1, secs_hi=1)
         p = 2: True by 2-descent
@@ -415,6 +432,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
     The ``return_BSD`` option gives an object with detailed information
     about the proof::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('26b')
         sage: B = E.prove_BSD(return_BSD=True)
         sage: B.two_tor_rk
@@ -432,6 +450,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
 
     This was fixed by :issue:`8184` and :issue:`7575`::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: EllipticCurve('438e1').prove_BSD(verbosity=1)
         p = 2: True by 2-descent...
         True for p not in {2} by Kolyvagin.
@@ -439,6 +458,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
 
     ::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('960d1')
         sage: E.prove_BSD(verbosity=1)  # long time (4s on sage.math, 2011)
         p = 2: True by 2-descent
@@ -447,6 +467,7 @@ def prove_BSD(E, verbosity=0, two_desc='mwrank', proof=None, secs_hi=5,
 
     ::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('66b3')
         sage: E.prove_BSD(two_desc="pari",verbosity=1)
         p = 2: True by 2-descent

--- a/src/sage/schemes/elliptic_curves/Qcurves.py
+++ b/src/sage/schemes/elliptic_curves/Qcurves.py
@@ -117,6 +117,7 @@ def is_Q_curve(E, maxp=100, certificate=False, verbose=False):
         sage: cert
         {'CM': 0, 'N': 1, 'core_poly': x, 'r': 0, 'rho': 0}
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve(j=8000)
         sage: flag, cert = is_Q_curve(E, certificate=True)
         sage: flag

--- a/src/sage/schemes/elliptic_curves/constructor.py
+++ b/src/sage/schemes/elliptic_curves/constructor.py
@@ -100,6 +100,7 @@ class EllipticCurveFactory(UniqueFactory):
 
     We create a curve from a Cremona label::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: EllipticCurve('37b2')
         Elliptic Curve defined by y^2 + y = x^3 + x^2 - 1873*x - 31833 over Rational Field
         sage: EllipticCurve('5077a')
@@ -109,11 +110,13 @@ class EllipticCurveFactory(UniqueFactory):
 
     Old Cremona labels are allowed::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: EllipticCurve('2400FF')
         Elliptic Curve defined by y^2 = x^3 + x^2 + 2*x + 8 over Rational Field
 
     Unicode labels are allowed::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: EllipticCurve(u'389a')
         Elliptic Curve defined by y^2 + y = x^3 + x^2 - 2*x over Rational Field
 
@@ -177,6 +180,7 @@ class EllipticCurveFactory(UniqueFactory):
 
     We can explicitly specify the `j`-invariant::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve(j=1728); E; E.j_invariant(); E.label()
         Elliptic Curve defined by y^2 = x^3 - x over Rational Field
         1728
@@ -195,6 +199,7 @@ class EllipticCurveFactory(UniqueFactory):
     coefficients are identical, even when they are constructed in
     different ways (see :issue:`11474`)::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: EllipticCurve('11a3') is EllipticCurve(QQ, [0, -1, 1, 0, 0])
         True
 
@@ -336,6 +341,7 @@ class EllipticCurveFactory(UniqueFactory):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve.create_key_and_extra_args(j=8000)
             ((Rational Field, (0, 1, 0, -3, 1)), {})
 
@@ -343,6 +349,7 @@ class EllipticCurveFactory(UniqueFactory):
         label, the invariants from the database are returned as
         ``extra_args``::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: key, data = EllipticCurve.create_key_and_extra_args('389.a1')
             sage: key
             (Rational Field, (0, 1, 1, -2, 0))
@@ -367,6 +374,7 @@ class EllipticCurveFactory(UniqueFactory):
         database, which can be used to specify an alternative set of
         generators for the Mordell-Weil group::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: key, data = EllipticCurve.create_key_and_extra_args('5077a1', gens=[[1, -1], [-2, 3], [4, -7]])
             sage: data['gens']
             [[1, -1], [-2, 3], [4, -7]]
@@ -380,6 +388,7 @@ class EllipticCurveFactory(UniqueFactory):
         A consequence of this is that passing keyword arguments only
         works when constructing an elliptic curve the first time::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('433a1', gens=[[-1, 1], [3, 4]])
             sage: E.gens()
             [(-1 : 1 : 1), (3 : 4 : 1)]
@@ -486,6 +495,7 @@ class EllipticCurveFactory(UniqueFactory):
 
         ``names`` is ignored at the moment, however it is used to support a convenient way to get a generator::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E.<P> = EllipticCurve(QQ, [1, 3])
             sage: P
             (-1 : 1 : 1)
@@ -723,11 +733,13 @@ def EllipticCurve_from_j(j, minimal_twist=True):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve_from_j(0); E; E.j_invariant(); E.label()
         Elliptic Curve defined by y^2 + y = x^3 over Rational Field
         0
         '27a3'
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve_from_j(1728); E; E.j_invariant(); E.label()
         Elliptic Curve defined by y^2 = x^3 - x over Rational Field
         1728
@@ -918,6 +930,7 @@ def EllipticCurve_from_cubic(F, P=None, morphism=True):
     First we find that the Fermat cubic is isomorphic to the curve
     with Cremona label 27a1::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: R.<x,y,z> = QQ[]
         sage: cubic = x^3 + y^3 + z^3
         sage: P = [1,-1,0]
@@ -1025,6 +1038,7 @@ def EllipticCurve_from_cubic(F, P=None, morphism=True):
     points on the cubic.  First we find the preimages of multiples of
     the generator::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = f.codomain()
         sage: E.label()
         '720e2'
@@ -1554,6 +1568,7 @@ def EllipticCurves_with_good_reduction_outside_S(S=[], proof=None, verbose=False
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: EllipticCurves_with_good_reduction_outside_S([])
         []
         sage: elist = EllipticCurves_with_good_reduction_outside_S([2])

--- a/src/sage/schemes/elliptic_curves/descent_two_isogeny.pyx
+++ b/src/sage/schemes/elliptic_curves/descent_two_isogeny.pyx
@@ -1155,6 +1155,7 @@ def two_descent_by_two_isogeny(E,
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.descent_two_isogeny import two_descent_by_two_isogeny
         sage: E = EllipticCurve('14a')
         sage: n1, n2, n1_prime, n2_prime = two_descent_by_two_isogeny(E)
@@ -1178,6 +1179,7 @@ def two_descent_by_two_isogeny(E,
 
     Using the verbosity option::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('14a')
         sage: two_descent_by_two_isogeny(E, verbosity=1)
         2-isogeny
@@ -1194,6 +1196,7 @@ def two_descent_by_two_isogeny(E,
 
     Handling curves whose discriminants involve larger than wordsize primes::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('14a')
         sage: E = E.quadratic_twist(next_prime(10^20))
         sage: E
@@ -1214,6 +1217,7 @@ def two_descent_by_two_isogeny(E,
     for rational points which do not exist, and by setting global_limit_large
     to a very high bound, it will still be working when we simulate a ``CTRL-C``::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.descent_two_isogeny import two_descent_by_two_isogeny
         sage: E = EllipticCurve('960d'); E
         Elliptic Curve defined by y^2 = x^3 - x^2 - 900*x - 10098 over Rational Field

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -83,21 +83,21 @@ AUTHORS:
 
 from copy import copy, deepcopy
 
-from sage.structure.sequence import Sequence
-
-from sage.schemes.elliptic_curves.hom import EllipticCurveHom
-
-from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+from sage.rings.fraction_field import FractionField
 from sage.rings.integer import Integer
 from sage.rings.laurent_series_ring import LaurentSeriesRing
 from sage.rings.polynomial.polynomial_element import Polynomial
-from sage.rings.fraction_field import FractionField
-
+from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.schemes.elliptic_curves.constructor import EllipticCurve
 from sage.schemes.elliptic_curves.ell_generic import EllipticCurve_generic
-
-from sage.schemes.elliptic_curves.weierstrass_morphism \
-        import WeierstrassIsomorphism, _isomorphisms, baseWI, negation_morphism
+from sage.schemes.elliptic_curves.hom import EllipticCurveHom
+from sage.schemes.elliptic_curves.weierstrass_morphism import (
+    WeierstrassIsomorphism,
+    _isomorphisms,
+    baseWI,
+    negation_morphism,
+)
+from sage.structure.sequence import Sequence
 
 #
 # Private function for parsing input to determine the type of
@@ -721,6 +721,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
 
     A more complicated example over the rationals (of odd degree)::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('11a1')
         sage: P_list = E.torsion_points()
         sage: phi_v = EllipticCurveIsogeny(E, P_list); phi_v
@@ -746,7 +747,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
     We can also do this same example over the number field defined by
     the irreducible two-torsion polynomial of `E`::
 
-        sage: # needs sage.rings.number_field
+        sage: # needs database_cremona_mini_ellcurve sage.rings.number_field
         sage: E = EllipticCurve('11a1')
         sage: P_list = E.torsion_points()
         sage: x = polygen(ZZ, 'x')
@@ -785,6 +786,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
     The following example shows how to specify an isogeny from domain
     and codomain::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('11a1')
         sage: R.<x> = QQ[]
         sage: f = x^2 - 21*x + 80
@@ -1002,6 +1004,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
              from Elliptic Curve defined by y^2 = x^3 + x over Finite Field of size 31
                to Elliptic Curve defined by y^2 = x^3 + 10*x + 28 over Finite Field of size 31
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('17a1')
             sage: phi = EllipticCurveIsogeny(E, [41/3, -55, -1, -1, 1]); phi
             Isogeny of degree 9
@@ -1010,6 +1013,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
                to Elliptic Curve defined by y^2 + x*y + y = x^3 - x^2 - 56*x - 10124
                   over Rational Field
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: triv = EllipticCurveIsogeny(E, E(0)); triv
             Isogeny of degree 1
@@ -1018,6 +1022,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             sage: triv.rational_maps()
             (x, y)
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('49a3')
             sage: R.<X> = QQ[]
             sage: EllipticCurveIsogeny(E, X^3 - 13*X^2 - 58*X + 503, check=False)
@@ -1332,6 +1337,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             sage: negphi(E((18,6)))
             (17 : 0 : 1)
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: R.<x> = QQ[]
             sage: E = EllipticCurve('17a1')
             sage: R.<x> = QQ[]
@@ -1371,6 +1377,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             ((x^2 + 6*x + 4)/(x + 6),
              (2*x^3 - x^2*y - 5*x^2 + 5*x*y - 4*x + 2*y + 7)/(x^2 - 5*x + 2))
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: R.<x> = QQ[]
             sage: f = x^2 - 21*x + 80
@@ -2824,6 +2831,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             sage: phi.kernel_polynomial()
             x
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: phi = EllipticCurveIsogeny(E, E.torsion_points())
             sage: phi.kernel_polynomial()
@@ -2952,6 +2960,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: R.<x> = QQ[]
             sage: f = x^2 - 21*x + 80
@@ -3049,6 +3058,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
 
         Test (for :issue:`7096`)::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: phi = E.isogeny(E(5,5))
             sage: phi.dual().dual() == phi
@@ -3110,7 +3120,9 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             p = F.characteristic()
             k = d.valuation(p)
 
-            from sage.schemes.elliptic_curves.hom_frobenius import EllipticCurveHom_frobenius
+            from sage.schemes.elliptic_curves.hom_frobenius import (
+                EllipticCurveHom_frobenius,
+            )
             frob = EllipticCurveHom_frobenius(self._codomain, k)
 
             dsep = d // p**k
@@ -3138,7 +3150,9 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             else:
                 sep = frob.codomain().isomorphism_to(self._domain)
 
-            from sage.schemes.elliptic_curves.hom_composite import EllipticCurveHom_composite
+            from sage.schemes.elliptic_curves.hom_composite import (
+                EllipticCurveHom_composite,
+            )
             phi_hat = EllipticCurveHom_composite.from_factors([frob, sep])
 
             from sage.schemes.elliptic_curves.hom import find_post_isomorphism
@@ -3749,6 +3763,7 @@ def compute_sequence_of_maps(E1, E2, ell):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.ell_curve_isogeny import compute_sequence_of_maps
         sage: E = EllipticCurve('11a1')
         sage: R.<x> = QQ[]; f = x^2 - 21*x + 80

--- a/src/sage/schemes/elliptic_curves/ell_egros.py
+++ b/src/sage/schemes/elliptic_curves/ell_egros.py
@@ -131,6 +131,7 @@ def curve_key(E1):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.ell_egros import curve_key
         sage: E = EllipticCurve_from_j(1728)
         sage: curve_key(E)
@@ -170,6 +171,7 @@ def egros_from_j_1728(S=[]):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.ell_egros import egros_from_j_1728
         sage: egros_from_j_1728([])
         []
@@ -214,6 +216,7 @@ def egros_from_j_0(S=[]):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.ell_egros import egros_from_j_0
         sage: egros_from_j_0([])
         []
@@ -264,6 +267,7 @@ def egros_from_j(j, S=[]):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.ell_egros import egros_from_j
         sage: [e.label() for e in egros_from_j(0,[3])]
         ['27a1', '27a3', '243a1', '243a2', '243b1', '243b2']
@@ -319,6 +323,7 @@ def egros_from_jlist(jlist, S=[]):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.ell_egros import egros_get_j, egros_from_jlist
         sage: jlist=egros_get_j([3])
         sage: elist=egros_from_jlist(jlist,[3])
@@ -371,6 +376,7 @@ def egros_get_j(S=[], proof=None, verbose=False):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.ell_egros import egros_get_j
         sage: egros_get_j([])
         [1728]

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -13,20 +13,20 @@ This module defines the class :class:`EllipticCurve_field`, based on
 # *****************************************************************************
 
 import sage.rings.abc
-from sage.categories.number_fields import NumberFields
 from sage.categories.finite_fields import FiniteFields
+from sage.categories.number_fields import NumberFields
+from sage.misc.misc_c import prod
+from sage.rings.infinity import Infinity as oo
 from sage.rings.integer import Integer
 from sage.rings.integer_ring import ZZ
 from sage.rings.polynomial.polynomial_ring import polygen
 from sage.rings.rational_field import QQ
-from sage.misc.misc_c import prod
-from sage.rings.infinity import Infinity as oo
-from sage.schemes.elliptic_curves.ell_point import EllipticCurvePoint_field
 from sage.schemes.curves.projective_curve import ProjectivePlaneCurve_field
+from sage.schemes.elliptic_curves.ell_point import EllipticCurvePoint_field
 
+from . import ell_generic
 from .constructor import EllipticCurve
 from .ell_curve_isogeny import EllipticCurveIsogeny, isogeny_codomain_from_kernel
-from . import ell_generic
 
 
 class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurve_field):
@@ -234,27 +234,30 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: E.two_torsion_rank()
             0
-            sage: K.<alpha> = QQ.extension(E.division_polynomial(2).monic())            # needs sage.rings.number_field
-            sage: E.base_extend(K).two_torsion_rank()                                   # needs sage.rings.number_field
+            sage: K.<alpha> = QQ.extension(E.division_polynomial(2).monic())  # needs sage.rings.number_field
+            sage: E.base_extend(K).two_torsion_rank()  # needs sage.rings.number_field
             1
             sage: E.reduction(53).two_torsion_rank()
             2
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a1')
             sage: E.two_torsion_rank()
             1
             sage: f = E.division_polynomial(2).monic().factor()[1][0]
-            sage: K.<alpha> = QQ.extension(f)                                           # needs sage.rings.number_field
-            sage: E.base_extend(K).two_torsion_rank()                                   # needs sage.rings.number_field
+            sage: K.<alpha> = QQ.extension(f)  # needs sage.rings.number_field
+            sage: E.base_extend(K).two_torsion_rank()  # needs sage.rings.number_field
             2
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('15a1').two_torsion_rank()
             2
         """
@@ -376,6 +379,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: Et = E.quadratic_twist(-24)
             sage: E.is_quadratic_twist(Et)
@@ -718,7 +722,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
 
         Check that :issue:`16456` is fixed::
 
-            sage: # needs sage.rings.number_field
+            sage: # needs database_cremona_mini_ellcurve sage.rings.number_field
             sage: K.<a> = NumberField(x^3 - 2)
             sage: E = EllipticCurve('11a1').quadratic_twist(2)
             sage: EK = E.change_ring(K)
@@ -852,7 +856,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
         The 2-division field is the same as the splitting field of
         the 2-division polynomial (therefore, it has degree 1, 2, 3 or 6)::
 
-            sage: # needs sage.rings.number_field
+            sage: # needs database_cremona_mini_ellcurve sage.rings.number_field
             sage: E = EllipticCurve('15a1')
             sage: K.<b> = E.division_field(2); K
             Number Field in b with defining polynomial x
@@ -871,7 +875,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
         field of the `n`-division polynomial, or a quadratic extension
         of it. ::
 
-            sage: # needs sage.rings.number_field
+            sage: # needs database_cremona_mini_ellcurve sage.rings.number_field
             sage: E = EllipticCurve('50a1')
             sage: F.<a> = E.division_polynomial(3).splitting_field(simplify_all=True); F
             Number Field in a
@@ -906,7 +910,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
 
         Some higher-degree examples::
 
-            sage: # needs sage.rings.number_field
+            sage: # needs database_cremona_mini_ellcurve sage.rings.number_field
             sage: E = EllipticCurve('11a1')
             sage: K.<b> = E.division_field(2); K
             Number Field in b with defining polynomial
@@ -922,7 +926,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
              defined by y^2 + y = x^3 + (-1)*x^2 + (-10)*x + (-20)
              over Number Field in b with defining polynomial x^4 - x^3 + x^2 - x + 1
 
-            sage: # needs sage.rings.number_field
+            sage: # needs database_cremona_mini_ellcurve sage.rings.number_field
             sage: E = EllipticCurve('27a1')
             sage: K.<b> = E.division_field(3); K
             Number Field in b with defining polynomial x^2 + 3*x + 9
@@ -1104,6 +1108,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('90c3')
             sage: E.torsion_subgroup(5, algorithm='divpoly').invariants()
             ()
@@ -1134,6 +1139,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('30a2')
             sage: E.torsion_subgroup(5, algorithm='divpoly').invariants()
             ()
@@ -1332,8 +1338,8 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
                         z = F.primitive_element()**(q//l)
                         profile = lambda U: tuple(B.tate_pairing(U, l, 1, q=q).log(z, order=l) for B in (Pl, Ql))
 
-                        from sage.rings.finite_rings.integer_mod_ring import Zmod
                         from sage.matrix.constructor import matrix
+                        from sage.rings.finite_rings.integer_mod_ring import Zmod
 
                         while P._order < l**m:
                             mat = matrix(Zmod(l), [profile(R) for R in (P, Q)])
@@ -1375,7 +1381,9 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
 
             gens = list(filter(bool, [accP, accQ]))
 
-            from sage.groups.additive_abelian.additive_abelian_wrapper import AdditiveAbelianGroupWrapper
+            from sage.groups.additive_abelian.additive_abelian_wrapper import (
+                AdditiveAbelianGroupWrapper,
+            )
             return AdditiveAbelianGroupWrapper(E.point_homset(), gens, [pt.order() for pt in gens])
 
         raise ValueError(f'unknown algorithm {algorithm!r}')
@@ -1413,6 +1421,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: P, Q = E.torsion_gens(2, extend=True); (P.order(), Q.order())
             (2, 2)
@@ -1445,6 +1454,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('15a1')
             sage: E.torsion_basis(2)
             ((-13/4 : 9/8 : 1), (-1 : 0 : 1))
@@ -1494,6 +1504,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a2')
             sage: E.torsion_subgroup()
             Torsion Subgroup isomorphic to Trivial group
@@ -1683,6 +1694,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: P = E.torsion_points()[1]
             sage: E.isogeny(P)
@@ -1839,10 +1851,14 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
         if algorithm is not None and degree is not None:
             raise TypeError('cannot pass "degree" and "algorithm" parameters simultaneously')
         if algorithm == "velusqrt":
-            from sage.schemes.elliptic_curves.hom_velusqrt import EllipticCurveHom_velusqrt
+            from sage.schemes.elliptic_curves.hom_velusqrt import (
+                EllipticCurveHom_velusqrt,
+            )
             return EllipticCurveHom_velusqrt(self, kernel, codomain=codomain, model=model)
         if algorithm == "factored":
-            from sage.schemes.elliptic_curves.hom_composite import EllipticCurveHom_composite
+            from sage.schemes.elliptic_curves.hom_composite import (
+                EllipticCurveHom_composite,
+            )
             return EllipticCurveHom_composite(self, kernel, codomain=codomain, model=model, velu_sqrt_bound=velu_sqrt_bound)
         if algorithm == "traditional":
             return EllipticCurveIsogeny(self, kernel, codomain, degree, model, check=check)
@@ -1851,7 +1867,9 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
             # Check for multiple points or point of known order
             kernel_is_list = isinstance(kernel, (list, tuple))
             if kernel_is_list and kernel[0] in self and len(kernel) > 1:
-                from sage.schemes.elliptic_curves.hom_composite import EllipticCurveHom_composite
+                from sage.schemes.elliptic_curves.hom_composite import (
+                    EllipticCurveHom_composite,
+                )
                 return EllipticCurveHom_composite(self, kernel, codomain=codomain, model=model, velu_sqrt_bound=velu_sqrt_bound)
 
             if not kernel_is_list or (len(kernel) == 1 and kernel[0] in self):
@@ -1863,15 +1881,21 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
 
                 if known_order and kernel._order.is_pseudoprime():
                     if not velu_sqrt_bound:
-                        from sage.schemes.elliptic_curves.hom_velusqrt import _velu_sqrt_bound
+                        from sage.schemes.elliptic_curves.hom_velusqrt import (
+                            _velu_sqrt_bound,
+                        )
                         velu_sqrt_bound = _velu_sqrt_bound.get()
 
                     if kernel._order > velu_sqrt_bound:
-                        from sage.schemes.elliptic_curves.hom_velusqrt import EllipticCurveHom_velusqrt
+                        from sage.schemes.elliptic_curves.hom_velusqrt import (
+                            EllipticCurveHom_velusqrt,
+                        )
                         return EllipticCurveHom_velusqrt(self, kernel, codomain=codomain, model=model)
                     # Otherwise fall back to the standard case
                 elif known_order:
-                    from sage.schemes.elliptic_curves.hom_composite import EllipticCurveHom_composite
+                    from sage.schemes.elliptic_curves.hom_composite import (
+                        EllipticCurveHom_composite,
+                    )
                     return EllipticCurveHom_composite(self, kernel, codomain=codomain, model=model, velu_sqrt_bound=velu_sqrt_bound)
         try:
             return EllipticCurveIsogeny(self, kernel, codomain, degree, model, check=check)
@@ -1895,6 +1919,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('17a1')
             sage: R.<x> = QQ[]
             sage: E2 = E.isogeny_codomain(x - 11/4); E2
@@ -2184,7 +2209,9 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
         if not f.degree().divides(l//2):
             raise ValueError(f'given polynomial does not define a rational {l}-isogeny')
 
-        from sage.schemes.elliptic_curves.isogeny_small_degree import _least_semi_primitive
+        from sage.schemes.elliptic_curves.isogeny_small_degree import (
+            _least_semi_primitive,
+        )
         a = _least_semi_primitive(l)
 
         def mul_a(x):
@@ -2736,6 +2763,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: E.weierstrass_p(prec=10)
             z^-2 + 31/15*z^2 + 2501/756*z^4 + 961/675*z^6 + 77531/41580*z^8 + O(z^10)
@@ -2985,6 +3013,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
             ['0', '0*', '1', '1*']
         """
         from warnings import warn
+
         from sage.matrix.constructor import Matrix
 
         # warn users if things are getting big

--- a/src/sage/schemes/elliptic_curves/ell_finite_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_finite_field.py
@@ -1086,6 +1086,7 @@ class EllipticCurve_finite_field(EllipticCurve_field, ProjectivePlaneCurve_finit
         This tests the patch for :issue:`3111`, using 10 primes randomly
         selected::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: for p in [5927, 2297, 1571, 1709, 3851, 127, 3253, 5783, 3499, 4817]:
             ....:     G = E.change_ring(GF(p)).abelian_group()

--- a/src/sage/schemes/elliptic_curves/ell_generic.py
+++ b/src/sage/schemes/elliptic_curves/ell_generic.py
@@ -367,10 +367,11 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
-            sage: E._symbolic_(SR)                                                      # needs sage.symbolic
+            sage: E._symbolic_(SR)  # needs sage.symbolic
             y^2 + y == x^3 - x^2 - 10*x - 20
-            sage: E.torsion_subgroup().gens()                                           # needs sage.symbolic
+            sage: E.torsion_subgroup().gens()  # needs sage.symbolic
             ((5 : 5 : 1),)
 
         We find the corresponding symbolic equality::
@@ -542,20 +543,22 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         Another example involving `p`-adics::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: P = E([0,0]); P
             (0 : 0 : 1)
-            sage: R = pAdicField(3, 20)                                                 # needs sage.rings.padics
-            sage: Ep = E.base_extend(R); Ep                                             # needs sage.rings.padics
+            sage: R = pAdicField(3, 20)  # needs sage.rings.padics
+            sage: Ep = E.base_extend(R); Ep  # needs sage.rings.padics
             Elliptic Curve defined by
             y^2 + (1+O(3^20))*y = x^3 + (2+2*3+2*3^2+2*3^3+2*3^4+2*3^5+2*3^6+2*3^7+2*3^8+2*3^9+2*3^10+2*3^11+2*3^12+2*3^13+2*3^14+2*3^15+2*3^16+2*3^17+2*3^18+2*3^19+O(3^20))*x
             over 3-adic Field with capped relative precision 20
-            sage: Ep(P)                                                                 # needs sage.rings.padics
+            sage: Ep(P)  # needs sage.rings.padics
             (0 : 0 : 1 + O(3^20))
 
         Constructing points from the torsion subgroup (which is an abstract
         abelian group)::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a1')
             sage: T = E.torsion_subgroup()
             sage: [E(t) for t in T]
@@ -575,6 +578,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: T = E.torsion_subgroup()
             sage: [E(t) for t in T]
@@ -666,6 +670,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a'); E
             Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field
             sage: E.is_x_coord(1)
@@ -696,6 +701,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         TESTS::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('5077a1')
             sage: [x for x in srange(-10,10) if E.is_x_coord (x)]
             [-3, -2, -1, 0, 1, 2, 3, 4, 8]
@@ -762,6 +768,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a'); E
             Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field
             sage: E.lift_x(1)
@@ -818,6 +825,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         We can perform these operations over finite fields too::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a').change_ring(GF(17)); E
             Elliptic Curve defined by y^2 + y = x^3 + 16*x over Finite Field of size 17
             sage: E.lift_x(7)
@@ -838,20 +846,21 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
         value is in an extension of the base, note that the point
         returned is on the base-extended curve::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
-            sage: P = E.lift_x(pAdicField(17, 5)(6)); P                                 # needs sage.rings.padics
+            sage: P = E.lift_x(pAdicField(17, 5)(6)); P  # needs sage.rings.padics
             (6 + O(17^5) : 14 + O(17^5) : 1 + O(17^5))
-            sage: P.curve()                                                             # needs sage.rings.padics
+            sage: P.curve()  # needs sage.rings.padics
             Elliptic Curve defined by
             y^2 + (1+O(17^5))*y = x^3 + (16+16*17+16*17^2+16*17^3+16*17^4+O(17^5))*x
             over 17-adic Field with capped relative precision 5
             sage: K.<t> = PowerSeriesRing(QQ, 't', 5)
             sage: P = E.lift_x(1 + t); P
             (1 + t : -1 - 2*t + t^2 - 5*t^3 + 21*t^4 + O(t^5) : 1)
-            sage: K.<a> = GF(16)                                                        # needs sage.rings.finite_rings
-            sage: P = E.change_ring(K).lift_x(a^3); P                                   # needs sage.rings.finite_rings
+            sage: K.<a> = GF(16)  # needs sage.rings.finite_rings
+            sage: P = E.change_ring(K).lift_x(a^3); P  # needs sage.rings.finite_rings
             (a^3 : a^3 + a : 1)
-            sage: P.curve()                                                             # needs sage.rings.finite_rings
+            sage: P.curve()  # needs sage.rings.finite_rings
             Elliptic Curve defined by y^2 + y = x^3 + x over Finite Field in a of size 2^4
 
         We can extend the base field to include the associated `y` value(s)::
@@ -888,6 +897,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         TESTS::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a').short_weierstrass_model().change_ring(GF(17))
             sage: E.lift_x(3, all=True)
             []
@@ -905,6 +915,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         Check python types::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a').short_weierstrass_model().change_ring(GF(17))
             sage: E.lift_x(int(7), all=True)
             [(7 : 3 : 1), (7 : 14 : 1)]
@@ -1488,6 +1499,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: R.<a1,a2,a3,a4,a6> = QQ[]
             sage: E = EllipticCurve([a1,a2,a3,a4,a6])
             sage: E.gens()
@@ -1755,6 +1767,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("37a")
             sage: E.division_polynomial_0(1)
             1
@@ -1820,6 +1833,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
         The roots of the polynomial are the `x`-coordinates of the points `P`
         such that `mP=0` but `2P\not=0`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a1')
             sage: T = E.torsion_subgroup()
             sage: [n*T.0 for n in range(6)]
@@ -1900,13 +1914,14 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('5077a1')
             sage: E.two_division_polynomial()
             4*x^3 - 28*x + 25
-            sage: E = EllipticCurve(GF(3^2,'a'), [1,1,1,1,1])                           # needs sage.rings.finite_rings
-            sage: E.two_division_polynomial()                                           # needs sage.rings.finite_rings
+            sage: E = EllipticCurve(GF(3^2,'a'), [1,1,1,1,1])  # needs sage.rings.finite_rings
+            sage: E.two_division_polynomial()  # needs sage.rings.finite_rings
             x^3 + 2*x^2 + 2
-            sage: E.two_division_polynomial().roots()                                   # needs sage.rings.finite_rings
+            sage: E.two_division_polynomial().roots()  # needs sage.rings.finite_rings
             [(2, 1), (2*a, 1), (a + 2, 1)]
         """
         return self.division_polynomial_0(-1,x)
@@ -2025,6 +2040,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         Check that :issue:`33164` is fixed::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a3')
             sage: R.<X> = QQ[]
             sage: S.<Y> = R.quotient(X^2)
@@ -2171,6 +2187,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("37a")
             sage: P = E.gens()[0]
             sage: x = P[0]
@@ -2195,6 +2212,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         An example where cancellation occurs::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("88a1")
             sage: P = E([2,2])   # fixed choice of generator
             sage: n = E._multiple_x_numerator(11, P[0]); n
@@ -2210,6 +2228,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         Check that the results are cached::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("88a1")
             sage: E._multiple_x_numerator(11) is E._multiple_x_numerator(11)
             True
@@ -2293,6 +2312,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("43a")
             sage: P = E.gens()[0]
             sage: x = P[0]
@@ -2307,6 +2327,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         Check that the results are cached::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("88a1")
             sage: E._multiple_x_denominator(11) is E._multiple_x_denominator(11)
             True
@@ -2560,6 +2581,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('77a1')
             sage: m = E.scalar_multiplication(-7); m
             Scalar-multiplication endomorphism [-7]
@@ -2574,6 +2596,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: E.scalar_multiplication(7)
             Scalar-multiplication endomorphism [7]
@@ -2596,6 +2619,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('99.a1')
             sage: E.scalar_multiplication(5)
             Scalar-multiplication endomorphism [5]
@@ -2650,6 +2674,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve(j=42)
             sage: E.identity_morphism()
             Elliptic-curve endomorphism of Elliptic Curve defined by y^2 = x^3 + 5901*x + 1105454 over Rational Field
@@ -2682,6 +2707,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: F = E.short_weierstrass_model()
             sage: w = E.isomorphism_to(F); w
@@ -2818,6 +2844,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve_from_j(QQ(0)) # a curve with j=0 over QQ
             sage: F = EllipticCurve('27a3') # should be the same one
             sage: E.isomorphisms(F)
@@ -2874,6 +2901,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: F = E.change_weierstrass_model([2,3,4,5]); F
             Elliptic Curve defined by y^2 + 4*x*y + 11/8*y = x^3 - 3/2*x^2 - 13/16*x
@@ -2910,6 +2938,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('15a')
             sage: F1 = E.change_weierstrass_model([1/2,0,0,0]); F1
             Elliptic Curve defined by y^2 + 2*x*y + 8*y = x^3 + 4*x^2 - 160*x - 640
@@ -3052,8 +3081,9 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         EXAMPLES::
 
-            sage: E = EllipticCurve(QQbar, '11a1')                                      # needs sage.rings.number_field
-            sage: E.montgomery_model()                                                  # needs sage.rings.number_field
+            sage: # needs database_cremona_mini_ellcurve
+            sage: E = EllipticCurve(QQbar, '11a1')  # needs sage.rings.number_field
+            sage: E.montgomery_model()  # needs sage.rings.number_field
             Elliptic Curve defined by y^2 = x^3 + (-1.953522420987248?)*x^2 + x
             over Algebraic Field
 
@@ -3273,13 +3303,14 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve([0, -1])
-            sage: plot(E, rgbcolor=hue(0.7))                                            # needs sage.plot
+            sage: plot(E, rgbcolor=hue(0.7))  # needs sage.plot
             Graphics object consisting of 1 graphics primitive
             sage: E = EllipticCurve('37a')
-            sage: plot(E)                                                               # needs sage.plot
+            sage: plot(E)  # needs sage.plot
             Graphics object consisting of 2 graphics primitives
-            sage: plot(E, xmin=25, xmax=26)                                             # needs sage.plot
+            sage: plot(E, xmin=25, xmax=26)  # needs sage.plot
             Graphics object consisting of 2 graphics primitives
 
         With :issue:`12766` we added the components keyword::
@@ -3294,8 +3325,9 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
         If there is only one component then specifying
         components='bounded' raises a ValueError::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('9990be2')
-            sage: E.plot(components='bounded')                                          # needs sage.plot
+            sage: E.plot(components='bounded')  # needs sage.plot
             Traceback (most recent call last):
             ...
             ValueError: no bounded component for this curve
@@ -3445,6 +3477,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("37a")
             sage: E.formal_group()
             Formal Group associated to the Elliptic Curve
@@ -3484,6 +3517,7 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: E._p_primary_torsion_basis(5)
             [[(5 : -6 : 1), 1]]
@@ -3735,8 +3769,9 @@ class EllipticCurve_generic(WithEqualityById, plane_curve.ProjectivePlaneCurve):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
-            sage: pari(E)                                                               # needs sage.libs.pari
+            sage: pari(E)  # needs sage.libs.pari
             [0, -1, 1, -10, -20, -4, -20, -79, -21, 496, 20008, -161051, -122023936/161051, Vecsmall([1]), [Vecsmall([64, -1])], [0, 0, 0, 0, 0, 0, 0, 0]]
 
         Over a finite field::

--- a/src/sage/schemes/elliptic_curves/ell_local_data.py
+++ b/src/sage/schemes/elliptic_curves/ell_local_data.py
@@ -92,17 +92,15 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from sage.structure.sage_object import SageObject
 from sage.misc.verbose import verbose
-
+from sage.rings.ideal import Ideal_generic
+from sage.rings.integer import Integer
+from sage.rings.integer_ring import ZZ
+from sage.rings.number_field.number_field_base import NumberField
+from sage.rings.number_field.number_field_ideal import NumberFieldFractionalIdeal
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.rings.rational_field import QQ
-from sage.rings.integer_ring import ZZ
-from sage.rings.integer import Integer
-from sage.rings.number_field.number_field_ideal import NumberFieldFractionalIdeal
-
-from sage.rings.number_field.number_field_base import NumberField
-from sage.rings.ideal import Ideal_generic
+from sage.structure.sage_object import SageObject
 
 from .constructor import EllipticCurve
 from .kodaira_symbol import KodairaSymbol
@@ -142,6 +140,7 @@ class EllipticCurveLocalData(SageObject):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.ell_local_data import EllipticCurveLocalData
         sage: E = EllipticCurve('14a1')
         sage: EllipticCurveLocalData(E,2)
@@ -189,6 +188,7 @@ class EllipticCurveLocalData(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.ell_local_data import EllipticCurveLocalData
             sage: E = EllipticCurve('14a1')
             sage: EllipticCurveLocalData(E, 2)
@@ -295,6 +295,7 @@ class EllipticCurveLocalData(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.ell_local_data import EllipticCurveLocalData
             sage: E = EllipticCurve('14a1')
             sage: EllipticCurveLocalData(E,2).__repr__()
@@ -473,6 +474,7 @@ class EllipticCurveLocalData(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.ell_local_data import EllipticCurveLocalData
             sage: E = EllipticCurve('816a1')
             sage: data = EllipticCurveLocalData(E, 2)
@@ -483,6 +485,7 @@ class EllipticCurveLocalData(SageObject):
             sage: data.tamagawa_exponent()
             2
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('200c4')
             sage: data = EllipticCurveLocalData(E, 5)
             sage: data.kodaira_symbol()
@@ -515,6 +518,7 @@ class EllipticCurveLocalData(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a1')
             sage: [(p,E.local_data(p).bad_reduction_type()) for p in prime_range(15)]
             [(2, -1), (3, None), (5, None), (7, 1), (11, None), (13, None)]
@@ -535,6 +539,7 @@ class EllipticCurveLocalData(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a1')
             sage: [(p,E.local_data(p).has_good_reduction()) for p in prime_range(15)]
             [(2, False), (3, True), (5, True), (7, False), (11, True), (13, True)]
@@ -556,6 +561,7 @@ class EllipticCurveLocalData(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a1')
             sage: [(p,E.local_data(p).has_bad_reduction()) for p in prime_range(15)]
             [(2, True), (3, False), (5, False), (7, True), (11, False), (13, False)]
@@ -584,6 +590,7 @@ class EllipticCurveLocalData(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a1')
             sage: [(p, E.local_data(p).has_multiplicative_reduction()) for p in prime_range(15)]
             [(2, True), (3, False), (5, False), (7, True), (11, False), (13, False)]
@@ -606,6 +613,7 @@ class EllipticCurveLocalData(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a1')
             sage: [(p, E.local_data(p).has_split_multiplicative_reduction())
             ....:  for p in prime_range(15)]
@@ -631,6 +639,7 @@ class EllipticCurveLocalData(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a1')
             sage: [(p, E.local_data(p).has_nonsplit_multiplicative_reduction())
             ....:  for p in prime_range(15)]
@@ -655,6 +664,7 @@ class EllipticCurveLocalData(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('27a1')
             sage: [(p, E.local_data(p).has_additive_reduction()) for p in prime_range(15)]
             [(2, False), (3, True), (5, False), (7, False), (11, False), (13, False)]
@@ -704,7 +714,7 @@ class EllipticCurveLocalData(SageObject):
 
         EXAMPLES (this raised a type error in sage prior to 4.4.4, see :issue:`7930`) ::
 
-            sage: # needs sage.rings.number_field
+            sage: # needs database_cremona_mini_ellcurve sage.rings.number_field
             sage: E = EllipticCurve('99d1')
             sage: R.<X> = QQ[]
             sage: K.<t> = NumberField(X^3 + X^2 - 2*X - 1)
@@ -789,7 +799,7 @@ class EllipticCurveLocalData(SageObject):
         # no problem to do an explicit conversion in that
         # case (Simon King, github issue #8800).
 
-        from sage.categories.pushout import pushout, CoercionException
+        from sage.categories.pushout import CoercionException, pushout
         try:
             if hasattr(F.p.ring(), 'maximal_order'): # it is not ZZ
                 pushout(F.p.ring().maximal_order(), K)

--- a/src/sage/schemes/elliptic_curves/ell_modular_symbols.py
+++ b/src/sage/schemes/elliptic_curves/ell_modular_symbols.py
@@ -33,6 +33,7 @@ Modular symbols are used to compute `p`-adic `L`-functions.
 
 EXAMPLES::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve("19a1")
     sage: m = E.modular_symbol()
     sage: m(0)
@@ -126,6 +127,7 @@ def modular_symbol_space(E, sign, base_ring, bound=None):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.ell_modular_symbols import modular_symbol_space
         sage: E = EllipticCurve('11a1')
         sage: M = modular_symbol_space(E, -1, GF(37))
@@ -170,6 +172,7 @@ class ModularSymbol(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: m = EllipticCurve('11a1').modular_symbol()
             sage: m.sign()
             1
@@ -185,6 +188,7 @@ class ModularSymbol(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: m = EllipticCurve('11a1').modular_symbol()
             sage: m.elliptic_curve()
             Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
@@ -197,6 +201,7 @@ class ModularSymbol(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: m = EllipticCurve('11a1').modular_symbol()
             sage: m.base_ring()
             Rational Field
@@ -209,6 +214,7 @@ class ModularSymbol(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: m = EllipticCurve('11a1').modular_symbol()
             sage: m
             Modular symbol with sign 1 over Rational Field attached to
@@ -245,6 +251,7 @@ class ModularSymbolECLIB(ModularSymbol):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.ell_modular_symbols import ModularSymbolECLIB
             sage: E = EllipticCurve('11a1')
             sage: M = ModularSymbolECLIB(E,+1)
@@ -260,6 +267,7 @@ class ModularSymbolECLIB(ModularSymbol):
 
         This is a rank 1 case with vanishing positive twists::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('121b1')
             sage: M = ModularSymbolECLIB(E,+1)
             sage: M(0)
@@ -267,16 +275,19 @@ class ModularSymbolECLIB(ModularSymbol):
             sage: M(1/7)
             1/2
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: M = EllipticCurve('121d1').modular_symbol(implementation='eclib')
             sage: M(0)
             2
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('15a1')
             sage: [C.modular_symbol(implementation='eclib')(0) for C in E.isogeny_class()]
             [1/4, 1/8, 1/4, 1/2, 1/8, 1/16, 1/2, 1]
 
         Since :issue:`10256`, the interface for negative modular symbols in eclib is available::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: Mplus = E.modular_symbol(+1); Mplus
             Modular symbol with sign 1 over Rational Field attached to
@@ -291,6 +302,7 @@ class ModularSymbolECLIB(ModularSymbol):
 
         The scaling factor relative to eclib's normalization is 1/2 for curves of negative discriminant::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: [E.discriminant() for E in cremona_curves([14])]
             [-21952, 941192, -1835008, -28, 25088, 98]
             sage: [E.modular_symbol()._scaling for E in cremona_curves([14])]
@@ -300,6 +312,7 @@ class ModularSymbolECLIB(ModularSymbol):
 
         For :issue:`10236`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: m = E.modular_symbol(implementation='eclib')
             sage: m(1/7)
@@ -312,6 +325,7 @@ class ModularSymbolECLIB(ModularSymbol):
         v20210310 the value of ``nap`` is increased automatically by
         ``eclib``::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.ell_modular_symbols import ModularSymbolECLIB
             sage: E = EllipticCurve('1590g1')
             sage: m = ModularSymbolECLIB(E, sign=+1, nap=300)
@@ -348,6 +362,7 @@ class ModularSymbolECLIB(ModularSymbol):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: m = EllipticCurve('11a1').modular_symbol(implementation='eclib')
             sage: m._call_with_caching(0)
             1/5
@@ -367,6 +382,7 @@ class ModularSymbolECLIB(ModularSymbol):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: m = EllipticCurve('11a1').modular_symbol(implementation='eclib')
             sage: m(0)
             1/5
@@ -402,6 +418,7 @@ class ModularSymbolSage(ModularSymbol):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: from sage.schemes.elliptic_curves.ell_modular_symbols import ModularSymbolSage
             sage: M = ModularSymbolSage(E, +1)
@@ -421,6 +438,7 @@ class ModularSymbolSage(ModularSymbol):
         This is a rank 1 case with vanishing positive twists.
         The modular symbol is adjusted by -2::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('121b1')
             sage: M = ModularSymbolSage(E, -1, normalize='L_ratio')
             sage: M(1/3)
@@ -428,6 +446,7 @@ class ModularSymbolSage(ModularSymbol):
             sage: M._scaling
             1
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: M = EllipticCurve('121d1').modular_symbol(implementation='sage')
             sage: M(0)
             2
@@ -436,6 +455,7 @@ class ModularSymbolSage(ModularSymbol):
             sage: M(0)
             1
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('15a1')
             sage: [C.modular_symbol(implementation='sage', normalize='L_ratio')(0)
             ....:  for C in E.isogeny_class()]
@@ -487,6 +507,7 @@ class ModularSymbolSage(ModularSymbol):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: m = EllipticCurve('11a1').modular_symbol(implementation='sage')
             sage: m._scaling
             1/5
@@ -514,6 +535,7 @@ class ModularSymbolSage(ModularSymbol):
 
         Some harder cases fail::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: m = EllipticCurve('121b1').modular_symbol(implementation='sage')
             Warning : Could not normalize the modular symbols, maybe all further results will be multiplied by -1 and a power of 2
             sage: m._scaling
@@ -611,6 +633,7 @@ class ModularSymbolSage(ModularSymbol):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: m = E.modular_symbol(sign=+1, implementation='sage')
             sage: m.__lalg__(1)
@@ -651,6 +674,7 @@ class ModularSymbolSage(ModularSymbol):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: m = sage.schemes.elliptic_curves.ell_modular_symbols.ModularSymbolSage(E,+1,normalize='period')
             sage: m._e
@@ -666,12 +690,14 @@ class ModularSymbolSage(ModularSymbol):
 
         TESTS::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('19a1')
             sage: m = E.modular_symbol(sign=+1, implementation='sage', normalize='none')
             sage: m._find_scaling_period()
             sage: m._scaling
             1
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('19a2')
             sage: m = E.modular_symbol(sign=+1, implementation='sage', normalize='none')
             sage: m._scaling
@@ -716,6 +742,7 @@ class ModularSymbolSage(ModularSymbol):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: m = EllipticCurve('11a1').modular_symbol(implementation='sage')
             sage: m._call_with_caching(0)
             1/5
@@ -737,6 +764,7 @@ class ModularSymbolSage(ModularSymbol):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: m = EllipticCurve('11a1').modular_symbol(implementation='sage')
             sage: m(0)
             1/5

--- a/src/sage/schemes/elliptic_curves/ell_number_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_number_field.py
@@ -121,6 +121,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         A curve from the database of curves over `\QQ`, but over a larger field::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: K.<i> = NumberField(x^2 + 1)
             sage: EllipticCurve(K,'389a1')
             Elliptic Curve defined by y^2 + y = x^3 + x^2 + (-2)*x
@@ -143,6 +144,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a3')
             sage: K = QuadraticField(-5, 'a')
             sage: E.base_extend(K)
@@ -152,6 +154,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
         Check that non-torsion points are remembered when extending
         the base field (see :issue:`16034`)::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve([1, 0, 1, -1751, -31352])
             sage: K.<d> = QuadraticField(5)
             sage: E.gens()
@@ -223,6 +226,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: x = polygen(ZZ, 'x')
             sage: K.<a> = NumberField(x^2 + 23, 'a')
             sage: E = EllipticCurve(K, '37')
@@ -252,6 +256,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         A curve with 2-torsion::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: K.<a> = NumberField(x^2 + 7)
             sage: E = EllipticCurve(K, '15a')
             sage: E.simon_two_descent()  # long time (3s on sage.math, 2013), points can vary
@@ -272,6 +277,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
             sage: E1.rank()  # long time (about 5 s)
             0
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: K = CyclotomicField(43).subfields(3)[0][0]
             sage: E = EllipticCurve(K, '37')
             sage: E.simon_two_descent()  # long time (4s on sage.math, 2013)
@@ -329,12 +335,14 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve([0, 0, 1, -1, 0])
             sage: E.height_pairing_matrix()
             [0.0511114082399688]
 
         For rank 0 curves, the result is a valid 0x0 matrix::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('11a').height_pairing_matrix()
             []
             sage: E = EllipticCurve('5077a1')
@@ -343,6 +351,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
             [ -1.3095767070865761992624519454   2.7173593928122930896610589220   1.0998184305667292139777571432]
             [-0.63486715783715592064475542573   1.0998184305667292139777571432  0.66820516565192793503314205089]
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a1')
             sage: E = EllipticCurve('389a1')
             sage: P, Q = E.point([-1,1,1]), E.point([0,-1,1])
@@ -420,6 +429,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: P = E(0,0)
             sage: Q = E(1,0)
@@ -430,6 +440,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('5077a1')
             sage: points = [E.lift_x(x) for x in [-2,-7/4,1]]
             sage: E.regulator_of_points(points)
@@ -439,6 +450,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: E.regulator_of_points()
             1.00000000000000
@@ -473,6 +485,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: x = polygen(QQ)
             sage: K.<t> = NumberField(x^2 + 47)
@@ -490,6 +503,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a1')
             sage: P,Q = E.gens()
             sage: E.regulator_of_points([P,Q])
@@ -1068,6 +1082,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a1')
             sage: [(p, E.has_good_reduction(p)) for p in prime_range(15)]
             [(2, False), (3, True), (5, True), (7, False), (11, True), (13, True)]
@@ -1102,6 +1117,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a1')
             sage: [(p, E.has_bad_reduction(p)) for p in prime_range(15)]
             [(2, True), (3, False), (5, False), (7, True), (11, False), (13, False)]
@@ -1137,6 +1153,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a1')
             sage: [(p, E.has_multiplicative_reduction(p)) for p in prime_range(15)]
             [(2, True), (3, False), (5, False), (7, True), (11, False), (13, False)]
@@ -1166,6 +1183,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a1')
             sage: [(p, E.has_split_multiplicative_reduction(p)) for p in prime_range(15)]
             [(2, False), (3, False), (5, False), (7, True), (11, False), (13, False)]
@@ -1196,6 +1214,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a1')
             sage: [(p, E.has_nonsplit_multiplicative_reduction(p)) for p in prime_range(15)]
             [(2, True), (3, False), (5, False), (7, False), (11, False), (13, False)]
@@ -1226,6 +1245,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('27a1')
             sage: [(p, E.has_additive_reduction(p)) for p in prime_range(15)]
             [(2, False), (3, True), (5, False), (7, False), (11, False), (13, False)]
@@ -1256,6 +1276,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: x = polygen(ZZ, 'x')
             sage: K.<a> = NumberField(x^2 - 5)
             sage: E = EllipticCurve([20, 225, 750, 625*a + 6875, 31250*a + 46875])
@@ -1280,6 +1301,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: e = EllipticCurve('30a1')
             sage: e.tamagawa_numbers()
             [2, 3, 1]
@@ -1310,6 +1332,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: K.<a> = NumberField(x^2 - 5)
             sage: E = EllipticCurve([20, 225, 750, 625*a + 6875, 31250*a + 46875])
             sage: [E.tamagawa_exponent(P) for P in E.discriminant().support()]
@@ -1351,6 +1374,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         An example over `\QQ`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('30a')
             sage: E.tamagawa_product()
             6
@@ -1404,6 +1428,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         An example where the Neron model changes over K::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: K.<t> = NumberField(x^5 - 10*x^3 + 5*x^2 + 10*x + 1)
             sage: E = EllipticCurve(K, '75a1')
             sage: E.tamagawa_product_bsd()
@@ -1414,6 +1439,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         An example over `\QQ` (:issue:`9413`)::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('30a')
             sage: E.tamagawa_product_bsd()
             6
@@ -1454,6 +1480,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: K.<a> = NumberField(x^2 - 5)
             sage: E = EllipticCurve([20, 225, 750, 625*a + 6875, 31250*a + 46875])
             sage: bad_primes = E.discriminant().support(); bad_primes
@@ -1967,6 +1994,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('11a').torsion_subgroup()
             Torsion Subgroup isomorphic to Z/5 associated to the
              Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
@@ -1994,6 +2022,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: x = polygen(ZZ, 'x')
             sage: K.<t> = NumberField(x^4 + x^3 + 11*x^2 + 41*x + 101)
@@ -2008,6 +2037,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('15a1')
             sage: K.<t> = NumberField(x^2 + 2*x + 10)
             sage: EK = E.base_extend(K)
@@ -2018,6 +2048,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('19a1')
             sage: K.<t> = NumberField(x^9-3*x^8-4*x^7+16*x^6-3*x^5-21*x^4+5*x^3+7*x^2-7*x+1)
             sage: EK = E.base_extend(K)
@@ -2061,6 +2092,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: x = polygen(ZZ, 'x')
             sage: K.<t> = NumberField(x^4 + x^3 + 11*x^2 + 41*x + 101)
@@ -2070,6 +2102,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('15a1')
             sage: K.<t> = NumberField(x^2 + 2*x + 10)
             sage: EK = E.base_extend(K)
@@ -2078,6 +2111,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('19a1')
             sage: K.<t> = NumberField(x^9 - 3*x^8 - 4*x^7 + 16*x^6 - 3*x^5 - 21*x^4 + 5*x^3 + 7*x^2 - 7*x + 1)
             sage: EK = E.base_extend(K)
@@ -2101,6 +2135,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: E.torsion_points()
             [(0 : 1 : 0), (5 : -6 : 1), (5 : 5 : 1), (16 : -61 : 1), (16 : 60 : 1)]
@@ -2136,6 +2171,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('15a1')
             sage: K.<t> = NumberField(x^2 + 2*x + 10)
             sage: EK = E.base_extend(K)
@@ -2211,6 +2247,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: x = polygen(ZZ, 'x')
             sage: K.<a> = NumberField(x^2 + 23, 'a')
             sage: E = EllipticCurve(K, '37')
@@ -2230,6 +2267,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
         2-descent will not be able to determine the rank, but can only
         give bounds::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("15a5")
             sage: K.<t> = NumberField(x^2 - 6)
             sage: EK = E.base_extend(K)
@@ -2291,6 +2329,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: x = polygen(ZZ, 'x')
             sage: K.<a> = NumberField(x^2 + 23, 'a')
             sage: E = EllipticCurve(K, '37')
@@ -2303,6 +2342,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
         so here the bounds given by the algorithm do not uniquely
         determine the rank::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("15a5")
             sage: K.<t> = NumberField(x^2 - 6)
             sage: EK = E.base_extend(K)
@@ -2367,6 +2407,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: x = polygen(ZZ, 'x')
             sage: K.<a> = NumberField(x^2 + 23, 'a')
             sage: E = EllipticCurve(K,[0,0,0,101,0])
@@ -2396,6 +2437,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         Here is a curve of rank 2::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: K.<t> = NumberField(x^2 - 17)
             sage: E = EllipticCurve(K, [-4, 0])
             sage: E.gens()
@@ -2405,6 +2447,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         Test that points of finite order are not included (see :issue:`13593`)::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("17a3")
             sage: K.<t> = NumberField(x^2 + 3)
             sage: EK = E.base_extend(K)
@@ -2551,6 +2594,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: x = polygen(ZZ, 'x')
             sage: K.<a> = NumberField(x^2 - 5)
             sage: E = EllipticCurve(K, '11a3')
@@ -3118,6 +3162,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: x = polygen(QQ, 'x')
             sage: F = NumberField(x^2 - 2, 's'); F
             Number Field in s with defining polynomial x^2 - 2
@@ -3264,6 +3309,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: x = QQ['x'].0
             sage: F = NumberField(x^2 - 2, 's'); F
             Number Field in s with defining polynomial x^2 - 2
@@ -3279,6 +3325,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
             sage: E1.isogeny_degree(E5)  # long time
             6
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: [E2.label() for E2 in cremona_curves([11..20]) if E.isogeny_degree(E2)]
             ['11a1', '11a2', '11a3']
@@ -3408,6 +3455,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         Some examples over `\QQ`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve([0, 1, 1, -2, 42])
             sage: Pi = E.gens(); Pi
             [(-4 : 1 : 1), (-3 : 5 : 1), (-11/4 : 43/8 : 1), (-2 : 6 : 1)]
@@ -3457,6 +3505,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         An example to show the explicit use of the height pairing matrix::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve([0, 1, 1, -2, 42])
             sage: Pi = E.gens()
             sage: H = E.height_pairing_matrix(Pi,3)
@@ -3518,6 +3567,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: x = polygen(ZZ, 'x')
             sage: K = NumberField(x**2 + 1, 'a')
             sage: E = EllipticCurve('11a1').change_ring(K)
@@ -3556,6 +3606,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve(j=0).cm_discriminant()
             -3
             sage: EllipticCurve(j=1).cm_discriminant()
@@ -3606,6 +3657,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve(j=0).has_cm()
             True
             sage: EllipticCurve(j=1).has_cm()
@@ -3784,6 +3836,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
             sage: cert
             {'CM': 0, 'N': 1, 'core_poly': x, 'r': 0, 'rho': 0}
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve(j=8000)
             sage: flag, cert = E.is_Q_curve(certificate=True)
             sage: flag
@@ -3915,6 +3968,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: K.<i> = QuadraticField(-1)
             sage: E = EllipticCurve('389a1')
             sage: EK = E.change_ring(K)
@@ -3945,6 +3999,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         Another number field::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a1')
             sage: K.<a> = NumberField(x^3 - x + 1)
             sage: EK = E.change_ring(K)
@@ -3958,6 +4013,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         A different curve::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: K.<a> = QuadraticField(3)
             sage: E = EllipticCurve('37a1')
             sage: EK = E.change_ring(K)
@@ -3988,6 +4044,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         TESTS::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: K.<i> = QuadraticField(-1)
             sage: E = EllipticCurve('389a1')
             sage: EK = E.change_ring(K)
@@ -4091,6 +4148,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve([1,2,3,40,50])
             sage: E.conductor()
             2123582
@@ -4101,9 +4159,11 @@ class EllipticCurve_number_field(EllipticCurve_field):
             sage: EK.gens_quadratic()
             [(5 : 17 : 1), (-13 : 48*i + 5 : 1)]
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E.change_ring(QuadraticField(3, 'a')).gens_quadratic()
             [(5 : 17 : 1), (-1 : 2*a - 1 : 1), (11/4 : 33/4*a - 23/8 : 1)]
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: K.<a> = QuadraticField(-7)
             sage: E = EllipticCurve([0,0,0,197,0])
             sage: E.conductor()
@@ -4160,6 +4220,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: E.rational_points(bound=8) # long time
             [(-1 : -1 : 1),
@@ -4176,6 +4237,7 @@ class EllipticCurve_number_field(EllipticCurve_field):
 
         Check that :issue:`26677` is fixed::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("11a1")
             sage: E.rational_points(bound=5)
             [(0 : 1 : 0), (5 : 5 : 1)]

--- a/src/sage/schemes/elliptic_curves/ell_point.py
+++ b/src/sage/schemes/elliptic_curves/ell_point.py
@@ -16,6 +16,7 @@ EXAMPLES:
 
 An example over `\QQ`::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve('389a1')
     sage: P = E(-1,1); P
     (-1 : 1 : 1)
@@ -130,36 +131,35 @@ AUTHORS:
 
 import math
 
-from sage.groups import generic
 import sage.rings.abc
-
+from sage.groups import generic
 from sage.misc.lazy_import import lazy_import
 from sage.rings.finite_rings.integer_mod import Mod
 from sage.rings.infinity import Infinity as oo
 from sage.rings.integer import Integer
 from sage.rings.integer_ring import ZZ
 from sage.rings.padics.precision_error import PrecisionError
-from sage.rings.rational_field import QQ
-from sage.rings.real_mpfr import RealField, RR
 from sage.rings.quotient_ring import QuotientRing_generic
-
-from sage.structure.element import AdditiveGroupElement
-from sage.structure.sequence import Sequence
-from sage.structure.richcmp import richcmp
-
-from sage.structure.coerce_actions import IntegerMulAction
-
+from sage.rings.rational_field import QQ
+from sage.rings.real_mpfr import RR, RealField
 from sage.schemes.curves.projective_curve import Hasse_bounds
 from sage.schemes.elliptic_curves.constructor import EllipticCurve
-from sage.schemes.projective.projective_point import (SchemeMorphism_point_projective_ring,
-                                                      SchemeMorphism_point_abelian_variety_field)
+from sage.schemes.projective.projective_point import (
+    SchemeMorphism_point_abelian_variety_field,
+    SchemeMorphism_point_projective_ring,
+)
+from sage.structure.coerce_actions import IntegerMulAction
+from sage.structure.element import AdditiveGroupElement
+from sage.structure.richcmp import richcmp
+from sage.structure.sequence import Sequence
 
 lazy_import('sage.rings.padics.factory', 'Qp')
 lazy_import('sage.schemes.generic.morphism', 'SchemeMorphism')
 
 try:
-    from sage.libs.pari import pari
     from cypari2.handle_error import PariError
+
+    from sage.libs.pari import pari
 except ImportError:
     PariError = ()
 
@@ -199,6 +199,7 @@ class EllipticCurvePoint(AdditiveGroupElement,
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: P = E([-1, 1])
             sage: P.curve()
@@ -344,8 +345,8 @@ class EllipticCurvePoint(AdditiveGroupElement,
 
                         return E.point(Sequence(pt, E.base_ring()), check=False)
 
-        from sage.schemes.elliptic_curves.addition_formulas_ring import _add
         from sage.modules.free_module_element import vector
+        from sage.schemes.elliptic_curves.addition_formulas_ring import _add
 
         pts = []
         for pt in filter(any, _add(E, self, other)):
@@ -378,6 +379,7 @@ class EllipticCurvePoint(AdditiveGroupElement,
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: P = E([-1,1])
             sage: Q = -P; Q
@@ -410,6 +412,7 @@ class EllipticCurvePoint(AdditiveGroupElement,
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: P = E([-1,1]); Q = E([0,0])
             sage: P - Q
@@ -484,6 +487,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('37a')
         sage: E([0,0])
         (0 : 0 : 1)
@@ -529,6 +533,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
     TESTS::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: loads(S.dumps()) == S
         True
         sage: E = EllipticCurve('37a')
@@ -542,6 +547,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
     Test pickling an elliptic curve that has known points on it::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: e = EllipticCurve([0, 0, 1, -1, 0]); g = e.gens(); loads(dumps(e)) == e
         True
 
@@ -574,6 +580,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('43a')
             sage: P = E([2, -4, 2]); P
             (1 : -2 : 1)
@@ -601,6 +608,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('39a')
             sage: P = E([-2, 1, 1])
             sage: P._repr_()
@@ -614,6 +622,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('40a')
             sage: P = E([3, 0])
             sage: P._latex_()
@@ -627,6 +636,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('42a')
             sage: P = E([-17, -51, 17])
             sage: [P[i] for i in [2,1,0]]
@@ -640,6 +650,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: list(E([0,0]))
             [0, 0, 1]
@@ -652,6 +663,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('44a')
             sage: P = E([1, -2, 1])
             sage: P.__tuple__()
@@ -665,6 +677,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('45a')
             sage: P = E([2, -1, 1])
             sage: P == E(0)
@@ -844,6 +857,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: P = E(0); P
             (0 : 1 : 0)
@@ -869,6 +883,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('26b1')
             sage: P = E(1, 0)
             sage: P.has_order(7)
@@ -1020,9 +1035,10 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: P = E([-1,1])
-            sage: P.plot(pointsize=30, rgbcolor=(1,0,0))                                # needs sage.plot
+            sage: P.plot(pointsize=30, rgbcolor=(1,0,0))  # needs sage.plot
             Graphics object consisting of 1 graphics primitive
         """
         from sage.plot.point import point
@@ -1040,6 +1056,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: P = E([-1,1]); Q = E([0,0])
             sage: P + Q
@@ -1051,6 +1068,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         Example to show that bug :issue:`4820` is fixed::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: [type(c) for c in 2*EllipticCurve('37a1').gen(0)]
             [<... 'sage.rings.rational.Rational'>,
             <... 'sage.rings.rational.Rational'>,
@@ -1133,6 +1151,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: P = E([-1,1])
             sage: Q = -P; Q
@@ -1142,6 +1161,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         Example to show that bug :issue:`4820` is fixed::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: [type(c) for c in -EllipticCurve('37a1').gen(0)]
             [<... 'sage.rings.rational.Rational'>,
              <... 'sage.rings.rational.Rational'>,
@@ -1160,6 +1180,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: P = E([-1,1])
             sage: P.xy()
@@ -1182,6 +1203,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: P = E([-1,1])
             sage: P.x()
@@ -1204,6 +1226,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: P = E([-1,1])
             sage: P.y()
@@ -1241,6 +1264,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: Q = 5*E(0,0); Q
             (-2739/1444 : -77033/54872 : 1)
@@ -1367,6 +1391,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         We find the five 5-torsion points on an elliptic curve::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a'); E
             Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
             sage: P = E(0); P
@@ -1378,6 +1403,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         We create a curve of rank 1 with no torsion and do a consistency check::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a').quadratic_twist(-7)
             sage: Q = E([44,-270])
             sage: (4*Q).division_points(4)
@@ -1422,7 +1448,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         An example over a number field (see :issue:`3383`)::
 
-            sage: # needs sage.rings.number_field
+            sage: # needs database_cremona_mini_ellcurve sage.rings.number_field
             sage: E = EllipticCurve('19a1')
             sage: x = polygen(ZZ, 'x')
             sage: K.<t> = NumberField(x^9 - 3*x^8 - 4*x^7 + 16*x^6 - 3*x^5
@@ -1566,13 +1592,12 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
                         ans.append(Q)
                         if nQ != Q:
                             ans.append(nQ)
-                else:
-                    # P is not 2-torsion so at most one of Q, -Q works
-                    # and we must try both:
-                    if mQ == P:
-                        ans.append(Q)
-                    elif mQ == nP:
-                        ans.append(nQ)
+                # P is not 2-torsion so at most one of Q, -Q works
+                # and we must try both:
+                elif mQ == P:
+                    ans.append(Q)
+                elif mQ == nP:
+                    ans.append(nQ)
 
         if not ans:
             return ans
@@ -1622,6 +1647,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: P = E(5, 5); P.order()
             5
@@ -1632,6 +1658,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('574i1')
             sage: P = E(103, -276); P.order()
             7
@@ -1727,6 +1754,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: P = E([0, 0])
             sage: R = 12*P
@@ -2255,7 +2283,7 @@ class EllipticCurvePoint_field(EllipticCurvePoint,
 
         An example over a number field::
 
-            sage: # needs sage.rings.number_field
+            sage: # needs database_cremona_mini_ellcurve sage.rings.number_field
             sage: E = EllipticCurve('11a1').change_ring(CyclotomicField(5))
             sage: P, Q = E.torsion_subgroup().gens()
             sage: P, Q = (P.element(), Q.element())
@@ -2876,6 +2904,7 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('37a')
         sage: E([0,0])
         (0 : 0 : 1)
@@ -2914,6 +2943,7 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
 
     Test pickling an elliptic curve that has known points on it::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: e = EllipticCurve([0, 0, 1, -1, 0]); g = e.gens(); loads(dumps(e)) == e
         True
     """
@@ -3083,6 +3113,7 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a3')
             sage: P = next(filter(bool, E.torsion_points()))
             sage: P._has_order_at_least(5)
@@ -3114,8 +3145,8 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
         if n is not None:
             return n >= bound
 
-        from sage.sets.primes import Primes
         from sage.rings.finite_rings.finite_field_constructor import GF
+        from sage.sets.primes import Primes
         field_deg = self.curve().base_field().absolute_degree()
         if field_deg > 1:
             K = self.curve().base_field().absolute_field('T')
@@ -3187,6 +3218,7 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
 
         For `K=\QQ` there is no need to specify an embedding::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('5077a1')
             sage: [E.lift_x(x).is_on_identity_component() for x in srange(-3,5)]
             [False, False, False, False, False, True, True, True]
@@ -3260,6 +3292,7 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('990e1')
             sage: P = E.gen(0); P
             (15 : 51 : 1)
@@ -3303,15 +3336,16 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
 
         An example showing that :issue:`8498` is fixed::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
-            sage: K.<t> = NumberField(x^2 + 47)                                         # needs sage.rings.number_field
-            sage: EK = E.base_extend(K)                                                 # needs sage.rings.number_field
-            sage: T = EK(5, 5)                                                          # needs sage.rings.number_field
-            sage: P = EK(-2, -1/2*t - 1/2)                                              # needs sage.rings.number_field
-            sage: p = K.ideal(11)                                                       # needs sage.rings.number_field
-            sage: T.has_good_reduction(p)                                               # needs sage.rings.number_field
+            sage: K.<t> = NumberField(x^2 + 47)  # needs sage.rings.number_field
+            sage: EK = E.base_extend(K)  # needs sage.rings.number_field
+            sage: T = EK(5, 5)  # needs sage.rings.number_field
+            sage: P = EK(-2, -1/2*t - 1/2)  # needs sage.rings.number_field
+            sage: p = K.ideal(11)  # needs sage.rings.number_field
+            sage: T.has_good_reduction(p)  # needs sage.rings.number_field
             False
-            sage: P.has_good_reduction(p)                                               # needs sage.rings.number_field
+            sage: P.has_good_reduction(p)  # needs sage.rings.number_field
             True
         """
         if self.is_zero():       # trivial case
@@ -3452,6 +3486,7 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a'); E
             Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
             sage: P = E([5,5]); P
@@ -3464,6 +3499,7 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a'); E
             Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field
             sage: P = E([0,0])
@@ -3491,6 +3527,7 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('4602a1'); E
             Elliptic Curve defined by y^2 + x*y  = x^3 + x^2 - 37746035*x - 89296920339
             over Rational Field
@@ -3507,6 +3544,7 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
             sage: E([30, -90]).height()
             0
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a1'); E
             Elliptic Curve defined by y^2 + y = x^3 + x^2 - 2*x over Rational Field
             sage: P, Q = E(-1,1), E(0,-1)
@@ -3538,22 +3576,24 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
 
         Setting ``normalised=False`` multiplies the height by the degree of `K`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: P = E([0,0])
             sage: P.height()
             0.0511114082399688
             sage: P.height(normalised=False)
             0.0511114082399688
-            sage: K.<z> = CyclotomicField(5)                                            # needs sage.rings.number_field
-            sage: EK = E.change_ring(K)                                                 # needs sage.rings.number_field
-            sage: PK = EK([0,0])                                                        # needs sage.rings.number_field
-            sage: PK.height()                                                           # needs sage.rings.number_field
+            sage: K.<z> = CyclotomicField(5)  # needs sage.rings.number_field
+            sage: EK = E.change_ring(K)  # needs sage.rings.number_field
+            sage: PK = EK([0,0])  # needs sage.rings.number_field
+            sage: PK.height()  # needs sage.rings.number_field
             0.0511114082399688
-            sage: PK.height(normalised=False)                                           # needs sage.rings.number_field
+            sage: PK.height(normalised=False)  # needs sage.rings.number_field
             0.204445632959875
 
         Some consistency checks::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('5077a1')
             sage: P = E([-2,3,1])
             sage: P.height()
@@ -3574,17 +3614,18 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
             sage: (15*Q).height() / Q.height()
             225.000000000000
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: P = E([0,-1])
             sage: P.height()
             0.0511114082399688
-            sage: K.<a> = QuadraticField(-7)                                            # needs sage.rings.number_field
-            sage: ED = E.quadratic_twist(-7)                                            # needs sage.rings.number_field
-            sage: Q = E.isomorphism_to(ED.change_ring(K))(P); Q                         # needs sage.rings.number_field
+            sage: K.<a> = QuadraticField(-7)  # needs sage.rings.number_field
+            sage: ED = E.quadratic_twist(-7)  # needs sage.rings.number_field
+            sage: Q = E.isomorphism_to(ED.change_ring(K))(P); Q  # needs sage.rings.number_field
             (0 : -7/2*a - 1/2 : 1)
-            sage: Q.height()                                                            # needs sage.rings.number_field
+            sage: Q.height()  # needs sage.rings.number_field
             0.0511114082399688
-            sage: Q.height(precision=100)                                               # needs sage.rings.number_field
+            sage: Q.height(precision=100)  # needs sage.rings.number_field
             0.051111408239968840235886099757
 
         An example to show that the bug at :issue:`5252` is fixed::
@@ -3807,10 +3848,10 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
             sage: (2*P).height(200) / P.height(200)
             4.0000000000000000000000000000000000000000000000000000000000
         """
-        from sage.rings.number_field.number_field import refine_embedding
-        from sage.rings.real_mpfr import RealField
         from sage.rings.complex_mpfr import ComplexField
         from sage.rings.infinity import Infinity
+        from sage.rings.number_field.number_field import refine_embedding
+        from sage.rings.real_mpfr import RealField
 
         E = self.curve()
         K = E.base_ring()
@@ -4017,7 +4058,7 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
             sage: (3*Q).non_archimedean_local_height()                                  # needs sage.rings.number_field
             1/2*log(75923153929839865104)
 
-            sage: # needs sage.rings.number_field
+            sage: # needs database_cremona_mini_ellcurve sage.rings.number_field
             sage: F.<a> = NumberField(x^4 + 2*x^3 + 19*x^2 + 18*x + 288)
             sage: F.ring_of_integers().basis()
             [1, 5/6*a^3 + 1/6*a, 1/6*a^3 + 1/6*a^2, a^3]
@@ -4164,6 +4205,7 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: E.discriminant() > 0
             True
@@ -4180,6 +4222,7 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
 
         An example with negative discriminant, and a torsion point::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: E.discriminant() < 0
             True
@@ -4205,6 +4248,7 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
 
         This shows that the bug reported at :issue:`4901` has been fixed::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("4390c2")
             sage: P = E(683762969925/44944,-565388972095220019/9528128)
             sage: P.elliptic_logarithm()
@@ -4263,10 +4307,10 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
             sage: L.elliptic_logarithm(P, prec=100)
             0.70448375537782208460499649302 - 0.79246725643650979858266018068*I
         """
-        from sage.rings.number_field.number_field import refine_embedding
-        from sage.rings.real_mpfr import RealField
         from sage.rings.complex_mpfr import ComplexField
+        from sage.rings.number_field.number_field import refine_embedding
         from sage.rings.rational_field import QQ
+        from sage.rings.real_mpfr import RealField
 
         # Check the trivial case:
 
@@ -4397,13 +4441,14 @@ class EllipticCurvePoint_number_field(EllipticCurvePoint_field):
 
         An example which arose during reviewing :issue:`4741`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('794a1')
             sage: P = E(-1,2)
-            sage: P.padic_elliptic_logarithm(2)  # default precision=20                 # needs sage.rings.padics
+            sage: P.padic_elliptic_logarithm(2)  # default precision=20  # needs sage.rings.padics
             2^4 + 2^5 + 2^6 + 2^8 + 2^9 + 2^13 + 2^14 + 2^15 + O(2^16)
-            sage: P.padic_elliptic_logarithm(2, absprec=30)                             # needs sage.rings.padics
+            sage: P.padic_elliptic_logarithm(2, absprec=30)  # needs sage.rings.padics
             2^4 + 2^5 + 2^6 + 2^8 + 2^9 + 2^13 + 2^14 + 2^15 + 2^22 + 2^23 + 2^24 + O(2^26)
-            sage: P.padic_elliptic_logarithm(2, absprec=40)                             # needs sage.rings.padics
+            sage: P.padic_elliptic_logarithm(2, absprec=40)  # needs sage.rings.padics
             2^4 + 2^5 + 2^6 + 2^8 + 2^9 + 2^13 + 2^14 + 2^15 + 2^22 + 2^23 + 2^24
             + 2^28 + 2^29 + 2^31 + 2^34 + O(2^35)
         """

--- a/src/sage/schemes/elliptic_curves/ell_rational_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_rational_field.py
@@ -142,11 +142,13 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
     Constructor from a Cremona label::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: EllipticCurve('389a1')
         Elliptic Curve defined by y^2 + y = x^3 + x^2 - 2*x over Rational Field
 
     Constructor from an LMFDB label::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: EllipticCurve('462.f3')
         Elliptic Curve defined by y^2 + x*y = x^3 - 363*x + 1305 over Rational Field
     """
@@ -168,6 +170,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         right curve (see :issue:`10999`: the following used not to work when
         the large database was installed)::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a1')
             sage: [P.curve() is E for P in E.gens()]
             [True, True]
@@ -219,6 +222,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: E._set_rank(99)  # bogus value -- not checked
             sage: E.rank()         # returns bogus cached value
@@ -240,6 +244,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: E._set_torsion_order(99)  # bogus value -- not checked
             sage: E.torsion_order()         # returns bogus cached value
@@ -261,6 +266,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: E._set_cremona_label('bogus')
             sage: E.label()
@@ -288,6 +294,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: E._set_conductor(99)      # bogus value -- not checked
             sage: E.conductor()             # returns bogus cached value
@@ -307,6 +314,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('5077a1')
             sage: E.modular_degree()
             1984
@@ -328,6 +336,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('5077a1')
             sage: E.rank()
             3
@@ -351,6 +360,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('5077a1')
             sage: E.lmfdb_page()  # optional -- webbrowser
         """
@@ -442,6 +452,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: E.mwrank() # random
             ...
@@ -605,6 +616,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         When doing certain computations, PARI caches the results::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: _ = E.__dict__.pop('_pari_curve', None)  # clear cached data
             sage: Epari = E.pari_curve()
@@ -617,6 +629,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         This shows that the bug uncovered by :issue:`4715` is fixed::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: Ep = EllipticCurve('903b3').pari_curve()
 
         This still works, even when the curve coefficients are large
@@ -668,6 +681,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve((0, 0, 1, -1, 0))
             sage: data = E.database_attributes()
             sage: data['conductor']
@@ -679,6 +693,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
             sage: data['torsion_order']
             1
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve((8, 13, 21, 34, 55))
             sage: E.database_attributes()
             Traceback (most recent call last):
@@ -705,6 +720,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve([0,1,2,3,4])
             sage: E.database_curve()
             Elliptic Curve defined by y^2  = x^3 + x^2 + 3*x + 5 over Rational Field
@@ -754,6 +770,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         This even works when the prime is large::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: E.Np(next_prime(10^30))
             1000000000000001426441464441649
@@ -774,6 +791,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: EE = E.mwrank_curve()
             sage: EE
@@ -841,6 +859,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: E.two_descent(verbose=False)
             True
@@ -876,6 +895,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: e = EllipticCurve('37a')
             sage: e.aplist(1)
             []
@@ -992,6 +1012,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: E.q_expansion(20)
             q - 2*q^2 - 3*q^3 + 2*q^4 - 2*q^5 + 6*q^6 - q^7 + 6*q^9 + 4*q^10
@@ -1006,6 +1027,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: f = E.modular_form()
             sage: f
@@ -1042,6 +1064,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: f = EllipticCurve('37b')
             sage: f.modular_symbol_space()
             Modular Symbols subspace of dimension 1 of Modular Symbols space
@@ -1077,10 +1100,12 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: E.abelian_variety()
             Abelian variety J0(11) of dimension 1
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('33a')
             sage: E.abelian_variety()
             Abelian subvariety of dimension 1 of J0(33)
@@ -1093,6 +1118,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         TESTS::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: E.modular_symbol(implementation = 'eclib') is E.modular_symbol(implementation = 'eclib', normalize = 'L_ratio')
             True
@@ -1189,6 +1215,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: M = E.modular_symbol(); M
             Modular symbol with sign 1 over Rational Field attached to
@@ -1200,6 +1227,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('121b1')
             sage: M = E.modular_symbol(implementation='sage')
             Warning : Could not normalize the modular symbols, maybe all further results
@@ -1210,6 +1238,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         With the numerical version, rather high conductors can
         be computed::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve([999,997])
             sage: E.conductor()
             16059400956
@@ -1220,6 +1249,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         Different curves in an isogeny class have modular symbols
         which differ by a nonzero rational factor::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E1 = EllipticCurve('11a1')
             sage: M1 = E1.modular_symbol()
             sage: M1(0)
@@ -1242,6 +1272,7 @@ class EllipticCurve_rational_field(EllipticCurve_number_field):
         periods.  Here is an example where the symbol is already
         normalized::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a2')
             sage: E.modular_symbol(implementation = 'eclib')(0)
             1

--- a/src/sage/schemes/elliptic_curves/ell_tate_curve.py
+++ b/src/sage/schemes/elliptic_curves/ell_tate_curve.py
@@ -66,6 +66,7 @@ class TateCurve(SageObject):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: e = EllipticCurve('130a1')
         sage: eq = e.tate_curve(5); eq
         5-adic Tate curve associated to the Elliptic Curve
@@ -86,6 +87,7 @@ class TateCurve(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: e = EllipticCurve('130a1')
             sage: eq = e.tate_curve(2); eq
             2-adic Tate curve associated to the Elliptic Curve
@@ -105,6 +107,7 @@ class TateCurve(SageObject):
 
         TESTS::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('35a')
             sage: eq5 = E.tate_curve(5)
             sage: eq7 = E.tate_curve(7)
@@ -124,6 +127,7 @@ class TateCurve(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: e = EllipticCurve('130a1')
             sage: eq = e.tate_curve(2)
             sage: eq._repr_()
@@ -137,6 +141,7 @@ class TateCurve(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: eq = EllipticCurve('130a1').tate_curve(5)
             sage: eq.original_curve()
             Elliptic Curve defined by y^2 + x*y + y = x^3 - 33*x + 68
@@ -150,6 +155,7 @@ class TateCurve(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: eq = EllipticCurve('130a1').tate_curve(5)
             sage: eq.original_curve()
             Elliptic Curve defined by y^2 + x*y + y = x^3 - 33*x + 68
@@ -171,6 +177,7 @@ class TateCurve(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: eq = EllipticCurve('130a1').tate_curve(5)
             sage: eq.parameter(prec=5)
             3*5^3 + 3*5^4 + 2*5^5 + 2*5^6 + 3*5^7 + O(5^8)
@@ -213,6 +220,7 @@ class TateCurve(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: eq = EllipticCurve('130a1').tate_curve(5)
             sage: eq.curve(prec=5)
             Elliptic Curve defined by y^2 + (1+O(5^5))*x*y =
@@ -248,6 +256,7 @@ class TateCurve(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: eq = EllipticCurve('130a1').tate_curve(5)
             sage: eq._Csquare(prec=5)
             4 + 2*5^2 + 2*5^4 + O(5^5)
@@ -273,10 +282,12 @@ class TateCurve(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: eq = EllipticCurve('130a1').tate_curve(5)
             sage: eq.E2(prec=10)
             4 + 2*5^2 + 2*5^3 + 5^4 + 2*5^5 + 5^7 + 5^8 + 2*5^9 + O(5^10)
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: T = EllipticCurve('14').tate_curve(7)
             sage: T.E2(30)
             2 + 4*7 + 7^2 + 3*7^3 + 6*7^4 + 5*7^5 + 2*7^6 + 7^7 + 5*7^8 + 6*7^9 + 5*7^10 + 2*7^11 + 6*7^12 + 4*7^13 + 3*7^15 + 5*7^16 + 4*7^17 + 4*7^18 + 2*7^20 + 7^21 + 5*7^22 + 4*7^23 + 4*7^24 + 3*7^25 + 6*7^26 + 3*7^27 + 6*7^28 + O(7^30)
@@ -296,10 +307,12 @@ class TateCurve(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: eq = EllipticCurve('130a1').tate_curve(5)
             sage: eq.is_split()
             True
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: eq = EllipticCurve('37a1').tate_curve(37)
             sage: eq.is_split()
             False
@@ -320,6 +333,7 @@ class TateCurve(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: eq = EllipticCurve('130a1').tate_curve(5)
             sage: eq.parametrisation_onto_tate_curve(1+5+5^2+O(5^10), prec=10)
             (5^-2 + 4*5^-1 + 1 + 2*5 + 3*5^2 + 2*5^5 + 3*5^6 + O(5^7)
@@ -379,6 +393,7 @@ class TateCurve(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: eq = EllipticCurve('130a1').tate_curve(5)
             sage: eq.L_invariant(prec=10)
             5^3 + 4*5^4 + 2*5^5 + 2*5^6 + 2*5^7 + 3*5^8 + 5^9 + O(5^10)
@@ -410,6 +425,7 @@ class TateCurve(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: eq = EllipticCurve('130a1').tate_curve(5)
             sage: eq._isomorphism(prec=5)
             [2 + 3*5^2 + 2*5^3 + 4*5^4 + O(5^5),
@@ -447,6 +463,7 @@ class TateCurve(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: eq = EllipticCurve('130a1').tate_curve(5)
             sage: eq._inverse_isomorphism(prec=5)
             [3 + 2*5 + 3*5^3 + O(5^5), 4 + 2*5 + 4*5^3 + 3*5^4 + O(5^5),
@@ -472,6 +489,7 @@ class TateCurve(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: e = EllipticCurve('130a1')
             sage: eq = e.tate_curve(5)
             sage: P = e([-6,10])
@@ -529,6 +547,7 @@ class TateCurve(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: eq = EllipticCurve('130a1').tate_curve(5)
             sage: eq.parametrisation_onto_original_curve(1+5+5^2+O(5^10))
             (4*5^-2 + 4*5^-1 + 4 + 2*5^3 + 3*5^4 + 2*5^6 + O(5^7) :
@@ -584,6 +603,7 @@ class TateCurve(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: e = EllipticCurve('130a1')
             sage: eq = e.tate_curve(5)
             sage: h = eq.padic_height(prec=10)
@@ -641,6 +661,7 @@ class TateCurve(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: eq = EllipticCurve('130a1').tate_curve(5)
             sage: eq.padic_regulator()
             2*5^-1 + 1 + 2*5 + 2*5^2 + 3*5^3 + 3*5^6 + 5^7 + 3*5^9 + 3*5^10 + 3*5^12 + 4*5^13 + 3*5^15 + 2*5^16 + 3*5^18 + 4*5^19 +  4*5^20 + 3*5^21 + 4*5^22 + O(5^23)

--- a/src/sage/schemes/elliptic_curves/ell_torsion.py
+++ b/src/sage/schemes/elliptic_curves/ell_torsion.py
@@ -24,10 +24,10 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
+import sage.groups.additive_abelian.additive_abelian_wrapper as groups
 from sage.misc.cachefunc import cached_method
 from sage.rings.rational_field import RationalField
-import sage.groups.additive_abelian.additive_abelian_wrapper as groups
-from sage.structure.richcmp import richcmp_method, richcmp
+from sage.structure.richcmp import richcmp, richcmp_method
 
 
 @richcmp_method
@@ -70,6 +70,7 @@ class EllipticCurveTorsionSubgroup(groups.AdditiveAbelianGroupWrapper):
 
     Constructing points from the torsion subgroup::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('14a1')
         sage: T = E.torsion_subgroup()
         sage: [E(t) for t in T]
@@ -89,6 +90,7 @@ class EllipticCurveTorsionSubgroup(groups.AdditiveAbelianGroupWrapper):
 
     An example where the torsion subgroup is trivial::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('37a1')
         sage: T = E.torsion_subgroup()
         sage: T
@@ -99,7 +101,7 @@ class EllipticCurveTorsionSubgroup(groups.AdditiveAbelianGroupWrapper):
 
     Examples over other Number Fields::
 
-        sage: # needs sage.rings.number_field
+        sage: # needs database_cremona_mini_ellcurve sage.rings.number_field
         sage: E = EllipticCurve('11a1')
         sage: x = polygen(ZZ, 'x')
         sage: K.<i> = NumberField(x^2 + 1)
@@ -110,10 +112,11 @@ class EllipticCurveTorsionSubgroup(groups.AdditiveAbelianGroupWrapper):
          Elliptic Curve defined by y^2 + y = x^3 + (-1)*x^2 + (-10)*x + (-20)
           over Number Field in i with defining polynomial x^2 + 1
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('11a1')
-        sage: K.<i> = NumberField(x^2 + 1)                                              # needs sage.rings.number_field
-        sage: EK = E.change_ring(K)                                                     # needs sage.rings.number_field
-        sage: T = EK.torsion_subgroup()                                                 # needs sage.rings.number_field
+        sage: K.<i> = NumberField(x^2 + 1)  # needs sage.rings.number_field
+        sage: EK = E.change_ring(K)  # needs sage.rings.number_field
+        sage: T = EK.torsion_subgroup()  # needs sage.rings.number_field
         sage: T.ngens()
         1
         sage: T.gen(0)
@@ -145,12 +148,13 @@ class EllipticCurveTorsionSubgroup(groups.AdditiveAbelianGroupWrapper):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.ell_torsion import EllipticCurveTorsionSubgroup
             sage: E = EllipticCurve('11a1')
             sage: x = polygen(ZZ, 'x')
-            sage: K.<i> = NumberField(x^2 + 1)                                          # needs sage.rings.number_field
-            sage: EK = E.change_ring(K)                                                 # needs sage.rings.number_field
-            sage: EllipticCurveTorsionSubgroup(EK)                                      # needs sage.rings.number_field
+            sage: K.<i> = NumberField(x^2 + 1)  # needs sage.rings.number_field
+            sage: EK = E.change_ring(K)  # needs sage.rings.number_field
+            sage: EllipticCurveTorsionSubgroup(EK)  # needs sage.rings.number_field
             Torsion Subgroup isomorphic to Z/5 associated to the
              Elliptic Curve defined by y^2 + y = x^3 + (-1)*x^2 + (-10)*x + (-20)
               over Number Field in i with defining polynomial x^2 + 1
@@ -218,11 +222,12 @@ class EllipticCurveTorsionSubgroup(groups.AdditiveAbelianGroupWrapper):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: x = polygen(ZZ, 'x')
-            sage: K.<i> = NumberField(x^2 + 1)                                          # needs sage.rings.number_field
-            sage: EK = E.change_ring(K)                                                 # needs sage.rings.number_field
-            sage: T = EK.torsion_subgroup(); T._repr_()                                 # needs sage.rings.number_field
+            sage: K.<i> = NumberField(x^2 + 1)  # needs sage.rings.number_field
+            sage: EK = E.change_ring(K)  # needs sage.rings.number_field
+            sage: T = EK.torsion_subgroup(); T._repr_()  # needs sage.rings.number_field
             'Torsion Subgroup isomorphic to Z/5 associated to the Elliptic Curve defined by y^2 + y = x^3 + (-1)*x^2 + (-10)*x + (-20) over Number Field in i with defining polynomial x^2 + 1'
         """
         return "Torsion Subgroup isomorphic to %s associated to the %s" % (self.short_name(), self.__E)
@@ -233,6 +238,7 @@ class EllipticCurveTorsionSubgroup(groups.AdditiveAbelianGroupWrapper):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: tor = E.torsion_subgroup()
             sage: tor == tor
@@ -248,7 +254,7 @@ class EllipticCurveTorsionSubgroup(groups.AdditiveAbelianGroupWrapper):
 
         EXAMPLES::
 
-            sage: # needs sage.rings.number_field
+            sage: # needs database_cremona_mini_ellcurve sage.rings.number_field
             sage: E = EllipticCurve('11a1')
             sage: x = polygen(ZZ, 'x')
             sage: K.<i> = NumberField(x^2 + 1)
@@ -309,6 +315,7 @@ def torsion_bound(E, number_of_places=20):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: CDB = CremonaDatabase()
         sage: from sage.schemes.elliptic_curves.ell_torsion import torsion_bound
         sage: [torsion_bound(E) for E in CDB.iter([14])]
@@ -340,8 +347,8 @@ def torsion_bound(E, number_of_places=20):
         sage: E.torsion_subgroup().invariants()
         (4, 4)
     """
-    from sage.rings.integer_ring import ZZ
     from sage.rings.finite_rings.finite_field_constructor import GF
+    from sage.rings.integer_ring import ZZ
     from sage.schemes.elliptic_curves.constructor import EllipticCurve
 
     K = E.base_field()

--- a/src/sage/schemes/elliptic_curves/ell_wp.py
+++ b/src/sage/schemes/elliptic_curves/ell_wp.py
@@ -76,6 +76,7 @@ def weierstrass_p(E, prec=20, algorithm=None):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('11a1')
         sage: E.weierstrass_p(prec=10)
         z^-2 + 31/15*z^2 + 2501/756*z^4 + 961/675*z^6 + 77531/41580*z^8 + O(z^10)

--- a/src/sage/schemes/elliptic_curves/formal_group.py
+++ b/src/sage/schemes/elliptic_curves/formal_group.py
@@ -27,6 +27,7 @@ class EllipticCurveFormalGroup(SageObject):
         """
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: F = E.formal_group(); F
             Formal Group associated to the Elliptic Curve
@@ -42,6 +43,7 @@ class EllipticCurveFormalGroup(SageObject):
 
         TESTS::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('35a')
             sage: F1 = E.formal_group()
             sage: F2 = E.formal_group()
@@ -59,6 +61,7 @@ class EllipticCurveFormalGroup(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('35a')
             sage: F1 = E.formal_group()
             sage: F2 = E.formal_group()
@@ -73,6 +76,7 @@ class EllipticCurveFormalGroup(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('43a')
             sage: F = E.formal_group()
             sage: F._repr_()
@@ -86,6 +90,7 @@ class EllipticCurveFormalGroup(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("37a")
             sage: F = E.formal_group()
             sage: F.curve()
@@ -480,6 +485,7 @@ class EllipticCurveFormalGroup(SageObject):
             sage: e.formal_group().group_law(6)
             t1 + t2 - 2*t1^4*t2 - 4*t1^3*t2^2 - 4*t1^2*t2^3 - 2*t1*t2^4 + O(t1, t2)^6
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: e = EllipticCurve('14a1')
             sage: ehat = e.formal()
             sage: ehat.group_law(3)
@@ -618,6 +624,7 @@ class EllipticCurveFormalGroup(SageObject):
 
         It's quite fast::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("37a"); F = E.formal_group()
             sage: F.mult_by_n(100, 20)
             100*t - 49999950*t^4 + 3999999960*t^5 + 14285614285800*t^7 - 2999989920000150*t^8 + 133333325333333400*t^9 - 3571378571674999800*t^10 + 1402585362624965454000*t^11 - 146666057066712847999500*t^12 + 5336978000014213190385000*t^13 - 519472790950932256570002000*t^14 + 93851927683683567270392002800*t^15 - 6673787211563812368630730325175*t^16 + 320129060335050875009191524993000*t^17 - 45670288869783478472872833214986000*t^18 + 5302464956134111125466184947310391600*t^19 + O(t^20)
@@ -733,6 +740,7 @@ class EllipticCurveFormalGroup(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a')
             sage: F = E.formal_group()
             sage: F.sigma(5)

--- a/src/sage/schemes/elliptic_curves/gal_reps.py
+++ b/src/sage/schemes/elliptic_curves/gal_reps.py
@@ -38,6 +38,7 @@ For the classification of the representation
 
 EXAMPLES::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve('196a1')
     sage: rho = E.galois_representation()
     sage: rho.is_irreducible(7)
@@ -66,6 +67,7 @@ EXAMPLES::
 For semi-stable curve it is known that the representation is
 surjective if and only if it is irreducible::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve('11a1')
     sage: rho = E.galois_representation()
     sage: rho.non_surjective()
@@ -76,6 +78,7 @@ surjective if and only if it is irreducible::
 For cm curves it is not true that there are only finitely many primes for which the
 Galois representation mod p is surjective onto `GL_2(\GF{p})`::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve('27a1')
     sage: rho = E.galois_representation()
     sage: rho.non_surjective()
@@ -173,6 +176,7 @@ class GaloisRepresentation(SageObject):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: rho = EllipticCurve('11a1').galois_representation()
         sage: rho
         Compatible family of Galois representations associated to the Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
@@ -184,6 +188,7 @@ class GaloisRepresentation(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('11a1').galois_representation()
             sage: loads(rho.dumps()) == rho
             True
@@ -211,6 +216,7 @@ class GaloisRepresentation(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('11a1').galois_representation()
             sage: rho2 = EllipticCurve('11a2').galois_representation()
             sage: rho == rho
@@ -239,6 +245,7 @@ class GaloisRepresentation(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: rho = E.galois_representation()
             sage: rho.elliptic_curve() == E
@@ -268,6 +275,7 @@ class GaloisRepresentation(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('121a').galois_representation()
             sage: rho.is_reducible(7)
             False
@@ -317,6 +325,7 @@ class GaloisRepresentation(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('37b').galois_representation()
             sage: rho.is_irreducible(2)
             True
@@ -337,6 +346,7 @@ class GaloisRepresentation(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('225a').galois_representation()
             sage: rho.reducible_primes()
             [3]
@@ -381,6 +391,7 @@ class GaloisRepresentation(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('37b').galois_representation()
             sage: rho.is_surjective(2)
             True
@@ -389,6 +400,7 @@ class GaloisRepresentation(SageObject):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('121a1').galois_representation()
             sage: rho.non_surjective()
             [11]
@@ -397,6 +409,7 @@ class GaloisRepresentation(SageObject):
             sage: rho.is_surjective(11)
             False
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('121d1').galois_representation()
             sage: rho.is_surjective(5)
             False
@@ -449,6 +462,7 @@ class GaloisRepresentation(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('37b').galois_representation()
             sage: rho._is_surjective(7,100)
             True
@@ -457,6 +471,7 @@ class GaloisRepresentation(SageObject):
 
         Test for :issue:`8451`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('648a1')
             sage: rho = E.galois_representation()
             sage: rho._is_surjective(5,1000)
@@ -643,6 +658,7 @@ class GaloisRepresentation(SageObject):
             sage: rho.non_surjective()
             [2]
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('324b1')
             sage: rho = E.galois_representation()
             sage: rho.non_surjective()
@@ -713,16 +729,19 @@ class GaloisRepresentation(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a1')
             sage: rho = E.galois_representation()
             sage: rho.image_type(5)
             'The image is all of GL_2(F_5).'
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: rho = E.galois_representation()
             sage: rho.image_type(5)
             'The image is meta-cyclic inside a Borel subgroup as there is a 5-torsion point on the curve.'
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('27a1').galois_representation().image_type(5)
             'The image is contained in the normalizer of a non-split Cartan group. (cm)'
             sage: EllipticCurve('30a1').galois_representation().image_type(5)
@@ -736,9 +755,11 @@ class GaloisRepresentation(SageObject):
             sage: rho.image_type(5)
             'The image is contained in the normalizer of a split Cartan group.'
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('49a1').galois_representation().image_type(7)
             'The image is contained in a Borel subgroup as there is a 7-isogeny.'
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('121c1').galois_representation().image_type(11)
             'The image is contained in a Borel subgroup as there is a 11-isogeny.'
             sage: EllipticCurve('121d1').galois_representation().image_type(11)
@@ -769,41 +790,50 @@ class GaloisRepresentation(SageObject):
 
         For `p=2`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: rho = E.galois_representation()
             sage: rho.image_type(2)
             'The image is all of GL_2(F_2), i.e. a symmetric group of order 6.'
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('14a1').galois_representation()
             sage: rho.image_type(2)
             'The image is cyclic of order 2 as there is exactly one rational 2-torsion point.'
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('15a1').galois_representation()
             sage: rho.image_type(2)
             'The image is trivial as all 2-torsion points are rational.'
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('196a1').galois_representation()
             sage: rho.image_type(2)
             'The image is cyclic of order 3.'
 
         `p=3`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('33a1').galois_representation()
             sage: rho.image_type(3)
             'The image is all of GL_2(F_3).'
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('30a1').galois_representation()
             sage: rho.image_type(3)
             'The image is meta-cyclic inside a Borel subgroup as there is a 3-torsion point on the curve.'
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('50b1').galois_representation()
             sage: rho.image_type(3)
             'The image is contained in a Borel subgroup as there is a 3-isogeny.'
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('3840h1').galois_representation()
             sage: rho.image_type(3)
             'The image is contained in a dihedral group of order 8.'
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('32a1').galois_representation()
             sage: rho.image_type(3)
             'The image is a semi-dihedral group of order 16, gap.SmallGroup([16,8]).'
@@ -1111,11 +1141,13 @@ class GaloisRepresentation(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a1')
             sage: rho = E.galois_representation()
             sage: rho.image_classes(5)
             [0.2095, 0.1516, 0.2445, 0.1728, 0.2217]
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: rho = E.galois_representation()
             sage: rho.image_classes(5)
@@ -1123,6 +1155,7 @@ class GaloisRepresentation(SageObject):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('27a1').galois_representation().image_classes(5)
             [0.5839, 0.1645, 0.0000, 0.1702, 0.08143]
             sage: EllipticCurve('30a1').galois_representation().image_classes(5)
@@ -1138,16 +1171,19 @@ class GaloisRepresentation(SageObject):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('784h1').galois_representation().image_classes(7)
             [0.5049, 0.0000, 0.0000, 0.0000, 0.4951, 0.0000, 0.0000]
             sage: EllipticCurve('49a1').galois_representation().image_classes(7)
             [0.5045, 0.0000, 0.0000, 0.0000, 0.4955, 0.0000, 0.0000]
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('121c1').galois_representation().image_classes(11)
             [0.1001, 0.0000, 0.0000, 0.0000, 0.1017, 0.1953, 0.1993, 0.0000, 0.0000, 0.2010, 0.2026]
             sage: EllipticCurve('121d1').galois_representation().image_classes(11)
             [0.08869, 0.07974, 0.08706, 0.08137, 0.1001, 0.09439, 0.09764, 0.08218, 0.08625, 0.1017, 0.1009]
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('441f1').galois_representation().image_classes(13)
             [0.08232, 0.1663, 0.1663, 0.1663, 0.08232, 0.0000, 0.1549, 0.0000, 0.0000, 0.0000, 0.0000, 0.1817, 0.0000]
 
@@ -1246,6 +1282,7 @@ class GaloisRepresentation(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('20a3').galois_representation()
             sage: rho.is_unramified(5,7)
             True
@@ -1279,6 +1316,7 @@ class GaloisRepresentation(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('120a1').galois_representation()
             sage: rho.is_unipotent(2,5)
             True
@@ -1316,6 +1354,7 @@ class GaloisRepresentation(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('11a3').galois_representation()
             sage: rho.is_quasi_unipotent(11,13)
             True
@@ -1346,6 +1385,7 @@ class GaloisRepresentation(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('11a3').galois_representation()
             sage: rho.is_ordinary(11)
             True
@@ -1374,6 +1414,7 @@ class GaloisRepresentation(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('64a1').galois_representation()
             sage: rho.is_crystalline(5)
             True
@@ -1399,6 +1440,7 @@ class GaloisRepresentation(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('37b1').galois_representation()
             sage: rho.is_potentially_crystalline(37)
             False
@@ -1423,6 +1465,7 @@ class GaloisRepresentation(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('20a3').galois_representation()
             sage: rho.is_semistable(2)
             False
@@ -1449,6 +1492,7 @@ class GaloisRepresentation(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: rho = EllipticCurve('27a2').galois_representation()
             sage: rho.is_potentially_semistable(3)
             True

--- a/src/sage/schemes/elliptic_curves/gal_reps_number_field.py
+++ b/src/sage/schemes/elliptic_curves/gal_reps_number_field.py
@@ -76,6 +76,7 @@ class GaloisRepresentation(SageObject):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: x = polygen(ZZ, 'x')
         sage: K = NumberField(x**2 + 1, 'a')
         sage: E = EllipticCurve('11a1').change_ring(K)
@@ -92,6 +93,7 @@ class GaloisRepresentation(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: x = polygen(ZZ, 'x')
             sage: K = NumberField(x**2 + 1, 'a')
             sage: E = EllipticCurve('11a1').change_ring(K)
@@ -111,6 +113,7 @@ class GaloisRepresentation(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: x = polygen(ZZ, 'x')
             sage: K = NumberField(x**2 + 1, 'a')
             sage: E = EllipticCurve('11a1').change_ring(K)
@@ -516,6 +519,7 @@ def Frobenius_filter(E, L, patience=100):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('11a1') # has a 5-isogeny
         sage: sage.schemes.elliptic_curves.gal_reps_number_field.Frobenius_filter(E,primes(40))  # long time
         [5]

--- a/src/sage/schemes/elliptic_curves/gp_simon.py
+++ b/src/sage/schemes/elliptic_curves/gp_simon.py
@@ -28,7 +28,6 @@ from sage.rings.integer_ring import ZZ
 from sage.rings.rational_field import QQ
 from sage.structure.parent_gens import localvars
 
-
 simon_dir = Path(SAGE_EXTCODE) / 'pari' / 'simon'
 
 
@@ -43,6 +42,7 @@ def simon_two_descent(E, verbose=0, lim1=None, lim3=None, limtriv=None,
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: import sage.schemes.elliptic_curves.gp_simon
         sage: E = EllipticCurve('389a1')
         sage: sage.schemes.elliptic_curves.gp_simon.simon_two_descent(E)
@@ -53,7 +53,7 @@ def simon_two_descent(E, verbose=0, lim1=None, lim3=None, limtriv=None,
 
     TESTS::
 
-        sage: # needs sage.rings.number_field
+        sage: # needs database_cremona_mini_ellcurve sage.rings.number_field
         sage: E = EllipticCurve('37a1').change_ring(QuadraticField(-11,'x'))
         sage: E.simon_two_descent()
         (1, 1, [(0 : 0 : 1)])

--- a/src/sage/schemes/elliptic_curves/heegner.py
+++ b/src/sage/schemes/elliptic_curves/heegner.py
@@ -10,6 +10,7 @@ AUTHORS:
 
 EXAMPLES::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve('433a')
     sage: P = E.heegner_point(-8,3)
     sage: z = P.point_exact(201); z
@@ -44,12 +45,14 @@ Next try an inert prime::
 
 We find some Mordell-Weil generators in the rank 1 case using Heegner points::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve('43a'); P = E.heegner_point(-7)
     sage: P.x_poly_exact()
     x
     sage: z = P.point_exact(); z == E(0,0,1) or -z == E(0,0,1)
     True
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve('997a')
     sage: E.rank()
     1
@@ -63,6 +66,7 @@ We find some Mordell-Weil generators in the rank 1 case using Heegner points::
 
 Here we find that the Heegner point generates a subgroup of index 3::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve('92b1')
     sage: E.heegner_discriminants_list(1)
     [-7]
@@ -270,6 +274,7 @@ class RingClassField(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: K5 = E.heegner_point(-7,5).ring_class_field()
             sage: K11 = E.heegner_point(-7,11).ring_class_field()
@@ -288,6 +293,7 @@ class RingClassField(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: K5 = E.heegner_point(-7,5).ring_class_field()
             sage: K11 = E.heegner_point(-7,11).ring_class_field()
@@ -311,6 +317,7 @@ class RingClassField(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); K5 = E.heegner_point(-7,5).ring_class_field()
             sage: hash(K5) == hash((-7,5))
             True
@@ -323,6 +330,7 @@ class RingClassField(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); K5 = E.heegner_point(-7,5).ring_class_field()
             sage: K5.conductor()
             5
@@ -335,6 +343,7 @@ class RingClassField(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); K5 = E.heegner_point(-7,5).ring_class_field()
             sage: K5.discriminant_of_K()
             -7
@@ -348,6 +357,7 @@ class RingClassField(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); K55 = E.heegner_point(-7,55).ring_class_field()
             sage: K55.ramified_primes()
             [5, 7, 11]
@@ -378,6 +388,7 @@ class RingClassField(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); P = E.heegner_point(-7,5)
             sage: K5 = P.ring_class_field(); K5
             Ring class field extension of QQ[sqrt(-7)] of conductor 5
@@ -386,6 +397,7 @@ class RingClassField(SageObject):
             sage: type(K5.degree_over_K())
             <... 'sage.rings.integer.Integer'>
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); E.heegner_point(-20).ring_class_field().degree_over_K()
             2
             sage: E.heegner_point(-20,3).ring_class_field().degree_over_K()
@@ -407,6 +419,7 @@ class RingClassField(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: E.heegner_point(-59).ring_class_field().degree_over_H()
             1
@@ -444,6 +457,7 @@ class RingClassField(SageObject):
 
         Check that :issue:`15218` is solved::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("19a");
             sage: s = E.heegner_point(-3,2).ring_class_field().galois_group().complex_conjugation()
             sage: H = s.domain(); H.absolute_degree()
@@ -503,6 +517,7 @@ class RingClassField(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); K = E.heegner_point(-7,5).ring_class_field()
             sage: K.absolute_degree()
             12
@@ -520,6 +535,7 @@ class RingClassField(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); K = E.heegner_point(-7,5).ring_class_field()
             sage: K.quadratic_field()
             Number Field in sqrt_minus_7 with defining polynomial x^2 + 7
@@ -539,6 +555,7 @@ class RingClassField(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: A = E.heegner_point(-7,5).ring_class_field()
             sage: A.galois_group()
@@ -569,6 +586,7 @@ class RingClassField(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: A = E.heegner_point(-7,5).ring_class_field()
             sage: B = E.heegner_point(-7).ring_class_field()
@@ -605,6 +623,7 @@ class GaloisGroup(SageObject):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('389a')
         sage: G = E.heegner_point(-7,5).ring_class_field().galois_group(); G
         Galois group of Ring class field extension of QQ[sqrt(-7)] of conductor 5
@@ -657,6 +676,7 @@ class GaloisGroup(SageObject):
         """
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: G = EllipticCurve('389a').heegner_point(-7,5).ring_class_field().galois_group()
             sage: G == G
             True
@@ -672,6 +692,7 @@ class GaloisGroup(SageObject):
         """
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: G = EllipticCurve('389a').heegner_point(-7,5).ring_class_field().galois_group()
             sage: G != G
             False
@@ -690,6 +711,7 @@ class GaloisGroup(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: G = EllipticCurve('389a').heegner_point(-7,5).ring_class_field().galois_group()
             sage: hash(G) == hash((G.field(), G.base_field()))
             True
@@ -742,6 +764,7 @@ class GaloisGroup(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: G = E.heegner_point(-7,5).ring_class_field().galois_group()
             sage: G._repr_()
@@ -890,6 +913,7 @@ class GaloisGroup(SageObject):
 
         Example with order 1 (a special case)::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); F = E.heegner_point(-7,1).ring_class_field()
             sage: G = F.galois_group(F.quadratic_field())
             sage: G._list()
@@ -897,6 +921,7 @@ class GaloisGroup(SageObject):
 
         Example over quadratic imaginary field::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); F = E.heegner_point(-7,5).ring_class_field()
             sage: G = F.galois_group(F.quadratic_field())
             sage: G._list()
@@ -1173,6 +1198,7 @@ class GaloisGroup(SageObject):
         """
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); F = E.heegner_point(-7,5).ring_class_field()
             sage: G = F.galois_group(F.quadratic_field())
             sage: G[0]
@@ -1201,6 +1227,7 @@ class GaloisGroup(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: G = E.heegner_point(-7,5).ring_class_field().galois_group(); G
             Galois group of Ring class field extension of QQ[sqrt(-7)] of conductor 5
@@ -1223,6 +1250,7 @@ class GaloisGroup(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: G = E.heegner_point(-7,5).ring_class_field().galois_group()
             sage: G.complex_conjugation()
@@ -1272,6 +1300,7 @@ class GaloisAutomorphism(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: G = E.heegner_point(-7,5).ring_class_field().galois_group()
             sage: s = G.complex_conjugation()
@@ -1286,6 +1315,7 @@ class GaloisAutomorphism(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: G = E.heegner_point(-7,5).ring_class_field().galois_group()
             sage: s = G.complex_conjugation()
@@ -1338,6 +1368,7 @@ class GaloisAutomorphismComplexConjugation(GaloisAutomorphism):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: G = EllipticCurve('389a').heegner_point(-7,5).ring_class_field().galois_group()
             sage: conj = G.complex_conjugation()
             sage: hash(conj) == hash((conj.parent(), 1))
@@ -1349,6 +1380,7 @@ class GaloisAutomorphismComplexConjugation(GaloisAutomorphism):
         """
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: G = EllipticCurve('389a').heegner_point(-7,5).ring_class_field().galois_group()
             sage: conj = G.complex_conjugation()
             sage: conj2 = sage.schemes.elliptic_curves.heegner.GaloisAutomorphismComplexConjugation(G)
@@ -1364,6 +1396,7 @@ class GaloisAutomorphismComplexConjugation(GaloisAutomorphism):
         """
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: G = EllipticCurve('389a').heegner_point(-7,5).ring_class_field().galois_group()
             sage: conj = G.complex_conjugation()
             sage: conj2 = sage.schemes.elliptic_curves.heegner.GaloisAutomorphismComplexConjugation(G)
@@ -1662,6 +1695,7 @@ class GaloisAutomorphismQuadraticForm(GaloisAutomorphism):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); F = E.heegner_point(-20,3).ring_class_field()
             sage: G = F.galois_group(F.quadratic_field())
             sage: G[1].ideal()
@@ -1833,6 +1867,7 @@ class HeegnerPoint(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: heegner_point(389,-7,5).conductor()
             5
             sage: E = EllipticCurve('37a1'); P = E.kolyvagin_point(-67,7); P
@@ -1852,6 +1887,7 @@ class HeegnerPoint(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: heegner_point(389,-7,5).discriminant()
             -7
             sage: E = EllipticCurve('37a1'); P = E.kolyvagin_point(-67,7); P
@@ -1876,6 +1912,7 @@ class HeegnerPoint(SageObject):
             Number Field in sqrt_minus_7 with defining polynomial x^2 + 7
              with sqrt_minus_7 = 2.645751311064591?*I
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a'); P = E.heegner_point(-40)
             sage: P.quadratic_field()
             Number Field in sqrt_minus_40 with defining polynomial x^2 + 40
@@ -1902,6 +1939,7 @@ class HeegnerPoint(SageObject):
             sage: heegner_point(389,-7,5).quadratic_order().basis()
             [1, 5*sqrt_minus_7]
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a'); P = E.heegner_point(-40,11)
             sage: P.quadratic_order()
             Order of conductor 22 generated by 11*sqrt_minus_40
@@ -1925,6 +1963,7 @@ class HeegnerPoint(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); K.<a> = QuadraticField(-5)
             sage: len(K.factor(5))
             1
@@ -2213,6 +2252,7 @@ class HeegnerPoints_level_disc(HeegnerPoints):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); K = E.heegner_point(-7,5).ring_class_field()
             sage: K.quadratic_field()
             Number Field in sqrt_minus_7 with defining polynomial x^2 + 7
@@ -2246,6 +2286,7 @@ class HeegnerPoints_level_disc(HeegnerPoints):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: H = heegner_points(389, -7)
             sage: H.kolyvagin_conductors(0)
             [1]
@@ -2314,6 +2355,7 @@ def is_kolyvagin_conductor(N, E, D, r, n, c) -> bool:
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.heegner import is_kolyvagin_conductor
         sage: is_kolyvagin_conductor(389, None, -7, 1, None, 5)
         True
@@ -2768,6 +2810,7 @@ class HeegnerPointOnX0N(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: x1 = EllipticCurve('389a').heegner_point(-7).heegner_point_on_X0N()
             sage: x5 = EllipticCurve('389a').heegner_point(-7, 5).heegner_point_on_X0N()
             sage: x1 == x1
@@ -2902,6 +2945,7 @@ class HeegnerPointOnX0N(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: x = heegner_point(389, -7, 5); x
             Heegner point 5/778*sqrt(-7) - 147/778 of discriminant -7
              and conductor 5 on X_0(389)
@@ -2916,6 +2960,7 @@ class HeegnerPointOnX0N(HeegnerPoint):
 
         You can also directly apply the modular parametrization of the elliptic curve::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: x = heegner_point(37,-7); x
             Heegner point 1/74*sqrt(-7) - 17/74 of discriminant -7 on X_0(37)
             sage: E = EllipticCurve('37a'); phi = E.modular_parametrization()
@@ -2993,6 +3038,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('37a'); P = E.heegner_point(-7,5); P
         Heegner point of discriminant -7 and conductor 5 on elliptic curve of conductor 37
         sage: type(P)
@@ -3011,6 +3057,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: x = heegner_point(389,-7,5)
             sage: E = EllipticCurve('389a')
             sage: sage.schemes.elliptic_curves.heegner.HeegnerPointOnEllipticCurve(E, x)
@@ -3039,6 +3086,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('389a').heegner_point(-7).satisfies_kolyvagin_hypothesis()
             True
             sage: EllipticCurve('389a').heegner_point(-7, 5).satisfies_kolyvagin_hypothesis()
@@ -3060,6 +3108,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: x = EllipticCurve('389a').heegner_point(-7, 5)
             sage: hash(x) == hash( (x.curve(), x.heegner_point_on_X0N()) )
             True
@@ -3070,6 +3119,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
         """
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: y1 = EllipticCurve('389a').heegner_point(-7)
             sage: y5 = EllipticCurve('389a').heegner_point(-7, 5)
             sage: y1 == y1
@@ -3088,6 +3138,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
         """
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: y1 = EllipticCurve('389a').heegner_point(-7)
             sage: y5 = EllipticCurve('389a').heegner_point(-7, 5)
             sage: y1 != y1
@@ -3107,6 +3158,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); P = E.heegner_point(-7, 97)
             sage: P._repr_()
             'Heegner point of discriminant -7 and conductor 97 on elliptic curve of conductor 389'
@@ -3121,6 +3173,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a'); P = E.heegner_point(-7,5); P
             Heegner point of discriminant -7 and conductor 5 on elliptic curve
              of conductor 37
@@ -3141,6 +3194,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
         We compute a nonzero Heegner point over a ring class field on
         a curve of rank 2::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); y = E.heegner_point(-7,5)
             sage: y.map_to_complex_numbers()
             1.49979679635196 + 0.369156204821526*I
@@ -3152,6 +3206,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
         Here we see that the Heegner point is 0 since it lies in the
         lattice::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); y = E.heegner_point(-7)
             sage: y.map_to_complex_numbers(10)
             0.0034 - 3.9*I
@@ -3164,6 +3219,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         You can also directly coerce to the complex field::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); y = E.heegner_point(-7)
             sage: z = ComplexField(100)(y); z # real part approx. 0
             -... - 3.9434754031032964088448153963*I
@@ -3180,6 +3236,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a'); y = E.heegner_point(-7)
             sage: CC(y)                          # indirect doctest
             0.929592715285395 - 1.22569469099340*I
@@ -3203,6 +3260,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1'); y = E.heegner_point(-7); y
             Heegner point of discriminant -7 on elliptic curve of conductor 37
             sage: P = y.kolyvagin_point(); P
@@ -3227,6 +3285,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('77a1')
             sage: P = E.heegner_point(-19); y = P._trace_numerical_conductor_1()
             sage: [c.real() for c in y]
@@ -3260,6 +3319,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); P = E.heegner_point(-7, 5)
             sage: P.curve()
             Elliptic Curve defined by y^2 + y = x^3 + x^2 - 2*x over Rational Field
@@ -3276,9 +3336,11 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('389a').heegner_point(-7, 5).quadratic_form()
             389*x^2 + 147*x*y + 14*y^2
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: P = EllipticCurve('389a').heegner_point(-7, 5, (778,925,275)); P
             Heegner point of discriminant -7 and conductor 5 on elliptic curve
              of conductor 389
@@ -3305,6 +3367,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a'); P = E.heegner_point(-7); P
             Heegner point of discriminant -7 on elliptic curve of conductor 37
             sage: P.numerical_approx()  # abs tol 1e-15
@@ -3322,6 +3385,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         A rank 2 curve, where all Heegner points of conductor 1 are 0::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); E.rank()
             2
             sage: P = E.heegner_point(-7); P
@@ -3331,6 +3395,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         However, Heegner points of bigger conductor are often nonzero::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); P = E.heegner_point(-7, 5); P
             Heegner point of discriminant -7 and conductor 5 on elliptic curve
              of conductor 389
@@ -3368,6 +3433,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); P = E.heegner_point(-7, 5)
             sage: P.tau()
             5/778*sqrt_minus_7 - 147/778
@@ -3405,6 +3471,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
         We compute some `x`-coordinate polynomials of some conductor 1
         Heegner points::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: v = E.heegner_discriminants_list(10)
             sage: [E.heegner_point(D).x_poly_exact() for D in v]
@@ -3417,6 +3484,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
         We compute `x`-coordinate polynomials for some Heegner points
         of conductor bigger than 1 on a rank 2 curve::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); P = E.heegner_point(-7, 5); P
             Heegner point of discriminant -7 and conductor 5
              on elliptic curve of conductor 389
@@ -3436,6 +3504,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         Here we compute a Heegner point of conductor 5 on a rank 3 curve::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('5077a'); P = E.heegner_point(-7,5); P
             Heegner point of discriminant -7 and conductor 5
              on elliptic curve of conductor 5077
@@ -3444,6 +3513,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         See :issue:`34121`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: P = E.heegner_point(-7)
             sage: PE = P.point_exact()
@@ -3477,6 +3547,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); P = E.heegner_point(-7, 5); P
             Heegner point of discriminant -7 and conductor 5
              on elliptic curve of conductor 389
@@ -3533,6 +3604,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a'); P = E.heegner_point(-7, 5); P
             Heegner point of discriminant -7 and conductor 5
              on elliptic curve of conductor 389
@@ -3542,6 +3614,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
             sage: f = P.numerical_approx(500)[1].algebraic_dependency(12); f / f.leading_coefficient()
             x^12 + 6*x^11 + 90089/1715*x^10 + 71224/343*x^9 + 52563964/588245*x^8 - 483814934/588245*x^7 - 156744579/16807*x^6 - 2041518032/84035*x^5 + 1259355443184/14706125*x^4 + 3094420220918/14706125*x^3 + 123060442043827/367653125*x^2 + 82963044474852/367653125*x + 211679465261391/1838265625
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('5077a')
             sage: P = E.heegner_point(-7)
             sage: P.point_exact(prec=100)
@@ -3611,6 +3684,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('77a')
             sage: y = E.heegner_point(-52,5); y
             Heegner point of discriminant -52 and conductor 5
@@ -3641,6 +3715,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: y = E.heegner_point(-7,3); y
             Heegner point of discriminant -7 and conductor 3 on elliptic curve of conductor 37
@@ -3674,6 +3749,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: y = E.heegner_point(-7,3); y
             Heegner point of discriminant -7 and conductor 3 on elliptic curve of conductor 37
@@ -3707,6 +3783,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: y = E.heegner_point(-7,3); y
             Heegner point of discriminant -7 and conductor 3 on elliptic curve of conductor 37
@@ -3731,6 +3808,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a'); y = E.heegner_point(-7,3)
             sage: y._xy_poly_simplest()
             [X^8 + 6*X^7 + 9*X^6 - 12*X^5 - 42*X^4 - 18*X^3 + 36*X^2 + 36*X + 9,
@@ -3749,6 +3827,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a'); P = E.heegner_point(-40); P
             Heegner point of discriminant -40 on elliptic curve of conductor 37
             sage: P._square_roots_mod_2N_of_D_mod_4N()
@@ -3773,6 +3852,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('57a1')
             sage: P = E.heegner_point(-8); P
             Heegner point of discriminant -8 on elliptic curve of conductor 57
@@ -3822,6 +3902,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: P = EllipticCurve('389a1').heegner_point(-7)
             sage: P._good_tau_representatives()
             ([(1, 1, 2)], [((389, 185, 22), 1)])
@@ -3886,6 +3967,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: P = EllipticCurve('57a1').heegner_point(-8)
             sage: R, U = P._good_tau_representatives()
             sage: f = U[0][0]; f
@@ -3909,6 +3991,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: P = EllipticCurve('57a1').heegner_point(-8)
             sage: R, U = P._good_tau_representatives()
             sage: f = U[0][0]; f
@@ -3943,6 +4026,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: P = EllipticCurve('57a1').heegner_point(-8)
             sage: R, U = P._good_tau_representatives()
             sage: f = U[0][0]; f
@@ -3971,6 +4055,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: P = EllipticCurve('57a1').heegner_point(-8)
             sage: R, U = P._good_tau_representatives()
             sage: f = U[0][0]; f
@@ -3992,6 +4077,7 @@ class HeegnerPointOnEllipticCurve(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: y = EllipticCurve('389a').heegner_point(-7,5)
             sage: y.kolyvagin_cohomology_class(3)
             Kolyvagin cohomology class c(5) in H^1(K,E[3])
@@ -4011,6 +4097,7 @@ class KolyvaginPoint(HeegnerPoint):
 
     We create a few Kolyvagin points::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: EllipticCurve('11a1').kolyvagin_point(-7)
         Kolyvagin point of discriminant -7 on elliptic curve of conductor 11
         sage: EllipticCurve('37a1').kolyvagin_point(-7)
@@ -4023,6 +4110,7 @@ class KolyvaginPoint(HeegnerPoint):
 
     One can also associated a Kolyvagin point to a Heegner point::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: y = EllipticCurve('37a1').heegner_point(-7); y
         Heegner point of discriminant -7 on elliptic curve of conductor 37
         sage: y.kolyvagin_point()
@@ -4030,6 +4118,7 @@ class KolyvaginPoint(HeegnerPoint):
 
     TESTS::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: y = EllipticCurve('37a1').heegner_point(-7)
         sage: type(y)
         <class 'sage.schemes.elliptic_curves.heegner.HeegnerPointOnEllipticCurve'>
@@ -4048,6 +4137,7 @@ class KolyvaginPoint(HeegnerPoint):
 
         We directly construct a Kolyvagin point from the KolyvaginPoint class::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: y = EllipticCurve('37a1').heegner_point(-7)
             sage: sage.schemes.elliptic_curves.heegner.KolyvaginPoint(y)
             Kolyvagin point of discriminant -7 on elliptic curve of conductor 37
@@ -4066,6 +4156,7 @@ class KolyvaginPoint(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: y = EllipticCurve('389a').heegner_point(-7,5); P = y.kolyvagin_point()
             sage: P.kolyvagin_cohomology_class(3)
             Kolyvagin cohomology class c(5) in H^1(K,E[3])
@@ -4087,6 +4178,7 @@ class KolyvaginPoint(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1'); P = E.kolyvagin_point(-67, 3)
             sage: P.curve()
             Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field
@@ -4101,6 +4193,7 @@ class KolyvaginPoint(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: P = E.kolyvagin_point(-67); P
             Kolyvagin point of discriminant -67 on elliptic curve of conductor 37
@@ -4117,6 +4210,7 @@ class KolyvaginPoint(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1'); P = E.kolyvagin_point(-67,7); P._repr_()
             'Kolyvagin point of discriminant -67 and conductor 7 on elliptic curve of conductor 37'
         """
@@ -4135,6 +4229,7 @@ class KolyvaginPoint(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1'); P = E.kolyvagin_point(-67); P.index()
             6
         """
@@ -4153,6 +4248,7 @@ class KolyvaginPoint(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: P = EllipticCurve('37a1').kolyvagin_point(-7); P
             Kolyvagin point of discriminant -7 on elliptic curve of conductor 37
             sage: P.numerical_approx() # approx. (0 : 0 : 1)
@@ -4160,6 +4256,7 @@ class KolyvaginPoint(HeegnerPoint):
             sage: P.numerical_approx(100)[0].abs() < 2.0^-99
             True
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: P = EllipticCurve('389a1').kolyvagin_point(-7, 5); P
             Kolyvagin point of discriminant -7 and conductor 5
              on elliptic curve of conductor 389
@@ -4185,6 +4282,7 @@ class KolyvaginPoint(HeegnerPoint):
 
         A rank 1 curve::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1'); P = E.kolyvagin_point(-67)
             sage: P.point_exact()
             (6 : -15 : 1)
@@ -4197,12 +4295,14 @@ class KolyvaginPoint(HeegnerPoint):
 
         A rank 0 curve::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1'); P = E.kolyvagin_point(-7)
             sage: P.point_exact()
             (-1/2*sqrt_minus_7 + 1/2 : -2*sqrt_minus_7 - 2 : 1)
 
         A rank 2 curve::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a1'); P = E.kolyvagin_point(-7)
             sage: P.point_exact()
             (0 : 1 : 0)
@@ -4262,8 +4362,9 @@ class KolyvaginPoint(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a'); P = E.heegner_point(-11).kolyvagin_point()
-            sage: P.plot(prec=30, pointsize=50, rgbcolor='red') + E.plot()              # needs sage.plot
+            sage: P.plot(prec=30, pointsize=50, rgbcolor='red') + E.plot()  # needs sage.plot
             Graphics object consisting of 3 graphics primitives
         """
         from sage.plot.graphics import Graphics
@@ -4290,6 +4391,7 @@ class KolyvaginPoint(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1'); P = E.kolyvagin_point(-67)
             sage: PP = P.numerical_approx()
             sage: [c.real() for c in PP]
@@ -4327,6 +4429,7 @@ class KolyvaginPoint(HeegnerPoint):
 
         A Kolyvagin point on a rank 1 curve::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1'); P = E.kolyvagin_point(-67)
             sage: P.trace_to_real_numerical()
             (1.61355529131986 : -2.18446840788880 : 1.00000000000000)
@@ -4353,6 +4456,7 @@ class KolyvaginPoint(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('43a'); P = E.heegner_point(-20).kolyvagin_point()
             sage: PP = P.numerical_approx(); PP
             (0.000000000000000 : -1.00000000000000 : 1.00000000000000)
@@ -4389,6 +4493,7 @@ class KolyvaginPoint(HeegnerPoint):
 
         A Kolyvagin point on a rank 1 curve::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1'); P = E.kolyvagin_point(-67)
             sage: P.mod(2)
             (1 : 1 : 1)
@@ -4408,6 +4513,7 @@ class KolyvaginPoint(HeegnerPoint):
         Here the Kolyvagin point is a torsion point (since `E` has
         rank 1), and we reduce it modulo several primes.::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1'); P = E.kolyvagin_point(-7)
             sage: P.mod(3,70)  # long time (4s on sage.math, 2013)
             (1 : 2 : 1)
@@ -4471,11 +4577,13 @@ class KolyvaginPoint(HeegnerPoint):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: y = EllipticCurve('389a').heegner_point(-7, 5)
             sage: P = y.kolyvagin_point()
             sage: P.kolyvagin_cohomology_class(3)
             Kolyvagin cohomology class c(5) in H^1(K,E[3])
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: y = EllipticCurve('37a').heegner_point(-7, 5).kolyvagin_point()
             sage: y.kolyvagin_cohomology_class()
             Kolyvagin cohomology class c(5) in H^1(K,E[2])
@@ -4490,6 +4598,7 @@ class KolyvaginCohomologyClass(SageObject):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: y = EllipticCurve('37a').heegner_point(-7)
         sage: c = y.kolyvagin_cohomology_class(3); c
         Kolyvagin cohomology class c(1) in H^1(K,E[3])
@@ -4505,6 +4614,7 @@ class KolyvaginCohomologyClass(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: y = EllipticCurve('389a').heegner_point(-7, 5)
             sage: y.kolyvagin_cohomology_class(3)
             Kolyvagin cohomology class c(5) in H^1(K,E[3])
@@ -4523,6 +4633,7 @@ class KolyvaginCohomologyClass(SageObject):
         """
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: y = EllipticCurve('37a').heegner_point(-7)
             sage: c = y.kolyvagin_cohomology_class(3)
             sage: c == y.kolyvagin_cohomology_class(3)
@@ -4543,6 +4654,7 @@ class KolyvaginCohomologyClass(SageObject):
         """
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: y = EllipticCurve('37a').heegner_point(-7)
             sage: c = y.kolyvagin_cohomology_class(3)
             sage: c != y.kolyvagin_cohomology_class(3)
@@ -4559,6 +4671,7 @@ class KolyvaginCohomologyClass(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: y = EllipticCurve('37a').heegner_point(-7)
             sage: t = y.kolyvagin_cohomology_class(3); t
             Kolyvagin cohomology class c(1) in H^1(K,E[3])
@@ -4574,6 +4687,7 @@ class KolyvaginCohomologyClass(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: y = EllipticCurve('37a').heegner_point(-7, 5)
             sage: t = y.kolyvagin_cohomology_class()
             sage: t.conductor()
@@ -4588,6 +4702,7 @@ class KolyvaginCohomologyClass(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: y = EllipticCurve('37a').heegner_point(-7, 5)
             sage: t = y.kolyvagin_cohomology_class()
             sage: t.kolyvagin_point()
@@ -4603,6 +4718,7 @@ class KolyvaginCohomologyClass(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: y = EllipticCurve('37a').heegner_point(-7, 5)
             sage: t = y.kolyvagin_cohomology_class()
             sage: t.heegner_point()
@@ -4618,6 +4734,7 @@ class KolyvaginCohomologyClassEn(KolyvaginCohomologyClass):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: y = EllipticCurve('37a').heegner_point(-7, 5)
             sage: t = y.kolyvagin_cohomology_class()
             sage: t._repr_()
@@ -5390,6 +5507,7 @@ class HeegnerQuatAlg(SageObject):
         We first try to verify Kolyvagin's conjecture for a rank 2
         curve by working modulo 5, but we are unlucky with `c=17`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: N = 389; D = -7; ell = 5; c = 17; q = 3
             sage: H = heegner_points(N).reduce_mod(ell)
             sage: E = EllipticCurve('389a')
@@ -5421,6 +5539,7 @@ class HeegnerQuatAlg(SageObject):
 
         Another example, but where the curve has rank 1::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: N = 37; D = -7; ell = 17; c = 41; q = 3
             sage: H = heegner_points(N).reduce_mod(ell)
             sage: H.heegner_divisor(D,1).element().nonzero_positions()
@@ -5440,6 +5559,7 @@ class HeegnerQuatAlg(SageObject):
 
         An example with `c` a product of two primes::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: N = 389; D = -7; ell = 5; q = 3
             sage: H = heegner_points(N).reduce_mod(ell)
             sage: V = H.modp_dual_elliptic_curve_factor(EllipticCurve('389a'), q, 5)
@@ -5508,6 +5628,7 @@ class HeegnerQuatAlg(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: N = 37; D = -7; ell = 17; c = 41; q = 3
             sage: H = heegner_points(N).reduce_mod(ell)
             sage: V = H.modp_dual_elliptic_curve_factor(EllipticCurve('37a'), q, 5); V
@@ -5555,6 +5676,7 @@ class HeegnerQuatAlg(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: N = 389; D = -7; ell = 5; c = 17; q = 3
             sage: H = heegner_points(N).reduce_mod(ell)
             sage: k = H.rational_kolyvagin_divisor(D, c); k  # long time (5s on sage.math, 2013)
@@ -5603,6 +5725,7 @@ class HeegnerQuatAlg(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: N = 37; D = -7; ell = 17; c = 41; p = 3
             sage: H = heegner_points(N).reduce_mod(ell)
             sage: H.kolyvagin_point_on_curve(D, c, EllipticCurve('37a'), p)
@@ -5674,11 +5797,13 @@ def kolyvagin_reduction_data(E, q, first_only=True):
 
     A rank 1 example::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: kolyvagin_reduction_data(EllipticCurve('37a1'), 3)
         (17, -7, 1, 52)
 
     A rank 3 example::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: kolyvagin_reduction_data(EllipticCurve('5077a1'), 3)
         (11, -47, 5, 4234)
         sage: H = heegner_points(5077, -47)
@@ -5702,6 +5827,7 @@ def kolyvagin_reduction_data(E, q, first_only=True):
 
     The first rank 2 example::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: kolyvagin_reduction_data(EllipticCurve('389a'), 3)
         (5, -7, 1, 130)
         sage: kolyvagin_reduction_data(EllipticCurve('389a'), 3, first_only=False)
@@ -5709,11 +5835,13 @@ def kolyvagin_reduction_data(E, q, first_only=True):
 
     A large `q = 7`::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: kolyvagin_reduction_data(EllipticCurve('1143c1'), 7, first_only=False)
         (13, 83, -59, 3, 1536, 10496)
 
     Additive reduction::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: kolyvagin_reduction_data(EllipticCurve('2350g1'), 5, first_only=False)
         (19, 239, -311, 19, 6480, 85680)
     """
@@ -6272,6 +6400,7 @@ def satisfies_weak_heegner_hypothesis(N, D):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: s = sage.schemes.elliptic_curves.heegner.satisfies_weak_heegner_hypothesis
         sage: s(37,-7)
         True
@@ -6387,6 +6516,7 @@ def ell_heegner_point(self, D, c=ZZ.one(), f=None, check=True):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('37a')
         sage: E.heegner_discriminants_list(10)
         [-7, -11, -40, -47, -67, -71, -83, -84, -95, -104]
@@ -6413,6 +6543,7 @@ def ell_heegner_point(self, D, c=ZZ.one(), f=None, check=True):
 
     The Heegner hypothesis is checked::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('389a'); P = E.heegner_point(-5,7);
         Traceback (most recent call last):
         ...
@@ -6420,6 +6551,7 @@ def ell_heegner_point(self, D, c=ZZ.one(), f=None, check=True):
 
     We can specify the quadratic form::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: P = EllipticCurve('389a').heegner_point(-7, 5, (778,925,275)); P
         Heegner point of discriminant -7 and conductor 5
          on elliptic curve of conductor 389
@@ -6447,6 +6579,7 @@ def kolyvagin_point(self, D, c=ZZ.one(), check=True):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('37a1')
         sage: P = E.kolyvagin_point(-67); P
         Kolyvagin point of discriminant -67 on elliptic curve of conductor 37
@@ -6477,6 +6610,7 @@ def ell_heegner_discriminants(self, bound) -> list:
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E=EllipticCurve('11a')
         sage: E.heegner_discriminants(30)                     # indirect doctest
         [-7, -8, -19, -24]
@@ -6499,6 +6633,7 @@ def ell_heegner_discriminants_list(self, n) -> list:
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E=EllipticCurve('11a')
         sage: E.heegner_discriminants_list(4)                     # indirect doctest
         [-7, -8, -19, -24]
@@ -6537,12 +6672,14 @@ def heegner_point_height(self, D, prec=2, check_rank=True):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('11a')
         sage: E.heegner_point_height(-7)
         0.22227?
 
     Some higher rank examples::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('389a')
         sage: E.heegner_point_height(-7)
         0
@@ -6641,6 +6778,7 @@ def heegner_index(self, D, min_p=2, prec=5, descent_second_limit=12,
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('11a')
         sage: E.heegner_discriminants(50)
         [-7, -8, -19, -24, -35, -39, -40, -43]
@@ -6649,6 +6787,7 @@ def heegner_index(self, D, min_p=2, prec=5, descent_second_limit=12,
 
     ::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('37b')
         sage: E.heegner_discriminants(100)
         [-3, -4, -7, -11, -40, -47, -67, -71, -83, -84, -95]
@@ -6659,6 +6798,7 @@ def heegner_index(self, D, min_p=2, prec=5, descent_second_limit=12,
 
     ::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: EllipticCurve('675b').heegner_index(-11)
         3.0000?
 
@@ -6671,6 +6811,7 @@ def heegner_index(self, D, min_p=2, prec=5, descent_second_limit=12,
 
     The curve 681b returns the true index, which is `3`::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('681b')
         sage: I = E.heegner_index(-8); I
         3.0000?
@@ -6685,6 +6826,7 @@ def heegner_index(self, D, min_p=2, prec=5, descent_second_limit=12,
     which can be used to fine tune the 2-descent used to compute
     the regulator of the twist::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve([1,-1,0,-1228,-16267])
         sage: E.heegner_index(-8)
         Traceback (most recent call last):
@@ -6698,6 +6840,7 @@ def heegner_index(self, D, min_p=2, prec=5, descent_second_limit=12,
 
     Two higher rank examples (of ranks 2 and 3)::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('389a')
         sage: E.heegner_index(-7)
         +Infinity
@@ -6800,6 +6943,7 @@ def _adjust_heegner_index(self, a):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('11a1')
         sage: a = RIF(sqrt(2)) - RIF(1.4142135623730951)
         sage: E._adjust_heegner_index(a)
@@ -6856,6 +7000,7 @@ def heegner_index_bound(self, D=0, prec=5, max_height=None) -> tuple:
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('11a1')
         sage: E.heegner_index_bound()
         ([2], -7, 2)
@@ -6958,6 +7103,7 @@ def _heegner_index_in_EK(self, D):
 
     We compute the index for a rank 2 curve and found that it is 2::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('389a')
         sage: E._heegner_index_in_EK(-7)
         2
@@ -7071,6 +7217,7 @@ def heegner_sha_an(self, D, prec=53):
 
     An example where E has conductor 11::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('11a')
         sage: E.heegner_sha_an(-7)                                  # long time
         1.00000000000000
@@ -7094,6 +7241,7 @@ def heegner_sha_an(self, D, prec=53):
     quadratic imaginary field `K`; however, there is no Sha for `E`
     over `\QQ` or for the quadratic twist of `E`::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('37a')
         sage: E.heegner_sha_an(-40)                                 # long time
         4.00000000000000
@@ -7214,6 +7362,7 @@ def _heegner_forms_list(self, D, beta=None, expected_count=None) -> list:
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('37a')
         sage: E._heegner_forms_list(-7)
         [37*x^2 + 17*x*y + 2*y^2]
@@ -7226,6 +7375,7 @@ def _heegner_forms_list(self, D, beta=None, expected_count=None) -> list:
         sage: QQ[sqrt(-195)].class_number()
         4
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('389a')
         sage: E._heegner_forms_list(-7)
         [389*x^2 + 185*x*y + 22*y^2]
@@ -7269,6 +7419,7 @@ def _heegner_best_tau(self, D, prec=None):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('37a')
         sage: E._heegner_best_tau(-7)
         1/74*sqrt(-7) - 17/74
@@ -7291,6 +7442,7 @@ def satisfies_heegner_hypothesis(self, D):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('11a1')
         sage: E.satisfies_heegner_hypothesis(-7)
         True

--- a/src/sage/schemes/elliptic_curves/height.py
+++ b/src/sage/schemes/elliptic_curves/height.py
@@ -26,11 +26,11 @@ AUTHORS:
 #
 #                  https://www.gnu.org/licenses/
 ##############################################################################
-import numpy
-import math
 import bisect
-
+import math
 from itertools import product
+
+import numpy
 
 from sage.arith.functions import lcm
 from sage.arith.misc import factorial
@@ -1141,6 +1141,7 @@ class EllipticCurveCanonicalHeight:
 
         An example over `\QQ`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: v = QQ.places()[0]
             sage: L = E.period_lattice(v)
@@ -1204,6 +1205,7 @@ class EllipticCurveCanonicalHeight:
 
         An example over `\QQ`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: v = QQ.places()[0]
             sage: H = E.height_function()
@@ -1253,6 +1255,7 @@ class EllipticCurveCanonicalHeight:
 
         An example over `\QQ`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: v = QQ.places()[0]
             sage: H = E.height_function()
@@ -1303,6 +1306,7 @@ class EllipticCurveCanonicalHeight:
 
         An example over `\QQ`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: v = QQ.places()[0]
             sage: H = E.height_function()
@@ -1358,6 +1362,7 @@ class EllipticCurveCanonicalHeight:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: H = E.height_function()
             sage: H.tau(QQ.places()[0])
@@ -1392,7 +1397,7 @@ class EllipticCurveCanonicalHeight:
             sage: H.wp_c(QQ.places()[0])
             2.68744508779950
 
-            sage: # needs sage.rings.number_field
+            sage: # needs database_cremona_mini_ellcurve sage.rings.number_field
             sage: K.<i> = QuadraticField(-1)
             sage: E = EllipticCurve([0, 0, 0, 1 + 5*i, 3 + i])
             sage: H = E.height_function()
@@ -1431,6 +1436,7 @@ class EllipticCurveCanonicalHeight:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: L = E.period_lattice()
             sage: w1, w2 = L.normalised_basis()
@@ -1532,6 +1538,7 @@ class EllipticCurveCanonicalHeight:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: wp = E.height_function().wp_intervals()
             sage: z = CDF(0.3, 0.4)
@@ -1613,6 +1620,7 @@ class EllipticCurveCanonicalHeight:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: H = E.height_function()
             sage: v = QQ.places()[0]
@@ -1855,9 +1863,8 @@ class EllipticCurveCanonicalHeight:
                     if v(self.K.gen()) in RR:
                         if self.real_intersection_is_empty(Bk, v):
                             return True
-                    else:
-                        if self.complex_intersection_is_empty(Bk, v):
-                            return True
+                    elif self.complex_intersection_is_empty(Bk, v):
+                        return True
                     ok = True
                 except ArithmeticError:
                     v = refine_embedding(v)
@@ -2059,6 +2066,7 @@ class EllipticCurveCanonicalHeight:
 
         More examples over `\QQ`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: h = E.height_function()
             sage: h.min(.01, 5)
@@ -2072,6 +2080,7 @@ class EllipticCurveCanonicalHeight:
             sage: E.change_ring(K).height_function().min(0.5, 10)       # long time, needs sage.rings.number_field
             0.04419417382415922
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: h = E.height_function()
             sage: h.min(0.1, 5)

--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -213,6 +213,7 @@ class EllipticCurveHom(Morphism):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve(QQ, [0,0,0,1,0])
             sage: phi_v = EllipticCurveIsogeny(E, E((0,0)))
             sage: phi_k = EllipticCurveIsogeny(E, [0,1])
@@ -916,6 +917,7 @@ class EllipticCurveHom(Morphism):
         Check that the result is consistent with
         :meth:`~sage.schemes.elliptic_curves.ell_point.EllipticCurvePoint_field.division_points`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a'); E
             Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field
             sage: P = E(0, -1)
@@ -1058,6 +1060,7 @@ class EllipticCurveHom(Morphism):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a2')
             sage: R.<x> = QQ[]
             sage: phi = E.isogeny(x^2 + 101*x + 12751/5)
@@ -1134,6 +1137,7 @@ class EllipticCurveHom(Morphism):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: R.<x> = QQ[]
             sage: f = x^3 - x^2 - 10*x - 79/4
@@ -1217,6 +1221,7 @@ class EllipticCurveHom(Morphism):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: phi = EllipticCurveIsogeny(E, E.torsion_points())
             sage: phi.is_separable()
@@ -1289,6 +1294,7 @@ class EllipticCurveHom(Morphism):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: R.<x> = QQ[]
             sage: f = x^2 + x - 29/5
@@ -1323,6 +1329,7 @@ class EllipticCurveHom(Morphism):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: R.<x> = QQ[]
             sage: f = x^2 + x - 29/5
@@ -1450,6 +1457,7 @@ class EllipticCurveHom(Morphism):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('49a3')
             sage: R.<X> = QQ[]
             sage: EllipticCurveIsogeny(E,X^3-13*X^2-58*X+503,check=False)
@@ -1645,6 +1653,7 @@ class EllipticCurveHom(Morphism):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('54.b2')
             sage: K = next(T for T in E.torsion_points() if T.order() == 9)
             sage: phi, psi = E.isogeny(K).factors()
@@ -1675,6 +1684,7 @@ class EllipticCurveHom(Morphism):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('54.b2')
             sage: K = next(T for T in E.torsion_points() if T.order() == 9)
             sage: phi, psi = E.isogeny(K).factors()

--- a/src/sage/schemes/elliptic_curves/hom_composite.py
+++ b/src/sage/schemes/elliptic_curves/hom_composite.py
@@ -85,16 +85,16 @@ AUTHORS:
   documentation and tests, equality testing
 """
 
-from sage.structure.richcmp import op_EQ
-from sage.misc.cachefunc import cached_method
-from sage.structure.sequence import Sequence
-
 from sage.arith.misc import prod
-
+from sage.misc.cachefunc import cached_method
 from sage.schemes.elliptic_curves.ell_generic import EllipticCurve_generic
 from sage.schemes.elliptic_curves.hom import EllipticCurveHom, compare_via_evaluation
-from sage.schemes.elliptic_curves.ell_curve_isogeny import EllipticCurveIsogeny
-from sage.schemes.elliptic_curves.weierstrass_morphism import WeierstrassIsomorphism, identity_morphism
+from sage.schemes.elliptic_curves.weierstrass_morphism import (
+    WeierstrassIsomorphism,
+    identity_morphism,
+)
+from sage.structure.richcmp import op_EQ
+from sage.structure.sequence import Sequence
 
 
 def _eval_factored_isogeny(phis, P):
@@ -338,7 +338,7 @@ class EllipticCurveHom_composite(EllipticCurveHom):
 
         The given kernel generators need not be independent::
 
-            sage: # needs sage.rings.number_field
+            sage: # needs database_cremona_mini_ellcurve sage.rings.number_field
             sage: x = polygen(ZZ, 'x')
             sage: K.<a> = NumberField(x^2 - x - 5)
             sage: E = EllipticCurve('210.b6').change_ring(K)
@@ -470,6 +470,7 @@ class EllipticCurveHom_composite(EllipticCurveHom):
 
         TESTS::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('4730k1')
             sage: EllipticCurveHom_composite.from_factors([], E) == E.scalar_multiplication(1)
             True
@@ -513,7 +514,7 @@ class EllipticCurveHom_composite(EllipticCurveHom):
 
         TESTS::
 
-            sage: # needs sage.rings.number_field
+            sage: # needs database_cremona_mini_ellcurve sage.rings.number_field
             sage: from sage.schemes.elliptic_curves.hom_composite import EllipticCurveHom_composite
             sage: x = polygen(ZZ, 'x')
             sage: K.<a> = NumberField(x^2 - x - 5)

--- a/src/sage/schemes/elliptic_curves/hom_frobenius.py
+++ b/src/sage/schemes/elliptic_curves/hom_frobenius.py
@@ -137,6 +137,7 @@ TESTS::
 
 ::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: EllipticCurveHom_frobenius(EllipticCurve('11a1'))
     Traceback (most recent call last):
     ...
@@ -193,6 +194,7 @@ class EllipticCurveHom_frobenius(EllipticCurveHom):
 
         TESTS::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurveHom_frobenius(EllipticCurve('11a1'))
             Traceback (most recent call last):
             ...

--- a/src/sage/schemes/elliptic_curves/hom_scalar.py
+++ b/src/sage/schemes/elliptic_curves/hom_scalar.py
@@ -8,6 +8,7 @@ EXAMPLES:
 
 We can construct and evaluate scalar multiplications::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: from sage.schemes.elliptic_curves.hom_scalar import EllipticCurveHom_scalar
     sage: E = EllipticCurve('77a1')
     sage: phi = E.scalar_multiplication(5); phi
@@ -328,6 +329,7 @@ class EllipticCurveHom_scalar(EllipticCurveHom):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('77a1')
             sage: phi = E.scalar_multiplication(5)
             sage: phi.rational_maps()
@@ -391,6 +393,7 @@ class EllipticCurveHom_scalar(EllipticCurveHom):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: phi = E.scalar_multiplication(5)
             sage: u = phi.scaling_factor()

--- a/src/sage/schemes/elliptic_curves/hom_velusqrt.py
+++ b/src/sage/schemes/elliptic_curves/hom_velusqrt.py
@@ -91,6 +91,7 @@ Furthermore, the implementation is restricted to finite fields,
 since this appears to be the most relevant application for the
 square-root Vélu algorithm::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve('26b1')
     sage: P = E(1,0)
     sage: P.order()

--- a/src/sage/schemes/elliptic_curves/homset.py
+++ b/src/sage/schemes/elliptic_curves/homset.py
@@ -104,6 +104,7 @@ class EllipticCurveHomset(SchemeHomset_generic):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E1 = EllipticCurve(j=42)
             sage: E2 = EllipticCurve(j=43)
             sage: Hom(E1, E2)
@@ -164,6 +165,7 @@ class EllipticCurveHomset(SchemeHomset_generic):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E1 = EllipticCurve(j=42)
             sage: E2 = EllipticCurve(j=43)
             sage: Hom(E1, E1)._coerce_map_from_(ZZ)
@@ -183,6 +185,7 @@ class EllipticCurveHomset(SchemeHomset_generic):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E1 = EllipticCurve(j=42)
             sage: E2 = EllipticCurve(j=43)
             sage: Hom(E1, E1)(5)
@@ -238,6 +241,7 @@ class EllipticCurveHomset(SchemeHomset_generic):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve(j=42)
             sage: End(E).identity()
             Elliptic-curve endomorphism of Elliptic Curve defined by y^2 = x^3 + 5901*x + 1105454 over Rational Field
@@ -258,6 +262,7 @@ class EllipticCurveHomset(SchemeHomset_generic):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: End(EllipticCurve(j=123)).is_commutative()
             True
             sage: End(EllipticCurve(GF(11), [1,0])).is_commutative()

--- a/src/sage/schemes/elliptic_curves/isogeny_class.py
+++ b/src/sage/schemes/elliptic_curves/isogeny_class.py
@@ -61,6 +61,7 @@ class IsogenyClass_EC(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: cls = EllipticCurve('1011b1').isogeny_class()
             sage: print("\n".join(repr(E) for E in cls.curves))
             Elliptic Curve defined by y^2 + x*y = x^3 - 8*x - 9 over Rational Field
@@ -77,6 +78,7 @@ class IsogenyClass_EC(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('15a')
             sage: len(E.isogeny_class()) # indirect doctest
             8
@@ -89,6 +91,7 @@ class IsogenyClass_EC(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('15a')
             sage: all(C.conductor() == 15 for C in E.isogeny_class()) # indirect doctest
             True
@@ -101,6 +104,7 @@ class IsogenyClass_EC(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('990j1')
             sage: iso = E.isogeny_class(order='lmfdb') # orders lexicographically on a-invariants
             sage: iso[2] == E # indirect doctest
@@ -123,6 +127,7 @@ class IsogenyClass_EC(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('990j1')
             sage: iso = E.isogeny_class(order='lmfdb') # orders lexicographically on a-invariants
             sage: iso.index(E.short_weierstrass_model())
@@ -150,6 +155,7 @@ class IsogenyClass_EC(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('990j1')
             sage: EE = EllipticCurve('990j4')
             sage: E.isogeny_class() == EE.isogeny_class() # indirect doctest
@@ -167,6 +173,7 @@ class IsogenyClass_EC(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('990j1')
             sage: C = E.isogeny_class()
             sage: hash(C) == hash(tuple(sorted([curve.a_invariants() for curve in C.curves]))) # indirect doctest
@@ -195,6 +202,7 @@ class IsogenyClass_EC(SageObject):
         If the curve is constructed from an LMFDB label then that
         label is used::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('462.f3')
             sage: E.isogeny_class() # indirect doctest
             Elliptic curve isogeny class 462.f
@@ -202,6 +210,7 @@ class IsogenyClass_EC(SageObject):
         If the curve is constructed from a Cremona label then that
         label is used::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('990j1')
             sage: E.isogeny_class()
             Elliptic curve isogeny class 990j
@@ -246,6 +255,7 @@ class IsogenyClass_EC(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: cls = EllipticCurve('15a3').isogeny_class()
             sage: E = EllipticCurve('15a7'); E in cls
             True
@@ -270,6 +280,7 @@ class IsogenyClass_EC(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: isocls = EllipticCurve('15a3').isogeny_class()
             sage: isocls.matrix()
             [ 1  2  2  2  4  4  8  8]
@@ -357,6 +368,7 @@ class IsogenyClass_EC(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: isocls = EllipticCurve('15a3').isogeny_class()
             sage: f = isocls.isogenies()[0][1]; f
             Isogeny of degree 2
@@ -394,6 +406,7 @@ class IsogenyClass_EC(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: isocls = EllipticCurve('15a3').isogeny_class()
             sage: G = isocls.graph()
             sage: sorted(G._pos.items())
@@ -521,6 +534,7 @@ class IsogenyClass_EC(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: isocls = EllipticCurve('15a1').isogeny_class()
             sage: print("\n".join(repr(C) for C in isocls.curves))
             Elliptic Curve defined by y^2 + x*y + y = x^3 + x^2 - 10*x - 10 over Rational Field
@@ -974,6 +988,7 @@ class IsogenyClass_EC_NumberField(IsogenyClass_EC):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: isocls = EllipticCurve('1225h1').isogeny_class('database')
             sage: isocls._mat
             sage: isocls._compute_matrix(); isocls._mat
@@ -986,6 +1001,7 @@ class IsogenyClass_EC_NumberField(IsogenyClass_EC):
         """
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('15a1')
             sage: isocls = E.isogeny_class()
             sage: maps = isocls.isogenies() # indirect doctest
@@ -1025,6 +1041,7 @@ class IsogenyClass_EC_Rational(IsogenyClass_EC_NumberField):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: isocls = EllipticCurve('389a1').isogeny_class(); isocls
             Elliptic curve isogeny class 389a
             sage: E = EllipticCurve([0, 0, 0, 0, 1001]) # conductor 108216108
@@ -1044,6 +1061,7 @@ class IsogenyClass_EC_Rational(IsogenyClass_EC_NumberField):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: C = E.isogeny_class()
             sage: C2 = C.copy()
@@ -1068,6 +1086,7 @@ class IsogenyClass_EC_Rational(IsogenyClass_EC_NumberField):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: isocls = EllipticCurve('48a1').isogeny_class('sage').copy()
             sage: isocls._mat
             sage: isocls._compute(); isocls._mat
@@ -1387,6 +1406,7 @@ def possible_isogeny_degrees(E, algorithm='Billerey', max_l=None,
     Galois representation is reducible, i.e. contained in a Borel
     subgroup::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.isogeny_class import possible_isogeny_degrees
         sage: E = EllipticCurve('11a1')
         sage: possible_isogeny_degrees(E)

--- a/src/sage/schemes/elliptic_curves/isogeny_small_degree.py
+++ b/src/sage/schemes/elliptic_curves/isogeny_small_degree.py
@@ -268,6 +268,7 @@ def isogenies_prime_degree_genus_0(E, l=None, minimal_models=True):
         sage: isogenies_prime_degree_genus_0(E, 5)
         []
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('1450c1')
         sage: isogenies_prime_degree_genus_0(E)
         [Isogeny of degree 3
@@ -276,6 +277,7 @@ def isogenies_prime_degree_genus_0(E, l=None, minimal_models=True):
             to Elliptic Curve defined by y^2 + x*y = x^3 + x^2 - 5950*x - 182250
                over Rational Field]
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('50a1')
         sage: isogenies_prime_degree_genus_0(E)
         [Isogeny of degree 3
@@ -591,6 +593,7 @@ def isogenies_sporadic_Q(E, l=None, minimal_models=True):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.isogeny_small_degree import isogenies_sporadic_Q
         sage: E = EllipticCurve('121a1')
         sage: isogenies_sporadic_Q(E, 11)
@@ -735,6 +738,7 @@ def isogenies_2(E, minimal_models=True):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.isogeny_small_degree import isogenies_2
         sage: E = EllipticCurve('14a1'); E
         Elliptic Curve defined by y^2 + x*y + y = x^3 + 4*x - 6 over Rational Field
@@ -790,6 +794,7 @@ def isogenies_3(E, minimal_models=True):
         sage: [phi.codomain().ainvs() for phi in isogenies_3(E)]                        # needs sage.rings.finite_rings
         [(0, 0, 0, 9, 7), (0, 0, 0, 0, 1), (0, 0, 0, 5*a + 1, a + 13), (0, 0, 0, 12*a + 6, 16*a + 14)]
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('19a1')
         sage: [phi.codomain().ainvs() for phi in isogenies_3(E)]
         [(0, 1, 1, 1, 0), (0, 1, 1, -769, -8470)]
@@ -1133,9 +1138,10 @@ def isogenies_7_0(E, minimal_models=True):
 
     Examples over a number field::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.isogeny_small_degree import isogenies_7_0
-        sage: E = EllipticCurve('27a1').change_ring(QuadraticField(-3,'r'))             # needs sage.rings.number_field
-        sage: isogenies_7_0(E)                                                          # needs sage.rings.number_field
+        sage: E = EllipticCurve('27a1').change_ring(QuadraticField(-3,'r'))  # needs sage.rings.number_field
+        sage: isogenies_7_0(E)  # needs sage.rings.number_field
         [Isogeny of degree 7
           from Elliptic Curve defined by y^2 + y = x^3 + (-7) over Number Field in r
                with defining polynomial x^2 + 3 with r = 1.732050807568878?*I
@@ -1851,6 +1857,7 @@ def isogenies_prime_degree_genus_plus_0(E, l=None, minimal_models=True):
 
         sage: from sage.schemes.elliptic_curves.isogeny_small_degree import isogenies_prime_degree_genus_plus_0
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('121a1')
         sage: isogenies_prime_degree_genus_plus_0(E, 11)
         [Isogeny of degree 11
@@ -2461,16 +2468,17 @@ def isogenies_prime_degree_general(E, l, minimal_models=True):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.isogeny_small_degree import isogenies_prime_degree_general
-        sage: E = EllipticCurve_from_j(GF(2^6,'a')(1))                                  # needs sage.rings.finite_rings
-        sage: isogenies_prime_degree_general(E, 7)                                      # needs sage.rings.finite_rings
+        sage: E = EllipticCurve_from_j(GF(2^6,'a')(1))  # needs sage.rings.finite_rings
+        sage: isogenies_prime_degree_general(E, 7)  # needs sage.rings.finite_rings
         [Isogeny of degree 7
           from Elliptic Curve defined by y^2 + x*y = x^3 + 1
                over Finite Field in a of size 2^6
             to Elliptic Curve defined by y^2 + x*y = x^3 + x
                over Finite Field in a of size 2^6]
-        sage: E = EllipticCurve_from_j(GF(3^12,'a')(2))                                 # needs sage.rings.finite_rings
-        sage: isogenies_prime_degree_general(E, 17)                                     # needs sage.rings.finite_rings
+        sage: E = EllipticCurve_from_j(GF(3^12,'a')(2))  # needs sage.rings.finite_rings
+        sage: isogenies_prime_degree_general(E, 17)  # needs sage.rings.finite_rings
         [Isogeny of degree 17
           from Elliptic Curve defined by y^2 = x^3 + 2*x^2 + 2
                over Finite Field in a of size 3^12
@@ -2634,16 +2642,17 @@ def isogenies_prime_degree(E, l, minimal_models=True):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.isogeny_small_degree import isogenies_prime_degree
-        sage: E = EllipticCurve_from_j(GF(2^6,'a')(1))                                  # needs sage.rings.finite_rings
-        sage: isogenies_prime_degree(E, 7)                                              # needs sage.rings.finite_rings
+        sage: E = EllipticCurve_from_j(GF(2^6,'a')(1))  # needs sage.rings.finite_rings
+        sage: isogenies_prime_degree(E, 7)  # needs sage.rings.finite_rings
         [Isogeny of degree 7
           from Elliptic Curve defined by y^2 + x*y = x^3 + 1
                over Finite Field in a of size 2^6
             to Elliptic Curve defined by y^2 + x*y = x^3 + x
                over Finite Field in a of size 2^6]
-        sage: E = EllipticCurve_from_j(GF(3^12,'a')(2))                                 # needs sage.rings.finite_rings
-        sage: isogenies_prime_degree(E, 17)                                             # needs sage.rings.finite_rings
+        sage: E = EllipticCurve_from_j(GF(3^12,'a')(2))  # needs sage.rings.finite_rings
+        sage: isogenies_prime_degree(E, 17)  # needs sage.rings.finite_rings
         [Isogeny of degree 17
           from Elliptic Curve defined by y^2 = x^3 + 2*x^2 + 2
                over Finite Field in a of size 3^12

--- a/src/sage/schemes/elliptic_curves/kraus.py
+++ b/src/sage/schemes/elliptic_curves/kraus.py
@@ -71,6 +71,7 @@ def c4c6_nonsingular(c4, c6):
 
     Over `\QQ`::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.kraus import c4c6_nonsingular
         sage: c4c6_nonsingular(0,0)
         False
@@ -127,6 +128,7 @@ def c4c6_model(c4, c6, assume_nonsingular=False):
         Elliptic Curve defined by y^2 = x^3 + (4536*a+14148)*x + (-163728*a-474336)
          over Number Field in a with defining polynomial x^3 - 10
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: c4, c6 = EllipticCurve('389a1').c_invariants()
         sage: c4c6_model(c4,c6)
         Elliptic Curve defined by y^2 = x^3 - 7/3*x + 107/108 over Rational Field

--- a/src/sage/schemes/elliptic_curves/lseries_ell.py
+++ b/src/sage/schemes/elliptic_curves/lseries_ell.py
@@ -51,6 +51,7 @@ class Lseries_ell(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: L = E.lseries()
             sage: L.elliptic_curve ()
@@ -76,6 +77,7 @@ class Lseries_ell(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: L = E.lseries()
             sage: L.taylor_series(series_prec=3)   # abs tol 1e-14
@@ -90,6 +92,7 @@ class Lseries_ell(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: L = E.lseries()
             sage: L._repr_()
@@ -129,6 +132,7 @@ class Lseries_ell(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: L = E.lseries().dokchitser()
             sage: L(2)
@@ -147,6 +151,7 @@ class Lseries_ell(SageObject):
 
         TESTS::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: L = E.lseries().dokchitser(algorithm="zweistein")
             Traceback (most recent call last):
@@ -190,6 +195,7 @@ class Lseries_ell(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: a = E.lseries().sympow(2,16)   # not tested - requires precomputing "sympow('-new_data 2')"
             sage: a                              # not tested
@@ -224,6 +230,7 @@ class Lseries_ell(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: print(E.lseries().sympow_derivs(1,16,2))    # not tested -- requires precomputing "sympow('-new_data 2')"
             sympow 1.018 RELEASE  (c) Mark Watkins --- see README and COPYING for details
@@ -258,6 +265,7 @@ class Lseries_ell(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: E.lseries().zeros(2)
             [0.000000000, 5.00317001]
@@ -295,6 +303,7 @@ class Lseries_ell(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: E.lseries().zeros_in_interval(6, 10, 0.1)      # long time
             [(6.87039122, 0.248922780), (8.01433081, -0.140168533), (9.93309835, -0.129943029)]
@@ -326,6 +335,7 @@ class Lseries_ell(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: E.lseries().values_along_line(1, 0.5 + 20*I, 5)
             [(0.500000000, ...),
@@ -363,6 +373,7 @@ class Lseries_ell(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: vals = E.lseries().twist_values(1, -12, -4)
             sage: vals[0][0]
@@ -417,6 +428,7 @@ class Lseries_ell(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: E.lseries().twist_zeros(3, -4, -3)         # long time
             {-4: [1.60813783, 2.96144840, 3.89751747], -3: [2.06170900, 3.48216881, 4.45853219]}
@@ -476,6 +488,7 @@ class Lseries_ell(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: L, err = EllipticCurve('11a1').lseries().at1()
             sage: L, err
             (0.253804, 0.000181444)
@@ -498,6 +511,7 @@ class Lseries_ell(SageObject):
 
         Rank 1 through 3 elliptic curves::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: E.lseries().at1()
             (0.0000000, 0.000000)
@@ -625,12 +639,13 @@ class Lseries_ell(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
-            sage: E.lseries().deriv_at1()                                               # needs sage.symbolic
+            sage: E.lseries().deriv_at1()  # needs sage.symbolic
             (0.3059866, 0.000801045)
-            sage: E.lseries().deriv_at1(100)                                            # needs sage.symbolic
+            sage: E.lseries().deriv_at1(100)  # needs sage.symbolic
             (0.3059997738340523018204836833216764744526377745903, 1.52493e-45)
-            sage: E.lseries().deriv_at1(1000)                                           # needs sage.symbolic
+            sage: E.lseries().deriv_at1(1000)  # needs sage.symbolic
             (0.305999773834052301820483683321676474452637774590771998..., 2.75031e-449)
 
         With less numerical precision, the error is bounded by numerical accuracy::
@@ -646,13 +661,14 @@ class Lseries_ell(SageObject):
 
         Rank 2 and rank 3 elliptic curves::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a1')
-            sage: E.lseries().deriv_at1()                                               # needs sage.symbolic
+            sage: E.lseries().deriv_at1()  # needs sage.symbolic
             (0.0000000, 0.000000)
             sage: E = EllipticCurve((1, 0, 1, -131, 558))  # curve 59450i1
-            sage: E.lseries().deriv_at1()                                               # needs sage.symbolic
+            sage: E.lseries().deriv_at1()  # needs sage.symbolic
             (-0.00010911444, 0.142428)
-            sage: E.lseries().deriv_at1(4000)                                           # needs sage.symbolic
+            sage: E.lseries().deriv_at1(4000)  # needs sage.symbolic
             (6.990...e-50, 1.31318e-43)
         """
         sqrtN = sqrt(self.__E.conductor())
@@ -900,6 +916,7 @@ class Lseries_ell(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("5077a")
             sage: E.lseries().zero_sums()
             Zero sum estimator for L-function attached to

--- a/src/sage/schemes/elliptic_curves/mod_sym_num.pyx
+++ b/src/sage/schemes/elliptic_curves/mod_sym_num.pyx
@@ -60,6 +60,7 @@ The most likely usage for the code is through the functions
 ``modular_symbol`` with implementation set to "num" and through
 ``modular_symbol_numerical``::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve("5077a1")
     sage: M = E.modular_symbol(implementation='num')
     sage: M(0)
@@ -74,6 +75,7 @@ In more details. A numerical modular symbols ``M`` is created from an
 elliptic curve with a chosen ``sign`` (though the other sign will also be
 accessible, too)::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve([101,103])
     sage: E.conductor()
     35261176
@@ -126,6 +128,7 @@ example, a seemingly harmless command like ``M(1/2)`` would take a very
 very long time to return a value. However it is possible to compute them
 for smaller conductors::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve("664a1")
     sage: M = E.modular_symbol(implementation='num')
     sage: M(1/2)
@@ -134,6 +137,7 @@ for smaller conductors::
 The problem with non-unitary cusps is dealt with rather easily when one
 can twist to a semistable curve, like in this example::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: C = EllipticCurve("11a1")
     sage: E = C.quadratic_twist(101)
     sage: M = E.modular_symbol(implementation='num')
@@ -701,6 +705,7 @@ cdef class ModularSymbolNumerical:
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve("5077a1")
         sage: M = E.modular_symbol(implementation='num')
         sage: M(0)
@@ -713,6 +718,7 @@ cdef class ModularSymbolNumerical:
         sage: M(2/7)
         2
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.mod_sym_num \
         ....: import ModularSymbolNumerical
         sage: M = ModularSymbolNumerical(EllipticCurve("11a1"))
@@ -749,6 +755,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve([1,-1])
             sage: M = E.modular_symbol(implementation='num')
             sage: M(12/11) # indirect doctest
@@ -769,6 +776,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("27a1")
             sage: M = E. modular_symbol(implementation='num')
             sage: M(1/9)
@@ -819,6 +827,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("14a1")
             sage: M = E.modular_symbol(implementation='num')
             sage: M
@@ -833,6 +842,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("15a4")
             sage: M = E.modular_symbol(implementation='num')
             sage: M.elliptic_curve()
@@ -860,6 +870,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("36a1")
             sage: M = E.modular_symbol(implementation='num')
             sage: M(2/5)
@@ -867,6 +878,7 @@ cdef class ModularSymbolNumerical:
             sage: M(2/5, -1)
             1/2
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("54a1")
             sage: M = E.modular_symbol(implementation='num')
             sage: M(5/9)
@@ -927,6 +939,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("5077a1")
             sage: M = E.modular_symbol(implementation='num')
             sage: M.approximative_value(123/567)  # abs tol 1e-11
@@ -934,6 +947,7 @@ cdef class ModularSymbolNumerical:
             sage: M.approximative_value(123/567,prec=2) # abs tol 1e-9
             -4.00002815242902
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve([11,88])
             sage: E.conductor()
             1715296
@@ -999,6 +1013,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("20a2")
             sage: M = E.modular_symbol(implementation='num') #indirect doctest
         """
@@ -1020,6 +1035,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("240b3")
             sage: M = E.modular_symbol(implementation='num') #indirect doctest
         """
@@ -1155,6 +1171,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("63a2")
             sage: M = E.modular_symbol(implementation='num')
             sage: M(3/4, use_twist=True) # indirect doctest
@@ -1222,6 +1239,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.mod_sym_num \
             ....: import ModularSymbolNumerical
             sage: M = ModularSymbolNumerical(EllipticCurve("11a1"))
@@ -1271,6 +1289,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve([-11,13])
             sage: M = E.modular_symbol(implementation='num') #indirect doctest
         """
@@ -1301,6 +1320,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.mod_sym_num \
             ....: import ModularSymbolNumerical
             sage: M = ModularSymbolNumerical(EllipticCurve("11a1"))
@@ -1354,6 +1374,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("11a1")
             sage: M = E.modular_symbol(implementation='num')
             sage: M(0)
@@ -1390,6 +1411,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.mod_sym_num \
             ....: import ModularSymbolNumerical
             sage: I = ComplexField(53).0
@@ -1459,6 +1481,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.mod_sym_num \
             ....: import ModularSymbolNumerical
             sage: M = ModularSymbolNumerical(EllipticCurve("17a1"))
@@ -1517,6 +1540,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.mod_sym_num \
             ....: import ModularSymbolNumerical
             sage: M = ModularSymbolNumerical(EllipticCurve("37b2"))
@@ -1590,6 +1614,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from  sage.schemes.elliptic_curves.mod_sym_num \
             ....: import ModularSymbolNumerical
             sage: E = EllipticCurve([1,0,-1064,-1,0])
@@ -1668,6 +1693,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.mod_sym_num \
             ....: import ModularSymbolNumerical
             sage: M = ModularSymbolNumerical(EllipticCurve("11a2"))
@@ -1780,6 +1806,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("43a1")
             sage: M = E.modular_symbol(implementation='num')
             sage: M._kappa(3,4) # abs tol 1e-11
@@ -1889,6 +1916,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.mod_sym_num \
             ....: import ModularSymbolNumerical
             sage: E = EllipticCurve("37a1")
@@ -1900,6 +1928,7 @@ cdef class ModularSymbolNumerical:
             sage: m._from_ioo_to_r_approx(0/1,0.001)  # abs tol 1e-11
             -2.77555756156289e-17
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("37b1")
             sage: m = ModularSymbolNumerical(E)
             sage: m._from_ioo_to_r_approx(0/1,0.01)  # abs tol 1e-11
@@ -2033,6 +2062,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.mod_sym_num \
             ....: import ModularSymbolNumerical
             sage: M = ModularSymbolNumerical(EllipticCurve("11a1"))
@@ -2176,6 +2206,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.mod_sym_num \
             ....: import ModularSymbolNumerical
             sage: M = ModularSymbolNumerical(EllipticCurve("11a1"))
@@ -2186,6 +2217,7 @@ cdef class ModularSymbolNumerical:
             sage: M._from_r_to_rr_approx(0/1,2/5,0.001, "both", use_partials=1) # abs tol 1e-11
             1.90381395641933 - 1.45881661693850*I
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: M._from_r_to_rr_approx(1/11,1/7,0.001) # abs tol 1e-11
             -0.888446512995687 + 1.45881661693850*I
             sage: M._from_r_to_rr_approx(0/1,44/98761,0.001) # abs tol 1e-11
@@ -2193,6 +2225,7 @@ cdef class ModularSymbolNumerical:
             sage: M._from_r_to_rr_approx(0/1,123/456,0.0000001) # abs tol 1e-11
             1.26920930437008 - 2.91763323391590*I
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: M = ModularSymbolNumerical(EllipticCurve("389a1"))
             sage: M._from_r_to_rr_approx(0/1,1/5,0.0001, "both") # abs tol 1e-5
             -4.98042489791268 - 6.06124058444291e-8*I
@@ -2208,6 +2241,7 @@ cdef class ModularSymbolNumerical:
             sage: M._from_r_to_rr_approx(0/1, -7/3179, 0.001) # abs tol 1e-5 # long time
             -6.22753195853020 - 5.92219314384901*I
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve([91,127])
             sage: M = ModularSymbolNumerical(E)
             sage: M._from_r_to_rr_approx(7/11,14/75,0.01,"direct")
@@ -2345,6 +2379,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.mod_sym_num \
             ....: import ModularSymbolNumerical
             sage: M = ModularSymbolNumerical(EllipticCurve("11a1"))
@@ -2371,6 +2406,7 @@ cdef class ModularSymbolNumerical:
 
         This goes via i `\infty`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: M = ModularSymbolNumerical(EllipticCurve("5077a1"))
             sage: M._transportable_approx(0/1, -35/144, 0.001) # abs tol 1e-11
             -6.22753189644996 + 3.23405342839145e-7*I
@@ -2486,6 +2522,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.mod_sym_num \
             ....: import ModularSymbolNumerical
             sage: E = EllipticCurve("11a1")
@@ -2548,6 +2585,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.mod_sym_num \
             ....: import ModularSymbolNumerical
             sage: E = EllipticCurve("57a1")
@@ -2563,6 +2601,7 @@ cdef class ModularSymbolNumerical:
             sage: M._value_r_to_rr(174/179,-53/91,-1)
             -1
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve([91,127])
             sage: E.conductor()
             55196272
@@ -2613,11 +2652,13 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("11a1")
             sage: M = E.modular_symbol(implementation='num')
             sage: M.transportable_symbol(0/1,-2/7)
             -1/2
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("37a1")
             sage: M = E.modular_symbol(implementation='num')
             sage: M.transportable_symbol(0/1,-1/19)
@@ -2677,6 +2718,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.mod_sym_num \
             ....: import ModularSymbolNumerical
             sage: M = ModularSymbolNumerical(EllipticCurve("49a1"))
@@ -2741,6 +2783,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.mod_sym_num \
             ....: import ModularSymbolNumerical
             sage: E = EllipticCurve('37a1')
@@ -2869,6 +2912,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: M = E.modular_symbol(implementation='num')
             sage: M.manin_symbol(1,3)
@@ -2998,6 +3042,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.mod_sym_num \
             ....: import ModularSymbolNumerical
             sage: E = EllipticCurve('5077a1')
@@ -3009,17 +3054,20 @@ cdef class ModularSymbolNumerical:
             sage: M._evaluate(-1/4112)
             3
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: M = ModularSymbolNumerical(E)
             sage: M._evaluate(1/99999)
             -4/5
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: M = ModularSymbolNumerical(EllipticCurve("32a1"))
             sage: M._evaluate(3/5)
             -1/4
 
         Non-unitary examples::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: M = ModularSymbolNumerical(EllipticCurve("20a1"))
             sage: M._evaluate(1/2)
             -1/6
@@ -3134,6 +3182,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('5077a1')
             sage: M = E.modular_symbol(implementation='num')
             sage: M.all_values_for_one_denominator(7)
@@ -3143,6 +3192,7 @@ cdef class ModularSymbolNumerical:
             sage: M.all_values_for_one_denominator(3,-1)
             {1/3: 4, 2/3: -4}
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: M = E.modular_symbol(implementation='num')
             sage: M.all_values_for_one_denominator(12)
@@ -3233,6 +3283,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("735e4")
             sage: M = E.modular_symbol(implementation='num')
             sage: M(1/19, sign=-1, use_twist=False) #indirect doctest
@@ -3286,6 +3337,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.mod_sym_num \
             ....: import ModularSymbolNumerical
             sage: E = EllipticCurve('5077a1')
@@ -3295,6 +3347,7 @@ cdef class ModularSymbolNumerical:
             sage: m._evaluate_approx(1/17,0.000001) # abs tol 1e-11
             -9.01145713605445e-10 + 7.40274134212215*I
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: M = ModularSymbolNumerical(EllipticCurve([-12,79]))
             sage: M.elliptic_curve().conductor()
             287280
@@ -3388,12 +3441,14 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.mod_sym_num \
             ....: import ModularSymbolNumerical
             sage: M = ModularSymbolNumerical(EllipticCurve("20a1"))
             sage: M._symbol_non_unitary_approx(1/2,0.0001) # abs tol 1e-11
             -0.470729190326520 + 2.59052039079203e-16*I
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: M = ModularSymbolNumerical(EllipticCurve("49a1"))
             sage: M._symbol_non_unitary_approx(2/7,0.000000001) # abs tol 1e-11
             -0.483327926404308 + 0.548042354981878*I
@@ -3463,6 +3518,7 @@ cdef class ModularSymbolNumerical:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("735e4")
             sage: M = E.modular_symbol(implementation='num')
             sage: M.approximative_value(1/19, sign=-1, prec=20, use_twist=False) # indirect doctest abs tol 1e-11
@@ -3529,6 +3585,7 @@ def _test_init(E):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.mod_sym_num import _test_init
         sage: _test_init(EllipticCurve("11a1")) # abs tol 1e-11
         ({1: 1, 11: -1}, [1, -2, -1, -15, -12], [10, 2, 10, 2],
@@ -3549,6 +3606,7 @@ def _test_init(E):
         0.06346046521397768,
         0.7294083084692478])
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: _test_init(EllipticCurve("14a6")) # abs tol 1e-11
         ({1: 1, 2: 1, 7: -1, 14: -1},
          [1, -1, -2, 18, 0],
@@ -3558,6 +3616,7 @@ def _test_init(E):
           0.16511182967224025,
           0.6627456198412432])
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: _test_init(EllipticCurve("20a1")) # abs tol 1e-11
         ({1: 1, 2: -1, 4: -1, 5: 1, 10: -1, 20: -1},
         [1, 0, -2, -6, 0], [48, 48, 12, 2],
@@ -3572,6 +3631,7 @@ def _test_init(E):
         1.4967293231159797,
         0.6128473454966975])
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve([91,127])
         sage: E.conductor().factor()
         2^4 * 3449767
@@ -3630,6 +3690,7 @@ def _test_integration(E, a, b, T):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.mod_sym_num \
         ....: import _test_integration
         sage: E = EllipticCurve("11a1")
@@ -3671,6 +3732,7 @@ def _test_integration_via_partials(E, y, m, T):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.mod_sym_num \
         ....: import _test_integration_via_partials
         sage: E = EllipticCurve("11a1")

--- a/src/sage/schemes/elliptic_curves/modular_parametrization.py
+++ b/src/sage/schemes/elliptic_curves/modular_parametrization.py
@@ -13,6 +13,7 @@ The map sends the cusp `\infty` to the origin of `E`.
 
 EXAMPLES::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: phi = EllipticCurve('11a1').modular_parametrization()
     sage: phi
     Modular parameterization
@@ -43,12 +44,11 @@ AUTHORS:
 #                  http://www.gnu.org/licenses/
 ######################################################################
 
-from . import heegner
-
-from sage.rings.laurent_series_ring import LaurentSeriesRing
-from sage.rings.rational_field import RationalField
 from sage.rings.complex_mpfr import ComplexField
-from sage.rings.rational_field import QQ
+from sage.rings.laurent_series_ring import LaurentSeriesRing
+from sage.rings.rational_field import QQ, RationalField
+
+from . import heegner
 
 
 class ModularParameterization:
@@ -63,6 +63,7 @@ class ModularParameterization:
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: phi = EllipticCurve('11a1').modular_parametrization()
         sage: phi
         Modular parameterization
@@ -74,6 +75,7 @@ class ModularParameterization:
         r"""
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.ell_rational_field import ModularParameterization
             sage: phi = ModularParameterization(EllipticCurve('389a'))
             sage: phi(CC.0/5)
@@ -90,6 +92,7 @@ class ModularParameterization:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('15a')
             sage: phi = E.modular_parametrization()
             sage: phi.curve() is E
@@ -101,6 +104,7 @@ class ModularParameterization:
         """
         TESTS::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: phi = E.modular_parametrization()
             sage: phi
@@ -116,6 +120,7 @@ class ModularParameterization:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: phi = E.modular_parametrization()
             sage: phi == phi
@@ -132,6 +137,7 @@ class ModularParameterization:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: phi = E.modular_parametrization()
             sage: phi != phi
@@ -149,14 +155,16 @@ class ModularParameterization:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: phi = E.modular_parametrization()
-            sage: phi((sqrt(7)*I - 17)/74, 53)                                          # needs sage.symbolic
+            sage: phi((sqrt(7)*I - 17)/74, 53)  # needs sage.symbolic
             (...e-16 - ...e-16*I : ...e-16 + ...e-16*I : 1.00000000000000)
 
         Verify that the mapping is invariant under the action of `\Gamma_0(N)`
         on the upper half plane::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: phi = E.modular_parametrization()
             sage: tau = CC((1+1j)/5)
@@ -169,6 +177,7 @@ class ModularParameterization:
 
         We can also apply the modular parametrization to a Heegner point on `X_0(N)`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: H = heegner_points(389,-7,5); H
             All Heegner points of conductor 5 on X_0(389) associated to QQ[sqrt(-7)]
             sage: x = H[0]; x
@@ -210,7 +219,7 @@ class ModularParameterization:
 
         EXAMPLES::
 
-            sage: # needs sage.symbolic
+            sage: # needs database_cremona_mini_ellcurve sage.symbolic
             sage: E = EllipticCurve('37a'); phi = E.modular_parametrization()
             sage: x = polygen(ZZ, 'x')
             sage: tau = (sqrt(7)*I - 17)/74
@@ -270,6 +279,7 @@ class ModularParameterization:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a1')
             sage: phi = E.modular_parametrization()
             sage: X, Y = phi.power_series(prec=10)

--- a/src/sage/schemes/elliptic_curves/padic_lseries.py
+++ b/src/sage/schemes/elliptic_curves/padic_lseries.py
@@ -99,6 +99,7 @@ class pAdicLseries(SageObject):
 
     An ordinary example::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: e = EllipticCurve('389a')
         sage: L = e.padic_lseries(5)
         sage: L.series(0)
@@ -116,6 +117,7 @@ class pAdicLseries(SageObject):
 
     A prime p such that E[p] is reducible::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: L = EllipticCurve('11a').padic_lseries(5)
         sage: L.series(1)
         5 + O(5^2) + O(T)
@@ -126,6 +128,7 @@ class pAdicLseries(SageObject):
 
     An example showing the calculation of nontrivial Teichmueller twists::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('11a1')
         sage: lp = E.padic_lseries(7)
         sage: lp.series(4,eta=1)
@@ -146,6 +149,7 @@ class pAdicLseries(SageObject):
 
     The load-dumps test::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: lp = EllipticCurve('11a').padic_lseries(5)
         sage: lp == loads(dumps(lp))
         True
@@ -166,6 +170,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: Lp = E.padic_lseries(3)
             sage: Lp.series(2,prec=3)
@@ -201,6 +206,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: lp = E.padic_lseries(5)
             sage: lp.modular_symbol(1/7,sign=-1)  #indirect doctest
@@ -214,6 +220,7 @@ class pAdicLseries(SageObject):
 
         TESTS::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: lp1 = EllipticCurve('11a1').padic_lseries(5)
             sage: lp2 = EllipticCurve('11a1').padic_lseries(7)
             sage: lp3 = EllipticCurve('11a2').padic_lseries(5)
@@ -234,6 +241,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: L = EllipticCurve('11a').padic_lseries(5)
             sage: L.elliptic_curve()
             Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
@@ -246,6 +254,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: L = EllipticCurve('11a').padic_lseries(5)
             sage: L.prime()
             5
@@ -258,6 +267,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: e = EllipticCurve('37a')
             sage: e.padic_lseries(3)._repr_()
             '3-adic L-series of Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field'
@@ -297,6 +307,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: lp = E.padic_lseries(5)
             sage: [lp.modular_symbol(r) for r in [0,1/5,oo,1/11]]
@@ -306,6 +317,7 @@ class pAdicLseries(SageObject):
             sage: [lp.modular_symbol(r,quadratic_twist=-20) for r in [0,1/5,oo,1/11]]
             [1, 1, 0, 1/2]
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('20a1')
             sage: Et = E.quadratic_twist(-4)
             sage: lpt = Et.padic_lseries(5)
@@ -386,6 +398,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: L = E.padic_lseries(5)
             sage: L.measure(1,2, prec=9)
@@ -395,6 +408,7 @@ class pAdicLseries(SageObject):
             sage: L.measure(1,2, quadratic_twist=-4,prec=15)
             4 + 4*5 + 4*5^2 + 3*5^3 + 2*5^4 + 5^5 + 3*5^6 + 5^8 + 2*5^9 + 3*5^12 + 2*5^13 + 4*5^14 + O(5^15)
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: a = E.quadratic_twist(-3).padic_lseries(5).measure(1,2,prec=15)
             sage: b = E.padic_lseries(5).measure(1,2, quadratic_twist=-3,prec=15)
@@ -459,6 +473,7 @@ class pAdicLseries(SageObject):
 
         Consider the elliptic curve 37a::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
 
         An ordinary prime::
@@ -479,6 +494,7 @@ class pAdicLseries(SageObject):
 
         A reducible prime::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: L = EllipticCurve('11a').padic_lseries(5)
             sage: L.alpha(5)
             1 + 4*5 + 3*5^2 + 2*5^3 + 4*5^4 + O(5^5)
@@ -532,6 +548,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: L = EllipticCurve('11a').padic_lseries(3)
             sage: L.order_of_vanishing()
             0
@@ -591,6 +608,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: L = EllipticCurve('11a').padic_lseries(7)
             sage: L.teichmuller(1)
             [0, 1, 2, 3, 4, 5, 6]
@@ -610,6 +628,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: Lp = E.padic_lseries(2)
             sage: Lp._e_bounds(1,10)
@@ -639,6 +658,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: Lp = E.padic_lseries(5)
             sage: Lp._pAdicLseries__series = {}  # clear cached series
@@ -666,6 +686,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: Lp = E.padic_lseries(5)
             sage: Lp.series(3,prec=5)
@@ -691,6 +712,7 @@ class pAdicLseries(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37b1')
             sage: lp = E.padic_lseries(3)
             sage: lp._quotient_of_periods_to_twist(-20)
@@ -708,6 +730,7 @@ class pAdicLseries(SageObject):
             sage: lp._quotient_of_periods_to_twist(12)
             1
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: Et = E.quadratic_twist(-3)
             sage: lpt = Et.padic_lseries(5)
@@ -768,6 +791,7 @@ class pAdicLseriesOrdinary(pAdicLseries):
         We compute some `p`-adic `L`-functions associated to the elliptic
         curve 11a::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: p = 3
             sage: E.is_ordinary(p)
@@ -780,6 +804,7 @@ class pAdicLseriesOrdinary(pAdicLseries):
         `p`-adic `L`-function has an extra 0 (compared to the non
         `p`-adic `L`-function)::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a')
             sage: p = 11
             sage: E.is_ordinary(p)
@@ -790,6 +815,7 @@ class pAdicLseriesOrdinary(pAdicLseries):
 
         We compute a `p`-adic `L`-function that vanishes to order 2::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: p = 3
             sage: E.is_ordinary(p)
@@ -812,6 +838,7 @@ class pAdicLseriesOrdinary(pAdicLseries):
         Rather than computing the `p`-adic `L`-function for the curve '15523a1', one can
         compute it as a quadratic_twist::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('43a1')
             sage: lp = E.padic_lseries(3)
             sage: lp.series(2,quadratic_twist=-19)
@@ -823,6 +850,7 @@ class pAdicLseriesOrdinary(pAdicLseries):
 
         We calculate the `L`-series in the nontrivial Teichmueller components::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: L = EllipticCurve('110a1').padic_lseries(5, implementation='sage')
             sage: for j in [0..3]: print(L.series(4, eta=j))
             O(5^6) + (2 + 2*5 + 2*5^2 + O(5^3))*T + (5 + 5^2 + O(5^3))*T^2 + (4 + 4*5 + 2*5^2 + O(5^3))*T^3 + (1 + 5 + 3*5^2 + O(5^3))*T^4 + O(T^5)
@@ -832,11 +860,13 @@ class pAdicLseriesOrdinary(pAdicLseries):
 
         It should now also work with `p=2` (:issue:`20798`)::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("53a1")
             sage: lp = E.padic_lseries(2)
             sage: lp.series(7)
             O(2^8) + (1 + 2^2 + 2^3 + O(2^5))*T + (1 + 2^3 + O(2^4))*T^2 + (2^2 + 2^3 + O(2^4))*T^3 + (2 + 2^2 + O(2^3))*T^4 + O(T^5)
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("109a1")
             sage: lp = E.padic_lseries(2)
             sage: lp.series(6)
@@ -844,6 +874,7 @@ class pAdicLseriesOrdinary(pAdicLseries):
 
         Check that twists by odd Teichmuller characters are ok (:issue:`32258`)::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("443c1")
             sage: lp = E.padic_lseries(17, implementation='num')
             sage: l8 = lp.series(2,eta=8,prec=3)
@@ -984,6 +1015,7 @@ class pAdicLseriesOrdinary(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: L = EllipticCurve('11a').padic_lseries(5)
             sage: L.is_ordinary()
             True
@@ -997,6 +1029,7 @@ class pAdicLseriesOrdinary(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: L = EllipticCurve('11a').padic_lseries(5)
             sage: L.is_supersingular()
             False
@@ -1021,6 +1054,7 @@ class pAdicLseriesOrdinary(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: Lp = E.padic_lseries(5)
             sage: Lp._c_bound()
@@ -1118,6 +1152,7 @@ class pAdicLseriesOrdinary(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: Lp = E.padic_lseries(5)
             sage: Lp._prec_bounds(3,10)
@@ -1180,6 +1215,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         A supersingular example, where we must compute to higher precision to see anything::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: e = EllipticCurve('37a')
             sage: L = e.padic_lseries(3); L
             3-adic L-series of Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field
@@ -1192,6 +1228,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         An example where we only compute the leading term (:issue:`15737`)::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("17a1")
             sage: L = E.padic_lseries(3)
             sage: L.series(4,prec=1)
@@ -1199,6 +1236,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         It works also for `p=2`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("11a1")
             sage: lp = E.padic_lseries(2)
             sage: lp.series(10)
@@ -1322,6 +1360,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: L = EllipticCurve('11a').padic_lseries(19)
             sage: L.is_ordinary()
             False
@@ -1335,6 +1374,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: L = EllipticCurve('11a').padic_lseries(19)
             sage: L.is_supersingular()
             True
@@ -1350,6 +1390,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: Lp = E.padic_lseries(19)
             sage: Lp._prec_bounds(3,5)
@@ -1373,6 +1414,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("14a1")
             sage: lp = E.padic_lseries(5)
             sage: K = lp.alpha().parent()
@@ -1419,6 +1461,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a')
             sage: L = E.padic_lseries(5)
             sage: L.Dp_valued_series(4)  # long time (9s on sage.math, 2011)
@@ -1464,6 +1507,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a')
             sage: L = E.padic_lseries(5)
             sage: phi = L.frobenius(5)
@@ -1526,12 +1570,14 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: lp = E.padic_lseries(19)
             sage: lp.frobenius(prec=1,algorithm='approx')   #indirect doctest
             [          O(19^0) 4*19^-1 + O(19^0)]
             [       14 + O(19)           O(19^0)]
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('17a1')
             sage: lp = E.padic_lseries(3)
             sage: lp.frobenius(prec=3,algorithm='approx')
@@ -1613,6 +1659,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('14a')
             sage: L = E.padic_lseries(5)
             sage: L.bernardi_sigma_function(prec=5) # Todo: some sort of consistency check!?
@@ -1652,6 +1699,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('53a')
             sage: L = E.padic_lseries(5)
             sage: h = L.Dp_valued_height(7)
@@ -1708,6 +1756,7 @@ class pAdicLseriesSupersingular(pAdicLseries):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('43a')
             sage: L = E.padic_lseries(7)
             sage: L.Dp_valued_regulator(7)

--- a/src/sage/schemes/elliptic_curves/padics.py
+++ b/src/sage/schemes/elliptic_curves/padics.py
@@ -55,6 +55,7 @@ def __check_padic_hypotheses(self, p):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('11a1')
         sage: from sage.schemes.elliptic_curves.padics import __check_padic_hypotheses
         sage: __check_padic_hypotheses(E,5)
@@ -131,6 +132,7 @@ def padic_lseries(self, p, normalize=None, implementation='eclib',
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('37a')
         sage: L = E.padic_lseries(5); L
         5-adic L-series of Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field
@@ -141,6 +143,7 @@ def padic_lseries(self, p, normalize=None, implementation='eclib',
     rank `0` and in each case verify the interpolation property
     for their leading coefficient (i.e., value at 0)::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: e = EllipticCurve('11a')
         sage: ms = e.modular_symbol()
         sage: [ms(1/11), ms(1/3), ms(0), ms(oo)]
@@ -166,6 +169,7 @@ def padic_lseries(self, p, normalize=None, implementation='eclib',
 
     Next consider the curve 37b::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: e = EllipticCurve('37b')
         sage: L = e.padic_lseries(3)
         sage: P = L.series(5)
@@ -180,6 +184,7 @@ def padic_lseries(self, p, normalize=None, implementation='eclib',
 
     We can use Sage modular symbols instead to compute the `L`-series::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: e = EllipticCurve('11a')
         sage: L = e.padic_lseries(3, implementation = 'sage')
         sage: L.series(5,prec=10)
@@ -188,6 +193,7 @@ def padic_lseries(self, p, normalize=None, implementation='eclib',
     Also the numerical modular symbols can be used.
     This may allow for much larger conductor in some instances::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve([101,103])
         sage: L = E.padic_lseries(5, implementation='num')
         sage: L.series(2)
@@ -195,6 +201,7 @@ def padic_lseries(self, p, normalize=None, implementation='eclib',
 
     Finally, we can use the overconvergent method of Pollack-Stevens.::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: e = EllipticCurve('11a')
         sage: L = e.padic_lseries(3, implementation = 'pollackstevens', precision = 6)
         sage: L.series(5)
@@ -204,6 +211,7 @@ def padic_lseries(self, p, normalize=None, implementation='eclib',
 
     Another example with a semistable prime.::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve("11a1")
         sage: L = E.padic_lseries(11, implementation = 'pollackstevens', precision=3)
         sage: L[1]
@@ -271,6 +279,7 @@ def padic_regulator(self, p, prec=20, height=None, check_hypotheses=True):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve("37a")
         sage: E.padic_regulator(5, 10)
         5 + 5^2 + 5^3 + 3*5^6 + 4*5^7 + 5^9 + O(5^10)
@@ -282,6 +291,7 @@ def padic_regulator(self, p, prec=20, height=None, check_hypotheses=True):
 
     An anomalous case where the precision drops some::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve("5077a")
         sage: E.padic_regulator(5, 10)
         5 + 5^2 + 4*5^3 + 2*5^4 + 2*5^5 + 2*5^6 + 4*5^7 + 2*5^8 + 5^9 + O(5^10)
@@ -296,12 +306,14 @@ def padic_regulator(self, p, prec=20, height=None, check_hypotheses=True):
     A case where the generator belongs to the formal group already
     (:issue:`3632`)::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve([37,0])
         sage: E.padic_regulator(5,10)
         2*5^2 + 2*5^3 + 5^4 + 5^5 + 4*5^6 + 3*5^8 + 4*5^9 + O(5^10)
 
     The result is not dependent on the model for the curve::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve([0,0,0,0,2^12*17])
         sage: Em = E.minimal_model()
         sage: E.padic_regulator(7) == Em.padic_regulator(7)
@@ -309,6 +321,7 @@ def padic_regulator(self, p, prec=20, height=None, check_hypotheses=True):
 
     Allow a python int as input::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('37a')
         sage: E.padic_regulator(int(5))
         5 + 5^2 + 5^3 + 3*5^6 + 4*5^7 + 5^9 + 5^10 + 3*5^11 + 3*5^12 + 5^13 + 4*5^14 + 5^15 + 2*5^16 + 5^17 + 2*5^18 + 4*5^19 + O(5^20)
@@ -372,12 +385,14 @@ def padic_height_pairing_matrix(self, p, prec=20, height=None, check_hypotheses=
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve("37a")
         sage: E.padic_height_pairing_matrix(5, 10)
         [5 + 5^2 + 5^3 + 3*5^6 + 4*5^7 + 5^9 + O(5^10)]
 
     A rank two example::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: e =EllipticCurve('389a')
         sage: e._set_gens([e(-1, 1), e(1,0)])  # avoid platform dependent gens
         sage: e.padic_height_pairing_matrix(5,10)
@@ -386,6 +401,7 @@ def padic_height_pairing_matrix(self, p, prec=20, height=None, check_hypotheses=
 
     An anomalous rank 3 example::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: e = EllipticCurve("5077a")
         sage: e._set_gens([e(-1,3), e(2,0), e(4,6)])
         sage: e.padic_height_pairing_matrix(5,4)
@@ -464,6 +480,7 @@ def _multiply_point(E, R, P, m):
     37a has trivial Tamagawa numbers so all points have nonsingular
     reduction at all primes::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve("37a")
         sage: P = E([0, -1]); P
         (0 : -1 : 1)
@@ -494,6 +511,7 @@ def _multiply_point(E, R, P, m):
     Test over a range of `n` for a single curve with fairly
     random coefficients::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: R = Integers(625)
         sage: E = EllipticCurve([4, -11, 17, -8, -10])
         sage: P = E.gens()[0] * LCM(E.tamagawa_numbers())
@@ -707,6 +725,7 @@ def padic_height(self, p, prec=20, sigma=None, check_hypotheses=True):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve("37a")
         sage: P = E.gens()[0]
         sage: h = E.padic_height(5, 10)
@@ -738,6 +757,7 @@ def padic_height(self, p, prec=20, sigma=None, check_hypotheses=True):
 
     A supersingular prime for a curve::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('37a')
         sage: E.is_supersingular(3)
         True
@@ -751,6 +771,7 @@ def padic_height(self, p, prec=20, sigma=None, check_hypotheses=True):
 
     A torsion point in both the good and supersingular cases::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('11a')
         sage: P = E.torsion_subgroup().gen(0).element(); P
         (5 : 5 : 1)
@@ -763,6 +784,7 @@ def padic_height(self, p, prec=20, sigma=None, check_hypotheses=True):
 
     The result is not dependent on the model for the curve::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve([0,0,0,0,2^12*17])
         sage: Em = E.minimal_model()
         sage: P = E.gens()[0]
@@ -776,6 +798,7 @@ def padic_height(self, p, prec=20, sigma=None, check_hypotheses=True):
 
     Check that issue :issue:`20798` is solved::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve("91b")
         sage: h = E.padic_height(7,10)
         sage: P = E.gen(0)
@@ -902,6 +925,7 @@ def padic_height_via_multiply(self, p, prec=20, E2=None, check_hypotheses=True):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve("37a")
         sage: P = E.gens()[0]
         sage: h = E.padic_height_via_multiply(5, 10)
@@ -1069,6 +1093,7 @@ def padic_sigma(self, p, N=20, E2=None, check=False, check_hypotheses=True):
 
     Run it with a consistency check::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: EllipticCurve("37a").padic_sigma(5, 10, check=True)
         O(5^11) + (1 + O(5^10))*t + O(5^9)*t^2 + (3 + 2*5^2 + 3*5^3 + 3*5^6 + 4*5^7 + O(5^8))*t^3 + (3 + 2*5 + 2*5^2 + 2*5^3 + 2*5^4 + 2*5^5 + 2*5^6 + O(5^7))*t^4 + (2 + 4*5^2 + 4*5^3 + 5^4 + 5^5 + O(5^6))*t^5 + (2 + 3*5 + 5^4 + O(5^5))*t^6 + (4 + 3*5 + 2*5^2 + O(5^4))*t^7 + (2 + 3*5 + 2*5^2 + O(5^3))*t^8 + (4*5 + O(5^2))*t^9 + (1 + O(5))*t^10 + O(t^11)
 
@@ -1081,6 +1106,7 @@ def padic_sigma(self, p, N=20, E2=None, check=False, check_hypotheses=True):
 
     Supply your very own value of E2::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: X = EllipticCurve("37a")
         sage: my_E2 = X.padic_E2(5, 8)
         sage: my_E2 = my_E2 + 5**5    # oops!!!
@@ -1599,6 +1625,7 @@ def matrix_of_frobenius(self, p, prec=20, check=False, check_hypotheses=True, al
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('37a1')
         sage: E.matrix_of_frobenius(7)
         [             2*7 + 4*7^2 + 5*7^4 + 6*7^5 + 6*7^6 + 7^8 + 4*7^9 + 3*7^10 + 2*7^11 + 5*7^12 + 4*7^14 + 7^16 + 2*7^17 + 3*7^18 + 4*7^19 + 3*7^20 + O(7^21)                                   2 + 3*7 + 6*7^2 + 7^3 + 3*7^4 + 5*7^5 + 3*7^7 + 7^8 + 3*7^9 + 6*7^13 + 7^14 + 7^16 + 5*7^17 + 4*7^18 + 7^19 + O(7^20)]

--- a/src/sage/schemes/elliptic_curves/period_lattice.py
+++ b/src/sage/schemes/elliptic_curves/period_lattice.py
@@ -73,7 +73,7 @@ upper half plane::
 
 We test that bug :issue:`8415` (caused by a PARI bug fixed in v2.3.5) is OK::
 
-    sage: # needs sage.rings.number_field
+    sage: # needs database_cremona_mini_ellcurve sage.rings.number_field
     sage: E = EllipticCurve('37a')
     sage: K.<a> = QuadraticField(-7)
     sage: EK = E.change_ring(K)
@@ -107,7 +107,6 @@ AUTHORS:
 """
 
 import sage.rings.abc
-
 from sage.categories.morphism import IdentityMorphism
 from sage.misc.cachefunc import cached_method
 from sage.misc.lazy_import import lazy_import
@@ -119,7 +118,7 @@ from sage.rings.qqbar import AA, QQbar
 from sage.rings.rational_field import QQ
 from sage.rings.real_mpfr import RealField, RealNumber
 from sage.schemes.elliptic_curves.constructor import EllipticCurve
-from sage.structure.richcmp import richcmp_method, richcmp, richcmp_not_equal
+from sage.structure.richcmp import richcmp, richcmp_method, richcmp_not_equal
 
 lazy_import('sage.libs.pari', 'pari')
 lazy_import('sage.rings.number_field.number_field', 'refine_embedding')
@@ -174,6 +173,7 @@ class PeriodLattice_ell(PeriodLattice):
         called by the period_lattice() function of classes
         ell_number_field and ell_rational_field::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.period_lattice import PeriodLattice_ell
             sage: E = EllipticCurve('37a')
             sage: PeriodLattice_ell(E)
@@ -332,6 +332,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: E.period_lattice()
             Period lattice associated to Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field
@@ -377,6 +378,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: L = E.period_lattice()
             sage: E.discriminant() > 0
@@ -401,6 +403,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         An example with negative discriminant, and a torsion point::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: L = E.period_lattice()
             sage: E.discriminant() < 0
@@ -444,12 +447,14 @@ class PeriodLattice_ell(PeriodLattice):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: E.period_lattice().basis()
             (2.99345864623196, 2.45138938198679*I)
 
         This shows that the issue reported at :issue:`3954` is fixed::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: b1 = E.period_lattice().basis(prec=30)
             sage: b2 = E.period_lattice().basis(prec=30)
@@ -458,6 +463,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         This shows that the issue reported at :issue:`4064` is fixed::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: E.period_lattice().basis(prec=30)[0].parent()
             Real Field with 30 bits of precision
@@ -528,6 +534,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: E.period_lattice().gens()
             (2.99345864623196, 2.45138938198679*I)
@@ -563,6 +570,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: E.period_lattice().normalised_basis()
             (2.99345864623196, -2.45138938198679*I)
@@ -618,6 +626,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: L = E.period_lattice()
             sage: L.tau()
@@ -813,6 +822,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: f = EllipticCurve('11a')
             sage: f.period_lattice().is_real()
             True
@@ -853,6 +863,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: f = EllipticCurve('11a')
             sage: f.period_lattice().basis()
             (1.26920930427955, 0.634604652139777 + 1.45881661693850*I)
@@ -861,6 +872,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: f = EllipticCurve('37b')
             sage: f.period_lattice().basis()
             (1.08852159290423, 1.76761067023379*I)
@@ -898,6 +910,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: E.period_lattice().real_period()
             2.99345864623196
@@ -947,6 +960,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: E.period_lattice().omega()
             5.98691729246392
@@ -1019,6 +1033,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: E.period_lattice().basis_matrix()
             [ 2.99345864623196 0.000000000000000]
@@ -1038,6 +1053,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         See :issue:`4388`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: L = EllipticCurve('11a1').period_lattice()
             sage: L.basis_matrix()
             [ 1.26920930427955 0.000000000000000]
@@ -1048,6 +1064,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         ::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: L = EllipticCurve('389a1').period_lattice()
             sage: L.basis_matrix()
             [ 2.49021256085505 0.000000000000000]
@@ -1078,6 +1095,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: E.period_lattice().complex_area()
             7.33813274078958
@@ -1129,6 +1147,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('389a1').period_lattice().sigma(CC(2,1))
             2.60912163570108 - 0.200865080824587*I
         """
@@ -1145,6 +1164,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: L = E.period_lattice()
             sage: L.curve() is E
@@ -1205,6 +1225,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: L = E.period_lattice()
             sage: L.ei()
@@ -1265,6 +1286,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: L = E.period_lattice()
             sage: w1, w2 = L.basis(prec=100)
@@ -1287,15 +1309,14 @@ class PeriodLattice_ell(PeriodLattice):
         if isinstance(C, sage.rings.abc.RealField):
             C = ComplexField(C.precision())
             z = C(z)
+        elif isinstance(C, sage.rings.abc.ComplexField):
+            pass
         else:
-            if isinstance(C, sage.rings.abc.ComplexField):
-                pass
-            else:
-                try:
-                    C = ComplexField()
-                    z = C(z)
-                except TypeError:
-                    raise TypeError("%s is not a complex number" % z)
+            try:
+                C = ComplexField()
+                z = C(z)
+            except TypeError:
+                raise TypeError("%s is not a complex number" % z)
         prec = C.precision()
         from sage.matrix.constructor import Matrix
         from sage.modules.free_module_element import vector
@@ -1330,6 +1351,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: L = E.period_lattice()
             sage: w1, w2 = L.basis(prec=100)
@@ -1416,6 +1438,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: L = E.period_lattice()
             sage: P = E([-1,1])
@@ -1498,11 +1521,10 @@ class PeriodLattice_ell(PeriodLattice):
             w1, w2 = self._compute_periods_complex(prec, normalise=False)
             if xP == e1:
                 z = w2/2
+            elif xP == e3:
+                z = w1/2
             else:
-                if xP == e3:
-                    z = w1/2
-                else:
-                    z = (w1+w2)/2
+                z = (w1+w2)/2
             if reduce:
                 z = self.reduce(z)
             return z
@@ -1619,6 +1641,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: L = E.period_lattice()
             sage: E.discriminant() > 0
@@ -1643,6 +1666,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         An example with negative discriminant, and a torsion point::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: L = E.period_lattice()
             sage: E.discriminant() < 0
@@ -1905,7 +1929,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         Examples over number fields::
 
-            sage: # needs sage.rings.number_field
+            sage: # needs database_cremona_mini_ellcurve sage.rings.number_field
             sage: x = polygen(QQ)
             sage: K.<a> = NumberField(x^3 - 2)
             sage: embs = K.embeddings(CC)
@@ -1947,7 +1971,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         Test to show that :issue:`8820` is fixed::
 
-            sage: # needs sage.rings.number_field
+            sage: # needs database_cremona_mini_ellcurve sage.rings.number_field
             sage: E = EllipticCurve('37a')
             sage: K.<a> = QuadraticField(-5)
             sage: L = E.change_ring(K).period_lattice(K.places()[0])
@@ -1969,7 +1993,7 @@ class PeriodLattice_ell(PeriodLattice):
 
         ::
 
-            sage: # needs sage.rings.number_field
+            sage: # needs database_cremona_mini_ellcurve sage.rings.number_field
             sage: E = EllipticCurve('37a')
             sage: K.<a> = QuadraticField(-5)
             sage: L = E.change_ring(K).period_lattice(K.places()[0])
@@ -2006,16 +2030,15 @@ class PeriodLattice_ell(PeriodLattice):
             z_is_real = True
             C = ComplexField(C.precision())
             z = C(z)
+        elif isinstance(C, sage.rings.abc.ComplexField):
+            z_is_real = z.is_real()
         else:
-            if isinstance(C, sage.rings.abc.ComplexField):
+            try:
+                C = ComplexField()
+                z = C(z)
                 z_is_real = z.is_real()
-            else:
-                try:
-                    C = ComplexField()
-                    z = C(z)
-                    z_is_real = z.is_real()
-                except TypeError:
-                    raise TypeError("%s is not a complex number" % z)
+            except TypeError:
+                raise TypeError("%s is not a complex number" % z)
         prec = C.precision()
 
         # test for the point at infinity:

--- a/src/sage/schemes/elliptic_curves/saturation.py
+++ b/src/sage/schemes/elliptic_curves/saturation.py
@@ -158,6 +158,7 @@ class EllipticCurveSaturator(SageObject):
 
         Over `\QQ`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.saturation import EllipticCurveSaturator
             sage: E = EllipticCurve('11a1')
             sage: saturator = EllipticCurveSaturator(E)
@@ -224,6 +225,7 @@ class EllipticCurveSaturator(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.saturation import EllipticCurveSaturator
             sage: E = EllipticCurve('389a')
             sage: K.<i> = QuadraticField(-1)
@@ -323,6 +325,7 @@ class EllipticCurveSaturator(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.saturation import EllipticCurveSaturator
             sage: E = EllipticCurve('389a')
             sage: K.<i> = QuadraticField(-1)

--- a/src/sage/schemes/elliptic_curves/sha_tate.py
+++ b/src/sage/schemes/elliptic_curves/sha_tate.py
@@ -34,6 +34,7 @@ triviality the `p`-primary part of `Sha`.
 
 EXAMPLES::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve('11a1')
     sage: S = E.sha()
     sage: S.bound_kato()
@@ -47,6 +48,7 @@ EXAMPLES::
     sage: S.an_numerical()
     1.00000000000000
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: E = EllipticCurve('389a')
     sage: S = E.sha(); S
     Tate-Shafarevich group for the
@@ -110,6 +112,7 @@ class Sha(SageObject):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('571a1')
         sage: E._set_gens([])   # curve has rank 0, but non-trivial Sha[2]
         sage: S = E.sha()
@@ -124,6 +127,7 @@ class Sha(SageObject):
         sage: S.an_numerical()
         4.00000000000000
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: E = EllipticCurve('389a')
         sage: S = E.sha(); S
         Tate-Shafarevich group for the
@@ -147,6 +151,7 @@ class Sha(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: S = E.sha()
             sage: S
@@ -166,6 +171,7 @@ class Sha(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: S = E.sha()
             sage: S == S
@@ -181,6 +187,7 @@ class Sha(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a1')
             sage: S = E.sha()
             sage: S != S
@@ -194,6 +201,7 @@ class Sha(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('11a1')
             sage: S = E.sha()
             sage: S.__repr__()
@@ -238,6 +246,7 @@ class Sha(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('11a').sha().an_numerical()
             1.00000000000000
             sage: EllipticCurve('37a').sha().an_numerical()
@@ -261,6 +270,7 @@ class Sha(SageObject):
 
         See :issue:`1115`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: sha = EllipticCurve('37a1').sha()
             sage: [sha.an_numerical(prec) for prec in range(40,100,10)]  # long time (3s on sage.math, 2013)
             [1.0000000000,
@@ -347,6 +357,7 @@ class Sha(SageObject):
             sage: E.sha().an()
             1
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('14a4').sha().an()
             1
             sage: EllipticCurve('14a4').sha().an(use_database=True)   # will be faster if you have large Cremona database installed
@@ -386,6 +397,7 @@ class Sha(SageObject):
             sage: E.sha().an()
             1
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("1610f3")
             sage: E.sha().an()
             4
@@ -485,6 +497,7 @@ class Sha(SageObject):
 
         Good ordinary examples::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('11a1').sha().an_padic(5)    # rank 0
             1 + O(5^22)
             sage: EllipticCurve('43a1').sha().an_padic(5)    # rank 1
@@ -500,6 +513,7 @@ class Sha(SageObject):
 
         Exceptional cases::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('11a1').sha().an_padic(11) # rank 0
             1 + O(11^22)
             sage: EllipticCurve('130a1').sha().an_padic(5) # rank 1
@@ -517,6 +531,7 @@ class Sha(SageObject):
 
         Supersingular cases::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('34a1').sha().an_padic(5) # rank 0
             1 + O(5^22)
             sage: EllipticCurve('53a1').sha().an_padic(5) # rank 1, long time (11s on sage.math, 2011)
@@ -524,6 +539,7 @@ class Sha(SageObject):
 
         Cases that use a twist to a lower conductor::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('99a1').sha().an_padic(5)
             1 + O(5)
             sage: EllipticCurve('240d3').sha().an_padic(5)  # sha has 4 elements here
@@ -535,6 +551,7 @@ class Sha(SageObject):
 
         Test for :issue:`15737`::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve([-100,0])
             sage: s = E.sha()
             sage: s.an_padic(13)
@@ -734,6 +751,7 @@ class Sha(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("389a1")  # rank 2
             sage: E.sha().p_primary_order(5)
             0
@@ -811,6 +829,7 @@ class Sha(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: e = EllipticCurve('11a3')
             sage: e.sha().p_primary_bound(3)
             0
@@ -823,6 +842,7 @@ class Sha(SageObject):
             sage: e.sha().p_primary_bound(13)
             0
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: e = EllipticCurve('389a1')
             sage: e.sha().p_primary_bound(5)
             0
@@ -833,6 +853,7 @@ class Sha(SageObject):
             sage: e.sha().p_primary_bound(13)
             0
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: e = EllipticCurve('858k2')
             sage: e.sha().p_primary_bound(3)  # long time (10s on sage.math, 2011)
             0
@@ -842,6 +863,7 @@ class Sha(SageObject):
             sage: e.sha().p_primary_bound(7)  # long time
             2
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('608b1')
             sage: E.sha().p_primary_bound(5)
             Traceback (most recent call last):
@@ -853,6 +875,7 @@ class Sha(SageObject):
             sage: E.sha().an_padic(5)           # long time
             1 + O(5^22)
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve("5040bi1")
             sage: E.sha().p_primary_bound(5)    # long time
             0
@@ -881,18 +904,21 @@ class Sha(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: sh = EllipticCurve('571a1').sha()
             sage: sh.two_selmer_bound()
             2
             sage: sh.an()
             4
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: sh = EllipticCurve('66a1').sha()
             sage: sh.two_selmer_bound()
             0
             sage: sh.an()
             1
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: sh = EllipticCurve('960d1').sha()
             sage: sh.two_selmer_bound()
             2
@@ -957,6 +983,7 @@ class Sha(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('37a')
             sage: E.sha().bound_kolyvagin()
             ([2], 1)
@@ -968,6 +995,7 @@ class Sha(SageObject):
 
         We get no information when the curve has rank 2.::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('389a')
             sage: E.sha().bound_kolyvagin()
             (0, 0)
@@ -1148,6 +1176,7 @@ class Sha(SageObject):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: EllipticCurve('37a').sha().bound()
             ([2], 1)
         """

--- a/src/sage/schemes/elliptic_curves/weierstrass_morphism.py
+++ b/src/sage/schemes/elliptic_curves/weierstrass_morphism.py
@@ -234,6 +234,7 @@ def _isomorphisms(E, F):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.weierstrass_morphism import _isomorphisms
         sage: list(_isomorphisms(EllipticCurve_from_j(0), EllipticCurve('27a3')))
         [(1, 0, 0, 0), (-1, 0, 0, -1)]
@@ -421,6 +422,7 @@ class WeierstrassIsomorphism(EllipticCurveHom, baseWI):
 
     EXAMPLES::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.elliptic_curves.weierstrass_morphism import *
         sage: WeierstrassIsomorphism(EllipticCurve([0,1,2,3,4]), (-1,2,3,4))
         Elliptic-curve morphism:
@@ -526,6 +528,7 @@ class WeierstrassIsomorphism(EllipticCurveHom, baseWI):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.weierstrass_morphism import *
             sage: E = EllipticCurve('389a1')
             sage: F = E.change_weierstrass_model(1,2,3,4)
@@ -626,6 +629,7 @@ class WeierstrassIsomorphism(EllipticCurveHom, baseWI):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.schemes.elliptic_curves.weierstrass_morphism import *
             sage: E = EllipticCurve('37a1')
             sage: w = WeierstrassIsomorphism(E,(2,3,4,5))
@@ -682,6 +686,7 @@ class WeierstrassIsomorphism(EllipticCurveHom, baseWI):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E = EllipticCurve('5077')
             sage: F = E.change_weierstrass_model([2,3,4,5]); F
             Elliptic Curve defined by y^2 + 4*x*y + 11/8*y = x^3 - 7/4*x^2 - 3/2*x - 9/32 over Rational Field
@@ -712,6 +717,7 @@ class WeierstrassIsomorphism(EllipticCurveHom, baseWI):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E1 = EllipticCurve('5077')
             sage: E2 = E1.change_weierstrass_model([2,3,4,5])
             sage: w1 = E1.isomorphism_to(E2)
@@ -758,6 +764,7 @@ class WeierstrassIsomorphism(EllipticCurveHom, baseWI):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: E1 = EllipticCurve('5077')
             sage: E2 = E1.change_weierstrass_model([2,3,4,5])
             sage: E1.isomorphism_to(E2)

--- a/src/sage/schemes/generic/algebraic_scheme.py
+++ b/src/sage/schemes/generic/algebraic_scheme.py
@@ -1753,8 +1753,9 @@ class AlgebraicScheme_subscheme(AlgebraicScheme):
         One can enumerate points up to a given bound on a projective scheme
         over the rationals::
 
-            sage: E = EllipticCurve('37a')                                              # needs sage.schemes
-            sage: E.rational_points(bound=8)                                            # needs sage.libs.singular sage.schemes
+            sage: # needs database_cremona_mini_ellcurve
+            sage: E = EllipticCurve('37a')  # needs sage.schemes
+            sage: E.rational_points(bound=8)  # needs sage.libs.singular sage.schemes
             [(-1 : -1 : 1), (-1 : 0 : 1), (0 : -1 : 1), (0 : 0 : 1), (0 : 1 : 0),
              (1/4 : -5/8 : 1), (1/4 : -3/8 : 1), (1 : -1 : 1), (1 : 0 : 1),
              (2 : -3 : 1), (2 : 2 : 1)]

--- a/src/sage/schemes/projective/projective_homset.py
+++ b/src/sage/schemes/projective/projective_homset.py
@@ -48,7 +48,7 @@ from sage.rings.integer_ring import ZZ
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.rings.rational_field import RationalField
 from sage.schemes.generic.algebraic_scheme import AlgebraicScheme_subscheme
-from sage.schemes.generic.homset import SchemeHomset_points, SchemeHomset_generic
+from sage.schemes.generic.homset import SchemeHomset_generic, SchemeHomset_points
 
 lazy_import('sage.rings.cc', 'CC')
 lazy_import('sage.rings.real_mpfr', 'RR')
@@ -247,11 +247,10 @@ class SchemeHomset_points_projective_field(SchemeHomset_points):
                                     S.normalize_coordinates()
                                     if all(g(list(S)) < zero_tol for g in X.defining_polynomials()):
                                         rat_points.add(S)
-                            else:
-                                if len(points[i]) == N + 1 and I.subs(points[i]) == I0:
-                                    S = X([points[i][R.gen(j)] for j in range(N + 1)])
-                                    S.normalize_coordinates()
-                                    rat_points.add(S)
+                            elif len(points[i]) == N + 1 and I.subs(points[i]) == I0:
+                                S = X([points[i][R.gen(j)] for j in range(N + 1)])
+                                S.normalize_coordinates()
+                                rat_points.add(S)
 
                 # remove duplicate element using tolerance
                 if numerical:
@@ -277,15 +276,21 @@ class SchemeHomset_points_projective_field(SchemeHomset_points):
             if isinstance(X, AlgebraicScheme_subscheme): # sieve should only be called for subschemes
                 from sage.schemes.projective.projective_rational_point import sieve
                 return sieve(X, B)
-            from sage.schemes.projective.projective_rational_point import enum_projective_rational_field
+            from sage.schemes.projective.projective_rational_point import (
+                enum_projective_rational_field,
+            )
             return enum_projective_rational_field(self, B)
         if R in NumberFields():
             if not B > 0:
                 raise TypeError("a positive bound B (= %s) must be specified" % B)
-            from sage.schemes.projective.projective_rational_point import enum_projective_number_field
+            from sage.schemes.projective.projective_rational_point import (
+                enum_projective_number_field,
+            )
             return enum_projective_number_field(self, bound=B, tolerance=tol, precision=prec)
         if isinstance(R, FiniteField):
-            from sage.schemes.projective.projective_rational_point import enum_projective_finite_field
+            from sage.schemes.projective.projective_rational_point import (
+                enum_projective_finite_field,
+            )
             return enum_projective_finite_field(self.extended_codomain())
         raise TypeError("unable to enumerate points over %s" % R)
 
@@ -521,7 +526,9 @@ class SchemeHomset_points_projective_ring(SchemeHomset_points):
         if R == ZZ:
             if not B > 0:
                 raise TypeError("a positive bound B (= %s) must be specified" % B)
-            from sage.schemes.projective.projective_rational_point import enum_projective_rational_field
+            from sage.schemes.projective.projective_rational_point import (
+                enum_projective_rational_field,
+            )
             return enum_projective_rational_field(self,B)
         raise TypeError("unable to enumerate points over %s" % R)
 
@@ -575,7 +582,7 @@ class SchemeHomset_points_abelian_variety_field(SchemeHomset_points_projective_f
 
     The bug reported at :issue:`1785` is fixed::
 
-        sage: # needs sage.rings.number_field sage.schemes
+        sage: # needs database_cremona_mini_ellcurve sage.rings.number_field sage.schemes
         sage: x = polygen(ZZ, 'x')
         sage: K.<a> = NumberField(x^2 + x - (3^3-3))
         sage: E = EllipticCurve('37a')
@@ -623,7 +630,7 @@ class SchemeHomset_points_abelian_variety_field(SchemeHomset_points_projective_f
 
         EXAMPLES::
 
-            sage: # needs sage.schemes
+            sage: # needs database_cremona_mini_ellcurve sage.schemes
             sage: E = EllipticCurve('37a')
             sage: X = E(QQ)
             sage: P = X([0,1,0]);  P
@@ -650,9 +657,10 @@ class SchemeHomset_points_abelian_variety_field(SchemeHomset_points_projective_f
 
         EXAMPLES::
 
-            sage: E = EllipticCurve('37a')                                              # needs sage.schemes
-            sage: X = E(QQ)                                                             # needs sage.schemes
-            sage: X._repr_()                                                            # needs sage.schemes
+            sage: # needs database_cremona_mini_ellcurve
+            sage: E = EllipticCurve('37a')  # needs sage.schemes
+            sage: X = E(QQ)  # needs sage.schemes
+            sage: X._repr_()  # needs sage.schemes
             'Abelian group of points on Elliptic Curve defined by y^2 + y = x^3 - x over Rational Field'
         """
         s = 'Abelian group of points on ' + str(self.extended_codomain())
@@ -671,7 +679,7 @@ class SchemeHomset_points_abelian_variety_field(SchemeHomset_points_projective_f
 
         EXAMPLES::
 
-            sage: # needs sage.schemes
+            sage: # needs database_cremona_mini_ellcurve sage.schemes
             sage: E = EllipticCurve('37a')
             sage: Hom = E.point_homset();  Hom
             Abelian group of points on Elliptic Curve defined
@@ -708,6 +716,7 @@ class SchemeHomset_points_abelian_variety_field(SchemeHomset_points_projective_f
 
 
 from sage.misc.persist import register_unpickle_override
+
 register_unpickle_override('sage.schemes.generic.homset',
                            'SchemeHomsetModule_abelian_variety_coordinates_field',
                            SchemeHomset_points_abelian_variety_field)

--- a/src/sage/schemes/projective/projective_rational_point.py
+++ b/src/sage/schemes/projective/projective_rational_point.py
@@ -25,9 +25,10 @@ Projective, over `\QQ`::
 
 Projective over a finite field::
 
+    sage: # needs database_cremona_mini_ellcurve
     sage: from sage.schemes.projective.projective_rational_point import enum_projective_finite_field
-    sage: E = EllipticCurve('72').change_ring(GF(19))                                   # needs sage.schemes
-    sage: enum_projective_finite_field(E)                                               # needs sage.schemes
+    sage: E = EllipticCurve('72').change_ring(GF(19))  # needs sage.schemes
+    sage: enum_projective_finite_field(E)  # needs sage.schemes
     [(0 : 1 : 0), (1 : 0 : 1), (3 : 0 : 1), (4 : 9 : 1), (4 : 10 : 1),
      (6 : 6 : 1), (6 : 13 : 1), (7 : 6 : 1), (7 : 13 : 1), (9 : 4 : 1),
      (9 : 15 : 1), (12 : 8 : 1), (12 : 11 : 1), (13 : 8 : 1), (13 : 11 : 1),
@@ -352,9 +353,10 @@ def sieve(X, bound):
 
     ::
 
+        sage: # needs database_cremona_mini_ellcurve
         sage: from sage.schemes.projective.projective_rational_point import sieve
-        sage: E = EllipticCurve('37a')                                                  # needs sage.schemes
-        sage: sorted(sieve(E, 14))              # long time                             # needs sage.libs.singular sage.schemes
+        sage: E = EllipticCurve('37a')  # needs sage.schemes
+        sage: sorted(sieve(E, 14))              # long time  # needs sage.libs.singular sage.schemes
         [(0 : 1 : 0),
          (-1 : -1 : 1),
          (-1 : 0 : 1),

--- a/src/sage/schemes/riemann_surfaces/riemann_surface.py
+++ b/src/sage/schemes/riemann_surfaces/riemann_surface.py
@@ -2641,6 +2641,7 @@ class RiemannSurface:
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: S1 = EllipticCurve("11a1").riemann_surface()
             sage: S2 = EllipticCurve("11a3").riemann_surface()
             sage: [m.det() for m in S1.homomorphism_basis(S2)]

--- a/src/sage/structure/coerce.pyx
+++ b/src/sage/structure/coerce.pyx
@@ -35,9 +35,10 @@ On failure, a :exc:`TypeError` is always raised.
 Some arithmetic operations (such as multiplication) can indicate an action
 rather than arithmetic in a common parent. For example::
 
-    sage: E = EllipticCurve('37a')                                                      # needs sage.schemes
-    sage: P = E(0,0)                                                                    # needs sage.schemes
-    sage: 5*P                                                                           # needs sage.schemes
+    sage: # needs database_cremona_mini_ellcurve
+    sage: E = EllipticCurve('37a')  # needs sage.schemes
+    sage: P = E(0,0)  # needs sage.schemes
+    sage: 5*P  # needs sage.schemes
     (1/4 : -5/8 : 1)
 
 where there is action of `\ZZ` on the points of `E` given by the additive

--- a/src/sage/tests/benchmark.py
+++ b/src/sage/tests/benchmark.py
@@ -1631,6 +1631,7 @@ class EllipticCurveMW(Benchmark):
 
         EXAMPLES::
 
+            sage: # needs database_cremona_mini_ellcurve
             sage: from sage.tests.benchmark import EllipticCurveMW
             sage: B = EllipticCurveMW([1,2,3,4,5])
             sage: isinstance(B.sage()[1], float)

--- a/src/sage/tests/book_stein_ent.py
+++ b/src/sage/tests/book_stein_ent.py
@@ -619,14 +619,19 @@ sage: T([-4,0])
 sage: T([-1386747, 368636886])
 (2, 8)
 sage: r = lambda v: EllipticCurve(v).rank()
+sage: # needs database_cremona_mini_ellcurve
 sage: r([-5,4])
 1
+sage: # needs database_cremona_mini_ellcurve
 sage: r([0,1])
 0
+sage: # needs database_cremona_mini_ellcurve
 sage: r([-3024, 46224])
 2
+sage: # needs database_cremona_mini_ellcurve
 sage: r([-112, 400])
 3
+sage: # needs database_cremona_mini_ellcurve
 sage: r([-102627, 12560670])
 4
 sage: def cong(n):
@@ -634,12 +639,16 @@ sage: def cong(n):
 ....:     if len(G) == 0: return False
 ....:     x,y,_ = G[0]
 ....:     return ((n^2-x^2)/y,-2*x*n/y,(n^2+x^2)/y)
+sage: # needs database_cremona_mini_ellcurve
 sage: cong(6)
 (3, 4, 5)
+sage: # needs database_cremona_mini_ellcurve
 sage: cong(5)
 (3/2, 20/3, 41/6)
+sage: # needs database_cremona_mini_ellcurve
 sage: cong(1)
 False
+sage: # needs database_cremona_mini_ellcurve
 sage: cong(13)
 (323/30, 780/323, 106921/9690)
 sage: (323/30 * 780/323)/2


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

The uv-based CI workflows are failling on some systems with a quite a few errors due to a missing/not found ellcurve db (see eg https://github.com/cxzhong/sage/actions/runs/26278272434/job/77347800338#step:9:60). So we add here the required `#needs` tags.

There were quite a few places (around 1000), so this was done in a semi-automated way. I double-checked a few locations manually, but cannot guarantee that I got all instances nor that all annotations are 100% needed.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

- https://github.com/sagemath/sage/pull/42229: to be able to test these changes here in the uv workflows

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


