### PR TITLE
Added pushforward method to compute dual of a prime degree separable isogeny

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -2937,7 +2937,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
 
         self.__set_post_isomorphism(codomain, isom)
 
-    def dual(self, pushforward=False):
+    def dual(self, algorithm=None):
         r"""
         Return the isogeny dual to this isogeny.
 
@@ -3099,44 +3099,32 @@ class EllipticCurveIsogeny(EllipticCurveHom):
 
         Example for :issue:`42335`::
 
-            ....: p = 13;
-            ....: k.<w> = GF(p^8); #need to take a large enough field extensi
-            ....: on so E1[5] has all its points
-            ....: l = 5;
-            ....: E1 = EllipticCurve(k, [1,4]);
-            ....: E2 = EllipticCurve(k, [12,7]);
-            ....: R.<x> = k[];
-            ....: f1=x^2 + (w^7 + 5*w^6 + 9*w^5 + 3*w^4 + 9*w^3 + 3*w^2 + 10*
+            sage: p = 13
+            sage: k.<w> = GF(p^8); #need to take a large enough field extension so E1[5] has all its points
+            sage: l = 5
+            sage: E1 = EllipticCurve(k, [1,4])
+            sage: E2 = EllipticCurve(k, [12,7])
+            sage: R.<x> = k[]
+            sage: f1 = x^2 + (w^7 + 5*w^6 + 9*w^5 + 3*w^4 + 9*w^3 + 3*w^2 + 10*
             ....: w + 2)*x + 5*w^7 + 12*w^6 + 6*w^5 + 2*w^4 + 6*w^3 + 2*w^2 +
-            ....:  11*w + 12;
-            ....: f1 = R(f1);
-            ....: f2=x^2 + (12*w^7 + 8*w^6 + 4*w^5 + 10*w^4 + 4*w^3 + 10*w^2
+            ....:  11*w + 12
+            sage: f1 = R(f1)
+            sage: f2 = x^2 + (12*w^7 + 8*w^6 + 4*w^5 + 10*w^4 + 4*w^3 + 10*w^2
             ....: + 3*w + 8)*x + 8*w^7 + w^6 + 7*w^5 + 11*w^4 + 7*w^3 + 11*w^
-            ....: 2 + 2*w + 3;
-            ....: f2 = R(f2);
-            ....: phi1=E1.isogeny(f1);
-            ....: phi2=E1.isogeny(f2);
-            ....: phi1_hat=phi1.dual();
-            ....: phi2_hat=phi2.dual();
-            ....: print("phi_1: ", phi1, "\n");
-            ....: print("phi_2: ", phi2, "\n");
-            ....: # print(phi1.dual());
-            ....: # print(phi2.dual());
-            ....: print("phi1 == phi2:", phi1 == phi2);
-            ....: print("phi1.dual()==phi2.dual():", phi1.dual()==phi2.dual()
-            ....: ); #same dual, but this curve has trivial reduced automorph
-            ....: ism group
-            ....: #show my method fixes the issue
-            ....: phi1_dual = phi1.dual(pushforward=True);
-            ....: phi2_dual = phi2.dual(pushforward=True);
-            ....: print("phi1_dual == phi2_dual:", phi1_dual == phi2_dual);
-            phi_1:  Isogeny of degree 5 from Elliptic Curve defined by y^2 = x^3 + x + 4 over Finite Field in w of size 13^8 to Elliptic Curve defined by y^2 = x^3 + 12*x + 7 over Finite Field in w of size 13^8
-
-            phi_2:  Isogeny of degree 5 from Elliptic Curve defined by y^2 = x^3 + x + 4 over Finite Field in w of size 13^8 to Elliptic Curve defined by y^2 = x^3 + 12*x + 7 over Finite Field in w of size 13^8
-
-            phi1 == phi2: False
-            phi1.dual()==phi2.dual(): True
-            phi1_dual == phi2_dual: False
+            ....: 2 + 2*w + 3
+            sage: f2 = R(f2)
+            sage: phi1 = E1.isogeny(f1)
+            sage: phi2 = E1.isogeny(f2)
+            sage: phi1_hat = phi1.dual()
+            sage: phi2_hat = phi2.dual()
+            sage: print("phi_1: ", phi1, "\n")
+            sage: print("phi_2: ", phi2, "\n")
+            sage: assert phi1 != phi2
+            sage: assert phi1.dual() == phi2.dual(); #same dual, but this curve has trivial reduced automorphism group
+            sage: #show the method fixes the issue
+            sage: phi1_dual = phi1.dual(algorithm='pushforward')
+            sage: phi2_dual = phi2.dual(algorithm='pushforward')
+            sage: assert phi1_dual == phi2_dual
         """
         if self.__base_field.characteristic() in (2, 3):
             raise NotImplementedError("computation of dual isogenies not yet implemented in characteristics 2 and 3")
