### PR TITLE
add parameter immutable to `seidel_switching` and some `twographs` methods

### DIFF
--- a/src/sage/combinat/designs/twographs.py
+++ b/src/sage/combinat/designs/twographs.py
@@ -124,7 +124,7 @@ class TwoGraph(IncidenceStructure):
             return a
         return r
 
-    def descendant(self, v):
+    def descendant(self, v, immutable=False):
         """
         The descendant :class:`graph <sage.graphs.graph.Graph>` at ``v``.
 
@@ -137,15 +137,29 @@ class TwoGraph(IncidenceStructure):
 
         - ``v`` -- an element of :meth:`ground_set`
 
+        - ``immutable`` -- boolean (default: ``False``); whether to return an
+          immutable or a mutable graph
+
         EXAMPLES::
 
             sage: p = graphs.PetersenGraph().twograph().descendant(0)                   # needs sage.modules
             sage: p.is_strongly_regular(parameters=True)                                # needs sage.modules
             (9, 4, 1, 2)
+
+        TESTS:
+
+        Check the behavior of parameter ``immutable``::
+
+            sage: # needs sage.modules
+            sage: T = graphs.PetersenGraph().twograph()
+            sage: T.descendant(0, immutable=False).is_immutable()
+            False
+            sage: T.descendant(0, immutable=True).is_immutable()
+            True
         """
         from sage.graphs.graph import Graph
         return Graph([[z for z in x if z != v]
-                      for x in self.blocks() if v in x])
+                      for x in self.blocks() if v in x], immutable=immutable)
 
     def complement(self):
         """
@@ -252,7 +266,7 @@ def is_twograph(T) -> bool:
                    for quad in combinations(range(T.n_points()), 4))
 
 
-def twograph_descendant(G, v, name=None):
+def twograph_descendant(G, v, name=None, immutable=None):
     r"""
     Return the descendant graph w.r.t. vertex `v` of the two-graph of `G`.
 
@@ -269,6 +283,10 @@ def twograph_descendant(G, v, name=None):
     - ``v`` -- a vertex of ``G``
 
     - ``name`` -- (default: ``None``) no name, otherwise derive from the construction
+
+    - ``immutable`` -- boolean (default: ``None``); whether to create a
+      mutable/immutable graph. ``immutable=None`` (default) means that the graph
+      and its descendant will behave the same way.
 
     EXAMPLES:
 
@@ -292,11 +310,26 @@ def twograph_descendant(G, v, name=None):
         Graph on 9 vertices
         sage: twograph_descendant(p, 5, name=True)
         descendant of Petersen graph at 5: Graph on 9 vertices
+
+    Check the behavior of parameter ``immutable``::
+
+        sage: p = graphs.PetersenGraph()
+        sage: twograph_descendant(p, 5).is_immutable()
+        False
+        sage: twograph_descendant(p, 5, immutable=True).is_immutable()
+        True
+        sage: p = graphs.PetersenGraph(immutable=True)
+        sage: twograph_descendant(p, 5).is_immutable()
+        True
+        sage: twograph_descendant(p, 5, immutable=False).is_immutable()
+        False
     """
-    G = G.seidel_switching(G.neighbors(v), inplace=False)
+    if immutable is None:
+        immutable = G.is_immutable()
+    G = G.seidel_switching(G.neighbors(v), inplace=False, immutable=False)
     G.delete_vertex(v)
     if name:
         G.name('descendant of ' + G.name() + ' at ' + str(v))
     else:
         G.name('')
-    return G
+    return G.copy(immutable=True) if immutable else G

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -5595,7 +5595,7 @@ class Graph(GenericGraph):
         return C
 
     @doc_index("Leftovers")
-    def seidel_switching(self, s, inplace=True):
+    def seidel_switching(self, s, inplace=True, immutable=None):
         r"""
         Return the Seidel switching of ``self`` w.r.t. subset of vertices ``s``.
 
@@ -5613,6 +5613,11 @@ class Graph(GenericGraph):
           modification inplace, or to return a copy of the graph after
           switching
 
+        - ``immutable`` -- boolean (default: ``None``); whether to create a
+          mutable/immutable graph. ``immutable=None`` (default) means that the
+          graph and its Seidel switching will behave the same way.
+          This parameter is ignored when ``inplace`` is ``True``.
+
         EXAMPLES::
 
             sage: G = graphs.CycleGraph(5)
@@ -5629,13 +5634,41 @@ class Graph(GenericGraph):
             sage: G.seidel_switching([1,4,5])
             sage: G == H
             True
+
+        Check the behavior of parameter ``immutable``::
+
+            sage: G = graphs.CycleGraph(5)
+            sage: G = G.disjoint_union(graphs.CompleteGraph(1))
+            sage: s = [(0, 1), (1, 0), (0, 0)]
+            sage: H = G.copy(immutable=False)
+            sage: H.seidel_switching(s, inplace=True)
+            sage: H.is_immutable()
+            False
+            sage: H.seidel_switching(s, inplace=True, immutable=True)
+            sage: H.is_immutable()
+            False
+            sage: H = G.copy(immutable=True)
+            sage: H.seidel_switching(s, inplace=True)
+            Traceback (most recent call last):
+            ...
+            TypeError: this graph is immutable and so cannot be changed
+            sage: X = H.seidel_switching(s, inplace=False)
+            sage: X.is_immutable()
+            True
+            sage: X = H.seidel_switching(s, inplace=False, immutable=False)
+            sage: X.is_immutable()
+            False
         """
-        G = self if inplace else copy(self)
+        if inplace:
+            self._scream_if_immutable()
+        elif immutable is None:
+            immutable = self.is_immutable()
+        G = self if inplace else self.copy(immutable=False)
         boundary = self.edge_boundary(s)
         G.add_edges(itertools.product(s, set(self).difference(s)))
         G.delete_edges(boundary)
         if not inplace:
-            return G
+            return G.copy(immutable=False) if immutable else G
 
     @doc_index("Leftovers")
     def twograph(self):

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -5668,7 +5668,7 @@ class Graph(GenericGraph):
         G.add_edges(itertools.product(s, set(self).difference(s)))
         G.delete_edges(boundary)
         if not inplace:
-            return G.copy(immutable=False) if immutable else G
+            return G.copy(immutable=True) if immutable else G
 
     @doc_index("Leftovers")
     def twograph(self):

--- a/src/sage/matrix/matrix_gfpn_dense.pyx
+++ b/src/sage/matrix/matrix_gfpn_dense.pyx
@@ -1358,7 +1358,7 @@ cdef class Matrix_gfpn_dense(Matrix_dense):
             True
         """
         "multiply two meataxe matrices by the school book algorithm"
-        if self.Data == NULL or right.Data == NULL
+        if self.Data == NULL or right.Data == NULL:
             raise ValueError("The matrices must not be empty")
         check_matrix_multiplication_sizes(self, right)
         sig_on()


### PR DESCRIPTION
Following discussions in #39177, we add the option to return immutable graphs to methods
- `Graph.seidel_switching`  from file `src/sage/graphs/graph.py`
- `TwoGraph.descendant` and `twograph_descendant` from file `src/sage/combinat/designs/twographs.py`

This will help simplifying #42154  that adds parameter `immutable` to the graph generators in `src/sage/graphs/strongly_regular_db.pyx`.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

#42272: otherwise I cannot compile on macOS 


