### PR TITLE
Install the Jupyter kernel into sys.prefix and add a portable kernel spec

### DIFF
--- a/build/pkgs/sagelib/spkg-install.in
+++ b/build/pkgs/sagelib/spkg-install.in
@@ -70,7 +70,11 @@ if [ "$SAGE_EDITABLE" = yes ]; then
     # rather than "jupyter kernelspec install <dir>" because the latter would
     # copy the whole meson build tree (gigabytes); the command below writes
     # only kernel.json plus symlinked resources.  See Issue #40605.
-    python3 -m sage.repl.ipython_kernel.install install --sys-prefix
+    # --no-portable keeps the in-venv 'python3' argv, matching the wheel
+    # (data_files) kernel.json.in; the in-venv jupyter resolves it to this
+    # interpreter.  The portable spec (the command default) is meant for an
+    # explicit install into a *different* environment's Jupyter.
+    python3 -m sage.repl.ipython_kernel.install install --sys-prefix --no-portable
 else
     # Now implied: "$SAGE_WHEELS" = yes
     # We should remove the egg-link that may have been installed previously.

--- a/build/pkgs/sagelib/spkg-install.in
+++ b/build/pkgs/sagelib/spkg-install.in
@@ -63,9 +63,14 @@ if [ "$SAGE_EDITABLE" = yes ]; then
         cd $SAGE_PKGS/sagelib/src && time sdh_build_and_store_wheel --no-build-isolation .
     fi
 
-    # Install jupyter kernelspecs
-    # (needed since in editable mode the kernel spec is not copied to the correct location in the meson build)
-    jupyter kernelspec install --name=sagemath --user build/sage-distro/src/sage
+    # Install the jupyter kernel spec into the venv (sys.prefix), where the
+    # docbuild and an in-venv jupyter look for it.
+    # (Needed since in editable mode the kernel spec is not copied to the
+    # correct location by the meson build.)  We install it with our own command
+    # rather than "jupyter kernelspec install <dir>" because the latter would
+    # copy the whole meson build tree (gigabytes); the command below writes
+    # only kernel.json plus symlinked resources.  See Issue #40605.
+    python3 -m sage.repl.ipython_kernel.install install --sys-prefix
 else
     # Now implied: "$SAGE_WHEELS" = yes
     # We should remove the egg-link that may have been installed previously.

