### PR TITLE
Serialize the desktop-opener handoff so `show()` in a loop no longer drops or duplicates graphics

### DIFF
--- a/src/sage/repl/rich_output/backend_ipython.py
+++ b/src/sage/repl/rich_output/backend_ipython.py
@@ -15,10 +15,136 @@ This module defines the IPython backends for
 # ****************************************************************************
 
 import os
+import shlex
+import subprocess
 import html
 from IPython.display import publish_display_data
 from sage.repl.rich_output.backend_base import BackendBase
 from sage.repl.rich_output.output_catalog import *
+
+
+def _viewer_command_arguments(command, filename):
+    r"""
+    Return command-line arguments for launching a viewer.
+
+    INPUT:
+
+    - ``command`` -- string; the configured viewer command
+
+    - ``filename`` -- string; the file to show
+
+    OUTPUT: list; the command and arguments
+
+    EXAMPLES::
+
+        sage: from sage.repl.rich_output.backend_ipython import _viewer_command_arguments
+        sage: _viewer_command_arguments('xdg-open', '/tmp/plot.png')
+        ['xdg-open', '/tmp/plot.png']
+        sage: _viewer_command_arguments('gio open', '/tmp/plot.png')
+        ['gio', 'open', '/tmp/plot.png']
+
+    Empty viewer commands are rejected::
+
+        sage: _viewer_command_arguments('', '/tmp/plot.png')
+        Traceback (most recent call last):
+        ...
+        ValueError: viewer command must not be empty
+    """
+    argv = shlex.split(command)
+    if not argv:
+        raise ValueError('viewer command must not be empty')
+    argv.append(filename)
+    return argv
+
+
+def _viewer_command_uses_foreground_handoff(command):
+    r"""
+    Return whether ``command`` should be run to completion before continuing.
+
+    The Sage command line normally launches viewers in the background, since
+    many viewers keep running until their window is closed.  Freedesktop
+    openers such as ``xdg-open``, ``gio open`` and ``gvfs-open`` are short-lived
+    handoff commands instead.  Running those handoffs concurrently can race in
+    single-instance image viewers, causing some images shown in a loop to be
+    skipped or repeated; running them in the foreground serializes the handoff
+    and avoids the race.  See :issue:`42292`.
+
+    .. NOTE::
+
+        Only the common freedesktop openers are recognized.  A viewer that is
+        itself a single-instance application and is configured directly (for
+        example ``viewer.png_viewer('eog')``) is still launched in the
+        background and may exhibit the race.
+
+    EXAMPLES::
+
+        sage: from sage.repl.rich_output.backend_ipython import _viewer_command_uses_foreground_handoff as handoff
+        sage: handoff('xdg-open')
+        True
+        sage: handoff('/usr/bin/gio open')
+        True
+        sage: handoff('gvfs-open')
+        True
+
+    Long-running viewers and bare commands are not treated as handoffs::
+
+        sage: handoff('eog')
+        False
+        sage: handoff('gio')
+        False
+        sage: handoff('')
+        False
+    """
+    argv = shlex.split(command)
+    if not argv:
+        return False
+    program = os.path.basename(argv[0])
+    if program in ('xdg-open', 'gvfs-open'):
+        return True
+    return program == 'gio' and argv[1:2] == ['open']
+
+
+def _launch_viewer_command(command, filename):
+    r"""
+    Launch an external viewer command for ``filename``.
+
+    Short-lived desktop openers are run in the foreground so Sage serializes the
+    handoff to the user's desktop. Other viewer commands are launched in the
+    background, preserving the existing command-line behavior for viewers that
+    stay open until their window is closed.
+
+    INPUT:
+
+    - ``command`` -- string; the configured viewer command
+
+    - ``filename`` -- string; the file to show
+
+    EXAMPLES:
+
+    Long-running viewers are launched in the background (here ``true`` stands in
+    for such a viewer and simply exits)::
+
+        sage: from sage.repl.rich_output.backend_ipython import _launch_viewer_command
+        sage: from sage.misc.temporary_file import tmp_filename
+        sage: _launch_viewer_command('true', tmp_filename())
+    """
+    if _viewer_command_uses_foreground_handoff(command):
+        # These openers return as soon as the file is handed off to the desktop
+        # (they do not block until the viewer window is closed), so running them
+        # in the foreground only briefly pauses the prompt.  We deliberately do
+        # not impose a timeout: killing a slow but legitimate handoff could drop
+        # the very image we are trying to show.  A Ctrl-C still propagates if an
+        # opener misbehaves.
+        try:
+            subprocess.run(_viewer_command_arguments(command, filename),
+                           stdout=subprocess.DEVNULL,
+                           stderr=subprocess.DEVNULL,
+                           check=False)
+        except OSError:
+            pass
+    else:
+        os.system('{0} {1} 2>/dev/null 1>/dev/null &'
+                  .format(command, shlex.quote(filename)))
 
 
 class BackendIPython(BackendBase):
