### PR TITLE
Add montgomery constructor to EllipticCurve

### DIFF
--- a/src/sage/schemes/elliptic_curves/all.py
+++ b/src/sage/schemes/elliptic_curves/all.py
@@ -20,6 +20,7 @@ Exported elliptic curves functionality
 from sage.schemes.elliptic_curves.constructor import (EllipticCurve,
                                                       EllipticCurve_from_c4c6,
                                                       EllipticCurve_from_j,
+                                                      EllipticCurve_from_montgomery,
                                                       EllipticCurve_from_cubic,
                                                       EllipticCurves_with_good_reduction_outside_S)
 

--- a/src/sage/schemes/elliptic_curves/constructor.py
+++ b/src/sage/schemes/elliptic_curves/constructor.py
@@ -449,6 +449,8 @@ class EllipticCurveFactory(UniqueFactory):
             R, x = (x, y)
 
         if j is not None:
+            if A is not None:
+                raise ValueError("only one of A and j may be specified")
             if R is not None:
                 try:
                     j = R(j)
@@ -459,10 +461,7 @@ class EllipticCurveFactory(UniqueFactory):
                     "First parameter (if present) must be a ring when j is specified"
                 )
             x = coefficients_from_j(j, minimal_twist)
-
-        if A is not None:
-            if j is not None:
-                raise ValueError("only one of A and j may be specified")
+        elif A is not None:
             if R is not None:
                 try:
                     A = R(A)
@@ -473,8 +472,19 @@ class EllipticCurveFactory(UniqueFactory):
                     "First parameter (if present) must be a ring when A is specified"
                 )
             x = coefficients_from_montgomery(A)
+        elif isinstance(x, str):
+            # Interpret x as a Cremona or LMFDB label.
+            from sage.databases.cremona import CremonaDatabase
 
-        if isinstance(x, Expression) and x.is_relational():
+            with CremonaDatabase() as D:
+                x, data = D.coefficients_and_data(x)
+            # data is only valid for elliptic curves over QQ.
+            if R not in (None, QQ):
+                data = {}
+            # User-provided keywords may override database entries.
+            data.update(kwds)
+            kwds = data
+        elif isinstance(x, Expression) and x.is_relational():
             import operator
 
             if x.operator() != operator.eq:
@@ -492,19 +502,6 @@ class EllipticCurveFactory(UniqueFactory):
             else:
                 # x is a cubic, y a rational point
                 x = EllipticCurve_from_cubic(x, y, morphism=False).ainvs()
-
-        if isinstance(x, str):
-            # Interpret x as a Cremona or LMFDB label.
-            from sage.databases.cremona import CremonaDatabase
-
-            with CremonaDatabase() as D:
-                x, data = D.coefficients_and_data(x)
-            # data is only valid for elliptic curves over QQ.
-            if R not in (None, QQ):
-                data = {}
-            # User-provided keywords may override database entries.
-            data.update(kwds)
-            kwds = data
 
         if not isinstance(x, (list, tuple)):
             raise TypeError("invalid input to EllipticCurve constructor")

--- a/src/sage/schemes/elliptic_curves/constructor.py
+++ b/src/sage/schemes/elliptic_curves/constructor.py
@@ -198,8 +198,8 @@ class EllipticCurveFactory(UniqueFactory):
         sage: E.a_invariants()
         (0, 6, 0, 1, 0)
 
-        sage: E = EllipticCurve(A=GF(5)(1)); E
-        Elliptic Curve defined by y^2 = x^3 + x^2 + x over Finite Field of size 5       # needs sage.rings.finite_rings
+        sage: E = EllipticCurve(A=GF(5)(1)); E                                          # needs sage.rings.finite_rings
+        Elliptic Curve defined by y^2 = x^3 + x^2 + x over Finite Field of size 5
 
         sage: E = EllipticCurve(GF(144169), A=6); E                                     # needs sage.rings.finite_rings
         Elliptic Curve defined by y^2 = x^3 + 6*x^2 + x over Finite Field of size 144169

--- a/src/sage/schemes/elliptic_curves/constructor.py
+++ b/src/sage/schemes/elliptic_curves/constructor.py
@@ -88,6 +88,9 @@ class EllipticCurveFactory(UniqueFactory):
       plane cubic (homogeneous polynomial in three variables), with a
       rational point.
 
+    - ``EllipticCurve(A=A)``: Returns an elliptic curve that is in
+      Montgomery form, i.e. a curve with equation `y^2 = x^3 + Ax^2 + x`.
+
     Instead of giving the coefficients as a *list* of length 2 or 5,
     one can also give a *tuple*.
 
@@ -186,6 +189,21 @@ class EllipticCurveFactory(UniqueFactory):
         Elliptic Curve defined by y^2 = x^3 + x + 1 over Finite Field of size 5
         2
 
