### PR TITLE
Fix `sage --docbuild reference html` AttributeError in ReferenceBuilder

### DIFF
--- a/src/sage_docbuild/builders.py
+++ b/src/sage_docbuild/builders.py
@@ -430,6 +430,45 @@ class ReferenceBuilder():
         self.name = name
         self.options = options
 
+    def __getattr__(self, format):
+        """
+        Return a function that builds the reference manual in the given output
+        ``format`` (such as ``html``, ``inventory``, ``latex`` or ``pdf``).
+
+        Unlike a :class:`DocBuilder`, the reference manual is not produced by a
+        single Sphinx run but by orchestrating several sub-builders (see
+        :meth:`_wrapper`). The per-format entry points expected by the
+        ``sage --docbuild`` command (see :mod:`sage_docbuild.__main__`) are
+        therefore generated here on demand.
+
+        TESTS:
+
+        Each output format is exposed as a callable, see :issue:`42235`::
+
+            sage: from sage_docbuild.builders import ReferenceBuilder
+            sage: from sage_docbuild.build_options import BuildOptions
+            sage: builder = ReferenceBuilder('reference', BuildOptions())
+            sage: callable(builder.html)  # indirect doctest
+            True
+            sage: builder.html.func.__name__
+            '_wrapper'
+            sage: builder.inventory.args
+            ('inventory',)
+
+        Private and special attributes are not affected, so that ``hasattr``
+        probes, copying and pickling keep working as expected::
+
+            sage: builder._does_not_exist
+            Traceback (most recent call last):
+            ...
+            AttributeError: 'ReferenceBuilder' object has no attribute '_does_not_exist'
+        """
+        if format.startswith('_'):
+            raise AttributeError(
+                f"{type(self).__name__!r} object has no attribute {format!r}")
+        from functools import partial
+        return partial(self._wrapper, format)
+
     def _output_dir(self, type: Literal['html', 'latex', 'pdf']) -> Path:
         """
         Return the directory where the output of type ``type`` is stored.


### PR DESCRIPTION
`sage --docbuild reference html` currently fails with

```
AttributeError: 'ReferenceBuilder' object has no attribute 'html'
```

raised in `sage_docbuild/__main__.py` at `build = getattr(builder, typ)`, and
as a result `manual()` raises `OSError: The document 'reference' does not
exist...` because the reference manual is never built.

#### Root cause

`ReferenceBuilder` builds the reference manual by orchestrating its
sub-builders through `_wrapper(self, format, ...)`; it does **not** define
`html`, `pdf`, `inventory` or `latex` methods of its own. Those per-format
entry points used to be inherited from the base class `AllBuilder`, whose
`__getattr__` returned `partial(self._wrapper, attr)`. When `AllBuilder` was
removed (building "all" documents is now handled by the `src/doc` `Makefile`,
see #31948) and `ReferenceBuilder` stopped inheriting from it, nothing mapped a
format name to `_wrapper` anymore, so the dispatcher
`build = getattr(builder, typ); build()` started raising `AttributeError`.

#### Fix

Restore the per-format entry points by giving `ReferenceBuilder` a
`__getattr__` that maps an output format name (`html`, `inventory`, `latex`,
`pdf`, ...) to its `_wrapper`. Private/dunder lookups still raise
`AttributeError`, so copying, pickling and `hasattr` probes keep behaving
normally (the old `AllBuilder.__getattr__` was unguarded in this respect).

`ReferenceBuilder` is the only builder that is not a `DocBuilder` subclass; all
other builders inherit `DocBuilder`'s `builder_helper`-generated format
methods, so this is the only class affected.

Fixes #42235.

### 📝 Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### ⌛ Dependencies

None.