@@ -329,8 +455,7 @@ class BackendIPythonCommandline(BackendIPython):
             command = viewer.browser()
         from sage.doctest import DOCTEST_MODE
         if not DOCTEST_MODE:
-            os.system('{0} {1} 2>/dev/null 1>/dev/null &'
-                      .format(command, image_file))
+            _launch_viewer_command(command, image_file)
         return 'Launched {0} viewer for {1}'.format(ext, plain_text)
 
     def launch_jmol(self, output_jmol, plain_text):
@@ -365,8 +490,7 @@ class BackendIPythonCommandline(BackendIPython):
         launch_script = output_jmol.launch_script_filename()
         jmol_cmd = 'jmol'
         if not DOCTEST_MODE:
-            os.system('{0} {1} 2>/dev/null 1>/dev/null &'
-                      .format(jmol_cmd, launch_script))
+            _launch_viewer_command(jmol_cmd, launch_script)
         return 'Launched jmol viewer for {0}'.format(plain_text)
 
     def is_in_terminal(self):

--- a/src/sage/repl/rich_output/backend_ipython.py
+++ b/src/sage/repl/rich_output/backend_ipython.py
@@ -15,10 +15,136 @@ This module defines the IPython backends for
 # ****************************************************************************
 
 import os
+import shlex
+import subprocess
 import html
 from IPython.display import publish_display_data
 from sage.repl.rich_output.backend_base import BackendBase
 from sage.repl.rich_output.output_catalog import *