@@ -3147,16 +3135,22 @@ class EllipticCurveIsogeny(EllipticCurveHom):
         F = self.__base_field
         d = self._degree
 
-        if pushforward:
-            #If the flag to try pushforward method is True
-            #TODO: Optimize, implement non-prime degree cases and inseparable case
+        if algorithm == 'pushforward':
+        #TODO:
+            #Extra Features:
+                #Implement inseparable case.
+                #Implement composite degree cyclic case.
+                #Implement non-cyclic case.
+            #Optimizations:
+                #Faster root-finding for the quotient of the division polynomial by the kernel polynomial.
+                #x-only arithmetic when evaluating the preimage of a generator of the dual kernel.
             """
             Original Author: William E. Mahaney
             """
             if F(d) == 0:
-                raise NotImplementedError("Method not implemented for inseparable isogenies.")
+                raise NotImplementedError("``pushforward`` method not implemented for inseparable isogenies")
             if not d.is_prime():
-                raise NotImplementedError("Method not implemented for composite degree isogenies.")
+                raise NotImplementedError("``pushforward`` method not implemented for composite degree isogenies")
             """
             Construct the dual isogeny of a prime-degree isogeny phi: E -> E'.
 
@@ -3168,36 +3162,32 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             """
             E = self.domain()
             E_prime = self.codomain()
-            R = PolynomialRing(F, 'x');
 
-            kernel_poly = R(self.kernel_polynomial())
-            division_poly = R(E.division_polynomial(d))
-            quotient_poly = R(division_poly / kernel_poly)
+            kernel_poly = self.kernel_polynomial()
+            division_poly = E.division_polynomial(d)
+            quotient_poly = division_poly //kernel_poly
 
             roots = quotient_poly.roots(multiplicities=False)
             if not roots:
                 raise ValueError(
-                    "The dual isogeny is not defined over the current ground field."
-                    "Extension of the base field is not implemented."
+                    "the dual isogeny is not defined over the current ground field"
                 )
 
             x0 = roots[0]
-
             try:
                 pts = E.lift_x(x0, all=True)
             except (AttributeError, NotImplementedError, TypeError):
                 pts = []
 
             if not pts:
-                raise ValueError("Could not lift the chosen x-coordinate to a point on E.")
+                raise ValueError("could not lift the chosen x-coordinate to a point on E")
 
             P = pts[0]
             Q = self(P)
 
             return E_prime.isogeny(Q)
 
-        #After this is the old code
-
+        #General case:
         if F(d) == 0:   # inseparable dual!
             p = F.characteristic()
             k = d.valuation(p)
@@ -4021,5 +4011,3 @@ def unfill_isogeny_matrix(M):
                 M1[i,j] = zero
                 M1[j,i] = zero
     return M1
-
-

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -2937,7 +2937,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
 
         self.__set_post_isomorphism(codomain, isom)
 
