### PR TITLE
Remove unused imports in the Drinfeld modules library

### DIFF
--- a/src/sage/rings/function_field/drinfeld_modules/carlitz_module.py
+++ b/src/sage/rings/function_field/drinfeld_modules/carlitz_module.py
@@ -16,8 +16,6 @@ AUTHORS:
 #                   http://www.gnu.org/licenses/
 # *****************************************************************************
 
-from sage.misc.cachefunc import cached_function
-
 from sage.structure.parent import Parent
 from sage.structure.element import Element
 from sage.categories.finite_fields import FiniteFields

--- a/src/sage/rings/function_field/drinfeld_modules/homset.py
+++ b/src/sage/rings/function_field/drinfeld_modules/homset.py
@@ -33,7 +33,6 @@ from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.matrix.constructor import Matrix
 from sage.matrix.special import identity_matrix
 from sage.rings.function_field.drinfeld_modules.morphism import DrinfeldModuleMorphism
-from sage.structure.parent import Parent
 from sage.functions.log import logb
 
 


### PR DESCRIPTION
We have removed two unused imports in `sage.rings.function_field.drinfeld_modules`.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [X] The title is concise and informative.
- [X] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [X] I have created tests covering the changes.
- [X] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


