### PR TITLE
release.yml: use PyPI trusted publishing instead of an API token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,8 +75,13 @@ jobs:
   sdists:
 
     runs-on: ubuntu-latest
+    permissions:
+      # Read access to check out the repository
+      contents: read
+      # Needed for PyPI trusted publishing (OIDC token exchange)
+      id-token: write
     env:
-      CAN_DEPLOY: ${{ secrets.SAGEMATH_PYPI_API_TOKEN != '' && github.event_name != 'pull_request' }}
+      CAN_DEPLOY: ${{ github.event_name != 'pull_request' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -104,9 +109,8 @@ jobs:
           name: dist
 
       - uses: pypa/gh-action-pypi-publish@release/v1
+        # Uses PyPI trusted publishing (OIDC); no API token required.
         with:
-          user: __token__
-          password: ${{ secrets.SAGEMATH_PYPI_API_TOKEN }}
           skip-existing: true
           verbose: true
         if: env.CAN_DEPLOY == 'true'
@@ -176,7 +180,6 @@ jobs:
             arch: arm64
             build: macosx
     env:
-      CAN_DEPLOY: ${{ secrets.SAGEMATH_PYPI_API_TOKEN != '' }}
       # SPKGs to install as system packages
       SPKGS: _bootstrap _prereq
       # Non-Python packages to install as spkgs
@@ -251,8 +254,13 @@ jobs:
     # This needs to be a separate job because pypa/gh-action-pypi-publish cannot run on macOS
     needs: build_wheels
     runs-on: ubuntu-latest
+    permissions:
+      # Read access to the repository
+      contents: read
+      # Needed for PyPI trusted publishing (OIDC token exchange)
+      id-token: write
     env:
-      CAN_DEPLOY: ${{ secrets.SAGEMATH_PYPI_API_TOKEN != '' && github.event_name != 'pull_request' }}
+      CAN_DEPLOY: ${{ github.event_name != 'pull_request' }}
     steps:
 
       - uses: actions/download-artifact@v6
@@ -262,9 +270,8 @@ jobs:
           merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@release/v1
+        # Uses PyPI trusted publishing (OIDC); no API token required.
         with:
-          user: __token__
-          password: ${{ secrets.SAGEMATH_PYPI_API_TOKEN }}
           packages-dir: wheelhouse/
           skip-existing: true
           verbose: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,9 +76,7 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
-      # Read access to check out the repository
       contents: read
-      # Needed for PyPI trusted publishing (OIDC token exchange)
       id-token: write
     env:
       CAN_DEPLOY: ${{ github.event_name != 'pull_request' }}
@@ -255,9 +253,7 @@ jobs:
     needs: build_wheels
     runs-on: ubuntu-latest
     permissions:
-      # Read access to the repository
       contents: read
-      # Needed for PyPI trusted publishing (OIDC token exchange)
       id-token: write
     env:
       CAN_DEPLOY: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,6 @@ jobs:
           name: dist
 
       - uses: pypa/gh-action-pypi-publish@release/v1
-        # Uses PyPI trusted publishing (OIDC); no API token required.
         with:
           skip-existing: true
           verbose: true
@@ -266,7 +265,6 @@ jobs:
           merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@release/v1
-        # Uses PyPI trusted publishing (OIDC); no API token required.
         with:
           packages-dir: wheelhouse/
           skip-existing: true


### PR DESCRIPTION
<!-- Describe your changes here in detail. -->
The release CI fails to upload distributions to PyPI with a `403
Forbidden` / "Invalid or non-existent authentication information" error,
because the `SAGEMATH_PYPI_API_TOKEN` secret is no longer valid.

This PR migrates the `pypa/gh-action-pypi-publish` steps to PyPI
**trusted publishing** (OIDC), which removes the dependency on a
long-lived API token.

### Fixes
- Fixes #42205

### What this does
- Removes the `user: __token__` / `password: ${{ secrets.SAGEMATH_PYPI_API_TOKEN }}`
  inputs from both publish steps (`sdists` and `upload_wheels`), so the
  action authenticates via OIDC.
- Grants each publishing job `id-token: write` permission (required to
  mint the OIDC token). An explicit `contents: read` is added alongside
  it, because once a job declares a `permissions:` block all unlisted
  scopes default to `none`, which would otherwise break
  `actions/checkout`.
- Drops the now-meaningless `SAGEMATH_PYPI_API_TOKEN != ''` checks from
  the `CAN_DEPLOY` gates.



### :memo: Checklist
- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.