### PR TITLE
src/sage/doctest/external.py: remove has_dvipng()

### DIFF
--- a/src/sage/doctest/external.py
+++ b/src/sage/doctest/external.py
@@ -305,20 +305,6 @@ def has_imagemagick() -> bool:
     return ImageMagick().is_present()
 
 
-def has_dvipng() -> bool:
-    """
-    Test if dvipng is available.
-
-    EXAMPLES::
-
-        sage: from sage.doctest.external import has_dvipng
-        sage: has_dvipng() # optional -- dvipng
-        FeatureTestResult('dvipng', True)
-    """
-    from sage.features.dvipng import dvipng
-    return dvipng().is_present()
-
-
 def has_rubiks() -> bool:
     """
     Test if the rubiks package (``cu2``, ``cubex``, ``dikcube``,


### PR DESCRIPTION
There is a feature for this in sage.features.dvipng; in fact, `has_dvipng()` just checks if the feature is present. The one place we check for dvipng in the Sage library is in src/sage/misc/latex.py and that's already using the feature.