+    We can create an elliptic curve in Montgomery form, i.e. a curve
+    with equation `y^2 = x^3 + Ax^2 + x`, by specifying the parameter
+    `A`::
+
+        sage: E = EllipticCurve(A=6); E
+        Elliptic Curve defined by y^2 = x^3 + 6*x^2 + x over Rational Field
+        sage: E.a_invariants()
+        (0, 6, 0, 1, 0)
+
+        sage: E = EllipticCurve(A=GF(5)(1)); E
+        Elliptic Curve defined by y^2 = x^3 + x^2 + x over Finite Field of size 5       # needs sage.rings.finite_rings
+
+        sage: E = EllipticCurve(GF(144169), A=6); E                                     # needs sage.rings.finite_rings
+        Elliptic Curve defined by y^2 = x^3 + 6*x^2 + x over Finite Field of size 144169
+
     See :issue:`6657` ::
 
         sage: EllipticCurve(GF(144169), j=1728)                                         # needs sage.rings.finite_rings
@@ -265,6 +283,21 @@ class EllipticCurveFactory(UniqueFactory):
         ...
         ValueError: First parameter must be a ring containing 3/5
 
+    The parameter `A` behaves analogously, and cannot be combined with `j`::
+
+        sage: EllipticCurve(3, A=6)
+        Traceback (most recent call last):
+        ...
+        ValueError: First parameter (if present) must be a ring when A is specified
+        sage: EllipticCurve(GF(5), A=3/5)
+        Traceback (most recent call last):
+        ...
+        ValueError: First parameter must be a ring containing 3/5
+        sage: EllipticCurve(A=6, j=1728)
+        Traceback (most recent call last):
+        ...
+        ValueError: only one of A and j may be specified
+
     If the universe of the coefficients is a general field, the object
     constructed has type :class:`EllipticCurve_field`.  Otherwise it is
     :class:`EllipticCurve_generic`.  See :issue:`9816` ::
@@ -316,7 +349,7 @@ class EllipticCurveFactory(UniqueFactory):
     """
 
     def create_key_and_extra_args(
-        self, x=None, y=None, j=None, minimal_twist=True, **kwds
+        self, x=None, y=None, j=None, A=None, minimal_twist=True, **kwds
     ):
         r"""
         Return a ``UniqueFactory`` key and possibly extra parameters.
@@ -426,6 +459,20 @@ class EllipticCurveFactory(UniqueFactory):
                     "First parameter (if present) must be a ring when j is specified"
                 )
             x = coefficients_from_j(j, minimal_twist)
+
+        if A is not None:
+            if j is not None:
+                raise ValueError("only one of A and j may be specified")
+            if R is not None:
+                try:
+                    A = R(A)
+                except (ZeroDivisionError, ValueError, TypeError):
+                    raise ValueError("First parameter must be a ring containing %s" % A)
+            elif x is not None:
+                raise ValueError(
+                    "First parameter (if present) must be a ring when A is specified"
+                )
+            x = coefficients_from_montgomery(A)
 
         if isinstance(x, Expression) and x.is_relational():
             import operator
@@ -857,6 +904,52 @@ def coefficients_from_j(j, minimal_twist=True):
         return Sequence([0, 0, 0, 1, 0], universe=K)
     k = j - 1728
     return Sequence([0, 0, 0, -3 * j * k, -2 * j * k**2], universe=K)
+
+
+def coefficients_from_montgomery(A):
+    r"""
+    Return Weierstrass coefficients `(a_1, a_2, a_3, a_4, a_6)` for the
+    Montgomery elliptic curve `y^2 = x^3 + Ax^2 + x`.
+
+    INPUT:
+
+    - ``A`` -- an element of some field
+
+    EXAMPLES::
+
+        sage: from sage.schemes.elliptic_curves.constructor import coefficients_from_montgomery
+        sage: coefficients_from_montgomery(6)
+        [0, 6, 0, 1, 0]
+        sage: coefficients_from_montgomery(GF(83)(7))
+        [0, 7, 0, 1, 0]
+    """
+    return [0, A, 0, 1, 0]
+
+
+def EllipticCurve_from_montgomery(A):
+    r"""
+    Return the Montgomery elliptic curve `y^2 = x^3 + Ax^2 + x`.
+
+    INPUT:
+
+    - ``A`` -- an element of some field
+
+    OUTPUT: the elliptic curve `y^2 = x^3 + Ax^2 + x`
+
+    EXAMPLES::
+
+        sage: from sage.schemes.elliptic_curves.constructor import EllipticCurve_from_montgomery
+        sage: EllipticCurve_from_montgomery(6)
+        Elliptic Curve defined by y^2 = x^3 + 6*x^2 + x over Rational Field
+
+    The Montgomery curve is singular when `A = \pm 2`::
+
+        sage: EllipticCurve_from_montgomery(2)
+        Traceback (most recent call last):
+        ...
+        ArithmeticError: y^2 = x^3 + 2*x^2 + x defines a singular curve
+    """
+    return EllipticCurve(coefficients_from_montgomery(A))
 
 
 def EllipticCurve_from_cubic(F, P=None, morphism=True):


### PR DESCRIPTION
Requested a year ago in #40600.
Adds a simple shortcut to construct an elliptic curve with `y^2 = x^3 + Ax^2 + x` by calling `EllipticCurve(A=A)`.

closes #40600

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies


