### PR TITLE
link libprimesieve into the libecm module

### DIFF
--- a/build/pkgs/ecm/dependencies
+++ b/build/pkgs/ecm/dependencies
@@ -1,4 +1,4 @@
-$(MP_LIBRARY)
+$(MP_LIBRARY) primesieve
 
 ----------
 All lines of this file are ignored except the first.

--- a/build/pkgs/ecm/spkg-configure.m4
+++ b/build/pkgs/ecm/spkg-configure.m4
@@ -1,6 +1,6 @@
 SAGE_SPKG_CONFIGURE([ecm], [dnl CHECK - test whether the package is already installed
     m4_pushdef([SAGE_ECM_MINVER],[7.0.4])
-    SAGE_SPKG_DEPCHECK([gmp], [
+    SAGE_SPKG_DEPCHECK([gmp primesieve], [
         AC_CHECK_HEADER(ecm.h, [
             AX_ABSOLUTE_HEADER([ecm.h])
             if test x$gl_cv_absolute_ecm_h = x; then

--- a/build/pkgs/ecm/spkg-install.in
+++ b/build/pkgs/ecm/spkg-install.in
@@ -183,13 +183,6 @@ export CFLAGS # Not exported by 'sage-env'.  LDFLAGS are exported above if
               # necessary.  We currently don't set (or modify) any other
               # environment variables, so don't have to export them here.
 
-# Workaround for build failure with Xcode 15, https://github.com/sagemath/sage/issues/36342
-case "$UNAME" in
-    Darwin*)
-        export gmp_cv_asm_underscore=yes
-        ;;
-esac
-
 ###############################################################################
 # Now configure ECM:
 # (Note: Building (also) a *shared* library is disabled by default.

--- a/src/meson.build
+++ b/src/meson.build
@@ -203,6 +203,13 @@ ec = dependency(
   disabler: true,
 )
 ecm = cc.find_library('ecm', required: false, disabler: true)
+# GMP-ECM >= 7.0.7 optionally uses libprimesieve (HAVE_LIBPRIMESIEVE) for its
+# prime generator, so libecm references primesieve symbols and the Cython
+# wrapper must link it too (otherwise dlopen fails on macOS, see PR #42249).
+primesieve = dependency('primesieve', required: false)
+if not primesieve.found()
+  primesieve = cc.find_library('primesieve', required: false)
+endif
 gmpxx = dependency('gmpxx', required: not is_windows, disabler: true)
 fflas = dependency(
   'fflas-ffpack',

--- a/src/meson.build
+++ b/src/meson.build
@@ -203,12 +203,27 @@ ec = dependency(
   disabler: true,
 )
 ecm = cc.find_library('ecm', required: false, disabler: true)
-# GMP-ECM >= 7.0.7 optionally uses libprimesieve (HAVE_LIBPRIMESIEVE) for its
-# prime generator, so libecm references primesieve symbols and the Cython
-# wrapper must link it too (otherwise dlopen fails on macOS, see PR #42249).
-primesieve = dependency('primesieve', required: false)
-if not primesieve.found()
-  primesieve = cc.find_library('primesieve', required: false)
+# GMP-ECM >= 7.0.7 can use libprimesieve (HAVE_LIBPRIMESIEVE) for its prime
+# generator. Sage links the *static* libecm, so primesieve symbols pulled in by
+# ecm end up as undefined references in the Cython wrapper, which must then link
+# primesieve too (otherwise the module fails to dlopen on macOS, see PR #42249).
+# Earlier ecm releases do not reference primesieve, so gate on the version.
+ecm_uses_primesieve = false
+if ecm.found()
+  ecm_version = cc.get_define(
+    'ECM_VERSION',
+    prefix: '#include <ecm.h>',
+    dependencies: [gmp],
+  ).strip('"')
+  ecm_uses_primesieve = ecm_version != '' and ecm_version.version_compare(
+    '>=7.0.7',
+  )
+endif
+if ecm_uses_primesieve
+  primesieve = dependency('primesieve', required: false)
+  if not primesieve.found()
+    primesieve = cc.find_library('primesieve', required: true)
+  endif
 endif
 gmpxx = dependency('gmpxx', required: not is_windows, disabler: true)
 fflas = dependency(

--- a/src/sage/libs/meson.build
+++ b/src/sage/libs/meson.build
@@ -172,6 +172,9 @@ foreach name, pyx : extension_data
     deps += [homfly]
   elif name == 'libecm'
     deps += [ecm]
+    if primesieve.found()
+      deps += [primesieve]
+    endif
   endif
 
   py.extension_module(

--- a/src/sage/libs/meson.build
+++ b/src/sage/libs/meson.build
@@ -172,7 +172,7 @@ foreach name, pyx : extension_data
     deps += [homfly]
   elif name == 'libecm'
     deps += [ecm]
-    if primesieve.found()
+    if ecm_uses_primesieve
       deps += [primesieve]
     endif
   endif


### PR DESCRIPTION
### Problem

After #42249 upgraded the bundled `ecm` package to GMP-ECM 7.0.7, importing `sage.libs.libecm` fails on macOS (reported by @jhpalmieri, using Sage's own ecm):

```
ImportError: dlopen(.../libecm.cpython-*.so):
  symbol not found in flat namespace '_primesieve_free_iterator'
```

### Root cause

GMP-ECM 7.0.7 added `AC_CHECK_LIB(primesieve, primesieve_init)` to its `configure.ac` (commit `4b4a02dbd867`, *"Use libprimesieve for getprime_r if available"*). This is **new in 7.0.7** — 7.0.6 has no primesieve references at all.

Since `primesieve` is a **standard** Sage package and therefore always present in `SAGE_LOCAL`, gmp-ecm's `configure` always detects it, defines `HAVE_LIBPRIMESIEVE`, and compiles `getprime_r.c` with primesieve calls. As a result `libecm` now references primesieve symbols (e.g. `primesieve_free_iterator`) and links `-lprimesieve`.

Sage's `sage.libs.libecm` Cython extension only linked `-lecm`, never `-lprimesieve`. Linux tolerates the unresolved symbol (transitive / global symbol resolution at `dlopen`), but macOS's flat namespace does not — hence the import failure. CI was green because the bots are Linux/conda; the regression only surfaced on a macOS tester after merge.

This also affects the system/homebrew `gmp-ecm` path added in #42249, since homebrew's gmp-ecm 7.0.7 is likewise built against primesieve.

### Fix

Link `primesieve` into the `libecm` module so the symbols resolve, covering both Sage's own ecm build and the system/homebrew path:

- `build/pkgs/ecm/dependencies`: add `primesieve` (build ordering)
- `src/meson.build`: detect `primesieve` (pkg-config, with `cc.find_library` fallback)
- `src/sage/libs/meson.build`: add `primesieve` to the `libecm` extension's dependencies when found

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes. (N/A — build/link fix; existing `src/sage/libs/libecm.pyx` doctests cover the interface.)
- [ ] I have updated the documentation and checked the documentation preview. (N/A — no docs change.)

### :hourglass: Dependencies

Follow-up to #42249.

---

### Also: drop the obsolete Xcode 15 underscore workaround

`build/pkgs/ecm/spkg-install.in` carried `export gmp_cv_asm_underscore=yes` as a workaround for #36342, where GMP-ECM's **link-based** "globals prefixed by underscore" configure test errored under Xcode 15 (*"Test program links neither with nor without underscore"*).

GMP-ECM 7.0.7 replaces that link-based test with an **nm-based** one (taken from GMP 6.3.0). Its `acinclude.m4` comment states it *"replaces the previous link-based test which broke on macOS with Xcode 15+"* — i.e. exactly #36342. The new test never links (so it cannot hit the Xcode 15 failure), on macOS `nm` reports `_gurkmacka` → correctly `yes`, and the only fallback is an `AC_MSG_WARN` (no hard error). The workaround is now obsolete, so this PR removes it.