-    def dual(self):
+    def dual(self, pushforward=False, fast_Elkies=False):
         r"""
         Return the isogeny dual to this isogeny.
 
@@ -3106,6 +3106,68 @@ class EllipticCurveIsogeny(EllipticCurveHom):
         F = self.__base_field
         d = self._degree
 
+        if pushforward:
+            #If the flag to try pushforward method is True
+            #TODO: Optimize, implement more cases
+            """
+            Original Author: William E. Mahaney and Travis Morrison
+            Released under TO_DO License
+            """
+            if F(d) == 0:
+                raise NotImplementedError("Method not implemented for inseparable isogenies.")
+            if not d.is_prime():
+                raise NotImplementedError("Method not implemented for composite degree isogenies.")
+            """
+            Construct the dual isogeny of a prime-degree isogeny phi: E -> E'.
+
+            Strategy:
+                - Compute the quotient of the l-division polynomial by the kernel polynomial.
+                - Pick an x-coordinate of an l-torsion point not in Ker(phi).
+                - Use Sage's native lift_x to recover a point on E.
+                - Push that point forward to generate Ker(phi_dual).
+            """
+            E = self.domain()
+            E_prime = self.codomain()
+            R = PolynomialRing(F);
+
+            kernel_poly = R(self.kernel_polynomial())
+            division_poly = R(E.division_polynomial(d))
+            quotient_poly = division_poly / kernel_poly
+
+            roots = quotient_poly.roots(multiplicities=False)
+            if not roots:
+                raise ValueError(
+                    "The dual isogeny is not defined over the current ground field."
+                    "Extension of the base field is not implemented."
+                )
+
+            x0 = roots[0]
+
+            try:
+                pts = E.lift_x(x0, all=True)
+            except (AttributeError, NotImplementedError, TypeError):
+                pts = []
+
+            if not pts:
+                raise ValueError("Could not lift the chosen x-coordinate to a point on E.")
+
+            P = pts[0]
+            Q = self(P)
+
+            return E_prime.isogeny(Q)
+            
+            
+        if fast_Elkies:
+            #If the flag to try fastElkies method is set to true
+            """
+            Original Author: Travis Morrison
+            Released under TO_DO License
+            """
+            raise NotImplementedError("Not implemented yet. Need to do FastElkies first.")
+
+
+        #After this is the old code
+        
         if F(d) == 0:   # inseparable dual!
             p = F.characteristic()
             k = d.valuation(p)

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -3108,26 +3108,18 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             sage: E1 = EllipticCurve(k, [1,4])
             sage: E2 = EllipticCurve(k, [12,7])
             sage: R.<x> = k[]
-            sage: f1 = x^2 + (w^7 + 5*w^6 + 9*w^5 + 3*w^4 + 9*w^3 + 3*w^2 + 10*
-            ....: w + 2)*x + 5*w^7 + 12*w^6 + 6*w^5 + 2*w^4 + 6*w^3 + 2*w^2 +
-            ....:  11*w + 12
-            sage: f1 = R(f1)
-            sage: f2 = x^2 + (12*w^7 + 8*w^6 + 4*w^5 + 10*w^4 + 4*w^3 + 10*w^2
-            ....: + 3*w + 8)*x + 8*w^7 + w^6 + 7*w^5 + 11*w^4 + 7*w^3 + 11*w^
-            ....: 2 + 2*w + 3
-            sage: f2 = R(f2)
+            sage: f1 = x^2 + (w^7 + 5*w^6 + 9*w^5 + 3*w^4 + 9*w^3 + 3*w^2 + 10*w + 2)*x + 5*w^7 + 12*w^6 + 6*w^5 + 2*w^4 + 6*w^3 + 2*w^2 + 11*w + 12
+            sage: f2 = x^2 + (12*w^7 + 8*w^6 + 4*w^5 + 10*w^4 + 4*w^3 + 10*w^2 + 3*w + 8)*x + 8*w^7 + w^6 + 7*w^5 + 11*w^4 + 7*w^3 + 11*w^2 + 2*w + 3
             sage: phi1 = E1.isogeny(f1)
             sage: phi2 = E1.isogeny(f2)
             sage: phi1_hat = phi1.dual()
             sage: phi2_hat = phi2.dual()
-            sage: print("phi_1: ", phi1, "\n")
-            sage: print("phi_2: ", phi2, "\n")
             sage: assert phi1 != phi2
-            sage: assert phi1.dual() == phi2.dual(); #same dual, but this curve has trivial reduced automorphism group
+            sage: assert phi1_hat == phi2_hat; #same dual, but this curve has trivial reduced automorphism group
             sage: #show the method fixes the issue
             sage: phi1_dual = phi1.dual(algorithm='pushforward')
             sage: phi2_dual = phi2.dual(algorithm='pushforward')
-            sage: assert phi1_dual == phi2_dual
+            sage: assert phi1_dual != phi2_dual
         """
         if self.__base_field.characteristic() in (2, 3):
             raise NotImplementedError("computation of dual isogenies not yet implemented in characteristics 2 and 3")
