### PR TITLE
Do not import gnumake_tokenpool on OS X when doctesting

### DIFF
--- a/src/sage/doctest/forker.py
+++ b/src/sage/doctest/forker.py
@@ -1878,13 +1878,11 @@ class DocTestDispatcher(SageObject):
         if sys.platform != "darwin":
             try:
                 from gnumake_tokenpool import JobClient, NoJobServer
+                job_client = JobClient(use_cysignals=True)
             except ImportError:
                 pass
-            else:
-                try:
-                    job_client = JobClient(use_cysignals=True)
-                except NoJobServer:
-                    pass
+            except NoJobServer:
+                pass
 
         source_iter = iter(self.controller.sources)
 

--- a/src/sage/doctest/forker.py
+++ b/src/sage/doctest/forker.py
@@ -1873,15 +1873,18 @@ class DocTestDispatcher(SageObject):
         opt = self.controller.options
 
         job_client = None
-        try:
-            from gnumake_tokenpool import JobClient, NoJobServer
-        except ImportError:
-            pass
-        else:
+        # Using gnumake_tokenpool leads to doctest failures when
+        # testing in parallel. See #38116 and #41497.
+        if sys.platform != "darwin":
             try:
-                job_client = JobClient(use_cysignals=True)
-            except NoJobServer:
+                from gnumake_tokenpool import JobClient, NoJobServer
+            except ImportError:
                 pass
+            else:
+                try:
+                    job_client = JobClient(use_cysignals=True)
+                except NoJobServer:
+                    pass
 
         source_iter = iter(self.controller.sources)
 

--- a/src/sage/doctest/forker.py
+++ b/src/sage/doctest/forker.py
@@ -1874,7 +1874,7 @@ class DocTestDispatcher(SageObject):
 
         job_client = None
         # Using gnumake_tokenpool leads to doctest failures when
-        # testing in parallel. See #38116 and #41497.
+        # testing in parallel. See #38116 and #42293.
         if sys.platform != "darwin":
             try:
                 from gnumake_tokenpool import JobClient, NoJobServer


### PR DESCRIPTION
Do not import gnumake_tokenpool on OS X when doctesting

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Parallel testing has been broken on OS X for a long time: see #38116. I propose to fix this by not importing gnumake_tokenpool in src/sage/doctest/forker.py on OS X.



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [X] The title is concise and informative.
- [X] The description explains in detail what this PR is about.
- [X] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