+
+
+def _viewer_command_arguments(command, filename):
+    r"""
+    Return command-line arguments for launching a viewer.
+
+    INPUT:
+
+    - ``command`` -- string; the configured viewer command
+
+    - ``filename`` -- string; the file to show
+
+    OUTPUT: list; the command and arguments
+
+    EXAMPLES::
+
+        sage: from sage.repl.rich_output.backend_ipython import _viewer_command_arguments
+        sage: _viewer_command_arguments('xdg-open', '/tmp/plot.png')
+        ['xdg-open', '/tmp/plot.png']
+        sage: _viewer_command_arguments('gio open', '/tmp/plot.png')
+        ['gio', 'open', '/tmp/plot.png']
+
+    Empty viewer commands are rejected::
+
+        sage: _viewer_command_arguments('', '/tmp/plot.png')
+        Traceback (most recent call last):
+        ...
+        ValueError: viewer command must not be empty
+    """
+    argv = shlex.split(command)
+    if not argv:
+        raise ValueError('viewer command must not be empty')
+    argv.append(filename)
+    return argv
+
+
+def _viewer_command_uses_foreground_handoff(command):
+    r"""
+    Return whether ``command`` should be run to completion before continuing.
+
+    The Sage command line normally launches viewers in the background, since
+    many viewers keep running until their window is closed.  Freedesktop
+    openers such as ``xdg-open``, ``gio open`` and ``gvfs-open`` are short-lived
+    handoff commands instead.  Running those handoffs concurrently can race in
+    single-instance image viewers, causing some images shown in a loop to be
+    skipped or repeated; running them in the foreground serializes the handoff
+    and avoids the race.  See :issue:`42292`.
+
+    .. NOTE::
+
+        Only the common freedesktop openers are recognized.  A viewer that is
+        itself a single-instance application and is configured directly (for
+        example ``viewer.png_viewer('eog')``) is still launched in the
+        background and may exhibit the race.
+
+    EXAMPLES::
+
+        sage: from sage.repl.rich_output.backend_ipython import _viewer_command_uses_foreground_handoff as handoff
+        sage: handoff('xdg-open')
+        True
+        sage: handoff('/usr/bin/gio open')
+        True
+        sage: handoff('gvfs-open')
+        True
+
+    Long-running viewers and bare commands are not treated as handoffs::
+
+        sage: handoff('eog')
+        False
+        sage: handoff('gio')
+        False
+        sage: handoff('')
+        False
+    """
+    argv = shlex.split(command)
+    if not argv:
+        return False
+    program = os.path.basename(argv[0])
+    if program in ('xdg-open', 'gvfs-open'):
+        return True
+    return program == 'gio' and argv[1:2] == ['open']
+
+
+def _launch_viewer_command(command, filename):
+    r"""
+    Launch an external viewer command for ``filename``.
+
+    Short-lived desktop openers are run in the foreground so Sage serializes the
+    handoff to the user's desktop. Other viewer commands are launched in the
+    background, preserving the existing command-line behavior for viewers that
+    stay open until their window is closed.
+
+    INPUT:
+
+    - ``command`` -- string; the configured viewer command
+
+    - ``filename`` -- string; the file to show
+
+    EXAMPLES:
+
+    Long-running viewers are launched in the background (here ``true`` stands in
+    for such a viewer and simply exits)::
+
+        sage: from sage.repl.rich_output.backend_ipython import _launch_viewer_command
+        sage: from sage.misc.temporary_file import tmp_filename
+        sage: _launch_viewer_command('true', tmp_filename())
+    """
+    if _viewer_command_uses_foreground_handoff(command):
+        # These openers return as soon as the file is handed off to the desktop
+        # (they do not block until the viewer window is closed), so running them
+        # in the foreground only briefly pauses the prompt.  We deliberately do
+        # not impose a timeout: killing a slow but legitimate handoff could drop
+        # the very image we are trying to show.  A Ctrl-C still propagates if an
+        # opener misbehaves.
+        try:
+            subprocess.run(_viewer_command_arguments(command, filename),
+                           stdout=subprocess.DEVNULL,
+                           stderr=subprocess.DEVNULL,
+                           check=False)
+        except OSError:
+            pass
+    else:
+        os.system('{0} {1} 2>/dev/null 1>/dev/null &'
+                  .format(command, shlex.quote(filename)))
 
 
 class BackendIPython(BackendBase):
@@ -336,8 +462,7 @@ class BackendIPythonCommandline(BackendIPython):
             command = viewer.browser()
         from sage.doctest import DOCTEST_MODE
         if not DOCTEST_MODE:
-            os.system('{0} {1} 2>/dev/null 1>/dev/null &'
-                      .format(command, image_file))
+            _launch_viewer_command(command, image_file)
         return 'Launched {0} viewer for {1}'.format(ext, plain_text)
 
     def launch_jmol(self, output_jmol, plain_text):
@@ -372,8 +497,7 @@ class BackendIPythonCommandline(BackendIPython):
         launch_script = output_jmol.launch_script_filename()
         jmol_cmd = 'jmol'
         if not DOCTEST_MODE:
-            os.system('{0} {1} 2>/dev/null 1>/dev/null &'
-                      .format(jmol_cmd, launch_script))
+            _launch_viewer_command(jmol_cmd, launch_script)
         return 'Launched jmol viewer for {0}'.format(plain_text)
 
     def is_in_terminal(self):