@@ -3167,7 +3159,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             R = kernel_poly.parent()
             x = R.gens()[0]
             from sage.schemes.elliptic_curves.ell_field import EllipticCurve_field
-            pushforward_kernel_poly =   EllipticCurve_field.kernel_polynomial_from_divisor(E_prime, x-Qx0, d)
+            pushforward_kernel_poly = EllipticCurve_field.kernel_polynomial_from_divisor(E_prime, x-Qx0, d)
 
             return E_prime.isogeny(pushforward_kernel_poly)
 

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -2937,7 +2937,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
 
         self.__set_post_isomorphism(codomain, isom)
 
-    def dual(self, pushforward=False, fast_Elkies=False):
+    def dual(self, pushforward=False):
         r"""
         Return the isogeny dual to this isogeny.
 

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -72,6 +72,9 @@ AUTHORS:
 - Lorenz Panny (2022): inseparable duals
 
 - Rémy Oudompheng (2023): implementation of the BMSS algorithm
+
+- William E. Mahaney (2026): computing duals of prime degree separable isogenies via pushforward.
+
 """
 
 # ****************************************************************************
@@ -3144,9 +3147,6 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             #Optimizations:
                 #Faster root-finding for the quotient of the division polynomial by the kernel polynomial.
                 #x-only arithmetic when evaluating the preimage of a generator of the dual kernel.
-            """
-            Original Author: William E. Mahaney
-            """
             if F(d) == 0:
                 raise NotImplementedError("``pushforward`` method not implemented for inseparable isogenies")
             if not d.is_prime():
@@ -3165,13 +3165,11 @@ class EllipticCurveIsogeny(EllipticCurveHom):
 
             kernel_poly = self.kernel_polynomial()
             division_poly = E.division_polynomial(d)
-            quotient_poly = division_poly //kernel_poly
+            quotient_poly = division_poly // kernel_poly
 
             roots = quotient_poly.roots(multiplicities=False)
             if not roots:
-                raise ValueError(
-                    "the dual isogeny is not defined over the current ground field"
-                )
+                raise ValueError("the dual isogeny is not defined over the current ground field")
 
             x0 = roots[0]
             try:
@@ -3215,7 +3213,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
                     mu = S(mu_num) / S(mu_den)
                     f = mu.minpoly()
 
-                sep = self._domain.isogeny(f, codomain=frob.codomain()).dual()
+                sep = self._domain.isogeny(f, codomain=frob.codomain()).dual(algorithm=None)
 
             else:
                 sep = frob.codomain().isomorphism_to(self._domain)

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -3144,21 +3144,12 @@ class EllipticCurveIsogeny(EllipticCurveHom):
                 #Implement inseparable case.
                 #Implement composite degree cyclic case.
                 #Implement non-cyclic case.
-            #Optimizations:
-                #Faster root-finding for the quotient of the division polynomial by the kernel polynomial.
-                #x-only arithmetic when evaluating the preimage of a generator of the dual kernel.
             if F(d) == 0:
                 raise NotImplementedError("``pushforward`` method not implemented for inseparable isogenies")
             if not d.is_prime():
                 raise NotImplementedError("``pushforward`` method not implemented for composite degree isogenies")
             """
-            Construct the dual isogeny of a prime-degree isogeny phi: E -> E'.
-
-            Strategy:
-                - Compute the quotient of the l-division polynomial by the kernel polynomial.
-                - Pick an x-coordinate of an l-torsion point not in Ker(phi).
-                - Use Sage's native lift_x to recover a point on E.
-                - Push that point forward to generate Ker(phi_dual).
+            Construct the dual isogeny of a prime-degree separable isogeny phi: E -> E' by generating the kernel with a pushforward of a torsion point.
             """
             E = self.domain()
             E_prime = self.codomain()
