### PR TITLE
Fix incorrect max-flow objective in MILP thematic tutorial

### DIFF
--- a/src/doc/en/thematic_tutorials/linear_programming.rst
+++ b/src/doc/en/thematic_tutorials/linear_programming.rst
@@ -386,7 +386,7 @@ just as much as they receive. We can model the flow problem with the
 following LP
 
 .. MATH::
-    \text{Max: } & \sum_{sv \in G} f_{sv}\\
+    \text{Max: } & \sum_{su \in G} f_{su} - \sum_{vs \in G} f_{vs}\\
     \text{Such that: } & \forall v \in G, {\substack{v \neq s \\ v \neq t}}, \sum_{vu \in G} f_{vu} - \sum_{uv \in G} f_{uv} = 0\\
     & \forall uv \in G, f_{uv} \leq 1\\
 
@@ -425,7 +425,7 @@ graph, in which all the edges have a capacity of 1::
 
 ::
 
-    sage: p.set_objective(p.sum(f[s,u] for u in g.neighbors_out(s)))
+    sage: p.set_objective(p.sum(f[s,u] for u in g.neighbors_out(s)) - p.sum(f[v,s] for v in g.neighbors_in(s)))
 
 .. link
 


### PR DESCRIPTION
Corrects the objective function in the "Flows" section of the *Linear Programming (Mixed Integer)* thematic tutorial.

The maximum-flow objective should maximize the **net** flow leaving the source `s` — the flow out of `s` minus the flow back into `s`. The tutorial previously maximized only the outgoing flow, which can give an incorrect optimum on some graphs. This PR fixes both the LaTeX formula and the accompanying `set_objective` code so they match the standard max-flow formulation:

- Formula: `\sum_{su \in G} f_{su} - \sum_{vs \in G} f_{vs}`
- Code: `p.set_objective(p.sum(f[s,u] for u in g.neighbors_out(s)) - p.sum(f[v,s] for v in g.neighbors_in(s)))`

Fixes #35497.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

None.