--- a/src/sage/repl/rich_output/backend_ipython.py
+++ b/src/sage/repl/rich_output/backend_ipython.py
@@ -14,104 +14,61 @@ This module defines the IPython backends for
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
+import html
 import os
 import shlex
 import subprocess
-import html
 from IPython.display import publish_display_data
 from sage.repl.rich_output.backend_base import BackendBase
 from sage.repl.rich_output.output_catalog import *
 
 
-def _viewer_command_arguments(command, filename):
+_VIEWER_HANDOFF_TIMEOUT = 1
+
+
+def _is_desktop_opener(command):
     r"""
-    Return command-line arguments for launching a viewer.
+    Return whether ``command`` is a freedesktop opener.
 
-    INPUT:
-
-    - ``command`` -- string; the configured viewer command
-
-    - ``filename`` -- string; the file to show
-
-    OUTPUT: list; the command and arguments
+    These commands normally return after handing the file to the desktop.
+    Waiting briefly for them usually avoids racing requests in a single-instance
+    viewer.  See :issue:`42292`.
 
     EXAMPLES::
 
-        sage: from sage.repl.rich_output.backend_ipython import _viewer_command_arguments
-        sage: _viewer_command_arguments('xdg-open', '/tmp/plot.png')
-        ['xdg-open', '/tmp/plot.png']
-        sage: _viewer_command_arguments('gio open', '/tmp/plot.png')
-        ['gio', 'open', '/tmp/plot.png']
-
-    Empty viewer commands are rejected::
-
-        sage: _viewer_command_arguments('', '/tmp/plot.png')
-        Traceback (most recent call last):
-        ...
-        ValueError: viewer command must not be empty
-    """
-    argv = shlex.split(command)
-    if not argv:
-        raise ValueError('viewer command must not be empty')
-    argv.append(filename)
-    return argv
-
-
-def _viewer_command_uses_foreground_handoff(command):
-    r"""
-    Return whether ``command`` should be run to completion before continuing.
-
-    The Sage command line normally launches viewers in the background, since
-    many viewers keep running until their window is closed.  Freedesktop
-    openers such as ``xdg-open``, ``gio open`` and ``gvfs-open`` are short-lived
-    handoff commands instead.  Running those handoffs concurrently can race in
-    single-instance image viewers, causing some images shown in a loop to be
-    skipped or repeated; running them in the foreground serializes the handoff
-    and avoids the race.  See :issue:`42292`.
-
-    .. NOTE::
-
-        Only the common freedesktop openers are recognized.  A viewer that is
-        itself a single-instance application and is configured directly (for
-        example ``viewer.png_viewer('eog')``) is still launched in the
-        background and may exhibit the race.
-
-    EXAMPLES::
-
-        sage: from sage.repl.rich_output.backend_ipython import _viewer_command_uses_foreground_handoff as handoff
-        sage: handoff('xdg-open')
+        sage: from sage.repl.rich_output.backend_ipython import _is_desktop_opener as opener
+        sage: opener('xdg-open')
         True
-        sage: handoff('/usr/bin/gio open')
+        sage: opener('/usr/bin/gio open')
         True
-        sage: handoff('gvfs-open')
+        sage: opener('gvfs-open')
         True
-
-    Long-running viewers and bare commands are not treated as handoffs::
-
-        sage: handoff('eog')
+        sage: opener('eog')
         False
-        sage: handoff('gio')
+        sage: opener('gio')
         False
-        sage: handoff('')
+        sage: opener('')
         False
     """
-    argv = shlex.split(command)
+    try:
+        argv = shlex.split(command)
+    except ValueError:
+        return False
     if not argv:
         return False
     program = os.path.basename(argv[0])