@@ -3172,18 +3163,13 @@ class EllipticCurveIsogeny(EllipticCurveHom):
                 raise ValueError("the dual isogeny is not defined over the current ground field")
 
             x0 = roots[0]
-            try:
-                pts = E.lift_x(x0, all=True)
-            except (AttributeError, NotImplementedError, TypeError):
-                pts = []
+            Qx0 = EllipticCurveHom.xEVAL(self, x0)
+            R = kernel_poly.parent()
+            x = R.gens()[0]
+            from sage.schemes.elliptic_curves.ell_field import EllipticCurve_field
+            pushforward_kernel_poly =   EllipticCurve_field.kernel_polynomial_from_divisor(E_prime, x-Qx0, d)
 
-            if not pts:
-                raise ValueError("could not lift the chosen x-coordinate to a point on E")
-
-            P = pts[0]
-            Q = self(P)
-
-            return E_prime.isogeny(Q)
+            return E_prime.isogeny(pushforward_kernel_poly)
 
         #General case:
         if F(d) == 0:   # inseparable dual!

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -3213,7 +3213,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
                     mu = S(mu_num) / S(mu_den)
                     f = mu.minpoly()
 
-                sep = self._domain.isogeny(f, codomain=frob.codomain()).dual(algorithm=None)
+                sep = self._domain.isogeny(f, codomain=frob.codomain()).dual()
 
             else:
                 sep = frob.codomain().isomorphism_to(self._domain)

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -3096,6 +3096,47 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             Isogeny of degree 2
              from Elliptic Curve defined by y^2 = x^3 + 8*x + 1 over Finite Field in a of size 23^2
              to Elliptic Curve defined by y^2 = x^3 + 1 over Finite Field in a of size 23^2
+
+        Example for :issue:`42335`::
+
+            ....: p = 13;
+            ....: k.<w> = GF(p^8); #need to take a large enough field extensi
+            ....: on so E1[5] has all its points
+            ....: l = 5;
+            ....: E1 = EllipticCurve(k, [1,4]);
+            ....: E2 = EllipticCurve(k, [12,7]);
+            ....: R.<x> = k[];
+            ....: f1=x^2 + (w^7 + 5*w^6 + 9*w^5 + 3*w^4 + 9*w^3 + 3*w^2 + 10*
+            ....: w + 2)*x + 5*w^7 + 12*w^6 + 6*w^5 + 2*w^4 + 6*w^3 + 2*w^2 +
+            ....:  11*w + 12;
+            ....: f1 = R(f1);
+            ....: f2=x^2 + (12*w^7 + 8*w^6 + 4*w^5 + 10*w^4 + 4*w^3 + 10*w^2
+            ....: + 3*w + 8)*x + 8*w^7 + w^6 + 7*w^5 + 11*w^4 + 7*w^3 + 11*w^
+            ....: 2 + 2*w + 3;
+            ....: f2 = R(f2);
+            ....: phi1=E1.isogeny(f1);
+            ....: phi2=E1.isogeny(f2);
+            ....: phi1_hat=phi1.dual();
+            ....: phi2_hat=phi2.dual();
+            ....: print("phi_1: ", phi1, "\n");
+            ....: print("phi_2: ", phi2, "\n");
+            ....: # print(phi1.dual());
+            ....: # print(phi2.dual());
+            ....: print("phi1 == phi2:", phi1 == phi2);
+            ....: print("phi1.dual()==phi2.dual():", phi1.dual()==phi2.dual()
+            ....: ); #same dual, but this curve has trivial reduced automorph
+            ....: ism group
+            ....: #show my method fixes the issue
+            ....: phi1_dual = phi1.dual(pushforward=True);
+            ....: phi2_dual = phi2.dual(pushforward=True);
+            ....: print("phi1_dual == phi2_dual:", phi1_dual == phi2_dual);
+            phi_1:  Isogeny of degree 5 from Elliptic Curve defined by y^2 = x^3 + x + 4 over Finite Field in w of size 13^8 to Elliptic Curve defined by y^2 = x^3 + 12*x + 7 over Finite Field in w of size 13^8
+
+            phi_2:  Isogeny of degree 5 from Elliptic Curve defined by y^2 = x^3 + x + 4 over Finite Field in w of size 13^8 to Elliptic Curve defined by y^2 = x^3 + 12*x + 7 over Finite Field in w of size 13^8
+
+            phi1 == phi2: False
+            phi1.dual()==phi2.dual(): True
+            phi1_dual == phi2_dual: False
         """
         if self.__base_field.characteristic() in (2, 3):
             raise NotImplementedError("computation of dual isogenies not yet implemented in characteristics 2 and 3")
@@ -3108,10 +3149,9 @@ class EllipticCurveIsogeny(EllipticCurveHom):
 
         if pushforward:
             #If the flag to try pushforward method is True
-            #TODO: Optimize, implement more cases
+            #TODO: Optimize, implement non-prime degree cases and inseparable case
             """
