### PR TITLE
Kill the feature for sage.rings.real_double

### DIFF
--- a/src/sage/features/sagemath.py
+++ b/src/sage/features/sagemath.py
@@ -915,36 +915,6 @@ class sage__rings__padics(JoinFeature):
                              type='standard')
 
 
-class sage__rings__real_double(PythonModule):
-    r"""
-    A :class:`~sage.features.Feature` describing the presence of :mod:`sage.rings.real_double`.
-
-    EXAMPLES:
-
-    The Real Double Field is basically always available, and no ``# optional/needs`` tag is needed::
-
-        sage: RDF.characteristic()
-        0
-
-    The feature exists for use in doctests of Python modules that are shipped by the
-    most fundamental distributions.
-
-    TESTS::
-
-        sage: from sage.features.sagemath import sage__rings__real_double
-        sage: sage__rings__real_double().is_present()                                   # needs sage.rings.real_double
-        FeatureTestResult('sage.rings.real_double', True)
-    """
-    def __init__(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features.sagemath import sage__rings__real_double
-            sage: isinstance(sage__rings__real_double(), sage__rings__real_double)
-            True
-        """
-        PythonModule.__init__(self, 'sage.rings.real_double', type='standard')
-
 
 class sage__rings__real_mpfr(JoinFeature):
     r"""
@@ -1121,7 +1091,6 @@ def all_features():
         sage__rings__function_field(),
         sage__rings__number_field(),
         sage__rings__padics(),
-        sage__rings__real_double(),
         sage__rings__real_mpfr(),
         sage__sat(),
         sage__schemes(),

--- a/src/sage/geometry/polyhedron/backend_cdd_rdf.py
+++ b/src/sage/geometry/polyhedron/backend_cdd_rdf.py
@@ -1,5 +1,3 @@
-# sage.doctest: needs sage.rings.real_double
-
 r"""
 The cdd backend for polyhedral computations, floating point version
 """

--- a/src/sage/geometry/polyhedron/base_RDF.py
+++ b/src/sage/geometry/polyhedron/base_RDF.py
@@ -1,4 +1,3 @@
-# sage.doctest: needs sage.rings.real_double
 """
 Base class for polyhedra over ``RDF``
 """

--- a/src/sage/geometry/polyhedron/misc.py
+++ b/src/sage/geometry/polyhedron/misc.py
@@ -28,7 +28,7 @@ def _to_space_separated_string(l, base_ring=None):
         sage: import sage.geometry.polyhedron.misc as P
         sage: P._to_space_separated_string([2,3])
         '2 3'
-        sage: P._to_space_separated_string([2, 1/5], RDF)                               # needs sage.rings.real_double
+        sage: P._to_space_separated_string([2, 1/5], RDF)
         '2.0 0.2'
     """
     if base_ring:


### PR DESCRIPTION
Clean up the few `needs sage.rings.real_double` tags, and then remove the feature.

There is no way to install Sage without `RDF`, and nobody wants to.