-    if program in ('xdg-open', 'gvfs-open'):
-        return True
-    return program == 'gio' and argv[1:2] == ['open']
+    return (program in ('xdg-open', 'gvfs-open')
+            or program == 'gio' and argv[1:2] == ['open'])
 
 
 def _launch_viewer_command(command, filename):
     r"""
     Launch an external viewer command for ``filename``.
 
-    Short-lived desktop openers are run in the foreground so Sage serializes the
-    handoff to the user's desktop. Other viewer commands are launched in the
-    background, preserving the existing command-line behavior for viewers that
-    stay open until their window is closed.
+    Sage waits briefly for freedesktop openers so quick handoffs complete before
+    the next request.  Since ``xdg-open`` can instead run the viewer itself on
+    some desktops, the wait is bounded.  Other viewer commands remain in the
+    background.
 
     INPUT:
 
@@ -119,32 +76,56 @@ def _launch_viewer_command(command, filename):
 
     - ``filename`` -- string; the file to show
 
-    EXAMPLES:
+    TESTS::
 
-    Long-running viewers are launched in the background (here ``true`` stands in
-    for such a viewer and simply exits)::
-
+        sage: import subprocess
+        sage: from unittest.mock import Mock, patch
         sage: from sage.repl.rich_output.backend_ipython import _launch_viewer_command
-        sage: from sage.misc.temporary_file import tmp_filename
-        sage: _launch_viewer_command('true', tmp_filename())
+        sage: process = Mock()
+        sage: with patch('sage.repl.rich_output.backend_ipython.subprocess.Popen', return_value=process) as popen:
+        ....:     with patch('sage.repl.rich_output.backend_ipython.os.system') as system:
+        ....:         _launch_viewer_command(
+        ....:             '$HOME/bin/xdg-open > "$HOME/viewer.log"',
+        ....:             '/tmp/a b;$(not-a-command).png')
+        sage: popen.assert_called_once_with(
+        ....:     "$HOME/bin/xdg-open > \"$HOME/viewer.log\" "
+        ....:     "'/tmp/a b;$(not-a-command).png'", shell=True,
+        ....:     stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
+        ....:     stderr=subprocess.DEVNULL, start_new_session=True)
+        sage: system.assert_not_called()
+        sage: process.wait.assert_called_once_with(timeout=1)
+
+    A desktop opener that keeps running does not block the Sage prompt::
+
+        sage: slow_process = Mock()
+        sage: slow_process.wait.side_effect = subprocess.TimeoutExpired('xdg-open', 1)
+        sage: with patch('sage.repl.rich_output.backend_ipython.subprocess.Popen', return_value=slow_process):
+        ....:     with patch('sage.repl.rich_output.backend_ipython.os.system') as system:
+        ....:         _launch_viewer_command('xdg-open', '/tmp/plot.png')
+        sage: slow_process.wait.assert_called_once_with(timeout=1)
+        sage: system.assert_not_called()
+
+    Other viewers are launched in the background, with the filename quoted::
+
+        sage: with patch('sage.repl.rich_output.backend_ipython.os.system') as system:
+        ....:     with patch('sage.repl.rich_output.backend_ipython.subprocess.Popen') as popen:
+        ....:         _launch_viewer_command('eog', '/tmp/a b.png')
+        sage: system.assert_called_once_with(
+        ....:     "eog '/tmp/a b.png' 2>/dev/null 1>/dev/null &")
+        sage: popen.assert_not_called()
     """
-    if _viewer_command_uses_foreground_handoff(command):
-        # These openers return as soon as the file is handed off to the desktop
-        # (they do not block until the viewer window is closed), so running them
-        # in the foreground only briefly pauses the prompt.  We deliberately do
-        # not impose a timeout: killing a slow but legitimate handoff could drop
-        # the very image we are trying to show.  A Ctrl-C still propagates if an
-        # opener misbehaves.
+    shell_command = f'{command} {shlex.quote(filename)}'
+    if _is_desktop_opener(command):
         try:
-            subprocess.run(_viewer_command_arguments(command, filename),
-                           stdout=subprocess.DEVNULL,
-                           stderr=subprocess.DEVNULL,
-                           check=False)
-        except OSError:
+            process = subprocess.Popen(
+                shell_command, shell=True, stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                start_new_session=True)
+            process.wait(timeout=_VIEWER_HANDOFF_TIMEOUT)
+        except (OSError, subprocess.TimeoutExpired):
             pass
     else:
