### PR TITLE
Kill the feature for the sage.sat module

### DIFF
--- a/src/sage/combinat/matrices/dancing_links.pyx
+++ b/src/sage/combinat/matrices/dancing_links.pyx
@@ -904,11 +904,11 @@ cdef class dancing_linksWrapper:
             sage: from sage.combinat.matrices.dancing_links import dlx_solver
             sage: rows = [[0,1,2], [0,2], [1], [3]]
             sage: x = dlx_solver(rows)
-            sage: s = x.to_sat_solver()                                                 # needs sage.sat
+            sage: s = x.to_sat_solver()
 
         Using some optional SAT solvers::
 
-            sage: x.to_sat_solver('cryptominisat')      # optional - pycryptosat        # needs sage.sat
+            sage: x.to_sat_solver('cryptominisat')      # optional - pycryptosat
             CryptoMiniSat solver: 4 variables, 7 clauses.
         """
         from sage.sat.solvers.satsolver import SAT
@@ -960,20 +960,20 @@ cdef class dancing_linksWrapper:
             sage: rows = [[0,1,2], [3,4,5], [0,1], [2,3,4,5], [0], [1,2,3,4,5]]
             sage: d = dlx_solver(rows)
             sage: solutions = [[0,1], [2,3], [4,5]]
-            sage: d.one_solution_using_sat_solver() in solutions                        # needs sage.sat
+            sage: d.one_solution_using_sat_solver() in solutions
             True
 
         Using optional solvers::
 
-            sage: s = d.one_solution_using_sat_solver('glucose')                # optional - glucose, needs sage.sat
-            sage: s in solutions                                                # optional - glucose, needs sage.sat
+            sage: s = d.one_solution_using_sat_solver('glucose')                # optional - glucose
+            sage: s in solutions                                                # optional - glucose
             True
 
         When no solution is found::
 
             sage: rows = [[0,1,2], [2,3,4,5], [0,1,2,3]]
             sage: d = dlx_solver(rows)
-            sage: d.one_solution_using_sat_solver() is None                             # needs sage.sat
+            sage: d.one_solution_using_sat_solver() is None
             True
         """
         sat_solver = self.to_sat_solver(solver)

--- a/src/sage/features/sagemath.py
+++ b/src/sage/features/sagemath.py
@@ -971,28 +971,6 @@ class sage__rings__real_mpfr(JoinFeature):
                              spkg='sagemath_modules', type='standard')
 
 
-class sage__sat(JoinFeature):
-    r"""
-    A :class:`~sage.features.Feature` describing the presence of :mod:`sage.sat`.
-
-    TESTS::
-
-        sage: from sage.features.sagemath import sage__sat
-        sage: sage__sat().is_present()                                                  # needs sage.sat
-        FeatureTestResult('sage.sat', True)
-    """
-    def __init__(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features.sagemath import sage__sat
-            sage: isinstance(sage__sat(), sage__sat)
-            True
-        """
-        JoinFeature.__init__(self, 'sage.sat',
-                             [PythonModule('sage.sat.expression')],
-                             spkg='sagemath_combinat', type='standard')
-
 
 class sage__schemes(JoinFeature):
     r"""
@@ -1123,7 +1101,6 @@ def all_features():
         sage__rings__padics(),
         sage__rings__real_double(),
         sage__rings__real_mpfr(),
-        sage__sat(),
         sage__schemes(),
         sage__symbolic(),
     ]


### PR DESCRIPTION
There are only a few `# needs sage.sat` tags in the library. We remove them, and then remove the `sage__sat` feature class that implemented them.

(There is no way to install sage without sage.sat)