-            Original Author: William E. Mahaney and Travis Morrison
-            Released under TO_DO License
+            Original Author: William E. Mahaney
             """
             if F(d) == 0:
                 raise NotImplementedError("Method not implemented for inseparable isogenies.")
@@ -3128,11 +3168,11 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             """
             E = self.domain()
             E_prime = self.codomain()
-            R = PolynomialRing(F);
+            R = PolynomialRing(F, 'x');
 
             kernel_poly = R(self.kernel_polynomial())
             division_poly = R(E.division_polynomial(d))
-            quotient_poly = division_poly / kernel_poly
+            quotient_poly = R(division_poly / kernel_poly)
 
             roots = quotient_poly.roots(multiplicities=False)
             if not roots:
@@ -3155,19 +3195,9 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             Q = self(P)
 
             return E_prime.isogeny(Q)
-            
-            
-        if fast_Elkies:
-            #If the flag to try fastElkies method is set to true
-            """
-            Original Author: Travis Morrison
-            Released under TO_DO License
-            """
-            raise NotImplementedError("Not implemented yet. Need to do FastElkies first.")
-
 
         #After this is the old code
-        
+
         if F(d) == 0:   # inseparable dual!
             p = F.characteristic()
             k = d.valuation(p)
@@ -3991,3 +4021,5 @@ def unfill_isogeny_matrix(M):
                 M1[i,j] = zero
                 M1[j,i] = zero
     return M1
+
+

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -3115,7 +3115,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             sage: phi1_hat = phi1.dual()
             sage: phi2_hat = phi2.dual()
             sage: assert phi1 != phi2
-            sage: assert phi1_hat == phi2_hat; #same dual, but this curve has trivial reduced automorphism group
+            sage: assert phi1_hat != phi2_hat  # known bug -- see #42335
             sage: #show the method fixes the issue
             sage: phi1_dual = phi1.dual(algorithm='pushforward')
             sage: phi2_dual = phi2.dual(algorithm='pushforward')

--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -805,7 +805,7 @@ class EllipticCurveHom(Morphism):
         """
         return [g.element() for g in self.kernel_subgroup(**kwds).gens()]
 
-    def dual(self):
+    def dual(self, algorithm=None):
         r"""
         Return the dual of this elliptic-curve morphism.
 

--- a/src/sage/schemes/elliptic_curves/hom_composite.py
+++ b/src/sage/schemes/elliptic_curves/hom_composite.py
@@ -851,7 +851,7 @@ class EllipticCurveHom_composite(EllipticCurveHom):
         """
         if not self._phis:
             return self
-        return prod(phi.dual() for phi in self._phis)
+        return prod(phi.dual(algorithm=None) for phi in self._phis)
 
     def formal(self, prec=20):
         """

--- a/src/sage/schemes/elliptic_curves/hom_composite.py
+++ b/src/sage/schemes/elliptic_curves/hom_composite.py
@@ -822,7 +822,7 @@ class EllipticCurveHom_composite(EllipticCurveHom):
         return self.x_rational_map().denominator().radical()
 
     @cached_method
-    def dual(self):
+    def dual(self, algorithm=None):
         """
         Return the dual of this composite isogeny.
 
@@ -851,7 +851,7 @@ class EllipticCurveHom_composite(EllipticCurveHom):
         """
         if not self._phis:
             return self
-        return prod(phi.dual(algorithm=None) for phi in self._phis)
+        return prod(phi.dual(algorithm=algorithm) for phi in self._phis)
 
     def formal(self, prec=20):
         """

--- a/src/sage/schemes/elliptic_curves/hom_fractional.py
+++ b/src/sage/schemes/elliptic_curves/hom_fractional.py
@@ -470,7 +470,7 @@ class EllipticCurveHom_fractional(EllipticCurveHom):
         return self.to_isogeny_chain().kernel_polynomial()
 
     @cached_method
-    def dual(self):
+    def dual(self, algorithm=None):
         r"""
         Return the dual of this fractional isogeny.
 
@@ -481,7 +481,7 @@ class EllipticCurveHom_fractional(EllipticCurveHom):
             sage: ((phi + phi) / 2).dual() == phi.dual()
             True
         """
-        psi = EllipticCurveHom_fractional(self._phi.dual(algorithm=None), self._d)
+        psi = EllipticCurveHom_fractional(self._phi.dual(algorithm=algorithm), self._d)
         psi.dual.set_cache(self)
         return psi
 

--- a/src/sage/schemes/elliptic_curves/hom_fractional.py
+++ b/src/sage/schemes/elliptic_curves/hom_fractional.py
@@ -481,7 +481,7 @@ class EllipticCurveHom_fractional(EllipticCurveHom):
             sage: ((phi + phi) / 2).dual() == phi.dual()
             True
         """
-        psi = EllipticCurveHom_fractional(self._phi.dual(), self._d)
+        psi = EllipticCurveHom_fractional(self._phi.dual(algorithm=None), self._d)
         psi.dual.set_cache(self)
         return psi
 

--- a/src/sage/schemes/elliptic_curves/hom_frobenius.py
+++ b/src/sage/schemes/elliptic_curves/hom_frobenius.py
@@ -416,7 +416,7 @@ class EllipticCurveHom_frobenius(EllipticCurveHom):
         return self._poly_ring(1)
 
     @cached_method
-    def dual(self):
+    def dual(self, algorithm=None):
         """
         Compute the dual of this Frobenius isogeny.
 

--- a/src/sage/schemes/elliptic_curves/hom_scalar.py
+++ b/src/sage/schemes/elliptic_curves/hom_scalar.py
@@ -481,7 +481,7 @@ class EllipticCurveHom_scalar(EllipticCurveHom):
             raise ValueError('kernel subgroup has no generating points over the base field')
         return ker
 
-    def dual(self):
+    def dual(self, algorithm=None):
         """
         Return the dual isogeny of this scalar-multiplication map.
 

--- a/src/sage/schemes/elliptic_curves/hom_sum.py
+++ b/src/sage/schemes/elliptic_curves/hom_sum.py
@@ -440,12 +440,12 @@ class EllipticCurveHom_sum(EllipticCurveHom):
                 except ValueError:
                     continue   # supersingular and l == p
 
-                Q = self.dual(algorithm=None)._eval(self._eval(P))
+                Q = self.dual()._eval(self._eval(P))
                 d = discrete_log(Q, P, ord=l, operation='+')
                 rem = rem.crt(Mod(d-lo, l))
 
             self._degree = lo + rem.lift()
-            self.dual(algorithm=None)._degree = self._degree
+            self.dual()._degree = self._degree
 
     @staticmethod
     def _comparison_impl(left, right, op):
@@ -591,7 +591,7 @@ class EllipticCurveHom_sum(EllipticCurveHom):
         return sum(phi.scaling_factor() for phi in self._phis)
 
     @cached_method
-    def dual(self):
+    def dual(self, algorithm=None):
         r"""
         Return the dual of this sum morphism.
 
@@ -624,7 +624,7 @@ class EllipticCurveHom_sum(EllipticCurveHom):
 
         ALGORITHM: Taking the dual distributes over addition.
         """
