### PR TITLE
Fix syntax error (missing `:` after `NULL`) in matrix multiplication check

### DIFF
--- a/src/sage/matrix/matrix_gfpn_dense.pyx
+++ b/src/sage/matrix/matrix_gfpn_dense.pyx
@@ -1358,7 +1358,7 @@ cdef class Matrix_gfpn_dense(Matrix_dense):
             True
         """
         "multiply two meataxe matrices by the school book algorithm"
-        if self.Data == NULL or right.Data == NULL
+        if self.Data == NULL or right.Data == NULL:
             raise ValueError("The matrices must not be empty")
         check_matrix_multiplication_sizes(self, right)
         sig_on()


### PR DESCRIPTION
added missing `:` at the end of if. No idea how this (from 88fcb892087b) was merged, it doesn't compile for me.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


