### PR TITLE
Speed up Mod(n, m) construction via a direct UniqueFactory cache probe

### DIFF
--- a/src/sage/rings/finite_rings/integer_mod.pyx
+++ b/src/sage/rings/finite_rings/integer_mod.pyx
@@ -147,6 +147,28 @@ def Mod(n, m, parent=None):
         sage: a = randint(-100, 100)
         sage: Mod(a, 0) == a
         True
+
+    TESTS:
+
+    Construction of an element for which the ring already exists takes a
+    fast path through the cache of the ``IntegerModRing`` factory and must
+    give the very same parent (:issue:`36518`)::
+
+        sage: R = IntegerModRing(257)
+        sage: x = Mod(8, 257)
+        sage: x.parent() is R is IntegerModRing(257)
+        True
+        sage: Mod(8, int(257)).parent() is R
+        True
+
+    The fast path keeps no strong reference to the ring, so it does not
+    prevent garbage collection of otherwise unused rings::
+
+        sage: import gc, weakref
+        sage: wr = weakref.ref(Mod(3, 2^31 - 595).parent())
+        sage: _ = gc.collect()
+        sage: wr() is None
+        True
     """
     # when m is zero, then ZZ/0ZZ is isomorphic to ZZ
     if m == 0:
@@ -155,8 +177,13 @@ def Mod(n, m, parent=None):
     # m is nonzero, so return n mod m
     if parent is None:
         from sage.rings.finite_rings.integer_mod_ring import IntegerModRing
-        parent = IntegerModRing(m)
-    return IntegerMod(parent, n)
+        # Probing the factory cache directly is much faster than a full
+        # factory call and suffices whenever the ring already exists
+        # (:issue:`36518`).
+        parent = IntegerModRing.cached_object(m)
+        if parent is None:
+            parent = IntegerModRing(m)
+    return _IntegerMod(parent, n)
 
 
 mod = Mod
@@ -186,6 +213,10 @@ def IntegerMod(parent, value):
         sage: IntegerMod(R, -9158)
         42
     """
+    return _IntegerMod(parent, value)
+
+
+cdef _IntegerMod(parent, value):
     cdef NativeIntStruct modulus = parent._pyx_order
 
     cdef long val = 0

--- a/src/sage/structure/factory.pyx
+++ b/src/sage/structure/factory.pyx
@@ -436,6 +436,43 @@ cdef class UniqueFactory(SageObject):
             pass
         return obj
 
+    cpdef cached_object(self, key):
+        """
+        Return the object stored in the cache for ``key``, or ``None``.
+
+        Unlike calling the factory, this never creates an object: it
+        performs a single lookup in the cache. The key is used as is,
+        without normalisation through :meth:`create_key`, and a key that
+        is unhashable (hence possibly cached in transformed form by
+        :meth:`get_object`) gives ``None``.
+
+        This allows time-critical code to probe the cache directly and
+        fall back to an ordinary factory call on a cache miss, skipping
+        the generic ``__call__``/``create_key``/``get_object`` machinery
+        when the object already exists; see
+        :func:`sage.rings.finite_rings.integer_mod.Mod` (:issue:`36518`).
+
+        EXAMPLES::
+
+            sage: from sage.structure.test_factory import test_factory
+            sage: a = test_factory(36518, 'cached'); a
+            Making object (36518, 'cached')
+            <sage.structure.test_factory.A object at ...>
+            sage: test_factory.cached_object((36518, 'cached')) is a
+            True
+
+        A miss, including an unhashable key, gives ``None``::
+
+            sage: test_factory.cached_object((36518, 'nothing')) is None
+            True
+            sage: test_factory.cached_object([36518]) is None
+            True
+        """
+        try:
+            return self._cache[self.get_version(sage_version), key]
+        except (KeyError, TypeError):
+            return None
+
     cpdef get_version(self, sage_version):
         """
         This is provided to allow more or less granular control over


### PR DESCRIPTION
Construction of `Mod(n, m)` elements was the dominant cost in modular arithmetic with in-place construction (about 5x the cost of the arithmetic itself), because every call went through the full `UniqueFactory.__call__` machinery of `IntegerModRing` — Python-level `create_key_and_extra_args` (allocating a dict), `get_version`, and an overridden `get_object` — even when the ring already existed. Profiling shows the cached-ring lookup that all of this boils down to is a single weak-dict access costing ~57 ns, while the machinery around it costs ~560 ns per call.

This PR adds `UniqueFactory.cached_object(key)`: a `cpdef` method performing that single cache lookup and returning `None` on a miss (including unhashable keys), never creating an object. `Mod()` probes it first and falls back to the ordinary factory call when the ring is not cached yet. Other hot paths over a `UniqueFactory` can reuse the method.

Notes on safety:

- The key is used as is, without `create_key` normalisation (documented in the docstring). For `IntegerModRing` the key is the order exactly as passed, so the probe agrees with the factory byte-for-byte, including corner cases (negative moduli, Python `int` vs `Integer`). A mis-keyed probe in general can only miss and fall back, so behaviour never changes — same unique parents in all cases.
- `None` is unambiguous as a miss since a `WeakValueDictionary` cannot store `None`.
- No new strong references are introduced: rings remain garbage-collectable (new doctest).

The body of `IntegerMod()` is also factored into a `cdef _IntegerMod` helper so `Mod()` avoids one Python-level function call.

Benchmarks (67-bit prime `p`, best of 5 x 200k loops):

| benchmark | before | after |
|---|---|---|
| `Mod(a, p)` | 761 ns | 430 ns |
| `(Mod(a,p)/Mod(b,p)).lift()` (benchmark from the issue) | 2264 ns | 1590 ns |
| `Mod(a, 12345)` | 771 ns | 413 ns |

For a modulus whose ring was never constructed, building `IntegerModRing(m)` itself (~200 us) dominates; making that case PARI-fast would require non-unique lightweight parents and is out of scope here.

Fixes #36518.

### 📝 Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.