-        os.system('{0} {1} 2>/dev/null 1>/dev/null &'
-                  .format(command, shlex.quote(filename)))
+        os.system(f'{shell_command} 2>/dev/null 1>/dev/null &')
 
 
 class BackendIPython(BackendBase):


### PR DESCRIPTION
Fixes #42292.

#### Symptom and scope

On the **command-line REPL**, calling `.show()` repeatedly can open the expected
number of windows while displaying some objects more than once and omitting
others:

```python
for g in L:
    g.show()
```

Adding a pause between calls makes the problem disappear. Jupyter is not
affected because it embeds the image in the output instead of launching an
external viewer.

#### Root cause

`Graph.show()` eventually reaches
`BackendIPythonCommandline.launch_viewer`, which previously launched every
viewer through a background shell command:

```python
os.system(f'{command} {image_file} 2>/dev/null 1>/dev/null &')
```

The trailing `&` lets a loop issue all open requests almost simultaneously.
The temporary image files are distinct and remain available; the race occurs
afterwards, while `xdg-open`, `gio open`, or `gvfs-open` hands the burst of
requests to a single-instance desktop viewer during its startup. Those requests
can be coalesced, reordered, or dropped by the external desktop application.

#### Fix

Recognized freedesktop openers (`xdg-open`, `gio open`, and `gvfs-open`) now use
a short, bounded handoff window:

1. Launch the configured command with `subprocess.Popen`.
2. Wait for at most one second for a normal quick handoff to complete.
3. If the opener is still running, return control to Sage without killing it.

This usually serializes the short handoffs that caused the race, while keeping
the REPL responsive on desktops where `xdg-open` synchronously runs the viewer
itself and does not exit until its window closes. The one-second limit is
therefore deliberately a best-effort handoff window, not an assumption that
every implementation of `xdg-open` is short-lived.

Other viewer commands retain the previous background behavior. In particular,
a directly configured long-running viewer such as `eog` must not block the Sage
prompt until its window closes.

#### Why the configured command still uses a shell

Viewer settings have historically been shell command strings, not merely
executable names. For example, a user may configure:

```text
$HOME/bin/xdg-open > "$HOME/viewer.log"
```

Splitting such a value into an argument vector changes its established meaning:
environment expansion and redirection no longer work. The implementation uses
`shlex.split` only to recognize the opener, but executes the original command
with `shell=True`. The generated filename is the only untrusted addition and is
quoted independently with `shlex.quote`, so spaces and shell metacharacters in
the filename cannot become commands.

#### Process and signal behavior

The opener receives `DEVNULL` for standard input and output and is started with
`start_new_session=True`. This preserves the practical signal isolation of the
old background launch: if the one-second wait expires, a later Ctrl-C in Sage
does not accidentally terminate the still-running viewer.

The timed-out process is intentionally not killed or terminated, because doing
so could discard the image that Sage is trying to show. No worker thread,
retry loop, or custom child reaper is added; that extra machinery would be
disproportionate for a best-effort desktop handoff.

#### Testing

The doctests cover:

- recognition of `xdg-open`, `gio open`, and `gvfs-open`;
- preservation of shell expansion and redirection;
- safe quoting of a filename containing spaces and shell metacharacters;
- the one-second timeout without killing the viewer;
- preservation of the background path for ordinary viewers; and
- creation of a separate session for the bounded handoff.

The targeted backend doctest passes with **98 tests**. Both Ruff modes, the RST
check, Python byte-compilation, and `git diff --check` also pass.

A real-process smoke test used an environment-expanded `xdg-open` fixture that
recorded its arguments and then slept for five seconds. Sage returned after
approximately **1.001 seconds**, the complete injection-shaped filename arrived
as exactly one argument, and no injected command was executed.

A deterministic end-to-end test with a real GUI is not practical because the
original failure is timing- and desktop-dependent and occurs outside Sage.

### 📝 Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what is being fixed or added.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.