-        psi = EllipticCurveHom_sum((phi.dual(algorithm=None) for phi in self._phis),
+        psi = EllipticCurveHom_sum((phi.dual(algorithm=algorithm) for phi in self._phis),
                                    domain=self._codomain, codomain=self._domain)
         psi._degree = self._degree
         if self.trace.is_in_cache():

--- a/src/sage/schemes/elliptic_curves/hom_sum.py
+++ b/src/sage/schemes/elliptic_curves/hom_sum.py
@@ -440,12 +440,12 @@ class EllipticCurveHom_sum(EllipticCurveHom):
                 except ValueError:
                     continue   # supersingular and l == p
 
-                Q = self.dual()._eval(self._eval(P))
+                Q = self.dual(algorithm=None)._eval(self._eval(P))
                 d = discrete_log(Q, P, ord=l, operation='+')
                 rem = rem.crt(Mod(d-lo, l))
 
             self._degree = lo + rem.lift()
-            self.dual()._degree = self._degree
+            self.dual(algorithm=None)._degree = self._degree
 
     @staticmethod
     def _comparison_impl(left, right, op):
@@ -624,7 +624,7 @@ class EllipticCurveHom_sum(EllipticCurveHom):
 
         ALGORITHM: Taking the dual distributes over addition.
         """
-        psi = EllipticCurveHom_sum((phi.dual() for phi in self._phis),
+        psi = EllipticCurveHom_sum((phi.dual(algorithm=None) for phi in self._phis),
                                    domain=self._codomain, codomain=self._domain)
         psi._degree = self._degree
         if self.trace.is_in_cache():

--- a/src/sage/schemes/elliptic_curves/hom_velusqrt.py
+++ b/src/sage/schemes/elliptic_curves/hom_velusqrt.py
@@ -1105,7 +1105,7 @@ class EllipticCurveHom_velusqrt(EllipticCurveHom):
         return iso * phi
 
     # not explicitly cached here since .as_EllipticCurveIsogeny() and EllipticCurveIsogeny.dual() already cache their results
-    def dual(self):
+    def dual(self, algorithm=None):
         r"""
         Return the dual of this square-root Vélu
         isogeny as an :class:`EllipticCurveHom`.
@@ -1153,7 +1153,7 @@ class EllipticCurveHom_velusqrt(EllipticCurveHom):
         if self.base_ring().characteristic().divides(self.degree()):
             # The dual is inseparable.
             #TODO: This is a lazy workaround; it could be optimized more.
-            return self.as_EllipticCurveIsogeny().dual(algorithm=None)
+            return self.as_EllipticCurveIsogeny().dual(algorithm=algorithm)
 
         # The dual is separable.
         F = self._raw_domain.base_ring()

--- a/src/sage/schemes/elliptic_curves/hom_velusqrt.py
+++ b/src/sage/schemes/elliptic_curves/hom_velusqrt.py
@@ -1153,7 +1153,7 @@ class EllipticCurveHom_velusqrt(EllipticCurveHom):
         if self.base_ring().characteristic().divides(self.degree()):
             # The dual is inseparable.
             #TODO: This is a lazy workaround; it could be optimized more.
-            return self.as_EllipticCurveIsogeny().dual()
+            return self.as_EllipticCurveIsogeny().dual(algorithm=None)
 
         # The dual is separable.
         F = self._raw_domain.base_ring()

--- a/src/sage/schemes/elliptic_curves/weierstrass_morphism.py
+++ b/src/sage/schemes/elliptic_curves/weierstrass_morphism.py
@@ -874,7 +874,7 @@ class WeierstrassIsomorphism(EllipticCurveHom, baseWI):
         """
         return self._poly_ring(1)
 
-    def dual(self):
+    def dual(self, algorithm=None):
         """
         Return the dual isogeny of this isomorphism.
 


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->
I added a flag ``pushforward`` to ``.dual()`` in ``EllipticCurveIsogeny'' that computes the dual of an l-isogeny phi: E to E' by computing the kernel of the dual phi': E' to E by pushing forward an appropriate point in E[l]. This partially adresses Sagemath issue #42335 which points out that when E and E' have more than one l-isogeny between them (up to equivalence) Sagemath does not currently compute the dual isogenies correctly.


### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies
Sagemath
<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


