### PR TITLE
Add missing examples in sage/crypto/cipher.py

### DIFF
--- a/src/sage/crypto/cipher.py
+++ b/src/sage/crypto/cipher.py
@@ -154,28 +154,8 @@ class PublicKeyCipher(Cipher):
     Public key cipher class
     """
     def __init__(self, parent, key, public=True):
-        r"""
+        """
         Create a public key cipher.
-
-        INPUT:
-
-        - ``parent`` -- the parent cryptosystem of this cipher
-
-        - ``key`` -- the key used for this cipher
-
-        - ``public`` -- boolean (default: ``True``); whether ``key`` is the
-          public key (``True``) or the private key (``False``)
-
-        TESTS:
-
-        ``PublicKeyCipher`` is a base class that is not currently used by any
-        cryptosystem in Sage, so we exercise the constructor directly::
-
-            sage: from sage.crypto.cipher import PublicKeyCipher
-            sage: P = ShiftCryptosystem(AlphabeticStrings())
-            sage: E = PublicKeyCipher(P, 3)
-            sage: E.key()
-            3
         """
         Cipher.__init__(self, parent, key)
         self._public = public

--- a/src/sage/crypto/cipher.py
+++ b/src/sage/crypto/cipher.py
@@ -22,13 +22,36 @@ class Cipher(Element):
     Cipher class
     """
     def __init__(self, parent, key):
-        """
+        r"""
         Create a cipher.
+
+        EXAMPLES::
+
+            sage: S = ShiftCryptosystem(AlphabeticStrings())
+            sage: E = S(3)
+            sage: E.parent()
+            Shift cryptosystem on Free alphabetic string monoid on A-Z
+            sage: E.key()
+            3
         """
         Element.__init__(self, parent)
         self._key = key
 
     def __eq__(self, right):
+        r"""
+        Return whether ``self`` and ``right`` are equal.
+
+        Two ciphers are equal when they have the same type, the same
+        parent, and the same key.
+
+        EXAMPLES::
+
+            sage: S = ShiftCryptosystem(AlphabeticStrings())
+            sage: S(13) == S(13)
+            True
+            sage: S(13) == S(2)
+            False
+        """
         return type(self) is type(right) and self.parent() == right.parent() and self._key == right._key
 
     def _repr_(self):
@@ -45,12 +68,63 @@ class Cipher(Element):
         return "Cipher on %s" % self.parent().cipher_domain()
 
     def key(self):
+        r"""
+        Return the key of this cipher.
+
+        EXAMPLES::
+
+            sage: S = ShiftCryptosystem(HexadecimalStrings())
+            sage: S(5).key()
+            5
+        """
         return self._key # was str(self._key)
 
     def domain(self):
+        r"""
+        Return the domain (plaintext space) of this cipher.
+
+        EXAMPLES:
+
+        For the ciphers shipped with Sage the plaintext and ciphertext
+        alphabets coincide::
+
+            sage: S = ShiftCryptosystem(AlphabeticStrings())
+            sage: S(13).domain()
+            Free alphabetic string monoid on A-Z
+
+        They are distinct attributes of the parent, though, and need not
+        agree if the cryptosystem was built with different alphabets::
+
+            sage: from sage.crypto.cipher import Cipher
+            sage: from sage.crypto.cryptosystem import SymmetricKeyCryptosystem
+            sage: cs = SymmetricKeyCryptosystem(AlphabeticStrings(), HexadecimalStrings(), None)
+            sage: Cipher(cs, None).domain()
+            Free alphabetic string monoid on A-Z
+        """
         return self.parent().cipher_domain()
 
     def codomain(self):
+        r"""
+        Return the codomain (ciphertext space) of this cipher.
+
+        EXAMPLES:
+
+        For the ciphers shipped with Sage the plaintext and ciphertext
+        alphabets coincide::
+
+            sage: S = ShiftCryptosystem(AlphabeticStrings())
+            sage: S(13).codomain()
+            Free alphabetic string monoid on A-Z
+
+        The codomain reads the *ciphertext* alphabet, which may differ from
+        the domain::
+
+            sage: from sage.crypto.cipher import Cipher
+            sage: from sage.crypto.cryptosystem import SymmetricKeyCryptosystem
+            sage: cs = SymmetricKeyCryptosystem(AlphabeticStrings(), HexadecimalStrings(), None)
+            sage: Cipher(cs, None).codomain()
+            Free hexadecimal string monoid
+        """
         return self.parent().cipher_codomain()
 
 
@@ -59,8 +133,18 @@ class SymmetricKeyCipher(Cipher):
     Symmetric key cipher class
     """
     def __init__(self, parent, key):
-        """
-        Create a symmetric cipher.
+        r"""
+        Create a symmetric key cipher.
+
+        EXAMPLES::
+
+            sage: from sage.crypto.cipher import SymmetricKeyCipher
+            sage: A = AffineCryptosystem(AlphabeticStrings())
+            sage: E = A(3, 5)
+            sage: E
+            Affine cipher on Free alphabetic string monoid on A-Z
+            sage: isinstance(E, SymmetricKeyCipher)
+            True
         """
         Cipher.__init__(self, parent, key)
 
@@ -70,8 +154,28 @@ class PublicKeyCipher(Cipher):
     Public key cipher class
     """
     def __init__(self, parent, key, public=True):
-        """
+        r"""
         Create a public key cipher.
+
+        INPUT:
+
+        - ``parent`` -- the parent cryptosystem of this cipher
+
+        - ``key`` -- the key used for this cipher
+
+        - ``public`` -- boolean (default: ``True``); whether ``key`` is the
+          public key (``True``) or the private key (``False``)
+
+        TESTS:
+
+        ``PublicKeyCipher`` is a base class that is not currently used by any
+        cryptosystem in Sage, so we exercise the constructor directly::
+
+            sage: from sage.crypto.cipher import PublicKeyCipher
+            sage: P = ShiftCryptosystem(AlphabeticStrings())
+            sage: E = PublicKeyCipher(P, 3)
+            sage: E.key()
+            3
         """
         Cipher.__init__(self, parent, key)
         self._public = public


### PR DESCRIPTION
Methods in cipher.py lacked examples. 
Add EXAMPLES blocks except for the unused PublicKeyCipher class.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.


