### PR TITLE
gh-39514: fix weak_popov_form performance for unbalanced shifts

### DIFF
--- a/src/sage/matrix/matrix_polynomial_dense.pyx
+++ b/src/sage/matrix/matrix_polynomial_dense.pyx
@@ -2074,11 +2074,11 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
             ....:    [4*x^2+5*x+2, x^4+5*x^2+2*x+4, 4*x^3+6*x^2+6*x+5]])
             sage: P, U = M.weak_popov_form(transformation=True)
             sage: P
-            [              4             x^2   6*x^2 + x + 2]
+            [              0         3*x + 6   6*x^2 + x + 6]
             [              2 4*x^2 + 2*x + 4               5]
             sage: U
-            [2*x^2 + 1       4*x]
-            [      4*x         1]
+            [2*x^2 + 6*x + 1         4*x + 5]
+            [            4*x               1]
             sage: P.is_weak_popov() and U.is_invertible() and U*M == P
             True
 
@@ -2088,15 +2088,15 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
             [2, 1]
             sage: PP = M.weak_popov_form(ordered=True); PP
             [              2 4*x^2 + 2*x + 4               5]
-            [              4             x^2   6*x^2 + x + 2]
+            [              0         3*x + 6   6*x^2 + x + 6]
             sage: PP.leading_positions()
             [1, 2]
 
         Demonstrating shifts::
 
             sage: P = M.weak_popov_form(shifts=[0,2,4]); P
-            [            6*x^2 + 6*x + 4 5*x^4 + 4*x^3 + 5*x^2 + 5*x                     2*x + 2]
-            [                          2             4*x^2 + 2*x + 4                           5]
+            [                6*x^2 + x + 6 5*x^4 + x^3 + 4*x^2 + 4*x + 4                             0]
+            [                            2               4*x^2 + 2*x + 4                             5]
             sage: P == M.weak_popov_form(shifts=[-10,-8,-6])
             True
 
@@ -2108,19 +2108,19 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
         Zero vectors can be discarded::
 
             sage: M.weak_popov_form(row_wise=False)
-            [x + 4     6     0]
-            [    5     1     0]
+            [4*x + 1       3       0]
+            [      0       4       0]
 
             sage: P, U = M.weak_popov_form(transformation=True,
             ....:                          row_wise=False,
             ....:                          include_zero_vectors=False)
             sage: P
-            [x + 4     6]
-            [    5     1]
+            [4*x + 1       3]
+            [      0       4]
             sage: U
-            [                5*x + 2         5*x^2 + 4*x + 4 3*x^3 + 3*x^2 + 2*x + 4]
-            [                      1                       1                 2*x + 1]
-            [                5*x + 5                       2                       6]
+            [  x^3 + 6*x^2 + 6*x + 4 5*x^3 + 4*x^2 + 3*x + 4 2*x^3 + 2*x^2 + 6*x + 5]
+            [                3*x + 3                   x + 1                 6*x + 3]
+            [                6*x + 3                       4                       4]
             sage: M*U[:,:2] == P and (M*U[:,2]).is_zero()
             True
 
@@ -2153,8 +2153,22 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
             sage: A = matrix(R, [[x^3 + x, 0, 0], [2*x^2, x, 0], [x, 0, x], [x^2 + 1, x^2 + 1, 0], [2*x + 2, 2*x + 2, x], [x^2 + x + 1, x^2 + 2*x + 1, 2*x^3 + 2*x^2], [0, 0, x^2 + 1], [x^2 + x, x^2 + 2*x, 2*x^3 + 2*x^2 + 2*x + 2], [2*x^4 + x^3 + 2*x^2 + 2, 2*x^4 + x^2 + 2, x^5 + 2*x^4 + x^3 + x^2 + 2*x + 1]])
             sage: A.weak_popov_form(ordered=True, include_zero_vectors=False)
             [x + 2     2     2]
-            [    0   2*x     1]
-            [    x     0     x]
+            [    0     x     2]
+            [    1 x + 1     x]
+
+        For an ordered weak Popov form, zero rows are placed below the nonzero
+        rows even when there are more columns than rows, in which case a leading
+        position may exceed the number of rows (see :issue:`39514`)::
+
+            sage: pR.<x> = GF(7)[]
+            sage: M = matrix(pR, [[1, x, x^2, x^3], [2, 2*x, 2*x^2, 2*x^3]])
+            sage: P = M.weak_popov_form(ordered=True); P
+            [  1   x x^2 x^3]
+            [  0   0   0   0]
+            sage: P.leading_positions()
+            [3, -1]
+            sage: P.is_weak_popov(ordered=True)
+            True
         """
         # if column-wise, call the algorithm on transpose
         if not row_wise:
@@ -2166,8 +2180,9 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
             return (W[0].T, W[1].T) if transformation else W.T
 
         # --> now, below, we are working row-wise
-        # row dimension:
+        # row and column dimensions:
         m = self.nrows()
+        n = self.ncols()
         # make shift nonnegative, required by main call _weak_popov_form
         self._check_shift_dimension(shifts, row_wise=True)
         if shifts is None:
@@ -2203,8 +2218,10 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
         if ordered:
             lpos = M[:nnzr, :].leading_positions(nonnegative_shifts)
             if include_zero_vectors:
-                # --> insert max value for zero rows so that they remain at the bottom
-                lpos.extend(m for i in range(m - nnzr))
+                # --> insert, for each zero row, a value strictly larger than
+                # any possible leading position (which is at most n-1) so that
+                # the zero rows remain at the bottom
+                lpos.extend(n for i in range(m - nnzr))
             # apply permutation to weak Popov form
             sorted_lpos = sorted([(lpos[i], i+1) for i in range(len(lpos))])
             row_permutation = Permutation([elt[1] for elt in sorted_lpos])
@@ -2214,7 +2231,7 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
                 if not include_zero_vectors:
                     # --> extend with virtual zero rows in M so that the
                     # corresponding rows of U remain at the bottom
-                    lpos.extend(m for i in range(m - nnzr))
+                    lpos.extend(n for i in range(m - nnzr))
                     sorted_lpos = sorted([(lpos[i], i+1) for i in range(len(lpos))])
                     row_permutation = Permutation([elt[1] for elt in sorted_lpos])
                 U.permute_rows(row_permutation)
@@ -2255,14 +2272,14 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
             sage: M = A.__copy__()
             sage: U = M._weak_popov_form(transformation=True, shifts=[16,8,0])
             sage: M
-            [               x              x^2              x^3]
-            [               0         -x^2 + x       -x^4 + x^3]
-            [               0                0 -x^5 + x^4 + x^3]
+            [              x             x^2             x^3]
+            [              0               0 x^5 - x^4 - x^3]
+            [              0        -x^2 + x      -x^4 + x^3]
             sage: U * A == M
             True
         """
         cdef Py_ssize_t i, j
-        cdef Py_ssize_t c, d, best, bestp
+        cdef Py_ssize_t c, c2, d, best, bestp
 
         cdef Py_ssize_t m = self.nrows()
         cdef Py_ssize_t n = self.ncols()
@@ -2273,13 +2290,17 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
         cdef list to_row, conflicts
 
         R = self.base_ring()
-        one = R.one()
 
         if transformation:
             from sage.matrix.constructor import matrix
             U = matrix.identity(R, m)
 
-        # initialise to_row and conflicts list
+        # For each column c, to_row[c] collects the rows whose (shifted)
+        # leading position is c, stored as ``(shifted_degree, row_index)`` and
+        # kept sorted by increasing shifted degree (so the two highest-degree
+        # rows are at the end of the list).  A column is a "conflict" as soon
+        # as it holds at least two rows.
+        from bisect import insort
         to_row = [[] for i in range(n)]
         conflicts = []
         for i in range(m):
@@ -2296,46 +2317,54 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
                     best = d
 
             if best >= 0:
-                to_row[bestp].append((i,best))
-                if len(to_row[bestp]) > 1:
+                insort(to_row[bestp], (best, i))
+                if len(to_row[bestp]) == 2:
                     conflicts.append(bestp)
 
-        # while there is a conflict, do a simple transformation
+        # While there is a conflict, fully resolve it by repeatedly reducing the
+        # two rows of highest shifted degree that share this leading position.
+        # Reducing the highest-degree row by the *second* highest keeps the
+        # degree ``ideg - jdeg`` of the quotient minimal; this avoids the
+        # intermediate degree growth (and the resulting blow-up in running time)
+        # that occurs for unbalanced shifts when an arbitrary pair is reduced
+        # instead (see :issue:`39514`).  We subtract the whole polynomial
+        # quotient of the two entries in the pivot column at once, rather than a
+        # single leading term, which lowers the number of row operations.
         while conflicts:
             c = conflicts.pop()
             row = to_row[c]
-            i,ideg = row.pop()
-            j,jdeg = row.pop()
+            while len(row) > 1:
+                _, i = row.pop()        # row of highest shifted degree, to reduce
+                _, j = row[len(row)-1]  # row of second-highest degree, the pivot
 
-            if jdeg > ideg:
-                i,j = j,i
-                ideg,jdeg = jdeg,ideg
+                s = - (M.get_unsafe(i,c) // M.get_unsafe(j,c))
 
-            coeff = - M.get_unsafe(i,c).lc() / M.get_unsafe(j,c).lc()
-            s = coeff * one.shift(ideg - jdeg)
+                M.add_multiple_of_row_c(i, j, s, 0)
+                if transformation:
+                    U.add_multiple_of_row_c(i, j, s, 0)
 
-            M.add_multiple_of_row_c(i, j, s, 0)
-            if transformation:
-                U.add_multiple_of_row_c(i, j, s, 0)
+                # the pair (shifted row degree, leading position) of row i has
+                # strictly decreased; recompute its leading position and
+                # re-dispatch it to the relevant column.
+                bestp = -1
+                best = -1
+                for c2 in range(n):
+                    d = M.get_unsafe(i,c2).degree()
 
-            row.append((j,jdeg))
+                    if shifts and d >= 0:
+                        d += shifts[c2]
 
-            bestp = -1
-            best = -1
-            for c in range(n):
-                d = M.get_unsafe(i,c).degree()
+                    if d >= best:
+                        bestp = c2
+                        best = d
 
-                if shifts and d >= 0:
-                    d += shifts[c]
-
-                if d >= best:
-                    bestp = c
-                    best = d
-
-            if best >= 0:
-                to_row[bestp].append((i,best))
-                if len(to_row[bestp]) > 1:
-                    conflicts.append(bestp)
+                if best >= 0:
+                    if bestp == c:
+                        insort(row, (best, i))
+                    else:
+                        insort(to_row[bestp], (best, i))
+                        if len(to_row[bestp]) == 2:
+                            conflicts.append(bestp)
 
         if transformation:
             return U
@@ -2432,9 +2461,9 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
             [x + 2     6]
             [    0     1]
             sage: U
-            [        3*x^2 + 6*x + 3         5*x^2 + 4*x + 4 3*x^3 + 3*x^2 + 2*x + 4]
-            [                      3                       1                 2*x + 1]
-            [                5*x + 2                       2                       6]
+            [2*x^3 + 5*x^2 + 5*x + 1   3*x^3 + x^2 + 6*x + 1 2*x^3 + 2*x^2 + 6*x + 5]
+            [                6*x + 6                 2*x + 2                 6*x + 3]
+            [                5*x + 6                       1                       4]
             sage: M*U[:,:2] == P and (M*U[:,2]).is_zero()
             True
 
@@ -2588,9 +2617,9 @@ cdef class Matrix_polynomial_dense(Matrix_generic_dense):
             sage: R.is_reduced()
             True
             sage: R2 = A.reduced_form(shifts=[6,3,0]); R2
-            [                x               x^2               x^3]
-            [                0         2*x^2 + x       2*x^4 + x^3]
-            [                0                 0 2*x^5 + x^4 + x^3]
+            [                  x                 x^2                 x^3]
+            [                  0                   0 x^5 + 2*x^4 + 2*x^3]
+            [                  0           2*x^2 + x         2*x^4 + x^3]
             sage: R2.is_reduced(shifts=[6,3,0])
             True
             sage: R2.is_reduced()


### PR DESCRIPTION
The Mulders-Storjohann implementation in `_weak_popov_form` resolved a conflict (two rows sharing a leading position) by reducing an arbitrary pair of rows. For unbalanced shifts this repeatedly paired rows of very different degree, so the cancelling x-power multiplier had a large exponent and inflated the other columns of the row (intermediate degree swell); the cost then depended heavily on the shift orientation, up to ~60x slower for some shifts than for almost identical ones.

Resolve each conflicted column by reducing the two rows of *highest* shifted degree (kept sorted), which keeps the multiplier degree minimal and removes the swell, and subtract the whole polynomial quotient of the two pivot-column entries at once instead of a single leading term, which lowers the number of row operations. The cost is now independent of the shift orientation and faster across the board, including the balanced common case.

Also fix a pre-existing bug in the ordered branch of weak_popov_form: zero rows were given the sort key m (number of rows) to keep them at the bottom, but a leading position can be as large as n-1 (number of columns), so for n > m the zero rows could sort above nonzero ones. Use n as the sentinel instead, and add a regression doctest.

The weak Popov form is not unique; several illustrative doctests are updated to the new (valid) representatives. The unique popov_form and hermite_form results are unchanged.

Close #39514 

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


