### PR TITLE
numpy/scipy: pin BLAS to OpenBLAS, and restore SAGE_FAT_BINARY cpu-baseline pinning

### DIFF
--- a/build/pkgs/numpy/spkg-install.in
+++ b/build/pkgs/numpy/spkg-install.in
@@ -8,7 +8,12 @@ set -e
 export CXX=$(echo "$CXX" | sed 's/-std=[a-z0-9+]*//g')
 
 if [ "$SAGE_FAT_BINARY" = "yes" ]; then
-    export NUMPY_FCONFIG="--cpu-baseline=NONE"
+    # Portable build: require no CPU features beyond the architecture default so
+    # the binary runs on the oldest CPUs.  Runtime dispatch is kept, so optimized
+    # kernels are still selected when the host supports them.  This is the meson
+    # replacement for the old numpy.distutils "--cpu-baseline=NONE"; see
+    # https://numpy.org/doc/stable/reference/simd/build-options.html
+    export NUMPY_FCONFIG="-Csetup-args=-Dcpu-baseline=none"
 else
     export NUMPY_FCONFIG=""
 fi
@@ -35,7 +40,7 @@ fi
 # openblas DEPCHECK in spkg-configure.m4), so pin the provider explicitly
 # instead of autodetecting.
 if [ "$SAGE_DARWIN_ACCELERATE" = yes ]; then
-    sdh_pip_install .
+    sdh_pip_install . ${NUMPY_FCONFIG}
 else
-    sdh_pip_install . -Csetup-args=-Dblas=openblas -Csetup-args=-Dlapack=openblas
+    sdh_pip_install . -Csetup-args=-Dblas=openblas -Csetup-args=-Dlapack=openblas ${NUMPY_FCONFIG}
 fi

--- a/build/pkgs/numpy/spkg-install.in
+++ b/build/pkgs/numpy/spkg-install.in
@@ -27,4 +27,15 @@ fi
 ### http://scipy.github.io/devdocs/building/index.html
 
 
-sdh_pip_install .
+# numpy's meson build autodetects BLAS/LAPACK via pkg-config and, by default,
+# prefers MKL ahead of OpenBLAS.  On systems with a (possibly broken) system
+# MKL installed -- e.g. Debian/Ubuntu's intel-mkl, whose
+# mkl-dynamic-lp64-iomp.pc links -liomp5 without shipping libiomp5 -- the build
+# would pick MKL and fail to link.  Sage always depends on OpenBLAS (see the
+# openblas DEPCHECK in spkg-configure.m4), so pin the provider explicitly
+# instead of autodetecting.
+if [ "$SAGE_DARWIN_ACCELERATE" = yes ]; then
+    sdh_pip_install .
+else
+    sdh_pip_install . -Csetup-args=-Dblas=openblas -Csetup-args=-Dlapack=openblas
+fi

--- a/build/pkgs/scipy/spkg-install.in
+++ b/build/pkgs/scipy/spkg-install.in
@@ -7,8 +7,9 @@ cd src/
 # even when --no-isolation (--no-build-isolation) is in used. We patch it out.
 sed -i.bak '/build-system/,/project/s/^ *"numpy.*/    "numpy",/' pyproject.toml
 
+# Pin the BLAS/LAPACK provider so the build doesn't autodetect a (possibly broken) system MKL; Sage always depends on OpenBLAS.
 if [ "$SAGE_DARWIN_ACCELERATE" = yes ]; then
     sdh_pip_install --no-build-isolation . -Csetup-args=-Dblas=accelerate
 else
-    sdh_pip_install --no-build-isolation .
+    sdh_pip_install --no-build-isolation . -Csetup-args=-Dblas=openblas -Csetup-args=-Dlapack=openblas
 fi


### PR DESCRIPTION
# numpy/scipy build fixes: pin BLAS to OpenBLAS, and restore SAGE_FAT_BINARY cpu-baseline pinning

Two small, related build-correctness fixes to the numpy and scipy spkgs. The
primary fix avoids autodetecting a broken system MKL; the second restores
fat-binary CPU-baseline pinning for numpy that was silently lost in the meson
switch.

## Description

numpy's and scipy's meson build systems autodetect the BLAS/LAPACK provider via
`pkg-config`. By default they prefer MKL ahead of OpenBLAS: numpy's
`blas-order` defaults to searching `mkl,openblas,blis,blas` (and `lapack-order`
to `mkl,openblas,lapack`), so a system MKL is picked first whenever it is
discoverable.

On Debian/Ubuntu systems with the distro `intel-mkl` package installed, that
package ships a broken `mkl-dynamic-lp64-iomp.pc` which links `-liomp5` even
though no `libiomp5` is provided. The numpy build therefore selects MKL and the
link step fails with:

```
cannot find -liomp5
```

This is effectively invisible to `update-alternatives`: the build-time BLAS
selection is done by meson/pkg-config and does not consult the
`libblas.so.3` / `liblapack.so.3` alternatives at all, so switching the system
BLAS alternative to OpenBLAS does not change which provider the numpy/scipy
build picks.

Sage always depends on OpenBLAS: the numpy and scipy spkgs `DEPCHECK openblas`,
and Sage's BLAS facade pkg-config files point at OpenBLAS. Letting the build
autodetect a possibly broken system MKL is therefore both unnecessary and a
source of build failures.

## Fix

The numpy and scipy spkgs now pin the BLAS/LAPACK provider explicitly on the
non-Accelerate path by passing:

```
-Csetup-args=-Dblas=openblas -Csetup-args=-Dlapack=openblas
```

The Darwin/Accelerate paths are left unchanged. scipy already used exactly this
mechanism to pin `accelerate` on macOS (`-Csetup-args=-Dblas=accelerate`), so
this is an established, low-risk approach extended to numpy and to the
non-Accelerate scipy path.

## How to reproduce

On Ubuntu 24.04:

```bash
sudo apt-get install intel-mkl
# configure Sage to use the system OpenBLAS, then build
./configure
make
```

The numpy spkg fails while linking `lapack_lite` / `_umath_linalg` with
`cannot find -liomp5`, because the build selected the system MKL via
`mkl-dynamic-lp64-iomp.pc` instead of OpenBLAS.

## Additional fix: restore `SAGE_FAT_BINARY` cpu-baseline pinning (numpy)

`build/pkgs/numpy/spkg-install.in` still computes
`NUMPY_FCONFIG="--cpu-baseline=NONE"` when `SAGE_FAT_BINARY=yes`, but the
variable stopped being passed to the install command when numpy switched to
meson-python (`2e652c0c45f`, Aug 2023). Fat-binary builds therefore silently
stopped disabling the CPU baseline and could emit a binary that executes
instructions unavailable on the oldest target CPUs.

This restores the behavior using the meson equivalent of the old flag,
`-Csetup-args=-Dcpu-baseline=none`, applied on both the Accelerate and
non-Accelerate paths. Per numpy's
[CPU build options](https://numpy.org/doc/stable/reference/simd/build-options.html),
`cpu-baseline=none` keeps runtime CPU dispatch, so optimized kernels are still
selected where the host supports them.

## 📝 Checklist

- [x] I have made sure that the title is self-explanatory and the description concisely explains the PR.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

This is a build-system change to two spkg `spkg-install.in` scripts; it has no
doctest surface and no user-facing documentation to update.

## ⌛ Dependencies

None.