--- a/src/bin/sage
+++ b/src/bin/sage
@@ -389,8 +389,8 @@ usage_advanced() {
     echo "  --jupyter-kernel [...]"
     echo "                      -- install the SageMath Jupyter kernel spec;"
     echo "                         run \"sage --jupyter-kernel install --help\""
-    echo "                         for options (e.g. --portable for use from an"
-    echo "                         external Jupyter server)"
+    echo "                         for options.  The installed spec works from"
+    echo "                         an external Jupyter server by default."
     echo "  --kash [...]        -- run Sage's Kash with the given arguments"
     command -v kash &>/dev/null || \
     echo "                         (not installed currently, run sage -i kash)"

--- a/src/bin/sage
+++ b/src/bin/sage
@@ -386,6 +386,11 @@ usage_advanced() {
     echo "                         environment (not Sage), passing additional"
     echo "                         additional options to IPython"
     echo "  --jupyter [...]     -- run Sage's Jupyter with given arguments"
+    echo "  --jupyter-kernel [...]"
+    echo "                      -- install the SageMath Jupyter kernel spec;"
+    echo "                         run \"sage --jupyter-kernel install --help\""
+    echo "                         for options (e.g. --portable for use from an"
+    echo "                         external Jupyter server)"
     echo "  --kash [...]        -- run Sage's Kash with the given arguments"
     command -v kash &>/dev/null || \
     echo "                         (not installed currently, run sage -i kash)"
@@ -620,6 +625,11 @@ fi
 if [ "$1" = '-jupyter' -o "$1" = '--jupyter' ]; then
     shift
     exec jupyter "$@"
+fi
+
+if [ "$1" = '-jupyter-kernel' -o "$1" = '--jupyter-kernel' ]; then
+    shift
+    exec python3 -m sage.repl.ipython_kernel.install "$@"
 fi
 
 #####################################################################

--- a/src/doc/en/installation/launching.rst
+++ b/src/doc/en/installation/launching.rst
@@ -195,13 +195,15 @@ SageMath, the kernel is already available. Otherwise, assuming that the command
 
 .. code-block:: console
 
-    $ sage --jupyter-kernel install --user --portable
+    $ sage --jupyter-kernel install --user
 
-This installs a kernel spec into your per-user Jupyter directory. Thanks to
-``--portable``, the spec records the absolute path to Sage's Python
-interpreter and adds Sage's ``bin`` directories to ``PATH``, so it works even
-when the Jupyter server runs in a different environment, for example a
-system-wide JupyterLab or a JupyterHub deployment.
+This installs a kernel spec into your per-user Jupyter directory. By default the
+spec is *portable*: it records the absolute path to Sage's Python interpreter
+and adds Sage's ``bin`` directories to ``PATH``, so it works even when the
+Jupyter server runs in a different environment, for example a system-wide
+JupyterLab or a JupyterHub deployment. (Pass ``--no-portable`` to instead write
+a spec that uses a bare ``python3``, which only works when the Jupyter server
+itself runs inside Sage's environment.)
 
 The portable kernel spec is portable between Jupyter environments, but it is
 not relocatable: it contains absolute paths to this SageMath installation. If

--- a/src/doc/en/installation/launching.rst
+++ b/src/doc/en/installation/launching.rst
@@ -166,11 +166,13 @@ Setting up SageMath as a Jupyter kernel in an existing Jupyter notebook or Jupyt
 
 By default, SageMath installs itself as a Jupyter kernel in the same
 environment as the SageMath installation. This is the most convenient way to
-use SageMath in a Jupyter notebook. To check if the Sage kernel is
-available, start a Jupyter notebook and look for the kernel named
-``SageMath <x.y.z>`` in the list of available kernels.
-Alternatively, you can use the following command to check which kernels are
-available:
+use SageMath in a Jupyter notebook. If your notebook or JupyterLab server also
+runs from that environment, no extra setup is needed.
+
+To check if the Sage kernel is available, start the Jupyter notebook or
+JupyterLab server that you plan to use and look for the kernel named
+``SageMath <x.y.z>`` in the list of available kernels. Alternatively, run the
+``jupyter`` command from that same Jupyter installation:
 
 .. code-block:: console
 
@@ -179,73 +181,50 @@ available:
       python3     <path to env>/share/jupyter/kernels/python3
       sagemath    <path to env>/share/jupyter/kernels/sagemath
 
-In case the Sage kernel is not listed, you can check if the file ``kernel.json``
-is present in ``<path to env>/share/jupyter/kernels/sagemath``.
-If it is not there, you can create it using ``jupyter kernelspec install``
-as described below.
+In case the Sage kernel is not listed in that Jupyter installation, you can
+install it with the ``sage --jupyter-kernel`` command described below.
 
 You may already have a global installation of Jupyter. For added
-convenience, it is possible to link your installation of SageMath into
-your Jupyter installation, adding it to the list of available kernels
+convenience, it is possible to make your installation of SageMath available
+in that Jupyter installation, adding it to the list of available kernels
 that can be selected in the notebook or JupyterLab interface.
 
-Assuming that SageMath can be invoked by typing ``sage``, you can use
+If that Jupyter installation lives in the *same* Python environment as
+SageMath, the kernel is already available. Otherwise, assuming that the command
+``sage`` starts the SageMath installation that you want to use as a kernel, run
 
 .. code-block:: console
 
-    $ sage -sh -c 'ls -d $SAGE_VENV/share/jupyter/kernels/sagemath'
+    $ sage --jupyter-kernel install --user --portable
 
-to find the location of the SageMath kernel description.
-Alternatively, use ``jupyter kernelspec list`` from the same environment
-where SageMath is installed to find the location of the SageMath kernel.
+This installs a kernel spec into your per-user Jupyter directory. Thanks to
+``--portable``, the spec records the absolute path to Sage's Python
+interpreter and adds Sage's ``bin`` directories to ``PATH``, so it works even
+when the Jupyter server runs in a different environment, for example a
+system-wide JupyterLab or a JupyterHub deployment.
 
-Now pick a name for the kernel that identifies it clearly and uniquely.
+The portable kernel spec is portable between Jupyter environments, but it is
+not relocatable: it contains absolute paths to this SageMath installation. If
+you move SageMath, switch to a different SageMath installation, or upgrade in a
+way that changes Sage's Python environment, rerun the command above.
 
-For example, if you install Sage from source tarballs, you could decide
-to include the version number in the name, such as ``sagemath-9.6``.
-If you build SageMath from a clone of the git repository, it is better to
-choose a name that identifies the directory, perhaps ``sagemath-dev``
-or ``sagemath-teaching`` because the version will change.
+Only ``kernel.json`` and the kernel icons are installed, and the SageMath
+documentation is symlinked rather than copied. This avoids copying gigabytes of
+documentation into your Jupyter configuration directory.
 
-Now assuming that the Jupyter notebook can be started by typing
-``jupyter notebook``, the following command will install SageMath as a
-new kernel named ``sagemath-dev``.
-
-.. code-block:: console
-
-    $ jupyter kernelspec install --user $(sage -sh -c 'ls -d $SAGE_VENV/share/jupyter/kernels/sagemath') --name sagemath-dev
-
-The ``jupyter kernelspec`` approach by default does lead to about 2Gb of
-SageMath documentation being copied into your personal jupyter configuration
-directory. You can avoid that by instead putting a symlink in the relevant spot
-and
+Run
 
 .. code-block:: console
 
-    $ jupyter --paths
+    $ sage --jupyter-kernel install --help
 
-to find valid data directories for your Jupyter installation.
-A command along the lines of
+to see the available options, such as ``--sys-prefix`` or ``--prefix`` to
+install into a different location instead of the per-user directory. For a
+shared JupyterHub or another managed Jupyter installation, an administrator may
+prefer ``--prefix`` with the Jupyter data prefix used by that installation.
 
-.. code-block:: console
-
-    $ ln -s $(sage -sh -c 'ls -d $SAGE_VENV/share/jupyter/kernels/sagemath') $HOME/.local/share/jupyter/kernels/sagemath-dev
-
-can then be used to create a symlink to the SageMath kernel description
-in a location where your own ``jupyter`` can find it.
-
-If you have installed SageMath from source, the alternative command
-
-.. code-block:: console
-
-    $ ln -s $(sage -sh -c 'ls -d $SAGE_ROOT/venv/share/jupyter/kernels/sagemath') $HOME/.local/share/jupyter/kernels/sagemath-dev
-
-creates a symlink that will stay current even if you switch to a different Python version
-later.
-
-To get the full functionality of the SageMath kernel in your global
-Jupyter installation, the following Notebook Extension packages also
-need to be installed (or linked) in the environment from which the
+The command above registers the SageMath kernel. Some optional frontend
+features may also need packages or assets in the environment from which the
 Jupyter installation runs.
 
 You can check the presence of some of these packages using the command

--- a/src/sage/cli/__init__.py
+++ b/src/sage/cli/__init__.py
@@ -4,10 +4,11 @@ import sys
 
 from sage.cli.eval_cmd import EvalCmd
 from sage.cli.interactive_shell_cmd import InteractiveShellCmd
+from sage.cli.jupyter_kernel_cmd import JupyterKernelCmd
 from sage.cli.notebook_cmd import JupyterNotebookCmd
 from sage.cli.options import CliOptions
-from sage.cli.version_cmd import VersionCmd
 from sage.cli.run_file_cmd import RunFileCmd
+from sage.cli.version_cmd import VersionCmd
 
 
 def main() -> int:
@@ -39,6 +40,7 @@ def main() -> int:
 
     VersionCmd.extend_parser(parser)
     JupyterNotebookCmd.extend_parser(parser)
+    JupyterKernelCmd.extend_parser(parser)
     EvalCmd.extend_parser(parser)
     RunFileCmd.extend_parser(parser)
 
@@ -50,6 +52,8 @@ def main() -> int:
 
     logging.basicConfig(level=logging.DEBUG if options.verbose else logging.INFO)
 
+    if args.jupyter_kernel is not None:
+        return JupyterKernelCmd(options).run()
     if args.file:
         return RunFileCmd(options).run()
     if args.command:

--- a/src/sage/cli/jupyter_kernel_cmd.py
+++ b/src/sage/cli/jupyter_kernel_cmd.py
@@ -1,0 +1,39 @@
+import argparse
+
+from sage.cli.options import CliOptions
+
+
+class JupyterKernelCmd:
+    @staticmethod
+    def extend_parser(parser: argparse.ArgumentParser):
+        r"""
+        Extend the parser with the Jupyter kernel installation command.
+
+        INPUT:
+
+        - ``parser`` -- the parser to extend
+
+        OUTPUT: the extended parser
+        """
+        parser.add_argument(
+            "--jupyter-kernel",
+            nargs=argparse.REMAINDER,
+            metavar="...",
+            help="install the SageMath Jupyter kernel spec; run "
+            "'sage --jupyter-kernel install --help' for options",
+        )
+
+    def __init__(self, options: CliOptions):
+        r"""
+        Initialize the command.
+        """
+        self.options = options
+
+    def run(self) -> int:
+        r"""
+        Install the SageMath Jupyter kernel spec.
+        """
+        from sage.repl.ipython_kernel.install import main
+
+        main(self.options.jupyter_kernel)
+        return 0

--- a/src/sage/cli/jupyter_kernel_cmd_test.py
+++ b/src/sage/cli/jupyter_kernel_cmd_test.py
@@ -1,0 +1,24 @@
+import argparse
+
+from sage.cli.jupyter_kernel_cmd import JupyterKernelCmd
+
+
+def test_no_jupyter_kernel_by_default():
+    parser = argparse.ArgumentParser()
+    JupyterKernelCmd.extend_parser(parser)
+    args = parser.parse_args([])
+    assert args.jupyter_kernel is None
+
+
+def test_install_subcommand_collected():
+    parser = argparse.ArgumentParser()
+    JupyterKernelCmd.extend_parser(parser)
+    args = parser.parse_args(["--jupyter-kernel", "install"])
+    assert args.jupyter_kernel == ["install"]
+
+
+def test_remaining_options_passed_through():
+    parser = argparse.ArgumentParser()
+    JupyterKernelCmd.extend_parser(parser)
+    args = parser.parse_args(["--jupyter-kernel", "install", "--user", "--portable"])
+    assert args.jupyter_kernel == ["install", "--user", "--portable"]

--- a/src/sage/cli/options.py
+++ b/src/sage/cli/options.py
@@ -19,6 +19,9 @@ class CliOptions:
     """The notebook type to start."""
     notebook: str = "jupyter"
 
+    """The arguments for the ``--jupyter-kernel`` command, or ``None``."""
+    jupyter_kernel: list[str] | None = None
+
     """The command to execute."""
     command: str | None = None
 

--- a/src/sage/ext_data/notebook-ipython/kernel.json.in
+++ b/src/sage/ext_data/notebook-ipython/kernel.json.in
@@ -1,6 +1,6 @@
 {
   "argv": [
-    "python",
+    "python3",
     "-m",
     "sage.repl.ipython_kernel",
     "-f",

--- a/src/sage/repl/ipython_kernel/install.py
+++ b/src/sage/repl/ipython_kernel/install.py
@@ -13,27 +13,41 @@ in the Jupyter notebook's kernel drop-down. This is done by
     such as ``/usr/share``.
 """
 
-import errno
 import os
 import warnings
 
 from sage.env import (
     SAGE_DOC,
     SAGE_EXTCODE,
+    SAGE_LOCAL,
     SAGE_VERSION,
 )
 
 
 class SageKernelSpec:
 
-    def __init__(self, prefix=None):
+    def __init__(self, prefix=None, portable=False, jupyter_dir=None):
         """
         Utility to manage SageMath kernels and extensions.
 
         INPUT:
 
         - ``prefix`` -- (default: ``sys.prefix``)
-          directory for the installation prefix
+          directory for the installation prefix; the Jupyter files are
+          installed under ``prefix/share/jupyter``. Ignored if
+          ``jupyter_dir`` is given.
+
+        - ``portable`` -- boolean (default: ``False``); if ``True``, generate
+          a kernel spec that launches the kernel via the absolute path to this
+          Python interpreter and adds Sage's ``bin`` directories to ``PATH``
+          (and its ``lib`` directory to the dynamic-loader path), so that it
+          works from a Jupyter server running outside Sage's virtual
+          environment
+
+        - ``jupyter_dir`` -- (default: ``prefix/share/jupyter``) the Jupyter
+          data directory to install into. This is used to install into a
+          location such as the per-user Jupyter directory that does not follow
+          the ``prefix/share/jupyter`` layout.
 
         EXAMPLES::
 
@@ -46,9 +60,11 @@ class SageKernelSpec:
             True
         """
         self._display_name = 'SageMath {0}'.format(SAGE_VERSION)
-        if prefix is None:
-            from sys import prefix
-        jupyter_dir = os.path.join(prefix, "share", "jupyter")
+        self._portable = portable
+        if jupyter_dir is None:
+            if prefix is None:
+                from sys import prefix
+            jupyter_dir = os.path.join(prefix, "share", "jupyter")
         self.nbextensions_dir = os.path.join(jupyter_dir, "nbextensions")
         self.kernel_dir = os.path.join(jupyter_dir, "kernels", self.identifier())
         self._mkdirs()
@@ -89,14 +105,24 @@ class SageKernelSpec:
         """
         return 'sagemath'
 
-    def symlink(self, src, dst):
+    def symlink(self, src, dst, replace_dir=False):
         """
         Symlink ``src`` to ``dst``.
 
         This is not an atomic operation.
 
-        Already-existing symlinks will be deleted, already existing
-        non-empty directories will be kept.
+        Already-existing files and symlinks at ``dst`` are removed first so
+        that they can be replaced by a fresh symlink. An already-existing
+        *directory* at ``dst`` is kept (and ``src`` is not linked), unless
+        ``replace_dir`` is ``True``, in which case it is removed first.
+
+        INPUT:
+
+        - ``replace_dir`` -- boolean (default: ``False``); if ``True``, replace
+          an existing directory at ``dst``. This is used to clean up a real
+          directory left behind by older installations that copied resources
+          (such as the documentation) here instead of symlinking them; see
+          :issue:`40605`.
 
         EXAMPLES::
 
@@ -106,12 +132,28 @@ class SageKernelSpec:
             sage: spec.symlink(os.path.join(path, 'a'), os.path.join(path, 'b'))
             sage: os.listdir(path)
             ['b']
+
+        An existing directory at the destination is kept by default (to avoid
+        deleting unrelated data), but is replaced with ``replace_dir=True``::
+
+            sage: d = os.path.join(path, 'c')
+            sage: os.mkdir(d)
+            sage: with open(os.path.join(d, 'stale'), 'w') as f:
+            ....:     _ = f.write('x')
+            sage: spec.symlink(os.path.join(path, 'a'), d)
+            sage: os.path.isdir(d) and not os.path.islink(d)
+            True
+            sage: spec.symlink(os.path.join(path, 'a'), d, replace_dir=True)
+            sage: os.path.islink(d)
+            True
         """
-        try:
+        if os.path.islink(dst) or os.path.isfile(dst):
             os.remove(dst)
-        except OSError as err:
-            if err.errno == errno.EEXIST:
+        elif os.path.isdir(dst):
+            if not replace_dir:
                 return
+            import shutil
+            shutil.rmtree(dst)
         os.symlink(src, dst)
 
     def use_local_threejs(self):
@@ -151,12 +193,91 @@ class SageKernelSpec:
              'sage.repl.ipython_kernel',
              '-f',
              '{connection_file}']
+
+        A *portable* kernel spec uses the absolute path to this Python
+        interpreter, so that it can be started from a Jupyter server running
+        outside Sage's virtual environment (see also :meth:`_kernel_env`)::
+
+            sage: spec = SageKernelSpec(prefix=tmp_dir(), portable=True)
+            sage: cmd = spec._kernel_cmd()
+            sage: import sys
+            sage: cmd[0] == os.path.abspath(sys.executable)
+            True
+            sage: cmd[1:]
+            ['-m', 'sage.repl.ipython_kernel', '-f', '{connection_file}']
         """
+        if self._portable:
+            import sys
+            executable = os.path.abspath(sys.executable)
+        else:
+            executable = 'python3'
         return [
-            'python3',
+            executable,
             '-m', 'sage.repl.ipython_kernel',
             '-f', '{connection_file}',
         ]
+
+    def _kernel_env(self):
+        """
+        Environment for a portable kernel spec.
+
+        This puts the ``bin`` directory containing this Python interpreter on
+        ``PATH``, along with Sage's installation ``bin`` directory when that is
+        separate. This lets helper programs such as ``gap`` be found even when
+        the kernel is launched by a Jupyter server running outside Sage's
+        virtual environment. When Sage's installation prefix is known, its
+        ``lib`` directory is set as ``LD_LIBRARY_PATH`` (and
+        ``DYLD_LIBRARY_PATH`` on macOS) so that the dynamic loader can find
+        Sage's shared libraries on installations that do not encode an RPATH
+        (for example some source builds). The loader variables are not
+        appended to, since the launching environment usually does not define
+        them; the default loader search path (and any RPATH) still applies.
+        Jupyter expands the ``${PATH}`` reference at launch time.
+
+        OUTPUT: a dictionary mapping environment variable names to values
+
+        EXAMPLES::
+
+            sage: from sage.repl.ipython_kernel.install import SageKernelSpec
+            sage: spec = SageKernelSpec(prefix=tmp_dir(), portable=True)
+            sage: import sys
+            sage: bindir = os.path.dirname(os.path.abspath(sys.executable))
+            sage: spec._kernel_env()['PATH'].endswith(os.pathsep + '${PATH}')
+            True
+
+        If Sage's installation prefix is separate from its Python virtual
+        environment, the portable kernel also needs the installation ``bin``
+        directory on ``PATH`` and the ``lib`` directory on the library path::
+
+            sage: from sage.repl.ipython_kernel import install
+            sage: old_sage_local = install.SAGE_LOCAL
+            sage: try:
+            ....:     install.SAGE_LOCAL = os.path.join(tmp_dir(), 'local')
+            ....:     spec = install.SageKernelSpec(prefix=tmp_dir(), portable=True)
+            ....:     env = spec._kernel_env()
+            ....:     sage_local_bin = os.path.abspath(os.path.join(install.SAGE_LOCAL, 'bin'))
+            ....:     sage_local_lib = os.path.abspath(os.path.join(install.SAGE_LOCAL, 'lib'))
+            ....:     ok = env['PATH'].split(os.pathsep) == [bindir, sage_local_bin, '${PATH}']
+            ....:     ok &= env['LD_LIBRARY_PATH'] == sage_local_lib
+            ....:     ok &= env['DYLD_LIBRARY_PATH'] == sage_local_lib
+            ....: finally:
+            ....:     install.SAGE_LOCAL = old_sage_local
+            sage: ok
+            True
+        """
+        import sys
+        paths = [os.path.dirname(os.path.abspath(sys.executable))]
+        env = {}
+        if SAGE_LOCAL:
+            sage_local_bin = os.path.abspath(os.path.join(SAGE_LOCAL, 'bin'))
+            if sage_local_bin not in paths:
+                paths.append(sage_local_bin)
+            sage_local_lib = os.path.abspath(os.path.join(SAGE_LOCAL, 'lib'))
+            for var in ('LD_LIBRARY_PATH', 'DYLD_LIBRARY_PATH'):
+                env[var] = sage_local_lib
+        paths.append('${PATH}')
+        env['PATH'] = os.pathsep.join(paths)
+        return env
 
     def kernel_spec(self):
         """
@@ -170,13 +291,22 @@ class SageKernelSpec:
             sage: spec = SageKernelSpec(prefix=tmp_dir())
             sage: spec.kernel_spec()
             {'argv': ..., 'display_name': 'SageMath ...', 'language': 'sage', 'metadata': {'debugger': True}}
+
+        A portable spec additionally carries an ``env`` entry::
+
+            sage: spec = SageKernelSpec(prefix=tmp_dir(), portable=True)
+            sage: 'PATH' in spec.kernel_spec()['env']
+            True
         """
-        return dict(
+        spec = dict(
             argv=self._kernel_cmd(),
             display_name=self._display_name,
             language='sage',
             metadata=dict(debugger=True),
         )
+        if self._portable:
+            spec['env'] = self._kernel_env()
+        return spec
 
     def _install_spec(self):
         """
@@ -207,16 +337,32 @@ class SageKernelSpec:
             sage: spec = SageKernelSpec(prefix=tmp_dir())
             sage: spec._install_spec()
             sage: spec._symlink_resources()
+            sage: 'logo.svg' in os.listdir(spec.kernel_dir)
+            True
+
+        The ``kernel.json.in`` template is not part of the kernel spec and is
+        not symlinked into the kernel directory::
+
+            sage: 'kernel.json.in' in os.listdir(spec.kernel_dir)
+            False
         """
         path = os.path.join(SAGE_EXTCODE, 'notebook-ipython')
         for filename in os.listdir(path):
+            if filename.endswith('.in'):
+                # Skip templates such as kernel.json.in; the configured
+                # kernel.json is written by _install_spec().
+                continue
             self.symlink(
                 os.path.join(path, filename),
                 os.path.join(self.kernel_dir, filename)
             )
+        # replace_dir=True cleans up a real doc/ directory left behind by
+        # older installations that copied the documentation here (see
+        # :issue:`40605`).
         self.symlink(
             SAGE_DOC,
-            os.path.join(self.kernel_dir, 'doc')
+            os.path.join(self.kernel_dir, 'doc'),
+            replace_dir=True
         )
 
     @classmethod
@@ -305,3 +451,98 @@ def have_prerequisites(debug=True) -> bool:
             import traceback
             traceback.print_exc()
         return False
+
+
+def main(argv=None):
+    r"""
+    Command-line entry point for ``sage --jupyter-kernel``.
+
+    INPUT:
+
+    - ``argv`` -- (default: ``sys.argv[1:]``) list of command-line arguments
+
+    EXAMPLES:
+
+    Installing a portable kernel spec into a given prefix writes a
+    ``kernel.json`` that uses the absolute path to this Python interpreter and
+    carries an ``env`` entry putting the Sage ``bin`` directory on ``PATH``::
+
+        sage: from sage.repl.ipython_kernel.install import main
+        sage: import json, os, sys
+        sage: prefix = tmp_dir()
+        sage: main(['install', '--prefix', prefix, '--portable'])
+        sage: kernel_json = os.path.join(prefix, 'share', 'jupyter',
+        ....:                            'kernels', 'sagemath', 'kernel.json')
+        sage: with open(kernel_json) as f:
+        ....:     spec = json.load(f)
+        sage: spec['argv'][0] == os.path.abspath(sys.executable)
+        True
+        sage: spec['argv'][1:]
+        ['-m', 'sage.repl.ipython_kernel', '-f', '{connection_file}']
+        sage: 'PATH' in spec['env']
+        True
+
+    Without ``--portable`` the in-venv spec (using ``python3``) is written::
+
+        sage: prefix = tmp_dir()
+        sage: main(['install', '--prefix', prefix])
+        sage: kernel_json = os.path.join(prefix, 'share', 'jupyter',
+        ....:                            'kernels', 'sagemath', 'kernel.json')
+        sage: with open(kernel_json) as f:
+        ....:     json.load(f)['argv']
+        ['python3', '-m', 'sage.repl.ipython_kernel', '-f', '{connection_file}']
+
+    The ``--user`` option installs into the per-user Jupyter directory
+    (here redirected to a temporary location)::
+
+        sage: import jupyter_core.paths
+        sage: datadir = tmp_dir()
+        sage: old = jupyter_core.paths.jupyter_data_dir
+        sage: try:
+        ....:     jupyter_core.paths.jupyter_data_dir = lambda: datadir
+        ....:     main(['install', '--user'])
+        ....: finally:
+        ....:     jupyter_core.paths.jupyter_data_dir = old
+        sage: os.path.exists(os.path.join(datadir, 'kernels', 'sagemath', 'kernel.json'))
+        True
+    """
+    import argparse
+    parser = argparse.ArgumentParser(
+        prog='sage --jupyter-kernel',
+        description='Install the SageMath Jupyter kernel spec.')
+    subparsers = parser.add_subparsers(dest='command', required=True)
+    install = subparsers.add_parser(
+        'install', help='install the SageMath Jupyter kernel spec')
+    location = install.add_mutually_exclusive_group()
+    location.add_argument(
+        '--user', action='store_true',
+        help='install into the per-user Jupyter directory')
+    location.add_argument(
+        '--sys-prefix', action='store_true',
+        help='install into sys.prefix of the active environment (default)')
+    location.add_argument(
+        '--prefix', default=None,
+        help='install into PREFIX/share/jupyter')
+    install.add_argument(
+        '--portable', action='store_true',
+        help="generate a spec with an absolute interpreter path and PATH / "
+             "library-path environment entries so that it works from a "
+             "Jupyter server outside Sage's virtual environment")
+    args = parser.parse_args(argv)
+
+    if args.command == 'install':
+        kwds = {'portable': args.portable}
+        if args.user:
+            from jupyter_core.paths import jupyter_data_dir
+            kwds['jupyter_dir'] = jupyter_data_dir()
+        elif args.prefix:
+            kwds['prefix'] = args.prefix
+        else:
+            # --sys-prefix (the default)
+            import sys
+            kwds['prefix'] = sys.prefix
+        SageKernelSpec.update(**kwds)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/sage/repl/ipython_kernel/install.py
+++ b/src/sage/repl/ipython_kernel/install.py
@@ -463,14 +463,15 @@ def main(argv=None):
 
     EXAMPLES:
 
-    Installing a portable kernel spec into a given prefix writes a
-    ``kernel.json`` that uses the absolute path to this Python interpreter and
-    carries an ``env`` entry putting the Sage ``bin`` directory on ``PATH``::
+    Installing a kernel spec into a given prefix writes a ``kernel.json`` that,
+    by default (``--portable``), uses the absolute path to this Python
+    interpreter and carries an ``env`` entry putting the Sage ``bin`` directory
+    on ``PATH``::
 
         sage: from sage.repl.ipython_kernel.install import main
         sage: import json, os, sys
         sage: prefix = tmp_dir()
-        sage: main(['install', '--prefix', prefix, '--portable'])
+        sage: main(['install', '--prefix', prefix])
         sage: kernel_json = os.path.join(prefix, 'share', 'jupyter',
         ....:                            'kernels', 'sagemath', 'kernel.json')
         sage: with open(kernel_json) as f:
@@ -482,10 +483,11 @@ def main(argv=None):
         sage: 'PATH' in spec['env']
         True
 
-    Without ``--portable`` the in-venv spec (using ``python3``) is written::
+    With ``--no-portable`` the in-venv spec (using ``python3``) is written
+    instead::
 
         sage: prefix = tmp_dir()
-        sage: main(['install', '--prefix', prefix])
+        sage: main(['install', '--prefix', prefix, '--no-portable'])
         sage: kernel_json = os.path.join(prefix, 'share', 'jupyter',
         ....:                            'kernels', 'sagemath', 'kernel.json')
         sage: with open(kernel_json) as f:
@@ -524,10 +526,13 @@ def main(argv=None):
         '--prefix', default=None,
         help='install into PREFIX/share/jupyter')
     install.add_argument(
-        '--portable', action='store_true',
+        '--portable', action=argparse.BooleanOptionalAction, default=True,
         help="generate a spec with an absolute interpreter path and PATH / "
              "library-path environment entries so that it works from a "
-             "Jupyter server outside Sage's virtual environment")
+             "Jupyter server outside Sage's virtual environment (the default). "
+             "Use --no-portable to write a spec that uses a bare 'python3', "
+             "which only works when the Jupyter server itself runs inside "
+             "Sage's environment")
     args = parser.parse_args(argv)
 
     if args.command == 'install':


### PR DESCRIPTION
This reworks how the SageMath Jupyter kernel spec is installed, fixing two related problems.

### Docbuild (#40605)

In editable builds the kernel spec was installed into the per-user Jupyter directory (`jupyter kernelspec install --user`). The PDF docbuild deliberately hides the user directory (`JUPYTER_DATA_DIR=/doesnotexist`, from #33650) so that a user's own kernel can't shadow Sage's — but that also hid the freshly installed `sagemath` kernel, and `make doc-pdf` aborted with `No such kernel named sagemath`.

The kernel is now installed into `sys.prefix/share/jupyter`, which the docbuild (and an in-venv Jupyter) still searches, while the user-dir hiding keeps doing its job. As a side effect this also stops copying the whole meson build tree (gigabytes) into the user's Jupyter directory that `jupyter kernelspec install <dir>` produced — see jupyter/jupyter_client#1070.

### External / system Jupyter (#41765)

The kernel spec used a bare `python`/`python3` as `argv[0]`, so it only worked when the Jupyter server itself ran inside Sage's virtual environment. With Sage installed in a conda environment and started from a *system* Jupyter, the kernel could not be launched.

There is now a dedicated command to install the kernel spec:

```console
$ sage --jupyter-kernel install [--user | --sys-prefix | --prefix DIR] [--portable | --no-portable]
```

By default (`--portable`), the generated `kernel.json` uses the absolute path to Sage's Python interpreter and adds Sage's `bin` directory to `PATH` (and its `lib` directory to the dynamic-loader path), so the kernel can be started by a Jupyter server running outside Sage's environment:

```console
$ sage --jupyter-kernel install --user
```

This default follows jupyter/jupyter_client#1070 (comment): an explicit install runs from a known, existing environment (Sage's own), so it should record the absolute `sys.executable` rather than the bare `python3` placeholder. `jupyter_client` only rewrites `python3` to the `sys.executable` of the *launching* Jupyter server, which is the wrong interpreter whenever that server lives in a different environment (the #41765 case); the absolute path is also a strict superset that still works for an in-environment Jupyter. Pass `--no-portable` to write the in-venv `python3` spec instead.

The command is available both through the `sage` console-script entry point (`sage.cli`) and through `src/bin/sage`. The installation documentation section "Setting up SageMath as a Jupyter kernel in an existing Jupyter notebook or JupyterLab installation" is updated to use it instead of the old manual `jupyter kernelspec install` + symlink dance.

### Smaller changes

- `kernel.json.in` (the meson-installed template) now uses `python3` instead of the bare `python`, matching the runtime installer.
- The editable-build install in `spkg-install.in` is pinned to `--no-portable`, so its in-`sys.prefix` `kernel.json` keeps the in-venv `python3` `argv[0]`, matching the wheel (`data_files`) `kernel.json.in`. Only the user-invoked `sage --jupyter-kernel install` command defaults to portable.
- `_symlink_resources` no longer symlinks the `kernel.json.in` template into the kernel directory, and `symlink()` now replaces a stale real `doc/` directory left behind by older installs (instead of crashing) — while keeping any unrelated directory it didn't create.

Fixes #40605.
Fixes #41765.

### 📝 Checklist

- [x] The title is concise and informative.
- [x] I have linked relevant issues.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### ⌛ Dependencies

None.