### PR TITLE
fix(ecm): disable primesieve auto-detection in bundled GMP-ECM 7.0.7

### DIFF
--- a/build/pkgs/ecm/spkg-install.in
+++ b/build/pkgs/ecm/spkg-install.in
@@ -183,13 +183,6 @@ export CFLAGS # Not exported by 'sage-env'.  LDFLAGS are exported above if
               # necessary.  We currently don't set (or modify) any other
               # environment variables, so don't have to export them here.
 
-# Workaround for build failure with Xcode 15, https://github.com/sagemath/sage/issues/36342
-case "$UNAME" in
-    Darwin*)
-        export gmp_cv_asm_underscore=yes
-        ;;
-esac
-
 ###############################################################################
 # Now configure ECM:
 # (Note: Building (also) a *shared* library is disabled by default.

--- a/build/pkgs/ecm/spkg-install.in
+++ b/build/pkgs/ecm/spkg-install.in
@@ -224,6 +224,10 @@ if [ -z "$ECM_CONFIGURE" ]; then
 fi
 echo
 
+# libecm (src/sage/libs/libecm.pyx) links only -lecm, so disable GMP-ECM's
+# libprimesieve auto-detection or dlopen of libecm fails on macOS.  See gh-42249.
+export ac_cv_lib_primesieve_primesieve_init=no
+
 sdh_configure $SAGE_CONFIGURE_GMP $ECM_CONFIGURE
 
 ###############################################################################


### PR DESCRIPTION
After #42249 (GMP-ECM 7.0.7), importing `sage.libs.libecm` fails on macOS, breaking the `libecm.pyx` doctests:

```
symbol not found in flat namespace '_primesieve_free_iterator'
```

(reported [here](https://github.com/sagemath/sage/pull/42249#issuecomment-4606866002) by @jhpalmieri ).

**Cause.** 7.0.7 newly auto-detects `libprimesieve` in `SAGE_LOCAL` and links it into the static `libecm.a`, but the Cython wrapper links only `-lecm`, so the primesieve symbols stay unresolved; macOS's two-level namespace then rejects them at `dlopen`. (Homebrew's `gmp-ecm` is a shared library that records the dependency, so it is unaffected.)

**Fix.** GMP-ECM 7.0.7 has no `--without-primesieve` flag, so disable the detection via the autoconf cache variable. ECM falls back to its built-in sieve, exactly as in 7.0.6; no functional change.

This PR also drops the now-obsolete `gmp_cv_asm_underscore=yes` Xcode 15 workaround (gh-36342): 7.0.7 reworked that configure test from compile-and-link to compile-and-`nm`, so Xcode 15's linker no longer breaks it.

Verified on Linux at the object level (the default 7.0.7 build references `primesieve_free_iterator`; with the fix it does not). macOS doctest confirmation (`./sage -t src/sage/libs/libecm.pyx`) left to CI.
