### PR TITLE
fix require_version() output when minor ≥ 10

### DIFF
--- a/src/sage/misc/banner.py
+++ b/src/sage/misc/banner.py
@@ -244,7 +244,6 @@ def require_version(major: int, minor: int = 0, tiny: float = 0,
             and vers['tiny'] == tiny and prerelease_checked)):
         return True
     if print_message:
-        txt = "This code requires at least version {} of SageMath to run correctly."
-        print(txt.format(major + 0.1 * minor + 0.01 * tiny))
-        print("You are running version {}.".format(SAGE_VERSION))
+        print(f"This code requires at least version {major}.{minor} of SageMath to run correctly.")
+        print(f"You are running version {SAGE_VERSION}.")
     return False


### PR DESCRIPTION
```sage
sage: from sage.misc.banner import require_version
sage: require_version(10, 10, print_message=True)
This code requires at least version 11.0 of SageMath to run correctly.
You are running version 10.9.
```

This is because of a strange hack for formatting the version number that involves a `float`.

(I don't quite know what to do about the `tiny` value in the version number. It seems to be unused in all versions of Sage that I recall, so I wrote the patch pretending it doesn't exist.)