### PR TITLE
Fix kernel_basis to respect the matrix side convention (#40933)

### DIFF
--- a/src/sage/modules/matrix_morphism.py
+++ b/src/sage/modules/matrix_morphism.py
@@ -886,25 +886,30 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
         r"""
         Return a basis of the kernel of this morphism, in echelon form.
 
-        This is consistent with :meth:`kernel`: every returned vector
-        lies in :meth:`kernel`. In particular, the matrix convention
-        determined by :meth:`side` is respected.
+        The basis is taken from :meth:`kernel`, so it spans the kernel and
+        respects the matrix convention determined by :meth:`side`: every
+        returned vector is mapped to zero by this morphism.
 
-        EXAMPLES::
+        EXAMPLES:
+
+        For a ``side='left'`` morphism (the default), ``f(x) = x*M``, so the
+        relevant kernel is the *left* kernel of the matrix.  Before
+        :issue:`40933` this method returned the right kernel ``((1, 0),)``
+        instead, whose vector is not annihilated by ``A``::
 
             sage: A = linear_transformation(matrix([[0, -1], [0, 0]]))
             sage: A.kernel_basis()
             ((0, 1),)
-            sage: all(v in A.kernel() for v in A.kernel_basis())
+            sage: all(A(v).is_zero() for v in A.kernel_basis())
             True
 
-        The matrix convention is respected, so that the result agrees
-        with :meth:`kernel` for both sides (:issue:`40933`)::
+        The convention is respected for both sides, so the result is
+        consistent with :meth:`kernel`::
 
             sage: B = linear_transformation(matrix([[0, -1], [0, 0]]), side='right')
             sage: B.kernel_basis()
             ((1, 0),)
-            sage: all(v in B.kernel() for v in B.kernel_basis())
+            sage: all(B(v).is_zero() for v in B.kernel_basis())
             True
 
         This also works for free module morphisms that are not vector
@@ -914,7 +919,7 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
             sage: phi = V.hom(matrix([[0, -1], [0, 0]]))
             sage: phi.kernel_basis()
             ((0, 1),)
-            sage: all(v in phi.kernel() for v in phi.kernel_basis())
+            sage: all(phi(v).is_zero() for v in phi.kernel_basis())
             True
         """
         return tuple(self.kernel().basis())

--- a/src/sage/modules/matrix_morphism.py
+++ b/src/sage/modules/matrix_morphism.py
@@ -882,6 +882,43 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
             V = B.row_module(D.base_ring())
         return self.domain().submodule(V, check=False)
 
+    def kernel_basis(self):
+        r"""
+        Return a basis of the kernel of this morphism, in echelon form.
+
+        This is consistent with :meth:`kernel`: every returned vector
+        lies in :meth:`kernel`. In particular, the matrix convention
+        determined by :meth:`side` is respected.
+
+        EXAMPLES::
+
+            sage: A = linear_transformation(matrix([[0, -1], [0, 0]]))
+            sage: A.kernel_basis()
+            ((0, 1),)
+            sage: all(v in A.kernel() for v in A.kernel_basis())
+            True
+
+        The matrix convention is respected, so that the result agrees
+        with :meth:`kernel` for both sides (:issue:`40933`)::
+
+            sage: B = linear_transformation(matrix([[0, -1], [0, 0]]), side='right')
+            sage: B.kernel_basis()
+            ((1, 0),)
+            sage: all(v in B.kernel() for v in B.kernel_basis())
+            True
+
+        This also works for free module morphisms that are not vector
+        space morphisms::
+
+            sage: V = ZZ^2
+            sage: phi = V.hom(matrix([[0, -1], [0, 0]]))
+            sage: phi.kernel_basis()
+            ((0, 1),)
+            sage: all(v in phi.kernel() for v in phi.kernel_basis())
+            True
+        """
+        return tuple(self.kernel().basis())
+
     def image(self):
         """
         Compute the image of this morphism.

--- a/src/sage/modules/matrix_morphism.py
+++ b/src/sage/modules/matrix_morphism.py
@@ -893,9 +893,7 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
         EXAMPLES:
 
         For a ``side='left'`` morphism (the default), ``f(x) = x*M``, so the
-        relevant kernel is the *left* kernel of the matrix.  Before
-        :issue:`40933` this method returned the right kernel ``((1, 0),)``
-        instead, whose vector is not annihilated by ``A``::
+        relevant kernel is the *left* kernel of the matrix::
 
             sage: A = linear_transformation(matrix([[0, -1], [0, 0]]))
             sage: A.kernel_basis()

--- a/src/sage/modules/matrix_morphism.py
+++ b/src/sage/modules/matrix_morphism.py
@@ -919,6 +919,14 @@ class MatrixMorphism_abstract(sage.categories.morphism.Morphism):
             ((0, 1),)
             sage: all(phi(v).is_zero() for v in phi.kernel_basis())
             True
+
+        TESTS:
+
+        Check that :issue:`40933` is fixed::
+
+            sage: A = linear_transformation(matrix([[0, -1], [0, 0]]))
+            sage: A.kernel_basis()[0] in A.kernel()
+            True
         """
         return tuple(self.kernel().basis())
 


### PR DESCRIPTION
## Fixes #40933

### The bug

```python
sage: A = linear_transformation(matrix([[0, -1], [0, 0]]))
sage: A.kernel_basis()[0] in A.kernel()
False
```

The elements returned by `kernel_basis()` were not actually in the kernel.

### Root cause

`kernel_basis()` is only defined in the `FiniteDimensionalModulesWithBasis`
category, where it always uses `self.matrix().right_kernel_matrix()` — i.e. the
column/right convention `f(x) = M·x`. That is correct for combinatorial
free-module morphisms.

However, `MatrixMorphism` (the base of `FreeModuleMorphism` and
`VectorSpaceMorphism`) represents a morphism by a matrix acting on **row**
vectors on the **left** (`f(x) = x·M`) by default, and accordingly provides its
own side-aware `kernel()`, `image()` and `is_injective()`. It never overrode
`kernel_basis()`, so it silently inherited the category version with the wrong
convention. The result was the *right* kernel where the *left* kernel was
needed (and vice versa for `side='right'`), so the returned vectors were not in
`kernel()`.

This affected **both** `VectorSpaceMorphism` and `FreeModuleMorphism` on
`side='left'`.

### The fix

Add a side-aware `kernel_basis()` to `MatrixMorphism_abstract` that delegates to
the already-correct `kernel()`:

```python
def kernel_basis(self):
    return tuple(self.kernel().basis())
```

Delegating to `kernel()` keeps `kernel_basis()` consistent with `kernel()` by
construction, respects the `side` convention, and correctly handles non-ambient
domains (which `kernel()` already does).



### 📝 Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what is being changed.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation builds.
