### PR TITLE
Flint polynomial rings

### DIFF
--- a/src/sage/coding/reed_muller_code.py
+++ b/src/sage/coding/reed_muller_code.py
@@ -758,8 +758,25 @@ class ReedMullerPolynomialEncoder(Encoder):
          Binary Reed-Muller Code of order 2 and number of variables 4
     """
 
-    def __init__(self, code, polynomial_ring=None):
+    def __init__(self, code, polynomial_ring=None, poly_implementation=None):
         r"""
+        INPUT:
+
+        - ``code`` -- a :class:`QAryReedMullerCode` or :class:`BinaryReedMullerCode`
+
+        - ``polynomial_ring`` -- (optional) a multivariate polynomial ring
+          over ``code.base_field()`` with ``code.number_of_variables()``
+          generators; if not given, one is constructed using
+          ``poly_implementation``
+
+        - ``poly_implementation`` -- (optional) the ``implementation``
+          keyword forwarded to
+          :func:`~sage.rings.polynomial.polynomial_ring_constructor.PolynomialRing`
+          when building the default polynomial ring. For prime finite
+          fields, ``'flint'`` enables the FLINT backend, which is
+          typically faster for the polynomial arithmetic used in
+          interpolation. Ignored when ``polynomial_ring`` is supplied.
+
         TESTS:
 
         If ``code`` is not a Reed-Muller code, an error is raised::
@@ -779,13 +796,21 @@ class ReedMullerPolynomialEncoder(Encoder):
             Traceback (most recent call last):
             ...
             ValueError: The Polynomial ring should be on Finite Field of size 59 and should have 3 variables
+
+        The FLINT backend is selected via ``poly_implementation``::
+
+            sage: C = codes.ReedMullerCode(GF(5), 2, 3)
+            sage: E = codes.encoders.ReedMullerPolynomialEncoder(C, poly_implementation='flint')
+            sage: E.polynomial_ring()
+            Multivariate Polynomial Ring in x0, x1, x2 over Finite Field of size 5 (using FLINT)
         """
         if not isinstance(code, (QAryReedMullerCode, BinaryReedMullerCode)):
             raise ValueError("the code has to be a Reed-Muller code")
         super().__init__(code)
         if polynomial_ring is None:
             self._polynomial_ring = PolynomialRing(code.base_field(),
-                    code.number_of_variables(), 'x')
+                    code.number_of_variables(), 'x',
+                    implementation=poly_implementation)
         else:
             if (polynomial_ring.base_ring() == code.base_field()) and (
                     len(polynomial_ring.variable_names()) == code.number_of_variables()):

--- a/src/sage/libs/flint/types.pxd
+++ b/src/sage/libs/flint/types.pxd
@@ -922,7 +922,7 @@ cdef extern from "flint_wrap.h":
     ctypedef fmpz_mpoly_ctx_struct fmpz_mpoly_ctx_t[1]
 
     ctypedef struct fmpq_mpoly_ctx_struct:
-        pass
+        fmpz_mpoly_ctx_t zctx
 
     ctypedef fmpq_mpoly_ctx_struct fmpq_mpoly_ctx_t[1]
 

--- a/src/sage/libs/flint/types.pxd
+++ b/src/sage/libs/flint/types.pxd
@@ -914,7 +914,7 @@ cdef extern from "flint_wrap.h":
     ctypedef mpoly_ctx_struct mpoly_ctx_t[1]
 
     ctypedef struct nmod_mpoly_ctx_struct:
-        pass
+        mpoly_ctx_t minfo
     ctypedef nmod_mpoly_ctx_struct nmod_mpoly_ctx_t[1]
 
     ctypedef struct fmpz_mpoly_ctx_struct:

--- a/src/sage/libs/flint/types.pxd
+++ b/src/sage/libs/flint/types.pxd
@@ -906,7 +906,11 @@ cdef extern from "flint_wrap.h":
         ORD_DEGREVLEX
 
     ctypedef struct mpoly_ctx_struct:
-        pass
+        slong nvars
+        slong nfields
+        ordering_t ord
+        int deg
+        int rev
     ctypedef mpoly_ctx_struct mpoly_ctx_t[1]
 
     ctypedef struct nmod_mpoly_ctx_struct:
@@ -914,7 +918,7 @@ cdef extern from "flint_wrap.h":
     ctypedef nmod_mpoly_ctx_struct nmod_mpoly_ctx_t[1]
 
     ctypedef struct fmpz_mpoly_ctx_struct:
-        pass
+        mpoly_ctx_t minfo
     ctypedef fmpz_mpoly_ctx_struct fmpz_mpoly_ctx_t[1]
 
     ctypedef struct fmpq_mpoly_ctx_struct:

--- a/src/sage/rings/polynomial/meson.build
+++ b/src/sage/rings/polynomial/meson.build
@@ -32,6 +32,8 @@ py.install_sources(
   'multi_polynomial_element.py',
   'multi_polynomial_integer_flint.pxd',
   'multi_polynomial_integer_flint.pyx',
+  'multi_polynomial_rational_flint.pxd',
+  'multi_polynomial_rational_flint.pyx',
   'multi_polynomial_zmod_flint.pxd',
   'multi_polynomial_zmod_flint.pyx',
   'multi_polynomial_ideal.py',
@@ -116,6 +118,7 @@ extension_data = {
   'laurent_polynomial_mpair': files('laurent_polynomial_mpair.pyx'),
   'multi_polynomial': files('multi_polynomial.pyx'),
   'multi_polynomial_integer_flint': files('multi_polynomial_integer_flint.pyx'),
+  'multi_polynomial_rational_flint': files('multi_polynomial_rational_flint.pyx'),
   'multi_polynomial_zmod_flint': files('multi_polynomial_zmod_flint.pyx'),
   'multi_polynomial_ring_base': files('multi_polynomial_ring_base.pyx'),
   'ore_polynomial_element': files('ore_polynomial_element.pyx'),
@@ -150,6 +153,8 @@ foreach name, pyx : extension_data
   elif name == 'hilbert'
     deps += [flint, mpfi]
   elif name == 'multi_polynomial_integer_flint'
+    deps += [flint]
+  elif name == 'multi_polynomial_rational_flint'
     deps += [flint]
   elif name == 'multi_polynomial_zmod_flint'
     deps += [flint]

--- a/src/sage/rings/polynomial/meson.build
+++ b/src/sage/rings/polynomial/meson.build
@@ -32,6 +32,8 @@ py.install_sources(
   'multi_polynomial_element.py',
   'multi_polynomial_integer_flint.pxd',
   'multi_polynomial_integer_flint.pyx',
+  'multi_polynomial_zmod_flint.pxd',
+  'multi_polynomial_zmod_flint.pyx',
   'multi_polynomial_ideal.py',
   'multi_polynomial_ideal_libsingular.pxd',
   'multi_polynomial_ideal_libsingular.pyx',
@@ -114,6 +116,7 @@ extension_data = {
   'laurent_polynomial_mpair': files('laurent_polynomial_mpair.pyx'),
   'multi_polynomial': files('multi_polynomial.pyx'),
   'multi_polynomial_integer_flint': files('multi_polynomial_integer_flint.pyx'),
+  'multi_polynomial_zmod_flint': files('multi_polynomial_zmod_flint.pyx'),
   'multi_polynomial_ring_base': files('multi_polynomial_ring_base.pyx'),
   'ore_polynomial_element': files('ore_polynomial_element.pyx'),
   'polydict': files('polydict.pyx'),
@@ -147,6 +150,8 @@ foreach name, pyx : extension_data
   elif name == 'hilbert'
     deps += [flint, mpfi]
   elif name == 'multi_polynomial_integer_flint'
+    deps += [flint]
+  elif name == 'multi_polynomial_zmod_flint'
     deps += [flint]
   endif
 

--- a/src/sage/rings/polynomial/meson.build
+++ b/src/sage/rings/polynomial/meson.build
@@ -30,6 +30,8 @@ py.install_sources(
   'multi_polynomial.pxd',
   'multi_polynomial.pyx',
   'multi_polynomial_element.py',
+  'multi_polynomial_integer_flint.pxd',
+  'multi_polynomial_integer_flint.pyx',
   'multi_polynomial_ideal.py',
   'multi_polynomial_ideal_libsingular.pxd',
   'multi_polynomial_ideal_libsingular.pyx',
@@ -111,6 +113,7 @@ extension_data = {
   'laurent_polynomial': files('laurent_polynomial.pyx'),
   'laurent_polynomial_mpair': files('laurent_polynomial_mpair.pyx'),
   'multi_polynomial': files('multi_polynomial.pyx'),
+  'multi_polynomial_integer_flint': files('multi_polynomial_integer_flint.pyx'),
   'multi_polynomial_ring_base': files('multi_polynomial_ring_base.pyx'),
   'ore_polynomial_element': files('ore_polynomial_element.pyx'),
   'polydict': files('polydict.pyx'),
@@ -143,6 +146,8 @@ foreach name, pyx : extension_data
     deps += [flint, mpfi]
   elif name == 'hilbert'
     deps += [flint, mpfi]
+  elif name == 'multi_polynomial_integer_flint'
+    deps += [flint]
   endif
 
   py.extension_module(

--- a/src/sage/rings/polynomial/multi_polynomial.pxd
+++ b/src/sage/rings/polynomial/multi_polynomial.pxd
@@ -9,3 +9,6 @@ cdef class MPolynomial(CommutativePolynomial):
 
 cdef class MPolynomial_libsingular(MPolynomial):
     pass
+
+cdef class MPolynomial_flint(MPolynomial):
+    pass

--- a/src/sage/rings/polynomial/multi_polynomial_integer_flint.pxd
+++ b/src/sage/rings/polynomial/multi_polynomial_integer_flint.pxd
@@ -1,0 +1,16 @@
+from sage.libs.flint.types cimport fmpz_mpoly_t, fmpz_mpoly_ctx_t
+
+from sage.rings.polynomial.multi_polynomial cimport MPolynomial_flint as MPolynomial_flint_base
+from sage.rings.polynomial.multi_polynomial_ring_base cimport MPolynomialRing_base
+
+
+cdef class MPolynomialRing_integer_flint(MPolynomialRing_base):
+    cdef fmpz_mpoly_ctx_t _ctx
+    cdef MPolynomial_integer_flint _new_element(self)
+
+
+cdef class MPolynomial_integer_flint(MPolynomial_flint_base):
+    cdef fmpz_mpoly_t _poly
+    cdef MPolynomial_integer_flint _new(self)
+    cpdef _new_constant_poly(self, scalar, parent)
+    cpdef long number_of_terms(self) noexcept

--- a/src/sage/rings/polynomial/multi_polynomial_integer_flint.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_integer_flint.pyx
@@ -1,0 +1,2014 @@
+# distutils: libraries = flint
+# distutils: depends = flint/fmpz_mpoly.h flint/fmpz_mpoly_factor.h
+r"""
+Multivariate polynomials over `\ZZ`, implemented using FLINT
+
+EXAMPLES::
+
+    sage: R.<x,y,z> = PolynomialRing(ZZ, 'x,y,z', implementation='flint')
+    sage: f = 3*x^2*y - z + 1; f
+    3*x^2*y - z + 1
+    sage: f * f
+    9*x^4*y^2 - 6*x^2*y*z + 6*x^2*y + z^2 - 2*z + 1
+
+.. automethod:: MPolynomial_integer_flint._add_
+.. automethod:: MPolynomial_integer_flint._sub_
+.. automethod:: MPolynomial_integer_flint._mul_
+.. automethod:: MPolynomial_integer_flint._neg_
+"""
+
+#*****************************************************************************
+#       Copyright (C) 2025 Vincent Delecroix <20100.delecroix@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#                  http://www.gnu.org/licenses/
+#*****************************************************************************
+
+import re
+
+from libc.stdlib cimport free
+
+from cysignals.signals cimport sig_on, sig_off
+from cysignals.memory cimport sig_malloc, sig_free
+
+from cpython.object cimport Py_EQ, Py_NE
+
+from sage.libs.flint.fmpz cimport (
+    fmpz_init, fmpz_clear, fmpz_set, fmpz_set_mpz, fmpz_get_mpz,
+    fmpz_zero, fmpz_one, fmpz_is_zero, fmpz_is_one,
+    fmpz_gcd, fmpz_abs, fmpz_sgn, fmpz_cmp_si)
+from sage.libs.flint.fmpz_mpoly cimport *
+from sage.libs.flint.fmpz_mpoly_factor cimport (
+    fmpz_mpoly_factor_init, fmpz_mpoly_factor_clear,
+    fmpz_mpoly_factor_length, fmpz_mpoly_factor_get_constant_fmpz,
+    fmpz_mpoly_factor_get_base, fmpz_mpoly_factor_get_exp_si,
+    fmpz_mpoly_factor)
+from sage.libs.flint.types cimport (
+    fmpz_t, fmpz_mpoly_t, fmpz_mpoly_ctx_t, fmpz_mpoly_struct,
+    fmpz_mpoly_factor_t,
+    ordering_t, ORD_LEX, ORD_DEGLEX, ORD_DEGREVLEX, ulong, slong)
+
+from sage.cpython.string cimport str_to_bytes, char_to_str
+
+from sage.rings.integer cimport Integer, _Integer_from_mpz
+from sage.rings.integer_ring import ZZ
+from sage.structure.element cimport Element
+from sage.structure.factorization import Factorization
+from sage.structure.richcmp cimport rich_to_bool
+
+from sage.rings.polynomial.multi_polynomial cimport MPolynomial_flint as MPolynomial_flint_base
+from sage.rings.polynomial.multi_polynomial_ring_base cimport MPolynomialRing_base
+from sage.rings.polynomial.multi_polynomial_integer_flint cimport (
+    MPolynomialRing_integer_flint,
+    MPolynomial_integer_flint)
+from sage.rings.polynomial.polydict cimport ETuple
+
+
+cdef ordering_t _term_order_to_flint(order) except? ORD_LEX:
+    name = order.name() if hasattr(order, 'name') else str(order)
+    if name == 'lex':
+        return ORD_LEX
+    elif name == 'deglex':
+        return ORD_DEGLEX
+    elif name == 'degrevlex':
+        return ORD_DEGREVLEX
+    raise NotImplementedError(
+        "term order '{}' is not supported by FLINT fmpz_mpoly".format(name))
+
+
+def _unpickle_MPolynomialRing_integer_flint(n, names, order):
+    r"""
+    Helper for unpickling :class:`MPolynomialRing_integer_flint`.
+
+    TESTS::
+
+        sage: R = PolynomialRing(ZZ, 'x,y', implementation='flint')
+        sage: loads(dumps(R)) is R
+        True
+    """
+    from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+    return PolynomialRing(ZZ, n, names=names, order=order, implementation='flint')
+
+
+def _unpickle_MPolynomial_integer_flint(parent, coeffs):
+    r"""
+    Helper for unpickling :class:`MPolynomial_integer_flint`.
+
+    TESTS::
+
+        sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+        sage: f = 3*x^2*y - x + 1
+        sage: loads(dumps(f)) == f
+        True
+    """
+    return parent(coeffs)
+
+
+cdef class MPolynomialRing_integer_flint(MPolynomialRing_base):
+    r"""
+    Multivariate polynomial ring over `\ZZ`, implemented via FLINT.
+
+    EXAMPLES::
+
+        sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+        sage: R
+        Multivariate Polynomial Ring in x, y over Integer Ring (using FLINT)
+    """
+
+    def __cinit__(self):
+        # nvars = -1 signals that fmpz_mpoly_ctx_init has not yet been called.
+        self._ctx[0].minfo[0].nvars = -1
+
+    def __init__(self, base_ring, n, names, order='degrevlex'):
+        r"""
+        Construct a multivariate polynomial ring over `\ZZ` using FLINT.
+
+        INPUT:
+
+        - ``base_ring`` -- must be `\ZZ`
+        - ``n`` -- number of variables (positive integer)
+        - ``names`` -- variable names
+        - ``order`` -- term order (``'lex'``, ``'deglex'``, or ``'degrevlex'``)
+
+        EXAMPLES::
+
+            sage: from sage.rings.polynomial.multi_polynomial_integer_flint import MPolynomialRing_integer_flint
+            sage: R = MPolynomialRing_integer_flint(ZZ, 3, ('x','y','z'), 'degrevlex')
+            sage: R
+            Multivariate Polynomial Ring in x, y, z over Integer Ring (using FLINT)
+        """
+        if base_ring is not ZZ:
+            raise TypeError("base ring must be ZZ")
+        MPolynomialRing_base.__init__(self, base_ring, n, names, order)
+        cdef ordering_t ord = _term_order_to_flint(self._term_order)
+        fmpz_mpoly_ctx_init(self._ctx, n, ord)
+
+    def __dealloc__(self):
+        if self._ctx[0].minfo[0].nvars != -1:
+            fmpz_mpoly_ctx_clear(self._ctx)
+
+    Element = MPolynomial_integer_flint
+
+    def __hash__(self):
+        r"""
+        Return a hash of this ring.
+
+        EXAMPLES::
+
+            sage: R = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: hash(R) == hash(R)
+            True
+        """
+        from sage.structure.category_object import CategoryObject
+        return CategoryObject.__hash__(self)
+
+    def __reduce__(self):
+        r"""
+        Return data for pickling this ring.
+
+        TESTS::
+
+            sage: R = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: loads(dumps(R)) is R
+            True
+        """
+        return (_unpickle_MPolynomialRing_integer_flint,
+                (self._ngens, self.variable_names(), self._term_order))
+
+    def _repr_(self):
+        r"""
+        Return a string representation of this ring.
+
+        EXAMPLES::
+
+            sage: PolynomialRing(ZZ, 'x,y', implementation='flint')
+            Multivariate Polynomial Ring in x, y over Integer Ring (using FLINT)
+        """
+        return "Multivariate Polynomial Ring in {} over Integer Ring (using FLINT)".format(
+            ", ".join(self.variable_names()))
+
+    def gen(self, int n=0):
+        r"""
+        Return the ``n``-th generator of this ring.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(ZZ, 'x,y,z', implementation='flint')
+            sage: R.gen(0)
+            x
+            sage: R.gen(2)
+            z
+        """
+        if n < 0 or n >= self._ngens:
+            raise ValueError("generator index out of range")
+        cdef MPolynomial_integer_flint g = self._new_element()
+        sig_on()
+        fmpz_mpoly_gen(g._poly, n, self._ctx)
+        sig_off()
+        return g
+
+    cdef MPolynomial_integer_flint _new_element(self):
+        cdef MPolynomial_integer_flint f = \
+            MPolynomial_integer_flint.__new__(MPolynomial_integer_flint)
+        f._parent = self
+        fmpz_mpoly_init(f._poly, self._ctx)
+        return f
+
+    def _element_constructor_(self, x):
+        r"""
+        Convert ``x`` into an element of this ring.
+
+        Accepted inputs include integers, strings, dictionaries mapping exponent
+        tuples to coefficients, and multivariate polynomials over a compatible
+        ring.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: R(3)
+            3
+            sage: R("x^2*y - 2*x + 1")
+            x^2*y - 2*x + 1
+            sage: R({(2,1): 5, (0,0): -1})
+            5*x^2*y - 1
+            sage: R(x + y)
+            x + y
+        """
+        cdef MPolynomial_integer_flint f
+        cdef Integer c
+        cdef ETuple e
+        cdef fmpz_t coeff
+        cdef ulong *exp
+        cdef slong n = self._ngens
+        cdef int i
+        cdef bytes bstr
+        cdef const char **cnames
+
+        if isinstance(x, MPolynomial_integer_flint) and x.parent() is self:
+            f = self._new_element()
+            sig_on()
+            fmpz_mpoly_set(f._poly, (<MPolynomial_integer_flint>x)._poly, self._ctx)
+            sig_off()
+            return f
+
+        if isinstance(x, int):
+            x = Integer(x)
+        if isinstance(x, Integer):
+            f = self._new_element()
+            fmpz_init(coeff)
+            fmpz_set_mpz(coeff, (<Integer>x).value)
+            sig_on()
+            fmpz_mpoly_set_fmpz(f._poly, coeff, self._ctx)
+            sig_off()
+            fmpz_clear(coeff)
+            return f
+
+        if isinstance(x, str):
+            f = self._new_element()
+            bnames = [str_to_bytes(v) for v in self.variable_names()]
+            cnames = <const char **>sig_malloc(n * sizeof(char *))
+            if cnames == NULL:
+                raise MemoryError
+            for i in range(n):
+                cnames[i] = bnames[i]
+            bstr = str_to_bytes(x)
+            sig_on()
+            ok = fmpz_mpoly_set_str_pretty(f._poly, bstr, cnames, self._ctx)
+            sig_off()
+            sig_free(cnames)
+            if ok != 0:
+                raise ValueError("could not parse '{}' as a polynomial".format(x))
+            return f
+
+        if isinstance(x, dict):
+            f = self._new_element()
+            exp = <ulong *>sig_malloc(n * sizeof(ulong))
+            if exp == NULL:
+                raise MemoryError
+            fmpz_init(coeff)
+            try:
+                for key, val in x.items():
+                    if not isinstance(val, Integer):
+                        val = ZZ(val)
+                    c = <Integer>val
+                    for i in range(n):
+                        exp[i] = key[i]
+                    fmpz_set_mpz(coeff, c.value)
+                    sig_on()
+                    fmpz_mpoly_set_coeff_fmpz_ui(f._poly, coeff, exp, self._ctx)
+                    sig_off()
+            finally:
+                fmpz_clear(coeff)
+                sig_free(exp)
+            return f
+
+        # try via _mpoly_dict_recursive for MPolynomial types
+        from sage.rings.polynomial.multi_polynomial import MPolynomial
+        if isinstance(x, MPolynomial):
+            return self._element_constructor_(
+                x._mpoly_dict_recursive(self.variable_names(), ZZ))
+
+        # last resort: coerce to ZZ
+        return self._element_constructor_(ZZ(x))
+
+    def _coerce_map_from_(self, R):
+        r"""
+        Return ``True`` if there is a coercion from ``R`` into this ring.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: R.has_coerce_map_from(ZZ)
+            True
+
+        Conversion from the libsingular backend and vice versa::
+
+            sage: R_f = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: R_s = PolynomialRing(ZZ, 'x,y', implementation='singular')
+            sage: x_f, y_f = R_f.gens()
+            sage: x_s, y_s = R_s.gens()
+            sage: p_f = 2*x_f^2 - x_f*y_f + 3
+            sage: p_s = 2*x_s^2 - x_s*y_s + 3
+            sage: R_f(p_s)
+            2*x^2 - x*y + 3
+            sage: R_s(p_f)
+            2*x^2 - x*y + 3
+            sage: R_f(p_s) == p_f
+            True
+            sage: R_s(p_f) == p_s
+            True
+        """
+        if R is ZZ:
+            return True
+        return MPolynomialRing_base._coerce_map_from_(self, R)
+
+
+cdef class MPolynomial_integer_flint(MPolynomial_flint_base):
+    r"""
+    A multivariate polynomial over `\ZZ`, implemented via FLINT.
+
+    EXAMPLES::
+
+        sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+        sage: f = 3*x^2 - y + 1; f
+        3*x^2 - y + 1
+        sage: type(f)
+        <class 'sage.rings.polynomial.multi_polynomial_integer_flint.MPolynomial_integer_flint'>
+
+    .. automethod:: _add_
+    .. automethod:: _sub_
+    .. automethod:: _mul_
+    .. automethod:: _neg_
+    """
+
+    def __cinit__(self):
+        # Python zero-initialises the memory; fmpz_mpoly_clear on a struct with
+        # alloc=0 is a no-op, so __dealloc__ is safe even if fmpz_mpoly_init
+        # was never called (e.g. if __new__ is used directly without _parent).
+        pass
+
+    def __dealloc__(self):
+        cdef MPolynomialRing_integer_flint R = self._parent
+        if R is not None:
+            fmpz_mpoly_clear(self._poly, R._ctx)
+
+    cdef MPolynomial_integer_flint _new(self):
+        return (<MPolynomialRing_integer_flint>self._parent)._new_element()
+
+    cpdef _new_constant_poly(self, scalar, parent):
+        r"""
+        Return a new constant polynomial with value ``scalar`` in ``parent``.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: x._new_constant_poly(3, R)
+            3
+        """
+        cdef MPolynomialRing_integer_flint R = parent
+        cdef MPolynomial_integer_flint f = R._new_element()
+        cdef fmpz_t coeff
+        if not isinstance(scalar, Integer):
+            scalar = ZZ(scalar)
+        fmpz_init(coeff)
+        fmpz_set_mpz(coeff, (<Integer>scalar).value)
+        fmpz_mpoly_set_fmpz(f._poly, coeff, R._ctx)
+        fmpz_clear(coeff)
+        return f
+
+    def __copy__(self):
+        r"""
+        Return a copy of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: f = 3*x^2 - y + 1
+            sage: g = copy(f)
+            sage: f == g
+            True
+            sage: f is g
+            False
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef MPolynomial_integer_flint f = R._new_element()
+        sig_on()
+        fmpz_mpoly_set(f._poly, self._poly, R._ctx)
+        sig_off()
+        return f
+
+    def __deepcopy__(self, memo=None):
+        r"""
+        Return a deep copy of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: f = x^2 + y
+            sage: g = deepcopy(f)
+            sage: f == g
+            True
+            sage: f is g
+            False
+        """
+        cpy = self.__copy__()
+        if memo is not None:
+            memo[id(self)] = cpy
+        return cpy
+
+    def __reduce__(self):
+        r"""
+        Return data for pickling this polynomial.
+
+        TESTS::
+
+            sage: R.<x,y,z> = PolynomialRing(ZZ, 'x,y,z', implementation='flint')
+            sage: f = 7*x^3*y - 2*y*z + 1
+            sage: loads(dumps(f)) == f
+            True
+        """
+        return (_unpickle_MPolynomial_integer_flint,
+                (self._parent, self.monomial_coefficients()))
+
+    def _repr_(self):
+        r"""
+        Return a string representation of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(ZZ, 'x,y,z', implementation='flint')
+            sage: 3*x^2*y - z + 1
+            3*x^2*y - z + 1
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef int n = R._ngens
+        cdef char *raw
+        cdef const char **cnames = <const char **>sig_malloc(n * sizeof(char *))
+        if cnames == NULL:
+            raise MemoryError
+        # keep byte strings alive for the duration of the call
+        bnames = [str_to_bytes(v) for v in R.variable_names()]
+        for i in range(n):
+            cnames[i] = bnames[i]
+        sig_on()
+        raw = fmpz_mpoly_get_str_pretty(self._poly, cnames, R._ctx)
+        sig_off()
+        sig_free(cnames)
+        result = char_to_str(raw)
+        free(raw)
+        # FLINT omits spaces around binary + and -; add them for readability
+        result = re.sub(r'([a-zA-Z0-9])\s*([+-])', r'\1 \2 ', result)
+        return result
+
+    def __hash__(self):
+        r"""
+        Return a hash of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: hash(x) == hash(x)
+            True
+            sage: hash(x) == hash(y)
+            False
+        """
+        return self._hash_c()
+
+    def __bool__(self):
+        r"""
+        Return ``True`` if this polynomial is nonzero.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: bool(x)
+            True
+            sage: bool(R(0))
+            False
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        return not fmpz_mpoly_is_zero(self._poly, R._ctx)
+
+    # ===== Predicates =====
+
+    def is_zero(self):
+        r"""
+        Return ``True`` if this polynomial is zero.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: R(0).is_zero()
+            True
+            sage: (x - x).is_zero()
+            True
+            sage: x.is_zero()
+            False
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        return bool(fmpz_mpoly_is_zero(self._poly, R._ctx))
+
+    def is_one(self):
+        r"""
+        Return ``True`` if this polynomial equals 1.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: R(1).is_one()
+            True
+            sage: x.is_one()
+            False
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        return bool(fmpz_mpoly_is_one(self._poly, R._ctx))
+
+    def is_constant(self):
+        r"""
+        Return ``True`` if this polynomial is a constant (an element of `\ZZ`).
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: R(0).is_constant()
+            True
+            sage: R(5).is_constant()
+            True
+            sage: x.is_constant()
+            False
+            sage: (x + 1).is_constant()
+            False
+
+        Constant polynomials can be converted to `\ZZ`::
+
+            sage: ZZ(R(5))
+            5
+            sage: ZZ(R(0))
+            0
+            sage: int(R(7))
+            7
+            sage: ZZ(x)
+            Traceback (most recent call last):
+            ...
+            TypeError: x is not a constant polynomial
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        return bool(fmpz_mpoly_is_fmpz(self._poly, R._ctx))
+
+    def is_term(self):
+        r"""
+        Return ``True`` if this polynomial is a single (nonzero) term.
+
+        A *term* is a product of a nonzero coefficient and a monomial in the
+        variables.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: x.is_term()
+            True
+            sage: (3*x^2*y).is_term()
+            True
+            sage: (x + y).is_term()
+            False
+            sage: R(0).is_term()
+            False
+            sage: R(5).is_term()
+            True
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        return fmpz_mpoly_length(self._poly, R._ctx) == 1
+
+    def is_monomial(self):
+        r"""
+        Return ``True`` if this polynomial is a monomial.
+
+        A *monomial* is a product of variables with coefficient 1.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: x.is_monomial()
+            True
+            sage: (x^2*y).is_monomial()
+            True
+            sage: (3*x).is_monomial()
+            False
+            sage: R(1).is_monomial()
+            True
+            sage: R(0).is_monomial()
+            False
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef fmpz_t c
+        if fmpz_mpoly_length(self._poly, R._ctx) != 1:
+            return False
+        fmpz_init(c)
+        fmpz_mpoly_get_term_coeff_fmpz(c, self._poly, 0, R._ctx)
+        result = fmpz_is_one(c)
+        fmpz_clear(c)
+        return bool(result)
+
+    def is_homogeneous(self):
+        r"""
+        Return ``True`` if this polynomial is homogeneous.
+
+        A polynomial is homogeneous if all its terms have the same total degree.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(ZZ, 'x,y,z', implementation='flint')
+            sage: (x^2 + y*z).is_homogeneous()
+            True
+            sage: (x^2 + y).is_homogeneous()
+            False
+            sage: R(0).is_homogeneous()
+            True
+            sage: R(5).is_homogeneous()
+            True
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong length = fmpz_mpoly_length(self._poly, R._ctx)
+        cdef slong i, j
+        cdef ulong *exp
+        if length <= 1:
+            return True
+        exp = <ulong *>sig_malloc(n * sizeof(ulong))
+        if exp == NULL:
+            raise MemoryError
+        try:
+            fmpz_mpoly_get_term_exp_ui(exp, self._poly, 0, R._ctx)
+            ref_deg = 0
+            for j in range(n):
+                ref_deg += exp[j]
+            for i in range(1, length):
+                fmpz_mpoly_get_term_exp_ui(exp, self._poly, i, R._ctx)
+                deg = 0
+                for j in range(n):
+                    deg += exp[j]
+                if deg != ref_deg:
+                    return False
+        finally:
+            sig_free(exp)
+        return True
+
+    def is_square(self):
+        r"""
+        Return ``True`` if this polynomial is a perfect square.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: (x^2 + 2*x*y + y^2).is_square()
+            True
+            sage: x.is_square()
+            False
+            sage: R(0).is_square()
+            True
+            sage: R(4).is_square()
+            True
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        return bool(fmpz_mpoly_is_square(self._poly, R._ctx))
+
+    # ===== Information =====
+
+    cpdef long number_of_terms(self) noexcept:
+        r"""
+        Return the number of nonzero terms.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: f = x^2 + 3*x*y - y + 2
+            sage: f.number_of_terms()
+            4
+            sage: R(0).number_of_terms()
+            0
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        return fmpz_mpoly_length(self._poly, R._ctx)
+
+    def degree(self, x=None):
+        r"""
+        Return the degree of this polynomial in the variable ``x``, or the
+        total degree if ``x`` is ``None``.
+
+        INPUT:
+
+        - ``x`` -- (optional) a generator of the parent ring
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(ZZ, 'x,y,z', implementation='flint')
+            sage: f = x^2*y + y^3*z^4
+            sage: f.degree()
+            7
+            sage: f.degree(x)
+            2
+            sage: f.degree(y)
+            3
+            sage: f.degree(z)
+            4
+            sage: R(0).degree()
+            -1
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        if fmpz_mpoly_is_zero(self._poly, R._ctx):
+            return -1
+        if x is None:
+            return self.total_degree()
+        cdef slong var_idx
+        names = R.variable_names()
+        var_name = str(x)
+        if var_name not in names:
+            raise ValueError("{} is not a variable of {}".format(x, R))
+        var_idx = names.index(var_name)
+        return Integer(fmpz_mpoly_degree_si(self._poly, var_idx, R._ctx))
+
+    def total_degree(self):
+        r"""
+        Return the total degree of this polynomial.
+
+        The total degree is the maximum, over all nonzero terms, of the sum of
+        the exponents.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(ZZ, 'x,y,z', implementation='flint')
+            sage: (x^2*y + y^3*z^4 + 1).total_degree()
+            7
+            sage: R(5).total_degree()
+            0
+            sage: R(0).total_degree()
+            -1
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        if fmpz_mpoly_is_zero(self._poly, R._ctx):
+            return -1
+        return Integer(fmpz_mpoly_total_degree_si(self._poly, R._ctx))
+
+    def degrees(self):
+        r"""
+        Return a tuple containing the degree of this polynomial in each
+        variable.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(ZZ, 'x,y,z', implementation='flint')
+            sage: f = x^2*y + y^3*z^4
+            sage: f.degrees()
+            (2, 3, 4)
+            sage: R(5).degrees()
+            (0, 0, 0)
+            sage: R(0).degrees()
+            (0, 0, 0)
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong i
+        cdef slong *degs = <slong *>sig_malloc(n * sizeof(slong))
+        if degs == NULL:
+            raise MemoryError
+        try:
+            fmpz_mpoly_degrees_si(degs, self._poly, R._ctx)
+            result = tuple(Integer(degs[i]) if degs[i] >= 0 else Integer(0)
+                           for i in range(n))
+        finally:
+            sig_free(degs)
+        return result
+
+    def variables(self):
+        r"""
+        Return a tuple of the variables (generators) actually occurring in
+        this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(ZZ, 'x,y,z', implementation='flint')
+            sage: (x^2*z + 1).variables()
+            (x, z)
+            sage: R(5).variables()
+            ()
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong i
+        cdef int *used = <int *>sig_malloc(n * sizeof(int))
+        if used == NULL:
+            raise MemoryError
+        try:
+            fmpz_mpoly_used_vars(used, self._poly, R._ctx)
+            result = tuple(R.gen(i) for i in range(n) if used[i])
+        finally:
+            sig_free(used)
+        return result
+
+    def variable(self, int i=0):
+        r"""
+        Return the ``i``-th variable occurring in this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(ZZ, 'x,y,z', implementation='flint')
+            sage: (x^2*z + 1).variable(0)
+            x
+            sage: (x^2*z + 1).variable(1)
+            z
+        """
+        return self.variables()[i]
+
+    def nvariables(self):
+        r"""
+        Return the number of variables actually occurring in this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(ZZ, 'x,y,z', implementation='flint')
+            sage: (x^2*z + 1).nvariables()
+            2
+            sage: R(5).nvariables()
+            0
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong i
+        cdef int *used = <int *>sig_malloc(n * sizeof(int))
+        if used == NULL:
+            raise MemoryError
+        try:
+            fmpz_mpoly_used_vars(used, self._poly, R._ctx)
+            result = sum(1 for i in range(n) if used[i])
+        finally:
+            sig_free(used)
+        return result
+
+    # ===== Coefficients =====
+
+    def monomial_coefficients(self):
+        r"""
+        Return a dictionary of ``{exponent: coefficient}`` pairs.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: f = 2*x^3 - x*y + 5
+            sage: sorted(f.monomial_coefficients().items())
+            [((0, 0), 5), ((1, 1), -1), ((3, 0), 2)]
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong length = fmpz_mpoly_length(self._poly, R._ctx)
+        cdef slong i
+        cdef fmpz_t coeff
+        cdef ulong *exp
+        cdef Integer c
+        fmpz_init(coeff)
+        exp = <ulong *>sig_malloc(n * sizeof(ulong))
+        if exp == NULL:
+            fmpz_clear(coeff)
+            raise MemoryError
+        result = {}
+        try:
+            for i in range(length):
+                fmpz_mpoly_get_term_coeff_fmpz(coeff, self._poly, i, R._ctx)
+                fmpz_mpoly_get_term_exp_ui(exp, self._poly, i, R._ctx)
+                c = Integer.__new__(Integer)
+                fmpz_get_mpz(c.value, coeff)
+                result[ETuple([exp[j] for j in range(n)])] = c
+        finally:
+            fmpz_clear(coeff)
+            sig_free(exp)
+        return result
+
+    def coefficients(self):
+        r"""
+        Return the list of coefficients of this polynomial, in the order
+        induced by the term order.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: f = 3*x^2*y - x + 5
+            sage: f.coefficients()
+            [3, -1, 5]
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef slong length = fmpz_mpoly_length(self._poly, R._ctx)
+        cdef slong i
+        cdef fmpz_t coeff
+        cdef Integer c
+        fmpz_init(coeff)
+        result = []
+        try:
+            for i in range(length):
+                fmpz_mpoly_get_term_coeff_fmpz(coeff, self._poly, i, R._ctx)
+                c = Integer.__new__(Integer)
+                fmpz_get_mpz(c.value, coeff)
+                result.append(c)
+        finally:
+            fmpz_clear(coeff)
+        return result
+
+    def exponents(self, as_ETuples=True):
+        r"""
+        Return the list of exponent tuples of the nonzero terms of this
+        polynomial, in the order induced by the term order.
+
+        INPUT:
+
+        - ``as_ETuples`` -- (default: ``True``) if ``True``, return a list of
+          :class:`ETuple`; otherwise, return a list of plain tuples
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: f = 3*x^2*y - x + 5
+            sage: f.exponents()
+            [(2, 1), (1, 0), (0, 0)]
+            sage: f.exponents(as_ETuples=False)
+            [(2, 1), (1, 0), (0, 0)]
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong length = fmpz_mpoly_length(self._poly, R._ctx)
+        cdef slong i, j
+        cdef ulong *exp
+        exp = <ulong *>sig_malloc(n * sizeof(ulong))
+        if exp == NULL:
+            raise MemoryError
+        result = []
+        try:
+            for i in range(length):
+                fmpz_mpoly_get_term_exp_ui(exp, self._poly, i, R._ctx)
+                t = tuple(int(exp[j]) for j in range(n))
+                if as_ETuples:
+                    result.append(ETuple(t))
+                else:
+                    result.append(t)
+        finally:
+            sig_free(exp)
+        return result
+
+    def monomials(self):
+        r"""
+        Return the list of monomials of this polynomial, in the order induced
+        by the term order.
+
+        Monomials are returned with coefficient 1.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: f = 3*x^2*y - x + 5
+            sage: f.monomials()
+            [x^2*y, x, 1]
+            sage: R(0).monomials()
+            []
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef slong length = fmpz_mpoly_length(self._poly, R._ctx)
+        cdef slong i
+        cdef MPolynomial_integer_flint m
+        result = []
+        for i in range(length):
+            m = R._new_element()
+            sig_on()
+            fmpz_mpoly_get_term_monomial(m._poly, self._poly, i, R._ctx)
+            sig_off()
+            result.append(m)
+        return result
+
+    def constant_coefficient(self):
+        r"""
+        Return the constant coefficient of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: (3*x^2 - 2*y + 7).constant_coefficient()
+            7
+            sage: x.constant_coefficient()
+            0
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef ulong *exp
+        cdef fmpz_t coeff
+        cdef Integer c
+        exp = <ulong *>sig_malloc(n * sizeof(ulong))
+        if exp == NULL:
+            raise MemoryError
+        fmpz_init(coeff)
+        try:
+            for i in range(n):
+                exp[i] = 0
+            fmpz_mpoly_get_coeff_fmpz_ui(coeff, self._poly, exp, R._ctx)
+            c = Integer.__new__(Integer)
+            fmpz_get_mpz(c.value, coeff)
+        finally:
+            fmpz_clear(coeff)
+            sig_free(exp)
+        return c
+
+    def monomial_coefficient(self, mon):
+        r"""
+        Return the coefficient of the monomial ``mon`` in this polynomial.
+
+        INPUT:
+
+        - ``mon`` -- a monomial in the same ring
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: f = 3*x^2*y - x*y + 5
+            sage: f.monomial_coefficient(x^2*y)
+            3
+            sage: f.monomial_coefficient(x*y)
+            -1
+            sage: f.monomial_coefficient(R(1))
+            5
+            sage: f.monomial_coefficient(x)
+            0
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef MPolynomial_integer_flint m
+        cdef fmpz_t coeff
+        cdef Integer c
+        if isinstance(mon, MPolynomial_integer_flint) and (<MPolynomial_integer_flint>mon)._parent is R:
+            m = <MPolynomial_integer_flint>mon
+        else:
+            m = <MPolynomial_integer_flint>R(mon)
+        if fmpz_mpoly_is_zero(m._poly, R._ctx):
+            raise ValueError("mon must not be equal to 0")
+        fmpz_init(coeff)
+        sig_on()
+        fmpz_mpoly_get_coeff_fmpz_monomial(coeff, self._poly, m._poly, R._ctx)
+        sig_off()
+        c = Integer.__new__(Integer)
+        fmpz_get_mpz(c.value, coeff)
+        fmpz_clear(coeff)
+        return c
+
+    def coefficient(self, degrees):
+        r"""
+        Return the coefficient of a monomial specified by ``degrees``.
+
+        INPUT:
+
+        - ``degrees`` -- a dictionary mapping generators to nonnegative
+          integers, or a tuple/list of nonnegative integers giving the
+          exponent of each variable
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: f = 3*x^2*y - x*y + 5
+            sage: f.coefficient({x: 2, y: 1})
+            3
+            sage: f.coefficient((2, 1))
+            3
+            sage: f.coefficient((0, 0))
+            5
+            sage: f.coefficient((1, 0))
+            0
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong i
+        cdef ulong *exp
+        cdef fmpz_t coeff
+        cdef Integer c
+
+        if isinstance(degrees, dict):
+            names = R.variable_names()
+            d = [0] * n
+            for k, v in degrees.items():
+                key = str(k)
+                if key not in names:
+                    raise ValueError("{} is not a variable of {}".format(k, R))
+                d[names.index(key)] = int(v)
+            degrees = d
+        else:
+            degrees = list(degrees)
+            if len(degrees) != n:
+                raise ValueError("degrees must have length {}".format(n))
+
+        exp = <ulong *>sig_malloc(n * sizeof(ulong))
+        if exp == NULL:
+            raise MemoryError
+        fmpz_init(coeff)
+        try:
+            for i in range(n):
+                exp[i] = degrees[i]
+            fmpz_mpoly_get_coeff_fmpz_ui(coeff, self._poly, exp, R._ctx)
+            c = Integer.__new__(Integer)
+            fmpz_get_mpz(c.value, coeff)
+        finally:
+            fmpz_clear(coeff)
+            sig_free(exp)
+        return c
+
+    # ===== Leading term/coefficient/monomial =====
+
+    def lc(self):
+        r"""
+        Return the leading coefficient of this polynomial, with respect to
+        the term order of the parent ring.
+
+        Returns 0 if this polynomial is zero.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint', order='lex')
+            sage: f = 3*x^2*y - x*y^3 + 5
+            sage: f.lc()
+            3
+            sage: R(0).lc()
+            0
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef fmpz_t coeff
+        cdef Integer c
+        if fmpz_mpoly_is_zero(self._poly, R._ctx):
+            return Integer(0)
+        fmpz_init(coeff)
+        fmpz_mpoly_get_term_coeff_fmpz(coeff, self._poly, 0, R._ctx)
+        c = Integer.__new__(Integer)
+        fmpz_get_mpz(c.value, coeff)
+        fmpz_clear(coeff)
+        return c
+
+    def lm(self):
+        r"""
+        Return the leading monomial of this polynomial, with respect to the
+        term order of the parent ring.
+
+        The leading monomial is the leading term divided by its coefficient.
+        Returns 0 if this polynomial is zero.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint', order='lex')
+            sage: f = 3*x^2*y - x*y^3 + 5
+            sage: f.lm()
+            x^2*y
+            sage: R(0).lm()
+            0
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef MPolynomial_integer_flint m
+        if fmpz_mpoly_is_zero(self._poly, R._ctx):
+            return R._new_element()
+        m = R._new_element()
+        sig_on()
+        fmpz_mpoly_get_term_monomial(m._poly, self._poly, 0, R._ctx)
+        sig_off()
+        return m
+
+    def lt(self):
+        r"""
+        Return the leading term of this polynomial, with respect to the
+        term order of the parent ring.
+
+        Returns 0 if this polynomial is zero.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint', order='lex')
+            sage: f = 3*x^2*y - x*y^3 + 5
+            sage: f.lt()
+            3*x^2*y
+            sage: R(0).lt()
+            0
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef MPolynomial_integer_flint t
+        if fmpz_mpoly_is_zero(self._poly, R._ctx):
+            return R._new_element()
+        t = R._new_element()
+        sig_on()
+        fmpz_mpoly_get_term(t._poly, self._poly, 0, R._ctx)
+        sig_off()
+        return t
+
+    # ===== Content =====
+
+    def content(self):
+        r"""
+        Return the content of this polynomial, that is, the positive gcd of
+        its coefficients.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: (6*x^2 - 4*x*y + 10).content()
+            2
+            sage: (x + y).content()
+            1
+            sage: R(0).content()
+            0
+            sage: R(-5).content()
+            5
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef slong length = fmpz_mpoly_length(self._poly, R._ctx)
+        cdef slong i
+        cdef fmpz_t g, c
+        cdef Integer result
+        if length == 0:
+            return Integer(0)
+        fmpz_init(g)
+        fmpz_init(c)
+        try:
+            fmpz_mpoly_get_term_coeff_fmpz(g, self._poly, 0, R._ctx)
+            fmpz_abs(g, g)
+            for i in range(1, length):
+                fmpz_mpoly_get_term_coeff_fmpz(c, self._poly, i, R._ctx)
+                fmpz_gcd(g, g, c)
+                if fmpz_is_one(g):
+                    break
+            result = Integer.__new__(Integer)
+            fmpz_get_mpz(result.value, g)
+        finally:
+            fmpz_clear(g)
+            fmpz_clear(c)
+        return result
+
+    def primitive_part(self):
+        r"""
+        Return the primitive part of this polynomial.
+
+        The primitive part is the polynomial divided by its content. By
+        convention, the result has a positive leading coefficient.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: (6*x^2 - 4*x*y + 10).primitive_part()
+            3*x^2 - 2*x*y + 5
+            sage: (-2*x - 4).primitive_part()
+            x + 2
+            sage: R(0).primitive_part()
+            0
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef MPolynomial_integer_flint result = R._new_element()
+        sig_on()
+        fmpz_mpoly_primitive_part(result._poly, self._poly, R._ctx)
+        sig_off()
+        return result
+
+    def term_content(self):
+        r"""
+        Return the GCD of the (nonzero) terms of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: (6*x^2*y^2 - 4*x^3*y).term_content()
+            2*x^2*y
+            sage: (x + y).term_content()
+            1
+            sage: R(0).term_content()
+            0
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef MPolynomial_integer_flint result = R._new_element()
+        sig_on()
+        fmpz_mpoly_term_content(result._poly, self._poly, R._ctx)
+        sig_off()
+        return result
+
+    # ===== Arithmetic =====
+
+    cpdef _add_(self, other):
+        r"""
+        Return the sum of this polynomial and ``other``.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: x + y
+            x + y
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef MPolynomial_integer_flint res = self._new()
+        sig_on()
+        fmpz_mpoly_add(res._poly, self._poly,
+                       (<MPolynomial_integer_flint>other)._poly, R._ctx)
+        sig_off()
+        return res
+
+    cpdef _sub_(self, other):
+        r"""
+        Return the difference of this polynomial and ``other``.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: x - y
+            x - y
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef MPolynomial_integer_flint res = self._new()
+        sig_on()
+        fmpz_mpoly_sub(res._poly, self._poly,
+                       (<MPolynomial_integer_flint>other)._poly, R._ctx)
+        sig_off()
+        return res
+
+    cpdef _neg_(self):
+        r"""
+        Return the negation of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: -(x + y)
+            -x - y
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef MPolynomial_integer_flint res = self._new()
+        sig_on()
+        fmpz_mpoly_neg(res._poly, self._poly, R._ctx)
+        sig_off()
+        return res
+
+    cpdef _lmul_(self, Element scalar):
+        r"""
+        Return this polynomial multiplied by the scalar ``scalar``.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: 3 * x
+            3*x
+            sage: x * 3
+            3*x
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef MPolynomial_integer_flint res = self._new()
+        cdef fmpz_t c
+        cdef Integer s = scalar if isinstance(scalar, Integer) else ZZ(scalar)
+        fmpz_init(c)
+        fmpz_set_mpz(c, s.value)
+        sig_on()
+        fmpz_mpoly_scalar_mul_fmpz(res._poly, self._poly, c, R._ctx)
+        sig_off()
+        fmpz_clear(c)
+        return res
+
+    cpdef _mul_(self, other):
+        r"""
+        Return the product of this polynomial and ``other``.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: (x + 1) * (y - 1)
+            x*y - x + y - 1
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef MPolynomial_integer_flint res = self._new()
+        sig_on()
+        fmpz_mpoly_mul(res._poly, self._poly,
+                       (<MPolynomial_integer_flint>other)._poly, R._ctx)
+        sig_off()
+        return res
+
+    def __pow__(self, exp, mod):
+        r"""
+        Return this polynomial raised to the power ``exp``.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: (x + y)^3
+            x^3 + 3*x^2*y + 3*x*y^2 + y^3
+        """
+        if mod is not None:
+            raise NotImplementedError("modular exponentiation not supported")
+        if exp < 0:
+            raise ValueError("exponent must be non-negative")
+        cdef MPolynomial_integer_flint self_ = self
+        cdef MPolynomialRing_integer_flint R = self_._parent
+        cdef MPolynomial_integer_flint res = self_._new()
+        cdef int ok
+        sig_on()
+        ok = fmpz_mpoly_pow_ui(res._poly, self_._poly, <ulong>exp, R._ctx)
+        sig_off()
+        if not ok:
+            raise ArithmeticError("power failed (exponent too large?)")
+        return res
+
+    cpdef _richcmp_(self, other, int op):
+        r"""
+        Compare this polynomial with ``other``.
+
+        Only equality and inequality are supported.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: x == x
+            True
+            sage: x == y
+            False
+            sage: x != y
+            True
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef bint eq = fmpz_mpoly_equal(
+            self._poly,
+            (<MPolynomial_integer_flint>other)._poly,
+            R._ctx)
+        if op == Py_EQ:
+            return bool(eq)
+        if op == Py_NE:
+            return not eq
+        return NotImplemented
+
+    # ===== Division and related =====
+
+    def divides(self, other):
+        r"""
+        Return ``True`` if this polynomial divides ``other``.
+
+        INPUT:
+
+        - ``other`` -- a polynomial in the same ring
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: f = x^2 - y^2
+            sage: g = x - y
+            sage: g.divides(f)
+            True
+            sage: (x + 1).divides(f)
+            False
+            sage: R(0).divides(f)
+            False
+            sage: g.divides(R(0))
+            True
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        if self.is_zero():
+            return R(other).is_zero()
+        cdef MPolynomial_integer_flint q = R._new_element()
+        cdef MPolynomial_integer_flint b = R(other)
+        sig_on()
+        result = fmpz_mpoly_divides(q._poly, b._poly, self._poly, R._ctx)
+        sig_off()
+        return bool(result)
+
+    def quo_rem(self, other):
+        r"""
+        Return the quotient and remainder of the division of this polynomial
+        by ``other``.
+
+        Division is performed with respect to the term order of the ring.
+        The result satisfies ``self == q * other + r`` where no monomial of
+        ``r`` is divisible by the leading monomial of ``other``.
+
+        INPUT:
+
+        - ``other`` -- a nonzero polynomial in the same ring
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: f = x^2*y + 3*x - 1
+            sage: g = x*y - 1
+            sage: q, r = f.quo_rem(g)
+            sage: q
+            x
+            sage: r
+            4*x - 1
+            sage: q * g + r == f
+            True
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef MPolynomial_integer_flint q = R._new_element()
+        cdef MPolynomial_integer_flint r = R._new_element()
+        cdef MPolynomial_integer_flint b = R(other)
+        if b.is_zero():
+            raise ZeroDivisionError("cannot divide by zero")
+        sig_on()
+        fmpz_mpoly_divrem(q._poly, r._poly, self._poly, b._poly, R._ctx)
+        sig_off()
+        return q, r
+
+    def gcd(self, other):
+        r"""
+        Return the greatest common divisor of this polynomial and ``other``.
+
+        Over `\ZZ`, the result is the primitive GCD with positive leading
+        coefficient.
+
+        INPUT:
+
+        - ``other`` -- a polynomial in the same ring
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: f = x^2 - y^2
+            sage: g = x - y
+            sage: f.gcd(g)
+            x - y
+            sage: (2*x).gcd(4*y)
+            2
+            sage: f.gcd(R(0))
+            x^2 - y^2
+            sage: R(0).gcd(R(0))
+            0
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef MPolynomial_integer_flint result = R._new_element()
+        cdef MPolynomial_integer_flint b = R(other)
+        sig_on()
+        ok = fmpz_mpoly_gcd(result._poly, self._poly, b._poly, R._ctx)
+        sig_off()
+        if not ok:
+            raise ArithmeticError("GCD computation failed")
+        return result
+
+    def lcm(self, other):
+        r"""
+        Return the least common multiple of this polynomial and ``other``.
+
+        Defined as ``self * other / gcd(self, other)``. The result has
+        positive leading coefficient (the primitive LCM over `\ZZ`).
+
+        INPUT:
+
+        - ``other`` -- a polynomial in the same ring
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: f = x^2 - y^2
+            sage: g = x - y
+            sage: f.lcm(g)
+            x^2 - y^2
+            sage: (2*x).lcm(3*y)
+            6*x*y
+            sage: R(0).lcm(x)
+            0
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef MPolynomial_integer_flint b = R(other)
+        if self.is_zero() or b.is_zero():
+            return R._new_element()
+        g = self.gcd(b)
+        q, r = (self * b).quo_rem(g)
+        return q
+
+    def sqrt(self):
+        r"""
+        Return the square root of this polynomial if it is a perfect square,
+        otherwise raise a :class:`ValueError`.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: f = x^2 + 2*x*y + y^2
+            sage: f.sqrt()
+            x + y
+            sage: R(4).sqrt()
+            2
+            sage: x.sqrt()
+            Traceback (most recent call last):
+            ...
+            ValueError: x is not a perfect square
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef MPolynomial_integer_flint result = R._new_element()
+        sig_on()
+        ok = fmpz_mpoly_sqrt(result._poly, self._poly, R._ctx)
+        sig_off()
+        if not ok:
+            raise ValueError("{} is not a perfect square".format(self))
+        return result
+
+    # ===== Calculus =====
+
+    def _derivative(self, var):
+        r"""
+        Return the partial derivative of this polynomial with respect to
+        ``var``.
+
+        INPUT:
+
+        - ``var`` -- a generator of the parent ring (or its name)
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: f = 3*x^3*y^2 + 5*y^2 + 3*x + 2
+            sage: f._derivative(x)
+            9*x^2*y^2 + 3
+            sage: f._derivative(y)
+            6*x^3*y + 10*y
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef MPolynomial_integer_flint result = R._new_element()
+        cdef slong var_idx
+        if var is None:
+            raise ValueError("you must specify the variable with respect to which to differentiate")
+        names = R.variable_names()
+        var_name = str(var)
+        if var_name not in names:
+            raise ValueError("{} is not a variable of {}".format(var, R))
+        var_idx = names.index(var_name)
+        sig_on()
+        fmpz_mpoly_derivative(result._poly, self._poly, var_idx, R._ctx)
+        sig_off()
+        return result
+
+    def derivative(self, *args):
+        r"""
+        Return the (iterated) partial derivative of this polynomial.
+
+        Repeated arguments give higher-order partial derivatives.
+
+        INPUT:
+
+        - ``*args`` -- a sequence of variables; if a variable is repeated, the
+          derivative is iterated
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: f = x^3 * y^2
+            sage: f.derivative(x)
+            3*x^2*y^2
+            sage: f.derivative(x, x)
+            6*x*y^2
+            sage: f.derivative(x, y)
+            6*x^2*y
+        """
+        result = self
+        for v in args:
+            result = result._derivative(v)
+        return result
+
+    # ===== Factorization =====
+
+    def factor(self, proof=None):
+        r"""
+        Return the factorization of this polynomial.
+
+        The factorization is returned as a :class:`Factorization` object,
+        with each irreducible factor paired with its multiplicity, and a
+        unit ``\pm 1`` collecting the integer content sign.
+
+        INPUT:
+
+        - ``proof`` -- ignored
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: f = (x^2 - y^2) * (x + 1)
+            sage: F = f.factor()
+            sage: F.unit() * prod(g^e for g, e in F) == f
+            True
+            sage: g = 6 * (x - y)^2
+            sage: g.factor()
+            2 * 3 * (x - y)^2
+
+        TESTS::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: R(0).factor()
+            Traceback (most recent call last):
+            ...
+            ArithmeticError: factorization of 0 is not defined
+            sage: R(1).factor()
+            1
+            sage: R(-12).factor()
+            (-1) * 2^2 * 3
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        if self.is_zero():
+            raise ArithmeticError("factorization of 0 is not defined")
+
+        cdef fmpz_mpoly_factor_t fac
+        cdef fmpz_t const_fmpz
+        cdef fmpz_mpoly_t base_poly
+        cdef MPolynomial_integer_flint base
+        cdef Integer constant
+        cdef slong i, length, exp
+        cdef int ok
+
+        fmpz_mpoly_factor_init(fac, R._ctx)
+        fmpz_init(const_fmpz)
+        fmpz_mpoly_init(base_poly, R._ctx)
+        polynomial_factors = []
+        try:
+            sig_on()
+            ok = fmpz_mpoly_factor(fac, self._poly, R._ctx)
+            sig_off()
+            if not ok:
+                raise ArithmeticError("factorization failed")
+            fmpz_mpoly_factor_get_constant_fmpz(const_fmpz, fac, R._ctx)
+            constant = Integer.__new__(Integer)
+            fmpz_get_mpz(constant.value, const_fmpz)
+            length = fmpz_mpoly_factor_length(fac, R._ctx)
+            for i in range(length):
+                fmpz_mpoly_factor_get_base(base_poly, fac, i, R._ctx)
+                exp = fmpz_mpoly_factor_get_exp_si(fac, i, R._ctx)
+                base = R._new_element()
+                sig_on()
+                fmpz_mpoly_set(base._poly, base_poly, R._ctx)
+                sig_off()
+                polynomial_factors.append((base, int(exp)))
+        finally:
+            fmpz_mpoly_clear(base_poly, R._ctx)
+            fmpz_clear(const_fmpz)
+            fmpz_mpoly_factor_clear(fac, R._ctx)
+
+        # split integer constant into sign and prime factorization
+        unit = Integer(1)
+        if constant < 0:
+            unit = -unit
+            constant = -constant
+        factors = []
+        if constant != 1:
+            for p, e in constant.factor():
+                factors.append((R(p), int(e)))
+        factors.extend(polynomial_factors)
+
+        return Factorization(factors, unit=unit, sort=False)
+
+    # ===== Resultant, discriminant =====
+
+    def resultant(self, other, variable=None):
+        r"""
+        Return the resultant of this polynomial and ``other`` with respect
+        to ``variable``.
+
+        If ``variable`` is not provided, the first variable of the ring is
+        used.
+
+        INPUT:
+
+        - ``other`` -- a polynomial in the same ring
+        - ``variable`` -- (optional) a generator of the ring
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: f = x^2 - y
+            sage: g = x - 1
+            sage: f.resultant(g)
+            -y + 1
+            sage: f.resultant(g, y)
+            x - 1
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef MPolynomial_integer_flint result = R._new_element()
+        cdef MPolynomial_integer_flint b = R(other)
+        cdef slong var_idx
+
+        if variable is None:
+            var_idx = 0
+        else:
+            names = R.variable_names()
+            var_name = str(variable)
+            if var_name not in names:
+                raise ValueError("{} is not a variable of {}".format(variable, R))
+            var_idx = names.index(var_name)
+
+        sig_on()
+        ok = fmpz_mpoly_resultant(result._poly, self._poly, b._poly, var_idx, R._ctx)
+        sig_off()
+        if not ok:
+            raise ArithmeticError("resultant computation failed")
+        return result
+
+    def discriminant(self, variable):
+        r"""
+        Return the discriminant of this polynomial with respect to
+        ``variable``.
+
+        INPUT:
+
+        - ``variable`` -- a generator of the parent ring
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(ZZ, 'x,y', implementation='flint')
+            sage: f = x^2 + y*x + 1
+            sage: f.discriminant(x)
+            y^2 - 4
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef MPolynomial_integer_flint result = R._new_element()
+        cdef slong var_idx
+        names = R.variable_names()
+        var_name = str(variable)
+        if var_name not in names:
+            raise ValueError("{} is not a variable of {}".format(variable, R))
+        var_idx = names.index(var_name)
+        sig_on()
+        ok = fmpz_mpoly_discriminant(result._poly, self._poly, var_idx, R._ctx)
+        sig_off()
+        if not ok:
+            raise ArithmeticError("discriminant computation failed")
+        return result
+
+    # ===== Evaluation and substitution =====
+
+    def __call__(self, *args, **kwds):
+        r"""
+        Evaluate this polynomial at the given values.
+
+        Positional arguments are assigned to the variables in order. Keyword
+        arguments name variables explicitly. When all assigned values are
+        integers and all variables are assigned, the result is an
+        :class:`~sage.rings.integer.Integer`; otherwise the result is a
+        polynomial in the same ring.
+
+        INPUT:
+
+        - ``*args`` -- values for the variables, in order
+        - ``**kwds`` -- variable-name keyword arguments
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(ZZ, 'x,y,z', implementation='flint')
+            sage: f = x^2 + y*z + 1
+            sage: f(1, 2, 3)
+            8
+            sage: f(1, 2, 3).parent()
+            Integer Ring
+            sage: f(x, y, z) == f
+            True
+            sage: f(y, x, z)
+            y^2 + x*z + 1
+            sage: f(x=2)
+            y*z + 5
+            sage: f(x=1, y=2, z=3)
+            8
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong i
+        cdef fmpz_t res_fmpz
+        cdef fmpz **vals
+        cdef fmpz_t *fmpz_storage
+        cdef MPolynomial_integer_flint p
+        cdef Integer result_int
+
+        if kwds and args:
+            raise TypeError("cannot mix positional and keyword arguments")
+
+        names = R.variable_names()
+        if args:
+            if len(args) != n:
+                raise TypeError("expected {} positional arguments, got {}".format(n, len(args)))
+            values = list(args)
+        else:
+            values = [None] * n
+            for k, v in kwds.items():
+                if k not in names:
+                    raise ValueError("{} is not a variable of {}".format(k, R))
+                values[names.index(k)] = v
+
+        # fast path: all values are integers and all assigned
+        if all(v is not None and isinstance(v, (int, Integer)) for v in values):
+            fmpz_storage = <fmpz_t *>sig_malloc(n * sizeof(fmpz_t))
+            vals = <fmpz **>sig_malloc(n * sizeof(fmpz *))
+            if fmpz_storage == NULL or vals == NULL:
+                if fmpz_storage != NULL:
+                    sig_free(fmpz_storage)
+                if vals != NULL:
+                    sig_free(vals)
+                raise MemoryError
+            for i in range(n):
+                fmpz_init(fmpz_storage[i])
+                fmpz_set_mpz(fmpz_storage[i], (<Integer>Integer(values[i])).value)
+                vals[i] = fmpz_storage[i]
+            fmpz_init(res_fmpz)
+            try:
+                sig_on()
+                ok = fmpz_mpoly_evaluate_all_fmpz(res_fmpz, self._poly, vals, R._ctx)
+                sig_off()
+                if not ok:
+                    raise ArithmeticError("evaluation failed")
+                result_int = Integer.__new__(Integer)
+                fmpz_get_mpz(result_int.value, res_fmpz)
+            finally:
+                fmpz_clear(res_fmpz)
+                for i in range(n):
+                    fmpz_clear(fmpz_storage[i])
+                sig_free(fmpz_storage)
+                sig_free(vals)
+            return result_int
+
+        # general path: do substitution (possibly partial)
+        fixed = {}
+        for i in range(n):
+            if values[i] is not None:
+                fixed[names[i]] = values[i]
+        return self.subs(fixed)
+
+    def subs(self, fixed=None, **kw):
+        r"""
+        Substitute variables in this polynomial and return the result.
+
+        Each substitution value may be an integer or a polynomial in the same
+        ring. Variables not mentioned are left unchanged. All substitutions
+        are applied simultaneously (not sequentially).
+
+        INPUT:
+
+        - ``fixed`` -- (optional) dict mapping generators or variable names to
+          values
+        - ``**kw`` -- variable names as keyword arguments
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(ZZ, 'x,y,z', implementation='flint')
+            sage: f = x^2 + y^2 + z^2
+            sage: f.subs(x=1, y=2)
+            z^2 + 5
+            sage: f.subs({x: y + 1})
+            2*y^2 + z^2 + 2*y + 1
+            sage: f.subs(x=1, y=2, z=3)
+            14
+            sage: f.subs({x: y, y: x})
+            x^2 + y^2 + z^2
+        """
+        cdef MPolynomialRing_integer_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong i
+        cdef fmpz_mpoly_struct **C
+        cdef MPolynomial_integer_flint res
+
+        # build var_name → value mapping
+        sub = {}
+        if fixed is not None:
+            for k, v in fixed.items():
+                if isinstance(k, MPolynomial_integer_flint):
+                    k = str(k)
+                sub[str(k)] = v
+        for k, v in kw.items():
+            sub[k] = v
+
+        # build list of substituting polynomials: one per variable
+        var_names = R.variable_names()
+        polys = []
+        for i in range(n):
+            name = var_names[i]
+            if name in sub:
+                v = sub[name]
+                if not isinstance(v, MPolynomial_integer_flint):
+                    v = R(v)
+                polys.append(<MPolynomial_integer_flint>v)
+            else:
+                polys.append(<MPolynomial_integer_flint>R.gen(i))
+
+        # call fmpz_mpoly_compose_fmpz_mpoly
+        C = <fmpz_mpoly_struct **>sig_malloc(n * sizeof(fmpz_mpoly_struct *))
+        if C == NULL:
+            raise MemoryError
+        for i in range(n):
+            C[i] = &(<MPolynomial_integer_flint>polys[i])._poly[0]
+        res = R._new_element()
+        sig_on()
+        ok = fmpz_mpoly_compose_fmpz_mpoly(res._poly, self._poly, C, R._ctx, R._ctx)
+        sig_off()
+        sig_free(C)
+        if not ok:
+            raise ArithmeticError("composition failed")
+        return res

--- a/src/sage/rings/polynomial/multi_polynomial_integer_flint.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_integer_flint.pyx
@@ -1892,6 +1892,10 @@ cdef class MPolynomial_integer_flint(MPolynomial_flint_base):
         if kwds and args:
             raise TypeError("cannot mix positional and keyword arguments")
 
+        # allow f((a, b, c)) as a shortcut for f(a, b, c)
+        if len(args) == 1 and isinstance(args[0], (list, tuple)):
+            args = tuple(args[0])
+
         names = R.variable_names()
         if args:
             if len(args) != n:

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -219,6 +219,7 @@ from sage.rings.finite_rings.finite_field_prime_modn import FiniteField_prime_mo
 from sage.rings.polynomial.multi_polynomial_ring import MPolynomialRing_polydict, MPolynomialRing_polydict_domain
 from sage.rings.polynomial.multi_polynomial_ring_base import BooleanPolynomialRing_base
 from sage.rings.polynomial.multi_polynomial_element import MPolynomial_polydict
+from sage.rings.polynomial.multi_polynomial import MPolynomial
 from sage.rings.polynomial.multi_polynomial_ideal import MPolynomialIdeal
 from sage.rings.polynomial.polydict cimport ETuple
 from sage.rings.polynomial.polynomial_ring import PolynomialRing_generic
@@ -914,6 +915,11 @@ cdef class MPolynomialRing_libsingular(MPolynomialRing_base):
                         sBucketDeleteAndDestroy(&bucket)
                         raise
                     return new_MP(self, _p)
+
+        elif isinstance(element, MPolynomial):
+            variable_names_t = self.variable_names()
+            if base_ring.has_coerce_map_from(element.parent()._mpoly_base_ring(variable_names_t)):
+                return self(element._mpoly_dict_recursive(variable_names_t, base_ring))
 
         elif isinstance(element, polynomial_element.Polynomial):
             if base_ring.has_coerce_map_from(element.parent()._mpoly_base_ring(self.variable_names())):

--- a/src/sage/rings/polynomial/multi_polynomial_rational_flint.pxd
+++ b/src/sage/rings/polynomial/multi_polynomial_rational_flint.pxd
@@ -1,0 +1,16 @@
+from sage.libs.flint.types cimport fmpq_mpoly_t, fmpq_mpoly_ctx_t
+
+from sage.rings.polynomial.multi_polynomial cimport MPolynomial_flint as MPolynomial_flint_base
+from sage.rings.polynomial.multi_polynomial_ring_base cimport MPolynomialRing_base
+
+
+cdef class MPolynomialRing_rational_flint(MPolynomialRing_base):
+    cdef fmpq_mpoly_ctx_t _ctx
+    cdef MPolynomial_rational_flint _new_element(self)
+
+
+cdef class MPolynomial_rational_flint(MPolynomial_flint_base):
+    cdef fmpq_mpoly_t _poly
+    cdef MPolynomial_rational_flint _new(self)
+    cpdef _new_constant_poly(self, scalar, parent)
+    cpdef long number_of_terms(self) noexcept

--- a/src/sage/rings/polynomial/multi_polynomial_rational_flint.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_rational_flint.pyx
@@ -1,0 +1,1893 @@
+# distutils: libraries = flint
+# distutils: depends = flint/fmpq_mpoly.h flint/fmpq_mpoly_factor.h
+r"""
+Multivariate polynomials over `\QQ`, implemented using FLINT
+
+EXAMPLES::
+
+    sage: R.<x,y,z> = PolynomialRing(QQ, 'x,y,z', implementation='flint')
+    sage: f = 3*x^2*y/2 - z + 1; f
+    3/2*x^2*y - z + 1
+    sage: f * f
+    9/4*x^4*y^2 - 3*x^2*y*z + 3*x^2*y + z^2 - 2*z + 1
+
+.. automethod:: MPolynomial_rational_flint._add_
+.. automethod:: MPolynomial_rational_flint._sub_
+.. automethod:: MPolynomial_rational_flint._mul_
+.. automethod:: MPolynomial_rational_flint._neg_
+"""
+
+#*****************************************************************************
+#       Copyright (C) 2025 Vincent Delecroix <20100.delecroix@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#                  http://www.gnu.org/licenses/
+#*****************************************************************************
+
+import re
+
+from libc.stdlib cimport free
+
+from cysignals.signals cimport sig_on, sig_off
+from cysignals.memory cimport sig_malloc, sig_free
+
+from cpython.object cimport Py_EQ, Py_NE
+
+from sage.libs.flint.fmpq cimport (
+    fmpq_init, fmpq_clear, fmpq_set_mpq, fmpq_get_mpq, fmpq_is_zero)
+from sage.libs.flint.fmpq_mpoly cimport *
+from sage.libs.flint.fmpq_mpoly_factor cimport (
+    fmpq_mpoly_factor_init, fmpq_mpoly_factor_clear,
+    fmpq_mpoly_factor_length, fmpq_mpoly_factor_get_constant_fmpq,
+    fmpq_mpoly_factor_get_base, fmpq_mpoly_factor_get_exp_si,
+    fmpq_mpoly_factor)
+from sage.libs.flint.types cimport (
+    fmpq_t, fmpq_mpoly_t, fmpq_mpoly_ctx_t, fmpq_mpoly_struct,
+    fmpq_mpoly_factor_t,
+    ordering_t, ORD_LEX, ORD_DEGLEX, ORD_DEGREVLEX, ulong, slong)
+
+from sage.cpython.string cimport str_to_bytes, char_to_str
+
+from sage.rings.integer cimport Integer
+from sage.rings.integer_ring import ZZ
+from sage.rings.rational cimport Rational
+from sage.rings.rational_field import QQ
+from sage.structure.element cimport Element
+from sage.structure.factorization import Factorization
+from sage.structure.richcmp cimport rich_to_bool
+
+from sage.rings.polynomial.multi_polynomial cimport MPolynomial_flint as MPolynomial_flint_base
+from sage.rings.polynomial.multi_polynomial_ring_base cimport MPolynomialRing_base
+from sage.rings.polynomial.multi_polynomial_rational_flint cimport (
+    MPolynomialRing_rational_flint,
+    MPolynomial_rational_flint)
+from sage.rings.polynomial.polydict cimport ETuple
+
+
+cdef ordering_t _term_order_to_flint(order) except? ORD_LEX:
+    name = order.name() if hasattr(order, 'name') else str(order)
+    if name == 'lex':
+        return ORD_LEX
+    elif name == 'deglex':
+        return ORD_DEGLEX
+    elif name == 'degrevlex':
+        return ORD_DEGREVLEX
+    raise NotImplementedError(
+        "term order '{}' is not supported by FLINT fmpq_mpoly".format(name))
+
+
+def _unpickle_MPolynomialRing_rational_flint(n, names, order):
+    r"""
+    Helper for unpickling :class:`MPolynomialRing_rational_flint`.
+
+    TESTS::
+
+        sage: R = PolynomialRing(QQ, 'x,y', implementation='flint')
+        sage: loads(dumps(R)) is R
+        True
+    """
+    from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+    return PolynomialRing(QQ, n, names=names, order=order, implementation='flint')
+
+
+def _unpickle_MPolynomial_rational_flint(parent, coeffs):
+    r"""
+    Helper for unpickling :class:`MPolynomial_rational_flint`.
+
+    TESTS::
+
+        sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+        sage: f = 3*x^2*y/2 - x + 1
+        sage: loads(dumps(f)) == f
+        True
+    """
+    return parent(coeffs)
+
+
+cdef class MPolynomialRing_rational_flint(MPolynomialRing_base):
+    r"""
+    Multivariate polynomial ring over `\QQ`, implemented via FLINT.
+
+    EXAMPLES::
+
+        sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+        sage: R
+        Multivariate Polynomial Ring in x, y over Rational Field (using FLINT)
+    """
+
+    def __cinit__(self):
+        # nvars = -1 signals that fmpq_mpoly_ctx_init has not yet been called.
+        self._ctx[0].zctx[0].minfo[0].nvars = -1
+
+    def __init__(self, base_ring, n, names, order='degrevlex'):
+        r"""
+        Construct a multivariate polynomial ring over `\QQ` using FLINT.
+
+        INPUT:
+
+        - ``base_ring`` -- must be `\QQ`
+        - ``n`` -- number of variables (positive integer)
+        - ``names`` -- variable names
+        - ``order`` -- term order (``'lex'``, ``'deglex'``, or ``'degrevlex'``)
+
+        EXAMPLES::
+
+            sage: from sage.rings.polynomial.multi_polynomial_rational_flint import MPolynomialRing_rational_flint
+            sage: R = MPolynomialRing_rational_flint(QQ, 3, ('x','y','z'), 'degrevlex')
+            sage: R
+            Multivariate Polynomial Ring in x, y, z over Rational Field (using FLINT)
+        """
+        if base_ring is not QQ:
+            raise TypeError("base ring must be QQ")
+        MPolynomialRing_base.__init__(self, base_ring, n, names, order)
+        cdef ordering_t ord = _term_order_to_flint(self._term_order)
+        fmpq_mpoly_ctx_init(self._ctx, n, ord)
+
+    def __dealloc__(self):
+        if self._ctx[0].zctx[0].minfo[0].nvars != -1:
+            fmpq_mpoly_ctx_clear(self._ctx)
+
+    Element = MPolynomial_rational_flint
+
+    def __hash__(self):
+        r"""
+        Return a hash of this ring.
+
+        EXAMPLES::
+
+            sage: R = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: hash(R) == hash(R)
+            True
+        """
+        from sage.structure.category_object import CategoryObject
+        return CategoryObject.__hash__(self)
+
+    def __reduce__(self):
+        r"""
+        Return data for pickling this ring.
+
+        TESTS::
+
+            sage: R = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: loads(dumps(R)) is R
+            True
+        """
+        return (_unpickle_MPolynomialRing_rational_flint,
+                (self._ngens, self.variable_names(), self._term_order))
+
+    def _repr_(self):
+        r"""
+        Return a string representation of this ring.
+
+        EXAMPLES::
+
+            sage: PolynomialRing(QQ, 'x,y', implementation='flint')
+            Multivariate Polynomial Ring in x, y over Rational Field (using FLINT)
+        """
+        return "Multivariate Polynomial Ring in {} over Rational Field (using FLINT)".format(
+            ", ".join(self.variable_names()))
+
+    def gen(self, int n=0):
+        r"""
+        Return the ``n``-th generator of this ring.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(QQ, 'x,y,z', implementation='flint')
+            sage: R.gen(0)
+            x
+            sage: R.gen(2)
+            z
+        """
+        if n < 0 or n >= self._ngens:
+            raise ValueError("generator index out of range")
+        cdef MPolynomial_rational_flint g = self._new_element()
+        sig_on()
+        fmpq_mpoly_gen(g._poly, n, self._ctx)
+        sig_off()
+        return g
+
+    cdef MPolynomial_rational_flint _new_element(self):
+        cdef MPolynomial_rational_flint f = \
+            MPolynomial_rational_flint.__new__(MPolynomial_rational_flint)
+        f._parent = self
+        fmpq_mpoly_init(f._poly, self._ctx)
+        return f
+
+    def _element_constructor_(self, x):
+        r"""
+        Convert ``x`` into an element of this ring.
+
+        Accepted inputs include integers, rationals, strings, dictionaries
+        mapping exponent tuples to coefficients, and multivariate
+        polynomials over a compatible ring.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: R(3)
+            3
+            sage: R(2/3)
+            2/3
+            sage: R("x^2*y - 2*x + 1/2")
+            x^2*y - 2*x + 1/2
+            sage: R({(2,1): 5/3, (0,0): -1})
+            5/3*x^2*y - 1
+            sage: R(x + y)
+            x + y
+        """
+        cdef MPolynomial_rational_flint f
+        cdef Rational c
+        cdef ETuple e
+        cdef fmpq_t coeff
+        cdef ulong *exp
+        cdef slong n = self._ngens
+        cdef int i
+        cdef bytes bstr
+        cdef const char **cnames
+
+        if isinstance(x, MPolynomial_rational_flint) and x.parent() is self:
+            f = self._new_element()
+            sig_on()
+            fmpq_mpoly_set(f._poly, (<MPolynomial_rational_flint>x)._poly, self._ctx)
+            sig_off()
+            return f
+
+        if isinstance(x, (int, Integer)):
+            x = Rational(x)
+        if isinstance(x, Rational):
+            f = self._new_element()
+            fmpq_init(coeff)
+            fmpq_set_mpq(coeff, (<Rational>x).value)
+            sig_on()
+            fmpq_mpoly_set_fmpq(f._poly, coeff, self._ctx)
+            sig_off()
+            fmpq_clear(coeff)
+            return f
+
+        if isinstance(x, str):
+            f = self._new_element()
+            bnames = [str_to_bytes(v) for v in self.variable_names()]
+            cnames = <const char **>sig_malloc(n * sizeof(char *))
+            if cnames == NULL:
+                raise MemoryError
+            for i in range(n):
+                cnames[i] = bnames[i]
+            bstr = str_to_bytes(x)
+            sig_on()
+            ok = fmpq_mpoly_set_str_pretty(f._poly, bstr, cnames, self._ctx)
+            sig_off()
+            sig_free(cnames)
+            if ok != 0:
+                raise ValueError("could not parse '{}' as a polynomial".format(x))
+            return f
+
+        if isinstance(x, dict):
+            f = self._new_element()
+            exp = <ulong *>sig_malloc(n * sizeof(ulong))
+            if exp == NULL:
+                raise MemoryError
+            fmpq_init(coeff)
+            try:
+                for key, val in x.items():
+                    if not isinstance(val, Rational):
+                        val = QQ(val)
+                    c = <Rational>val
+                    for i in range(n):
+                        exp[i] = key[i]
+                    fmpq_set_mpq(coeff, c.value)
+                    sig_on()
+                    fmpq_mpoly_set_coeff_fmpq_ui(f._poly, coeff, exp, self._ctx)
+                    sig_off()
+            finally:
+                fmpq_clear(coeff)
+                sig_free(exp)
+            return f
+
+        # try via _mpoly_dict_recursive for MPolynomial types
+        from sage.rings.polynomial.multi_polynomial import MPolynomial
+        if isinstance(x, MPolynomial):
+            return self._element_constructor_(
+                x._mpoly_dict_recursive(self.variable_names(), QQ))
+
+        # last resort: coerce to QQ
+        return self._element_constructor_(QQ(x))
+
+    def _coerce_map_from_(self, R):
+        r"""
+        Return ``True`` if there is a coercion from ``R`` into this ring.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: R.has_coerce_map_from(ZZ)
+            True
+            sage: R.has_coerce_map_from(QQ)
+            True
+        """
+        if R is QQ or R is ZZ:
+            return True
+        return MPolynomialRing_base._coerce_map_from_(self, R)
+
+
+cdef class MPolynomial_rational_flint(MPolynomial_flint_base):
+    r"""
+    A multivariate polynomial over `\QQ`, implemented via FLINT.
+
+    EXAMPLES::
+
+        sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+        sage: f = 3*x^2/2 - y + 1; f
+        3/2*x^2 - y + 1
+        sage: type(f)
+        <class 'sage.rings.polynomial.multi_polynomial_rational_flint.MPolynomial_rational_flint'>
+
+    .. automethod:: _add_
+    .. automethod:: _sub_
+    .. automethod:: _mul_
+    .. automethod:: _neg_
+    """
+
+    def __cinit__(self):
+        # Python zero-initialises the memory; fmpq_mpoly_clear on a struct
+        # with alloc=0 is a no-op, so __dealloc__ is safe even if
+        # fmpq_mpoly_init was never called.
+        pass
+
+    def __dealloc__(self):
+        cdef MPolynomialRing_rational_flint R = self._parent
+        if R is not None:
+            fmpq_mpoly_clear(self._poly, R._ctx)
+
+    cdef MPolynomial_rational_flint _new(self):
+        return (<MPolynomialRing_rational_flint>self._parent)._new_element()
+
+    cpdef _new_constant_poly(self, scalar, parent):
+        r"""
+        Return a new constant polynomial with value ``scalar`` in ``parent``.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: x._new_constant_poly(3/4, R)
+            3/4
+        """
+        cdef MPolynomialRing_rational_flint R = parent
+        cdef MPolynomial_rational_flint f = R._new_element()
+        cdef fmpq_t coeff
+        if not isinstance(scalar, Rational):
+            scalar = QQ(scalar)
+        fmpq_init(coeff)
+        fmpq_set_mpq(coeff, (<Rational>scalar).value)
+        fmpq_mpoly_set_fmpq(f._poly, coeff, R._ctx)
+        fmpq_clear(coeff)
+        return f
+
+    def __copy__(self):
+        r"""
+        Return a copy of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: f = 3*x^2/2 - y + 1
+            sage: g = copy(f)
+            sage: f == g
+            True
+            sage: f is g
+            False
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef MPolynomial_rational_flint f = R._new_element()
+        sig_on()
+        fmpq_mpoly_set(f._poly, self._poly, R._ctx)
+        sig_off()
+        return f
+
+    def __deepcopy__(self, memo=None):
+        r"""
+        Return a deep copy of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: f = x^2 + y
+            sage: g = deepcopy(f)
+            sage: f == g
+            True
+            sage: f is g
+            False
+        """
+        cpy = self.__copy__()
+        if memo is not None:
+            memo[id(self)] = cpy
+        return cpy
+
+    def __reduce__(self):
+        r"""
+        Return data for pickling this polynomial.
+
+        TESTS::
+
+            sage: R.<x,y,z> = PolynomialRing(QQ, 'x,y,z', implementation='flint')
+            sage: f = 7*x^3*y/2 - 2*y*z + 1
+            sage: loads(dumps(f)) == f
+            True
+        """
+        return (_unpickle_MPolynomial_rational_flint,
+                (self._parent, self.monomial_coefficients()))
+
+    def _repr_(self):
+        r"""
+        Return a string representation of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(QQ, 'x,y,z', implementation='flint')
+            sage: 3*x^2*y/2 - z + 1
+            3/2*x^2*y - z + 1
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef int n = R._ngens
+        cdef char *raw
+        cdef const char **cnames = <const char **>sig_malloc(n * sizeof(char *))
+        if cnames == NULL:
+            raise MemoryError
+        bnames = [str_to_bytes(v) for v in R.variable_names()]
+        for i in range(n):
+            cnames[i] = bnames[i]
+        sig_on()
+        raw = fmpq_mpoly_get_str_pretty(self._poly, cnames, R._ctx)
+        sig_off()
+        sig_free(cnames)
+        result = char_to_str(raw)
+        free(raw)
+        # FLINT omits spaces around binary + and -; add them for readability
+        result = re.sub(r'([a-zA-Z0-9])\s*([+-])', r'\1 \2 ', result)
+        return result
+
+    def __hash__(self):
+        r"""
+        Return a hash of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: hash(x) == hash(x)
+            True
+            sage: hash(x) == hash(y)
+            False
+        """
+        return self._hash_c()
+
+    def __bool__(self):
+        r"""
+        Return ``True`` if this polynomial is nonzero.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: bool(x)
+            True
+            sage: bool(R(0))
+            False
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        return not fmpq_mpoly_is_zero(self._poly, R._ctx)
+
+    # ===== Predicates =====
+
+    def is_zero(self):
+        r"""
+        Return ``True`` if this polynomial is zero.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: R(0).is_zero()
+            True
+            sage: x.is_zero()
+            False
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        return bool(fmpq_mpoly_is_zero(self._poly, R._ctx))
+
+    def is_one(self):
+        r"""
+        Return ``True`` if this polynomial equals 1.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: R(1).is_one()
+            True
+            sage: x.is_one()
+            False
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        return bool(fmpq_mpoly_is_one(self._poly, R._ctx))
+
+    def is_constant(self):
+        r"""
+        Return ``True`` if this polynomial is a constant.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: R(0).is_constant()
+            True
+            sage: R(5/3).is_constant()
+            True
+            sage: x.is_constant()
+            False
+            sage: (x + 1).is_constant()
+            False
+
+        Constant polynomials can be converted to `\QQ`::
+
+            sage: QQ(R(5/3))
+            5/3
+            sage: QQ(x)
+            Traceback (most recent call last):
+            ...
+            TypeError: x is not a constant polynomial
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        return bool(fmpq_mpoly_is_fmpq(self._poly, R._ctx))
+
+    def is_term(self):
+        r"""
+        Return ``True`` if this polynomial is a single nonzero term.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: x.is_term()
+            True
+            sage: (3*x^2*y/2).is_term()
+            True
+            sage: (x + y).is_term()
+            False
+            sage: R(0).is_term()
+            False
+            sage: R(5/3).is_term()
+            True
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        return fmpq_mpoly_length(self._poly, R._ctx) == 1
+
+    def is_monomial(self):
+        r"""
+        Return ``True`` if this polynomial is a monomial.
+
+        A *monomial* has coefficient 1.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: x.is_monomial()
+            True
+            sage: (x^2*y).is_monomial()
+            True
+            sage: (3*x).is_monomial()
+            False
+            sage: R(1).is_monomial()
+            True
+            sage: R(0).is_monomial()
+            False
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef fmpq_t c
+        if fmpq_mpoly_length(self._poly, R._ctx) != 1:
+            return False
+        fmpq_init(c)
+        fmpq_mpoly_get_term_coeff_fmpq(c, self._poly, 0, R._ctx)
+        cdef Rational rc = Rational.__new__(Rational)
+        fmpq_get_mpq(rc.value, c)
+        fmpq_clear(c)
+        return rc.is_one()
+
+    def is_homogeneous(self):
+        r"""
+        Return ``True`` if this polynomial is homogeneous.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(QQ, 'x,y,z', implementation='flint')
+            sage: (x^2 + y*z).is_homogeneous()
+            True
+            sage: (x^2 + y).is_homogeneous()
+            False
+            sage: R(0).is_homogeneous()
+            True
+            sage: R(5/3).is_homogeneous()
+            True
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong length = fmpq_mpoly_length(self._poly, R._ctx)
+        cdef slong i, j
+        cdef ulong *exp
+        if length <= 1:
+            return True
+        exp = <ulong *>sig_malloc(n * sizeof(ulong))
+        if exp == NULL:
+            raise MemoryError
+        try:
+            fmpq_mpoly_get_term_exp_ui(exp, self._poly, 0, R._ctx)
+            ref_deg = 0
+            for j in range(n):
+                ref_deg += exp[j]
+            for i in range(1, length):
+                fmpq_mpoly_get_term_exp_ui(exp, self._poly, i, R._ctx)
+                deg = 0
+                for j in range(n):
+                    deg += exp[j]
+                if deg != ref_deg:
+                    return False
+        finally:
+            sig_free(exp)
+        return True
+
+    def is_square(self):
+        r"""
+        Return ``True`` if this polynomial is a perfect square.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: (x^2 + 2*x*y + y^2).is_square()
+            True
+            sage: x.is_square()
+            False
+            sage: R(0).is_square()
+            True
+            sage: R(4).is_square()
+            True
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        return bool(fmpq_mpoly_is_square(self._poly, R._ctx))
+
+    # ===== Information =====
+
+    cpdef long number_of_terms(self) noexcept:
+        r"""
+        Return the number of nonzero terms.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: f = x^2 + 3*x*y - y + 2
+            sage: f.number_of_terms()
+            4
+            sage: R(0).number_of_terms()
+            0
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        return fmpq_mpoly_length(self._poly, R._ctx)
+
+    def degree(self, x=None):
+        r"""
+        Return the degree of this polynomial in the variable ``x``, or the
+        total degree if ``x`` is ``None``.
+
+        INPUT:
+
+        - ``x`` -- (optional) a generator of the parent ring
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(QQ, 'x,y,z', implementation='flint')
+            sage: f = x^2*y + y^3*z^4
+            sage: f.degree()
+            7
+            sage: f.degree(x)
+            2
+            sage: f.degree(y)
+            3
+            sage: f.degree(z)
+            4
+            sage: R(0).degree()
+            -1
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        if fmpq_mpoly_is_zero(self._poly, R._ctx):
+            return -1
+        if x is None:
+            return self.total_degree()
+        cdef slong var_idx
+        names = R.variable_names()
+        var_name = str(x)
+        if var_name not in names:
+            raise ValueError("{} is not a variable of {}".format(x, R))
+        var_idx = names.index(var_name)
+        return Integer(fmpq_mpoly_degree_si(self._poly, var_idx, R._ctx))
+
+    def total_degree(self):
+        r"""
+        Return the total degree of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(QQ, 'x,y,z', implementation='flint')
+            sage: (x^2*y + y^3*z^4 + 1).total_degree()
+            7
+            sage: R(5).total_degree()
+            0
+            sage: R(0).total_degree()
+            -1
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        if fmpq_mpoly_is_zero(self._poly, R._ctx):
+            return -1
+        return Integer(fmpq_mpoly_total_degree_si(self._poly, R._ctx))
+
+    def degrees(self):
+        r"""
+        Return a tuple containing the degree of this polynomial in each
+        variable.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(QQ, 'x,y,z', implementation='flint')
+            sage: f = x^2*y + y^3*z^4
+            sage: f.degrees()
+            (2, 3, 4)
+            sage: R(5).degrees()
+            (0, 0, 0)
+            sage: R(0).degrees()
+            (0, 0, 0)
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong i
+        cdef slong *degs = <slong *>sig_malloc(n * sizeof(slong))
+        if degs == NULL:
+            raise MemoryError
+        try:
+            fmpq_mpoly_degrees_si(degs, self._poly, R._ctx)
+            result = tuple(Integer(degs[i]) if degs[i] >= 0 else Integer(0)
+                           for i in range(n))
+        finally:
+            sig_free(degs)
+        return result
+
+    def variables(self):
+        r"""
+        Return a tuple of the variables (generators) actually occurring in
+        this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(QQ, 'x,y,z', implementation='flint')
+            sage: (x^2*z + 1).variables()
+            (x, z)
+            sage: R(5).variables()
+            ()
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong i
+        cdef int *used = <int *>sig_malloc(n * sizeof(int))
+        if used == NULL:
+            raise MemoryError
+        try:
+            fmpq_mpoly_used_vars(used, self._poly, R._ctx)
+            result = tuple(R.gen(i) for i in range(n) if used[i])
+        finally:
+            sig_free(used)
+        return result
+
+    def variable(self, int i=0):
+        r"""
+        Return the ``i``-th variable occurring in this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(QQ, 'x,y,z', implementation='flint')
+            sage: (x^2*z + 1).variable(0)
+            x
+            sage: (x^2*z + 1).variable(1)
+            z
+        """
+        return self.variables()[i]
+
+    def nvariables(self):
+        r"""
+        Return the number of variables actually occurring in this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(QQ, 'x,y,z', implementation='flint')
+            sage: (x^2*z + 1).nvariables()
+            2
+            sage: R(5).nvariables()
+            0
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong i
+        cdef int *used = <int *>sig_malloc(n * sizeof(int))
+        if used == NULL:
+            raise MemoryError
+        try:
+            fmpq_mpoly_used_vars(used, self._poly, R._ctx)
+            result = sum(1 for i in range(n) if used[i])
+        finally:
+            sig_free(used)
+        return result
+
+    # ===== Coefficients =====
+
+    def monomial_coefficients(self):
+        r"""
+        Return a dictionary of ``{exponent: coefficient}`` pairs.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: f = 2*x^3/3 - x*y + 5/7
+            sage: sorted(f.monomial_coefficients().items())
+            [((0, 0), 5/7), ((1, 1), -1), ((3, 0), 2/3)]
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong length = fmpq_mpoly_length(self._poly, R._ctx)
+        cdef slong i
+        cdef fmpq_t coeff
+        cdef ulong *exp
+        cdef Rational c
+        fmpq_init(coeff)
+        exp = <ulong *>sig_malloc(n * sizeof(ulong))
+        if exp == NULL:
+            fmpq_clear(coeff)
+            raise MemoryError
+        result = {}
+        try:
+            for i in range(length):
+                fmpq_mpoly_get_term_coeff_fmpq(coeff, self._poly, i, R._ctx)
+                fmpq_mpoly_get_term_exp_ui(exp, self._poly, i, R._ctx)
+                c = Rational.__new__(Rational)
+                fmpq_get_mpq(c.value, coeff)
+                result[ETuple([exp[j] for j in range(n)])] = c
+        finally:
+            fmpq_clear(coeff)
+            sig_free(exp)
+        return result
+
+    def coefficients(self):
+        r"""
+        Return the list of coefficients of this polynomial, in the order
+        induced by the term order.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: f = 3*x^2*y/2 - x + 5/7
+            sage: f.coefficients()
+            [3/2, -1, 5/7]
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef slong length = fmpq_mpoly_length(self._poly, R._ctx)
+        cdef slong i
+        cdef fmpq_t coeff
+        cdef Rational c
+        fmpq_init(coeff)
+        result = []
+        try:
+            for i in range(length):
+                fmpq_mpoly_get_term_coeff_fmpq(coeff, self._poly, i, R._ctx)
+                c = Rational.__new__(Rational)
+                fmpq_get_mpq(c.value, coeff)
+                result.append(c)
+        finally:
+            fmpq_clear(coeff)
+        return result
+
+    def exponents(self, as_ETuples=True):
+        r"""
+        Return the list of exponent tuples of the nonzero terms of this
+        polynomial, in the order induced by the term order.
+
+        INPUT:
+
+        - ``as_ETuples`` -- (default: ``True``) if ``True``, return a list of
+          :class:`ETuple`; otherwise, return a list of plain tuples
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: f = 3*x^2*y/2 - x + 5/7
+            sage: f.exponents()
+            [(2, 1), (1, 0), (0, 0)]
+            sage: f.exponents(as_ETuples=False)
+            [(2, 1), (1, 0), (0, 0)]
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong length = fmpq_mpoly_length(self._poly, R._ctx)
+        cdef slong i, j
+        cdef ulong *exp
+        exp = <ulong *>sig_malloc(n * sizeof(ulong))
+        if exp == NULL:
+            raise MemoryError
+        result = []
+        try:
+            for i in range(length):
+                fmpq_mpoly_get_term_exp_ui(exp, self._poly, i, R._ctx)
+                t = tuple(int(exp[j]) for j in range(n))
+                if as_ETuples:
+                    result.append(ETuple(t))
+                else:
+                    result.append(t)
+        finally:
+            sig_free(exp)
+        return result
+
+    def monomials(self):
+        r"""
+        Return the list of monomials of this polynomial, in the order
+        induced by the term order.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: f = 3*x^2*y/2 - x + 5/7
+            sage: f.monomials()
+            [x^2*y, x, 1]
+            sage: R(0).monomials()
+            []
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef slong length = fmpq_mpoly_length(self._poly, R._ctx)
+        cdef slong i
+        cdef MPolynomial_rational_flint m
+        result = []
+        for i in range(length):
+            m = R._new_element()
+            sig_on()
+            fmpq_mpoly_get_term_monomial(m._poly, self._poly, i, R._ctx)
+            sig_off()
+            result.append(m)
+        return result
+
+    def constant_coefficient(self):
+        r"""
+        Return the constant coefficient of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: (3*x^2 - 2*y + 7/3).constant_coefficient()
+            7/3
+            sage: x.constant_coefficient()
+            0
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef ulong *exp
+        cdef fmpq_t coeff
+        cdef Rational c
+        exp = <ulong *>sig_malloc(n * sizeof(ulong))
+        if exp == NULL:
+            raise MemoryError
+        fmpq_init(coeff)
+        try:
+            for i in range(n):
+                exp[i] = 0
+            fmpq_mpoly_get_coeff_fmpq_ui(coeff, self._poly, exp, R._ctx)
+            c = Rational.__new__(Rational)
+            fmpq_get_mpq(c.value, coeff)
+        finally:
+            fmpq_clear(coeff)
+            sig_free(exp)
+        return c
+
+    def monomial_coefficient(self, mon):
+        r"""
+        Return the coefficient of the monomial ``mon`` in this polynomial.
+
+        INPUT:
+
+        - ``mon`` -- a monomial in the same ring
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: f = 3*x^2*y/2 - x*y + 5/7
+            sage: f.monomial_coefficient(x^2*y)
+            3/2
+            sage: f.monomial_coefficient(x*y)
+            -1
+            sage: f.monomial_coefficient(R(1))
+            5/7
+            sage: f.monomial_coefficient(x)
+            0
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef MPolynomial_rational_flint m
+        cdef fmpq_t coeff
+        cdef Rational c
+        if isinstance(mon, MPolynomial_rational_flint) and (<MPolynomial_rational_flint>mon)._parent is R:
+            m = <MPolynomial_rational_flint>mon
+        else:
+            m = <MPolynomial_rational_flint>R(mon)
+        if fmpq_mpoly_is_zero(m._poly, R._ctx):
+            raise ValueError("mon must not be equal to 0")
+        fmpq_init(coeff)
+        sig_on()
+        fmpq_mpoly_get_coeff_fmpq_monomial(coeff, self._poly, m._poly, R._ctx)
+        sig_off()
+        c = Rational.__new__(Rational)
+        fmpq_get_mpq(c.value, coeff)
+        fmpq_clear(coeff)
+        return c
+
+    def coefficient(self, degrees):
+        r"""
+        Return the coefficient of a monomial specified by ``degrees``.
+
+        INPUT:
+
+        - ``degrees`` -- a dictionary mapping generators to nonnegative
+          integers, or a tuple/list of nonnegative integers giving the
+          exponent of each variable
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: f = 3*x^2*y/2 - x*y + 5/7
+            sage: f.coefficient({x: 2, y: 1})
+            3/2
+            sage: f.coefficient((2, 1))
+            3/2
+            sage: f.coefficient((0, 0))
+            5/7
+            sage: f.coefficient((1, 0))
+            0
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong i
+        cdef ulong *exp
+        cdef fmpq_t coeff
+        cdef Rational c
+
+        if isinstance(degrees, dict):
+            names = R.variable_names()
+            d = [0] * n
+            for k, v in degrees.items():
+                key = str(k)
+                if key not in names:
+                    raise ValueError("{} is not a variable of {}".format(k, R))
+                d[names.index(key)] = int(v)
+            degrees = d
+        else:
+            degrees = list(degrees)
+            if len(degrees) != n:
+                raise ValueError("degrees must have length {}".format(n))
+
+        exp = <ulong *>sig_malloc(n * sizeof(ulong))
+        if exp == NULL:
+            raise MemoryError
+        fmpq_init(coeff)
+        try:
+            for i in range(n):
+                exp[i] = degrees[i]
+            fmpq_mpoly_get_coeff_fmpq_ui(coeff, self._poly, exp, R._ctx)
+            c = Rational.__new__(Rational)
+            fmpq_get_mpq(c.value, coeff)
+        finally:
+            fmpq_clear(coeff)
+            sig_free(exp)
+        return c
+
+    # ===== Leading term/coefficient/monomial =====
+
+    def lc(self):
+        r"""
+        Return the leading coefficient of this polynomial.
+
+        Returns 0 if this polynomial is zero.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint', order='lex')
+            sage: f = 3*x^2*y/2 - x*y^3 + 5/7
+            sage: f.lc()
+            3/2
+            sage: R(0).lc()
+            0
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef fmpq_t coeff
+        cdef Rational c
+        if fmpq_mpoly_is_zero(self._poly, R._ctx):
+            return Rational(0)
+        fmpq_init(coeff)
+        fmpq_mpoly_get_term_coeff_fmpq(coeff, self._poly, 0, R._ctx)
+        c = Rational.__new__(Rational)
+        fmpq_get_mpq(c.value, coeff)
+        fmpq_clear(coeff)
+        return c
+
+    def lm(self):
+        r"""
+        Return the leading monomial of this polynomial.
+
+        Returns 0 if this polynomial is zero.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint', order='lex')
+            sage: f = 3*x^2*y/2 - x*y^3 + 5/7
+            sage: f.lm()
+            x^2*y
+            sage: R(0).lm()
+            0
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef MPolynomial_rational_flint m
+        if fmpq_mpoly_is_zero(self._poly, R._ctx):
+            return R._new_element()
+        m = R._new_element()
+        sig_on()
+        fmpq_mpoly_get_term_monomial(m._poly, self._poly, 0, R._ctx)
+        sig_off()
+        return m
+
+    def lt(self):
+        r"""
+        Return the leading term of this polynomial.
+
+        Returns 0 if this polynomial is zero.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint', order='lex')
+            sage: f = 3*x^2*y/2 - x*y^3 + 5/7
+            sage: f.lt()
+            3/2*x^2*y
+            sage: R(0).lt()
+            0
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef MPolynomial_rational_flint t
+        if fmpq_mpoly_is_zero(self._poly, R._ctx):
+            return R._new_element()
+        t = R._new_element()
+        sig_on()
+        fmpq_mpoly_get_term(t._poly, self._poly, 0, R._ctx)
+        sig_off()
+        return t
+
+    def term_content(self):
+        r"""
+        Return the GCD of the (nonzero) terms of this polynomial.
+
+        Over `\QQ`, the result is a monomial with coefficient `1`.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: (6*x^2*y^2 - 4*x^3*y).term_content()
+            x^2*y
+            sage: R(0).term_content()
+            0
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef MPolynomial_rational_flint result = R._new_element()
+        sig_on()
+        fmpq_mpoly_term_content(result._poly, self._poly, R._ctx)
+        sig_off()
+        return result
+
+    def monic(self):
+        r"""
+        Return this polynomial divided by its leading coefficient.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: (3*x^2/2 - y).monic()
+            x^2 - 2/3*y
+
+        TESTS::
+
+            sage: R(0).monic()
+            Traceback (most recent call last):
+            ...
+            ZeroDivisionError: cannot make the zero polynomial monic
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        if self.is_zero():
+            raise ZeroDivisionError("cannot make the zero polynomial monic")
+        cdef MPolynomial_rational_flint result = R._new_element()
+        sig_on()
+        fmpq_mpoly_make_monic(result._poly, self._poly, R._ctx)
+        sig_off()
+        return result
+
+    # ===== Arithmetic =====
+
+    cpdef _add_(self, other):
+        r"""
+        Return the sum of this polynomial and ``other``.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: x + y
+            x + y
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef MPolynomial_rational_flint res = self._new()
+        sig_on()
+        fmpq_mpoly_add(res._poly, self._poly,
+                       (<MPolynomial_rational_flint>other)._poly, R._ctx)
+        sig_off()
+        return res
+
+    cpdef _sub_(self, other):
+        r"""
+        Return the difference of this polynomial and ``other``.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: x - y
+            x - y
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef MPolynomial_rational_flint res = self._new()
+        sig_on()
+        fmpq_mpoly_sub(res._poly, self._poly,
+                       (<MPolynomial_rational_flint>other)._poly, R._ctx)
+        sig_off()
+        return res
+
+    cpdef _neg_(self):
+        r"""
+        Return the negation of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: -(x + y)
+            -x - y
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef MPolynomial_rational_flint res = self._new()
+        sig_on()
+        fmpq_mpoly_neg(res._poly, self._poly, R._ctx)
+        sig_off()
+        return res
+
+    cpdef _lmul_(self, Element scalar):
+        r"""
+        Return this polynomial multiplied by the scalar ``scalar``.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: 3*x
+            3*x
+            sage: x * (2/3)
+            2/3*x
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef MPolynomial_rational_flint res = self._new()
+        cdef fmpq_t c
+        cdef Rational s = scalar if isinstance(scalar, Rational) else QQ(scalar)
+        fmpq_init(c)
+        fmpq_set_mpq(c, s.value)
+        sig_on()
+        fmpq_mpoly_scalar_mul_fmpq(res._poly, self._poly, c, R._ctx)
+        sig_off()
+        fmpq_clear(c)
+        return res
+
+    cpdef _mul_(self, other):
+        r"""
+        Return the product of this polynomial and ``other``.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: (x + 1) * (y - 1)
+            x*y - x + y - 1
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef MPolynomial_rational_flint res = self._new()
+        sig_on()
+        fmpq_mpoly_mul(res._poly, self._poly,
+                       (<MPolynomial_rational_flint>other)._poly, R._ctx)
+        sig_off()
+        return res
+
+    def __pow__(self, exp, mod):
+        r"""
+        Return this polynomial raised to the power ``exp``.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: (x + y)^3
+            x^3 + 3*x^2*y + 3*x*y^2 + y^3
+        """
+        if mod is not None:
+            raise NotImplementedError("modular exponentiation not supported")
+        if exp < 0:
+            raise ValueError("exponent must be non-negative")
+        cdef MPolynomial_rational_flint self_ = self
+        cdef MPolynomialRing_rational_flint R = self_._parent
+        cdef MPolynomial_rational_flint res = self_._new()
+        cdef int ok
+        sig_on()
+        ok = fmpq_mpoly_pow_ui(res._poly, self_._poly, <ulong>exp, R._ctx)
+        sig_off()
+        if not ok:
+            raise ArithmeticError("power failed (exponent too large?)")
+        return res
+
+    cpdef _richcmp_(self, other, int op):
+        r"""
+        Compare this polynomial with ``other``.
+
+        Only equality and inequality are supported.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: x == x
+            True
+            sage: x == y
+            False
+            sage: x != y
+            True
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef bint eq = fmpq_mpoly_equal(
+            self._poly,
+            (<MPolynomial_rational_flint>other)._poly,
+            R._ctx)
+        if op == Py_EQ:
+            return bool(eq)
+        if op == Py_NE:
+            return not eq
+        return NotImplemented
+
+    # ===== Division and related =====
+
+    def divides(self, other):
+        r"""
+        Return ``True`` if this polynomial divides ``other``.
+
+        INPUT:
+
+        - ``other`` -- a polynomial in the same ring
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: f = x^2 - y^2
+            sage: g = x - y
+            sage: g.divides(f)
+            True
+            sage: (x + 1).divides(f)
+            False
+            sage: R(0).divides(f)
+            False
+            sage: g.divides(R(0))
+            True
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        if self.is_zero():
+            return R(other).is_zero()
+        cdef MPolynomial_rational_flint q = R._new_element()
+        cdef MPolynomial_rational_flint b = R(other)
+        sig_on()
+        result = fmpq_mpoly_divides(q._poly, b._poly, self._poly, R._ctx)
+        sig_off()
+        return bool(result)
+
+    def quo_rem(self, other):
+        r"""
+        Return the quotient and remainder of the division of this polynomial
+        by ``other``.
+
+        INPUT:
+
+        - ``other`` -- a nonzero polynomial in the same ring
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: f = x^2*y + 3*x - 1
+            sage: g = x*y - 1
+            sage: q, r = f.quo_rem(g)
+            sage: q * g + r == f
+            True
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef MPolynomial_rational_flint q = R._new_element()
+        cdef MPolynomial_rational_flint r = R._new_element()
+        cdef MPolynomial_rational_flint b = R(other)
+        if b.is_zero():
+            raise ZeroDivisionError("cannot divide by zero")
+        sig_on()
+        fmpq_mpoly_divrem(q._poly, r._poly, self._poly, b._poly, R._ctx)
+        sig_off()
+        return q, r
+
+    def gcd(self, other):
+        r"""
+        Return the greatest common divisor of this polynomial and ``other``.
+
+        The result is monic (over `\QQ`).
+
+        INPUT:
+
+        - ``other`` -- a polynomial in the same ring
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: f = x^2 - y^2
+            sage: g = x - y
+            sage: f.gcd(g)
+            x - y
+            sage: (2*x).gcd(4*y)
+            1
+            sage: f.gcd(R(0))
+            x^2 - y^2
+            sage: R(0).gcd(R(0))
+            0
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef MPolynomial_rational_flint result = R._new_element()
+        cdef MPolynomial_rational_flint b = R(other)
+        sig_on()
+        ok = fmpq_mpoly_gcd(result._poly, self._poly, b._poly, R._ctx)
+        sig_off()
+        if not ok:
+            raise ArithmeticError("GCD computation failed")
+        return result
+
+    def sqrt(self):
+        r"""
+        Return the square root of this polynomial if it is a perfect square,
+        otherwise raise a :class:`ValueError`.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: f = (x^2 + 2*x*y + y^2)/4
+            sage: f.sqrt()
+            1/2*x + 1/2*y
+            sage: R(9/4).sqrt()
+            3/2
+            sage: x.sqrt()
+            Traceback (most recent call last):
+            ...
+            ValueError: x is not a perfect square
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef MPolynomial_rational_flint result = R._new_element()
+        sig_on()
+        ok = fmpq_mpoly_sqrt(result._poly, self._poly, R._ctx)
+        sig_off()
+        if not ok:
+            raise ValueError("{} is not a perfect square".format(self))
+        return result
+
+    # ===== Calculus =====
+
+    def _derivative(self, var):
+        r"""
+        Return the partial derivative of this polynomial with respect to
+        ``var``.
+
+        INPUT:
+
+        - ``var`` -- a generator of the parent ring (or its name)
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: f = 3*x^3*y^2/4 + 5*y^2 + 3*x + 2
+            sage: f._derivative(x)
+            9/4*x^2*y^2 + 3
+            sage: f._derivative(y)
+            3/2*x^3*y + 10*y
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef MPolynomial_rational_flint result = R._new_element()
+        cdef slong var_idx
+        if var is None:
+            raise ValueError("you must specify the variable with respect to which to differentiate")
+        names = R.variable_names()
+        var_name = str(var)
+        if var_name not in names:
+            raise ValueError("{} is not a variable of {}".format(var, R))
+        var_idx = names.index(var_name)
+        sig_on()
+        fmpq_mpoly_derivative(result._poly, self._poly, var_idx, R._ctx)
+        sig_off()
+        return result
+
+    def derivative(self, *args):
+        r"""
+        Return the (iterated) partial derivative of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: f = x^3 * y^2
+            sage: f.derivative(x)
+            3*x^2*y^2
+            sage: f.derivative(x, x)
+            6*x*y^2
+            sage: f.derivative(x, y)
+            6*x^2*y
+        """
+        result = self
+        for v in args:
+            result = result._derivative(v)
+        return result
+
+    def integral(self, var):
+        r"""
+        Return the formal indefinite integral of this polynomial with respect
+        to ``var``, with zero constant term.
+
+        INPUT:
+
+        - ``var`` -- a generator of the parent ring (or its name)
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: f = 3*x^2*y + y
+            sage: f.integral(x)
+            x^3*y + x*y
+            sage: f.integral(y)
+            3/2*x^2*y^2 + 1/2*y^2
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef MPolynomial_rational_flint result = R._new_element()
+        cdef slong var_idx
+        if var is None:
+            raise ValueError("you must specify the variable with respect to which to integrate")
+        names = R.variable_names()
+        var_name = str(var)
+        if var_name not in names:
+            raise ValueError("{} is not a variable of {}".format(var, R))
+        var_idx = names.index(var_name)
+        sig_on()
+        fmpq_mpoly_integral(result._poly, self._poly, var_idx, R._ctx)
+        sig_off()
+        return result
+
+    # ===== Factorization =====
+
+    def factor(self):
+        r"""
+        Return the factorization of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: f = (x^2 - y^2) * (x + 1)
+            sage: F = f.factor()
+            sage: F.unit() * prod(g^e for g, e in F) == f
+            True
+
+        TESTS::
+
+            sage: R(0).factor()
+            Traceback (most recent call last):
+            ...
+            ArithmeticError: factorization of 0 is not defined
+            sage: R(3/4).factor()
+            3/4
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        if self.is_zero():
+            raise ArithmeticError("factorization of 0 is not defined")
+
+        cdef fmpq_mpoly_factor_t fac
+        cdef fmpq_t const_fmpq
+        cdef fmpq_mpoly_t base_poly
+        cdef MPolynomial_rational_flint base
+        cdef Rational constant
+        cdef slong i, length, exp
+        cdef int ok
+
+        fmpq_mpoly_factor_init(fac, R._ctx)
+        fmpq_init(const_fmpq)
+        fmpq_mpoly_init(base_poly, R._ctx)
+        factors = []
+        try:
+            sig_on()
+            ok = fmpq_mpoly_factor(fac, self._poly, R._ctx)
+            sig_off()
+            if not ok:
+                raise ArithmeticError("factorization failed")
+            fmpq_mpoly_factor_get_constant_fmpq(const_fmpq, fac, R._ctx)
+            constant = Rational.__new__(Rational)
+            fmpq_get_mpq(constant.value, const_fmpq)
+            length = fmpq_mpoly_factor_length(fac, R._ctx)
+            for i in range(length):
+                fmpq_mpoly_factor_get_base(base_poly, fac, i, R._ctx)
+                exp = fmpq_mpoly_factor_get_exp_si(fac, i, R._ctx)
+                base = R._new_element()
+                sig_on()
+                fmpq_mpoly_set(base._poly, base_poly, R._ctx)
+                sig_off()
+                factors.append((base, int(exp)))
+        finally:
+            fmpq_mpoly_clear(base_poly, R._ctx)
+            fmpq_clear(const_fmpq)
+            fmpq_mpoly_factor_clear(fac, R._ctx)
+
+        return Factorization(factors, unit=constant, sort=False)
+
+    # ===== Resultant, discriminant =====
+
+    def resultant(self, other, variable=None):
+        r"""
+        Return the resultant of this polynomial and ``other`` with respect
+        to ``variable``.
+
+        If ``variable`` is not provided, the first variable of the ring is
+        used.
+
+        INPUT:
+
+        - ``other`` -- a polynomial in the same ring
+        - ``variable`` -- (optional) a generator of the ring
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: f = x^2 - y
+            sage: g = x - 1
+            sage: f.resultant(g)
+            -y + 1
+            sage: f.resultant(g, y)
+            x - 1
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef MPolynomial_rational_flint result = R._new_element()
+        cdef MPolynomial_rational_flint b = R(other)
+        cdef slong var_idx
+
+        if variable is None:
+            var_idx = 0
+        else:
+            names = R.variable_names()
+            var_name = str(variable)
+            if var_name not in names:
+                raise ValueError("{} is not a variable of {}".format(variable, R))
+            var_idx = names.index(var_name)
+
+        sig_on()
+        ok = fmpq_mpoly_resultant(result._poly, self._poly, b._poly, var_idx, R._ctx)
+        sig_off()
+        if not ok:
+            raise ArithmeticError("resultant computation failed")
+        return result
+
+    def discriminant(self, variable):
+        r"""
+        Return the discriminant of this polynomial with respect to
+        ``variable``.
+
+        INPUT:
+
+        - ``variable`` -- a generator of the parent ring
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(QQ, 'x,y', implementation='flint')
+            sage: f = x^2 + y*x + 1
+            sage: f.discriminant(x)
+            y^2 - 4
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef MPolynomial_rational_flint result = R._new_element()
+        cdef slong var_idx
+        names = R.variable_names()
+        var_name = str(variable)
+        if var_name not in names:
+            raise ValueError("{} is not a variable of {}".format(variable, R))
+        var_idx = names.index(var_name)
+        sig_on()
+        ok = fmpq_mpoly_discriminant(result._poly, self._poly, var_idx, R._ctx)
+        sig_off()
+        if not ok:
+            raise ArithmeticError("discriminant computation failed")
+        return result
+
+    # ===== Evaluation and substitution =====
+
+    def __call__(self, *args, **kwds):
+        r"""
+        Evaluate this polynomial at the given values.
+
+        Positional arguments are assigned to the variables in order. Keyword
+        arguments name variables explicitly. When all assigned values are
+        rationals and all variables are assigned, the result is a
+        :class:`~sage.rings.rational.Rational`; otherwise the result is a
+        polynomial in the same ring.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(QQ, 'x,y,z', implementation='flint')
+            sage: f = x^2 + y*z + 1
+            sage: f(1, 2, 3)
+            8
+            sage: f(1, 2, 3).parent()
+            Rational Field
+            sage: f(x, y, z) == f
+            True
+            sage: f(y, x, z)
+            y^2 + x*z + 1
+            sage: f(x=2)
+            y*z + 5
+            sage: f(x=1, y=2, z=3)
+            8
+            sage: f(1/2, 1/3, 1)
+            19/12
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong i
+        cdef fmpq_t res_fmpq
+        cdef fmpq **vals
+        cdef fmpq_t *fmpq_storage
+        cdef Rational result_q
+
+        if kwds and args:
+            raise TypeError("cannot mix positional and keyword arguments")
+
+        names = R.variable_names()
+        if args:
+            if len(args) != n:
+                raise TypeError("expected {} positional arguments, got {}".format(n, len(args)))
+            values = list(args)
+        else:
+            values = [None] * n
+            for k, v in kwds.items():
+                if k not in names:
+                    raise ValueError("{} is not a variable of {}".format(k, R))
+                values[names.index(k)] = v
+
+        # fast path: all values are rationals (or integers) and all assigned
+        if all(v is not None and isinstance(v, (int, Integer, Rational)) for v in values):
+            fmpq_storage = <fmpq_t *>sig_malloc(n * sizeof(fmpq_t))
+            vals = <fmpq **>sig_malloc(n * sizeof(fmpq *))
+            if fmpq_storage == NULL or vals == NULL:
+                if fmpq_storage != NULL:
+                    sig_free(fmpq_storage)
+                if vals != NULL:
+                    sig_free(vals)
+                raise MemoryError
+            for i in range(n):
+                fmpq_init(fmpq_storage[i])
+                fmpq_set_mpq(fmpq_storage[i], (<Rational>Rational(values[i])).value)
+                vals[i] = fmpq_storage[i]
+            fmpq_init(res_fmpq)
+            try:
+                sig_on()
+                ok = fmpq_mpoly_evaluate_all_fmpq(res_fmpq, self._poly, vals, R._ctx)
+                sig_off()
+                if not ok:
+                    raise ArithmeticError("evaluation failed")
+                result_q = Rational.__new__(Rational)
+                fmpq_get_mpq(result_q.value, res_fmpq)
+            finally:
+                fmpq_clear(res_fmpq)
+                for i in range(n):
+                    fmpq_clear(fmpq_storage[i])
+                sig_free(fmpq_storage)
+                sig_free(vals)
+            return result_q
+
+        # general path: do substitution (possibly partial)
+        fixed = {}
+        for i in range(n):
+            if values[i] is not None:
+                fixed[names[i]] = values[i]
+        return self.subs(fixed)
+
+    def subs(self, fixed=None, **kw):
+        r"""
+        Substitute variables in this polynomial and return the result.
+
+        Each substitution value may be a rational or a polynomial in the
+        same ring. Variables not mentioned are left unchanged.
+
+        INPUT:
+
+        - ``fixed`` -- (optional) dict mapping generators or variable names
+          to values
+        - ``**kw`` -- variable names as keyword arguments
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(QQ, 'x,y,z', implementation='flint')
+            sage: f = x^2 + y^2 + z^2
+            sage: f.subs(x=1, y=2)
+            z^2 + 5
+            sage: f.subs({x: y + 1})
+            2*y^2 + z^2 + 2*y + 1
+            sage: f.subs(x=1, y=2, z=3)
+            14
+            sage: f.subs({x: y, y: x})
+            x^2 + y^2 + z^2
+        """
+        cdef MPolynomialRing_rational_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong i
+        cdef fmpq_mpoly_struct **C
+        cdef MPolynomial_rational_flint res
+
+        sub = {}
+        if fixed is not None:
+            for k, v in fixed.items():
+                if isinstance(k, MPolynomial_rational_flint):
+                    k = str(k)
+                sub[str(k)] = v
+        for k, v in kw.items():
+            sub[k] = v
+
+        var_names = R.variable_names()
+        polys = []
+        for i in range(n):
+            name = var_names[i]
+            if name in sub:
+                v = sub[name]
+                if not isinstance(v, MPolynomial_rational_flint):
+                    v = R(v)
+                polys.append(<MPolynomial_rational_flint>v)
+            else:
+                polys.append(<MPolynomial_rational_flint>R.gen(i))
+
+        C = <fmpq_mpoly_struct **>sig_malloc(n * sizeof(fmpq_mpoly_struct *))
+        if C == NULL:
+            raise MemoryError
+        for i in range(n):
+            C[i] = &(<MPolynomial_rational_flint>polys[i])._poly[0]
+        res = R._new_element()
+        sig_on()
+        ok = fmpq_mpoly_compose_fmpq_mpoly(res._poly, self._poly, C, R._ctx, R._ctx)
+        sig_off()
+        sig_free(C)
+        if not ok:
+            raise ArithmeticError("composition failed")
+        return res

--- a/src/sage/rings/polynomial/multi_polynomial_rational_flint.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_rational_flint.pyx
@@ -1775,6 +1775,10 @@ cdef class MPolynomial_rational_flint(MPolynomial_flint_base):
         if kwds and args:
             raise TypeError("cannot mix positional and keyword arguments")
 
+        # allow f((a, b, c)) as a shortcut for f(a, b, c)
+        if len(args) == 1 and isinstance(args[0], (list, tuple)):
+            args = tuple(args[0])
+
         names = R.variable_names()
         if args:
             if len(args) != n:

--- a/src/sage/rings/polynomial/multi_polynomial_zmod_flint.pxd
+++ b/src/sage/rings/polynomial/multi_polynomial_zmod_flint.pxd
@@ -1,0 +1,17 @@
+from sage.libs.flint.types cimport nmod_mpoly_t, nmod_mpoly_ctx_t
+
+from sage.rings.polynomial.multi_polynomial cimport MPolynomial_flint as MPolynomial_flint_base
+from sage.rings.polynomial.multi_polynomial_ring_base cimport MPolynomialRing_base
+
+
+cdef class MPolynomialRing_zmod_flint(MPolynomialRing_base):
+    cdef nmod_mpoly_ctx_t _ctx
+    cdef unsigned long _modulus
+    cdef MPolynomial_zmod_flint _new_element(self)
+
+
+cdef class MPolynomial_zmod_flint(MPolynomial_flint_base):
+    cdef nmod_mpoly_t _poly
+    cdef MPolynomial_zmod_flint _new(self)
+    cpdef _new_constant_poly(self, scalar, parent)
+    cpdef long number_of_terms(self) noexcept

--- a/src/sage/rings/polynomial/multi_polynomial_zmod_flint.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_zmod_flint.pyx
@@ -1,0 +1,1810 @@
+# distutils: libraries = flint
+# distutils: depends = flint/nmod_mpoly.h flint/nmod_mpoly_factor.h
+r"""
+Multivariate polynomials over `\ZZ/n\ZZ`, implemented using FLINT
+
+EXAMPLES::
+
+    sage: R.<x,y,z> = PolynomialRing(GF(7), 'x,y,z', implementation='flint')
+    sage: f = 3*x^2*y - z + 1; f
+    3*x^2*y + 6*z + 1
+    sage: f * f
+    2*x^4*y^2 + x^2*y*z + 6*x^2*y + z^2 + 5*z + 1
+
+.. automethod:: MPolynomial_zmod_flint._add_
+.. automethod:: MPolynomial_zmod_flint._sub_
+.. automethod:: MPolynomial_zmod_flint._mul_
+.. automethod:: MPolynomial_zmod_flint._neg_
+"""
+
+#*****************************************************************************
+#       Copyright (C) 2025 Vincent Delecroix <20100.delecroix@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#                  http://www.gnu.org/licenses/
+#*****************************************************************************
+
+import re
+
+from libc.stdlib cimport free
+
+from cysignals.signals cimport sig_on, sig_off
+from cysignals.memory cimport sig_malloc, sig_free
+
+from cpython.object cimport Py_EQ, Py_NE
+
+from sage.libs.flint.nmod_mpoly cimport *
+from sage.libs.flint.nmod_mpoly_factor cimport (
+    nmod_mpoly_factor_init, nmod_mpoly_factor_clear,
+    nmod_mpoly_factor_length, nmod_mpoly_factor_get_constant_ui,
+    nmod_mpoly_factor_get_base, nmod_mpoly_factor_get_exp_si,
+    nmod_mpoly_factor)
+from sage.libs.flint.types cimport (
+    nmod_mpoly_t, nmod_mpoly_ctx_t, nmod_mpoly_struct,
+    nmod_mpoly_factor_t,
+    ordering_t, ORD_LEX, ORD_DEGLEX, ORD_DEGREVLEX, ulong, slong)
+
+from sage.cpython.string cimport str_to_bytes, char_to_str
+
+from sage.rings.integer cimport Integer
+from sage.rings.integer_ring import ZZ
+from sage.structure.element cimport Element
+from sage.structure.factorization import Factorization
+from sage.structure.richcmp cimport rich_to_bool
+
+from sage.rings.polynomial.multi_polynomial cimport MPolynomial_flint as MPolynomial_flint_base
+from sage.rings.polynomial.multi_polynomial_ring_base cimport MPolynomialRing_base
+from sage.rings.polynomial.multi_polynomial_zmod_flint cimport (
+    MPolynomialRing_zmod_flint,
+    MPolynomial_zmod_flint)
+from sage.rings.polynomial.polydict cimport ETuple
+
+
+cdef ordering_t _term_order_to_flint(order) except? ORD_LEX:
+    name = order.name() if hasattr(order, 'name') else str(order)
+    if name == 'lex':
+        return ORD_LEX
+    elif name == 'deglex':
+        return ORD_DEGLEX
+    elif name == 'degrevlex':
+        return ORD_DEGREVLEX
+    raise NotImplementedError(
+        "term order '{}' is not supported by FLINT nmod_mpoly".format(name))
+
+
+def _unpickle_MPolynomialRing_zmod_flint(base_ring, n, names, order):
+    r"""
+    Helper for unpickling :class:`MPolynomialRing_zmod_flint`.
+
+    TESTS::
+
+        sage: R = PolynomialRing(GF(7), 'x,y', implementation='flint')
+        sage: loads(dumps(R)) is R
+        True
+    """
+    from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+    return PolynomialRing(base_ring, n, names=names, order=order, implementation='flint')
+
+
+def _unpickle_MPolynomial_zmod_flint(parent, coeffs):
+    r"""
+    Helper for unpickling :class:`MPolynomial_zmod_flint`.
+
+    TESTS::
+
+        sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+        sage: f = 3*x^2*y - x + 1
+        sage: loads(dumps(f)) == f
+        True
+    """
+    return parent(coeffs)
+
+
+cdef class MPolynomialRing_zmod_flint(MPolynomialRing_base):
+    r"""
+    Multivariate polynomial ring over `\ZZ/n\ZZ`, implemented via FLINT.
+
+    EXAMPLES::
+
+        sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+        sage: R
+        Multivariate Polynomial Ring in x, y over Finite Field of size 7 (using FLINT)
+        sage: R.<x,y> = PolynomialRing(Integers(10), 'x,y', implementation='flint')
+        sage: R
+        Multivariate Polynomial Ring in x, y over Ring of integers modulo 10 (using FLINT)
+    """
+
+    def __cinit__(self):
+        # nvars = -1 signals that nmod_mpoly_ctx_init has not yet been called.
+        self._ctx[0].minfo[0].nvars = -1
+
+    def __init__(self, base_ring, n, names, order='degrevlex'):
+        r"""
+        Construct a multivariate polynomial ring over `\ZZ/n\ZZ` using FLINT.
+
+        INPUT:
+
+        - ``base_ring`` -- a finite ring of the form `\ZZ/n\ZZ` (e.g.
+          ``Integers(n)`` or ``GF(p)`` for prime ``p``)
+        - ``n`` -- number of variables (positive integer)
+        - ``names`` -- variable names
+        - ``order`` -- term order (``'lex'``, ``'deglex'``, or ``'degrevlex'``)
+
+        EXAMPLES::
+
+            sage: from sage.rings.polynomial.multi_polynomial_zmod_flint import MPolynomialRing_zmod_flint
+            sage: R = MPolynomialRing_zmod_flint(GF(7), 3, ('x','y','z'), 'degrevlex')
+            sage: R
+            Multivariate Polynomial Ring in x, y, z over Finite Field of size 7 (using FLINT)
+        """
+        cdef Integer m = Integer(base_ring.characteristic())
+        if m <= 0:
+            raise TypeError("base ring must be a finite ring of characteristic > 0")
+        if base_ring.cardinality() != m:
+            raise TypeError("base ring must be of the form Z/nZ")
+        if m.nbits() > 63:
+            raise ValueError("FLINT does not support modulus {}".format(m))
+        self._modulus = <unsigned long>int(m)
+        MPolynomialRing_base.__init__(self, base_ring, n, names, order)
+        cdef ordering_t ord = _term_order_to_flint(self._term_order)
+        nmod_mpoly_ctx_init(self._ctx, n, ord, self._modulus)
+
+    def __dealloc__(self):
+        if self._ctx[0].minfo[0].nvars != -1:
+            nmod_mpoly_ctx_clear(self._ctx)
+
+    Element = MPolynomial_zmod_flint
+
+    def __hash__(self):
+        r"""
+        Return a hash of this ring.
+
+        EXAMPLES::
+
+            sage: R = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: hash(R) == hash(R)
+            True
+        """
+        from sage.structure.category_object import CategoryObject
+        return CategoryObject.__hash__(self)
+
+    def __reduce__(self):
+        r"""
+        Return data for pickling this ring.
+
+        TESTS::
+
+            sage: R = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: loads(dumps(R)) is R
+            True
+        """
+        return (_unpickle_MPolynomialRing_zmod_flint,
+                (self._base, self._ngens, self.variable_names(), self._term_order))
+
+    def _repr_(self):
+        r"""
+        Return a string representation of this ring.
+
+        EXAMPLES::
+
+            sage: PolynomialRing(GF(7), 'x,y', implementation='flint')
+            Multivariate Polynomial Ring in x, y over Finite Field of size 7 (using FLINT)
+        """
+        return "Multivariate Polynomial Ring in {} over {} (using FLINT)".format(
+            ", ".join(self.variable_names()), self._base)
+
+    def characteristic(self):
+        r"""
+        Return the characteristic of the base ring.
+
+        EXAMPLES::
+
+            sage: R = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: R.characteristic()
+            7
+            sage: R = PolynomialRing(Integers(10), 'x,y', implementation='flint')
+            sage: R.characteristic()
+            10
+        """
+        return Integer(self._modulus)
+
+    def gen(self, int n=0):
+        r"""
+        Return the ``n``-th generator of this ring.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(GF(7), 'x,y,z', implementation='flint')
+            sage: R.gen(0)
+            x
+            sage: R.gen(2)
+            z
+        """
+        if n < 0 or n >= self._ngens:
+            raise ValueError("generator index out of range")
+        cdef MPolynomial_zmod_flint g = self._new_element()
+        sig_on()
+        nmod_mpoly_gen(g._poly, n, self._ctx)
+        sig_off()
+        return g
+
+    cdef MPolynomial_zmod_flint _new_element(self):
+        cdef MPolynomial_zmod_flint f = \
+            MPolynomial_zmod_flint.__new__(MPolynomial_zmod_flint)
+        f._parent = self
+        nmod_mpoly_init(f._poly, self._ctx)
+        return f
+
+    def _element_constructor_(self, x):
+        r"""
+        Convert ``x`` into an element of this ring.
+
+        Accepted inputs include integers, strings, dictionaries mapping
+        exponent tuples to coefficients, and multivariate polynomials over
+        a compatible ring.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: R(3)
+            3
+            sage: R("x^2*y - 2*x + 1")
+            x^2*y + 5*x + 1
+            sage: R({(2,1): 5, (0,0): -1})
+            5*x^2*y + 6
+            sage: R(x + y)
+            x + y
+        """
+        cdef MPolynomial_zmod_flint f
+        cdef ETuple e
+        cdef ulong *exp
+        cdef ulong coeff
+        cdef slong n = self._ngens
+        cdef int i
+        cdef bytes bstr
+        cdef const char **cnames
+
+        if isinstance(x, MPolynomial_zmod_flint) and x.parent() is self:
+            f = self._new_element()
+            sig_on()
+            nmod_mpoly_set(f._poly, (<MPolynomial_zmod_flint>x)._poly, self._ctx)
+            sig_off()
+            return f
+
+        if isinstance(x, int) or isinstance(x, Integer):
+            f = self._new_element()
+            coeff = <ulong>int(Integer(x) % self._modulus)
+            sig_on()
+            nmod_mpoly_set_ui(f._poly, coeff, self._ctx)
+            sig_off()
+            return f
+
+        # base ring element
+        if x in self._base:
+            f = self._new_element()
+            coeff = <ulong>int(self._base(x))
+            sig_on()
+            nmod_mpoly_set_ui(f._poly, coeff, self._ctx)
+            sig_off()
+            return f
+
+        if isinstance(x, str):
+            f = self._new_element()
+            bnames = [str_to_bytes(v) for v in self.variable_names()]
+            cnames = <const char **>sig_malloc(n * sizeof(char *))
+            if cnames == NULL:
+                raise MemoryError
+            for i in range(n):
+                cnames[i] = bnames[i]
+            bstr = str_to_bytes(x)
+            sig_on()
+            ok = nmod_mpoly_set_str_pretty(f._poly, bstr, cnames, self._ctx)
+            sig_off()
+            sig_free(cnames)
+            if ok != 0:
+                raise ValueError("could not parse '{}' as a polynomial".format(x))
+            return f
+
+        if isinstance(x, dict):
+            f = self._new_element()
+            exp = <ulong *>sig_malloc(n * sizeof(ulong))
+            if exp == NULL:
+                raise MemoryError
+            try:
+                for key, val in x.items():
+                    coeff = <ulong>int(self._base(val))
+                    for i in range(n):
+                        exp[i] = key[i]
+                    sig_on()
+                    nmod_mpoly_set_coeff_ui_ui(f._poly, coeff, exp, self._ctx)
+                    sig_off()
+            finally:
+                sig_free(exp)
+            return f
+
+        # try via _mpoly_dict_recursive for MPolynomial types
+        from sage.rings.polynomial.multi_polynomial import MPolynomial
+        if isinstance(x, MPolynomial):
+            return self._element_constructor_(
+                x._mpoly_dict_recursive(self.variable_names(), self._base))
+
+        # last resort: coerce to base ring
+        return self._element_constructor_(self._base(x))
+
+    def _coerce_map_from_(self, R):
+        r"""
+        Return ``True`` if there is a coercion from ``R`` into this ring.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: R.has_coerce_map_from(GF(7))
+            True
+            sage: R.has_coerce_map_from(ZZ)
+            True
+        """
+        if R is self._base or R is ZZ:
+            return True
+        if self._base.has_coerce_map_from(R):
+            return True
+        return MPolynomialRing_base._coerce_map_from_(self, R)
+
+
+cdef class MPolynomial_zmod_flint(MPolynomial_flint_base):
+    r"""
+    A multivariate polynomial over `\ZZ/n\ZZ`, implemented via FLINT.
+
+    EXAMPLES::
+
+        sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+        sage: f = 3*x^2 - y + 1; f
+        3*x^2 + 6*y + 1
+        sage: type(f)
+        <class 'sage.rings.polynomial.multi_polynomial_zmod_flint.MPolynomial_zmod_flint'>
+
+    .. automethod:: _add_
+    .. automethod:: _sub_
+    .. automethod:: _mul_
+    .. automethod:: _neg_
+    """
+
+    def __cinit__(self):
+        # Python zero-initialises the memory; nmod_mpoly_clear on a struct with
+        # alloc=0 is a no-op, so __dealloc__ is safe even if nmod_mpoly_init
+        # was never called.
+        pass
+
+    def __dealloc__(self):
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        if R is not None:
+            nmod_mpoly_clear(self._poly, R._ctx)
+
+    cdef MPolynomial_zmod_flint _new(self):
+        return (<MPolynomialRing_zmod_flint>self._parent)._new_element()
+
+    cpdef _new_constant_poly(self, scalar, parent):
+        r"""
+        Return a new constant polynomial with value ``scalar`` in ``parent``.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: x._new_constant_poly(3, R)
+            3
+        """
+        cdef MPolynomialRing_zmod_flint R = parent
+        cdef MPolynomial_zmod_flint f = R._new_element()
+        cdef ulong c = <ulong>int(R._base(scalar))
+        nmod_mpoly_set_ui(f._poly, c, R._ctx)
+        return f
+
+    def __copy__(self):
+        r"""
+        Return a copy of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: f = 3*x^2 - y + 1
+            sage: g = copy(f)
+            sage: f == g
+            True
+            sage: f is g
+            False
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef MPolynomial_zmod_flint f = R._new_element()
+        sig_on()
+        nmod_mpoly_set(f._poly, self._poly, R._ctx)
+        sig_off()
+        return f
+
+    def __deepcopy__(self, memo=None):
+        r"""
+        Return a deep copy of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: f = x^2 + y
+            sage: g = deepcopy(f)
+            sage: f == g
+            True
+            sage: f is g
+            False
+        """
+        cpy = self.__copy__()
+        if memo is not None:
+            memo[id(self)] = cpy
+        return cpy
+
+    def __reduce__(self):
+        r"""
+        Return data for pickling this polynomial.
+
+        TESTS::
+
+            sage: R.<x,y,z> = PolynomialRing(GF(7), 'x,y,z', implementation='flint')
+            sage: f = 5*x^3*y - 2*y*z + 1
+            sage: loads(dumps(f)) == f
+            True
+        """
+        return (_unpickle_MPolynomial_zmod_flint,
+                (self._parent, self.monomial_coefficients()))
+
+    def _repr_(self):
+        r"""
+        Return a string representation of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(GF(7), 'x,y,z', implementation='flint')
+            sage: 3*x^2*y - z + 1
+            3*x^2*y + 6*z + 1
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef int n = R._ngens
+        cdef char *raw
+        cdef const char **cnames = <const char **>sig_malloc(n * sizeof(char *))
+        if cnames == NULL:
+            raise MemoryError
+        bnames = [str_to_bytes(v) for v in R.variable_names()]
+        for i in range(n):
+            cnames[i] = bnames[i]
+        sig_on()
+        raw = nmod_mpoly_get_str_pretty(self._poly, cnames, R._ctx)
+        sig_off()
+        sig_free(cnames)
+        result = char_to_str(raw)
+        free(raw)
+        # FLINT omits spaces around binary + and -; add them for readability
+        result = re.sub(r'([a-zA-Z0-9])\s*([+-])', r'\1 \2 ', result)
+        return result
+
+    def __hash__(self):
+        r"""
+        Return a hash of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: hash(x) == hash(x)
+            True
+            sage: hash(x) == hash(y)
+            False
+        """
+        return self._hash_c()
+
+    def __bool__(self):
+        r"""
+        Return ``True`` if this polynomial is nonzero.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: bool(x)
+            True
+            sage: bool(R(0))
+            False
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        return not nmod_mpoly_is_zero(self._poly, R._ctx)
+
+    # ===== Predicates =====
+
+    def is_zero(self):
+        r"""
+        Return ``True`` if this polynomial is zero.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: R(0).is_zero()
+            True
+            sage: x.is_zero()
+            False
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        return bool(nmod_mpoly_is_zero(self._poly, R._ctx))
+
+    def is_one(self):
+        r"""
+        Return ``True`` if this polynomial equals 1.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: R(1).is_one()
+            True
+            sage: x.is_one()
+            False
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        return bool(nmod_mpoly_is_one(self._poly, R._ctx))
+
+    def is_constant(self):
+        r"""
+        Return ``True`` if this polynomial is a constant.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: R(0).is_constant()
+            True
+            sage: R(5).is_constant()
+            True
+            sage: x.is_constant()
+            False
+            sage: (x + 1).is_constant()
+            False
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        return bool(nmod_mpoly_is_ui(self._poly, R._ctx))
+
+    def is_term(self):
+        r"""
+        Return ``True`` if this polynomial is a single nonzero term.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: x.is_term()
+            True
+            sage: (3*x^2*y).is_term()
+            True
+            sage: (x + y).is_term()
+            False
+            sage: R(0).is_term()
+            False
+            sage: R(5).is_term()
+            True
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        return nmod_mpoly_length(self._poly, R._ctx) == 1
+
+    def is_monomial(self):
+        r"""
+        Return ``True`` if this polynomial is a monomial.
+
+        A *monomial* has coefficient 1.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: x.is_monomial()
+            True
+            sage: (x^2*y).is_monomial()
+            True
+            sage: (3*x).is_monomial()
+            False
+            sage: R(1).is_monomial()
+            True
+            sage: R(0).is_monomial()
+            False
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        if nmod_mpoly_length(self._poly, R._ctx) != 1:
+            return False
+        return nmod_mpoly_get_term_coeff_ui(self._poly, 0, R._ctx) == 1
+
+    def is_homogeneous(self):
+        r"""
+        Return ``True`` if this polynomial is homogeneous.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(GF(7), 'x,y,z', implementation='flint')
+            sage: (x^2 + y*z).is_homogeneous()
+            True
+            sage: (x^2 + y).is_homogeneous()
+            False
+            sage: R(0).is_homogeneous()
+            True
+            sage: R(5).is_homogeneous()
+            True
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong length = nmod_mpoly_length(self._poly, R._ctx)
+        cdef slong i, j
+        cdef ulong *exp
+        if length <= 1:
+            return True
+        exp = <ulong *>sig_malloc(n * sizeof(ulong))
+        if exp == NULL:
+            raise MemoryError
+        try:
+            nmod_mpoly_get_term_exp_ui(exp, self._poly, 0, R._ctx)
+            ref_deg = 0
+            for j in range(n):
+                ref_deg += exp[j]
+            for i in range(1, length):
+                nmod_mpoly_get_term_exp_ui(exp, self._poly, i, R._ctx)
+                deg = 0
+                for j in range(n):
+                    deg += exp[j]
+                if deg != ref_deg:
+                    return False
+        finally:
+            sig_free(exp)
+        return True
+
+    def is_square(self):
+        r"""
+        Return ``True`` if this polynomial is a perfect square.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: (x^2 + 2*x*y + y^2).is_square()
+            True
+            sage: x.is_square()
+            False
+            sage: R(0).is_square()
+            True
+            sage: R(4).is_square()
+            True
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        return bool(nmod_mpoly_is_square(self._poly, R._ctx))
+
+    # ===== Information =====
+
+    cpdef long number_of_terms(self) noexcept:
+        r"""
+        Return the number of nonzero terms.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: f = x^2 + 3*x*y - y + 2
+            sage: f.number_of_terms()
+            4
+            sage: R(0).number_of_terms()
+            0
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        return nmod_mpoly_length(self._poly, R._ctx)
+
+    def degree(self, x=None):
+        r"""
+        Return the degree of this polynomial in the variable ``x``, or the
+        total degree if ``x`` is ``None``.
+
+        INPUT:
+
+        - ``x`` -- (optional) a generator of the parent ring
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(GF(7), 'x,y,z', implementation='flint')
+            sage: f = x^2*y + y^3*z^4
+            sage: f.degree()
+            7
+            sage: f.degree(x)
+            2
+            sage: f.degree(y)
+            3
+            sage: f.degree(z)
+            4
+            sage: R(0).degree()
+            -1
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        if nmod_mpoly_is_zero(self._poly, R._ctx):
+            return -1
+        if x is None:
+            return self.total_degree()
+        cdef slong var_idx
+        names = R.variable_names()
+        var_name = str(x)
+        if var_name not in names:
+            raise ValueError("{} is not a variable of {}".format(x, R))
+        var_idx = names.index(var_name)
+        return Integer(nmod_mpoly_degree_si(self._poly, var_idx, R._ctx))
+
+    def total_degree(self):
+        r"""
+        Return the total degree of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(GF(7), 'x,y,z', implementation='flint')
+            sage: (x^2*y + y^3*z^4 + 1).total_degree()
+            7
+            sage: R(5).total_degree()
+            0
+            sage: R(0).total_degree()
+            -1
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        if nmod_mpoly_is_zero(self._poly, R._ctx):
+            return -1
+        return Integer(nmod_mpoly_total_degree_si(self._poly, R._ctx))
+
+    def degrees(self):
+        r"""
+        Return a tuple containing the degree of this polynomial in each
+        variable.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(GF(7), 'x,y,z', implementation='flint')
+            sage: f = x^2*y + y^3*z^4
+            sage: f.degrees()
+            (2, 3, 4)
+            sage: R(5).degrees()
+            (0, 0, 0)
+            sage: R(0).degrees()
+            (0, 0, 0)
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong i
+        cdef slong *degs = <slong *>sig_malloc(n * sizeof(slong))
+        if degs == NULL:
+            raise MemoryError
+        try:
+            nmod_mpoly_degrees_si(degs, self._poly, R._ctx)
+            result = tuple(Integer(degs[i]) if degs[i] >= 0 else Integer(0)
+                           for i in range(n))
+        finally:
+            sig_free(degs)
+        return result
+
+    def variables(self):
+        r"""
+        Return a tuple of the variables (generators) actually occurring in
+        this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(GF(7), 'x,y,z', implementation='flint')
+            sage: (x^2*z + 1).variables()
+            (x, z)
+            sage: R(5).variables()
+            ()
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong i
+        cdef int *used = <int *>sig_malloc(n * sizeof(int))
+        if used == NULL:
+            raise MemoryError
+        try:
+            nmod_mpoly_used_vars(used, self._poly, R._ctx)
+            result = tuple(R.gen(i) for i in range(n) if used[i])
+        finally:
+            sig_free(used)
+        return result
+
+    def variable(self, int i=0):
+        r"""
+        Return the ``i``-th variable occurring in this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(GF(7), 'x,y,z', implementation='flint')
+            sage: (x^2*z + 1).variable(0)
+            x
+            sage: (x^2*z + 1).variable(1)
+            z
+        """
+        return self.variables()[i]
+
+    def nvariables(self):
+        r"""
+        Return the number of variables actually occurring in this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(GF(7), 'x,y,z', implementation='flint')
+            sage: (x^2*z + 1).nvariables()
+            2
+            sage: R(5).nvariables()
+            0
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong i
+        cdef int *used = <int *>sig_malloc(n * sizeof(int))
+        if used == NULL:
+            raise MemoryError
+        try:
+            nmod_mpoly_used_vars(used, self._poly, R._ctx)
+            result = sum(1 for i in range(n) if used[i])
+        finally:
+            sig_free(used)
+        return result
+
+    # ===== Coefficients =====
+
+    def monomial_coefficients(self):
+        r"""
+        Return a dictionary of ``{exponent: coefficient}`` pairs.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: f = 2*x^3 - x*y + 5
+            sage: sorted(f.monomial_coefficients().items())
+            [((0, 0), 5), ((1, 1), 6), ((3, 0), 2)]
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong length = nmod_mpoly_length(self._poly, R._ctx)
+        cdef slong i
+        cdef ulong *exp
+        cdef ulong c
+        exp = <ulong *>sig_malloc(n * sizeof(ulong))
+        if exp == NULL:
+            raise MemoryError
+        result = {}
+        try:
+            for i in range(length):
+                c = nmod_mpoly_get_term_coeff_ui(self._poly, i, R._ctx)
+                nmod_mpoly_get_term_exp_ui(exp, self._poly, i, R._ctx)
+                result[ETuple([exp[j] for j in range(n)])] = R._base(c)
+        finally:
+            sig_free(exp)
+        return result
+
+    def coefficients(self):
+        r"""
+        Return the list of coefficients of this polynomial, in the order
+        induced by the term order.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: f = 3*x^2*y - x + 5
+            sage: f.coefficients()
+            [3, 6, 5]
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef slong length = nmod_mpoly_length(self._poly, R._ctx)
+        cdef slong i
+        cdef ulong c
+        result = []
+        for i in range(length):
+            c = nmod_mpoly_get_term_coeff_ui(self._poly, i, R._ctx)
+            result.append(R._base(c))
+        return result
+
+    def exponents(self, as_ETuples=True):
+        r"""
+        Return the list of exponent tuples of the nonzero terms of this
+        polynomial, in the order induced by the term order.
+
+        INPUT:
+
+        - ``as_ETuples`` -- (default: ``True``) if ``True``, return a list of
+          :class:`ETuple`; otherwise, return a list of plain tuples
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: f = 3*x^2*y - x + 5
+            sage: f.exponents()
+            [(2, 1), (1, 0), (0, 0)]
+            sage: f.exponents(as_ETuples=False)
+            [(2, 1), (1, 0), (0, 0)]
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong length = nmod_mpoly_length(self._poly, R._ctx)
+        cdef slong i, j
+        cdef ulong *exp
+        exp = <ulong *>sig_malloc(n * sizeof(ulong))
+        if exp == NULL:
+            raise MemoryError
+        result = []
+        try:
+            for i in range(length):
+                nmod_mpoly_get_term_exp_ui(exp, self._poly, i, R._ctx)
+                t = tuple(int(exp[j]) for j in range(n))
+                if as_ETuples:
+                    result.append(ETuple(t))
+                else:
+                    result.append(t)
+        finally:
+            sig_free(exp)
+        return result
+
+    def monomials(self):
+        r"""
+        Return the list of monomials of this polynomial, in the order
+        induced by the term order.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: f = 3*x^2*y - x + 5
+            sage: f.monomials()
+            [x^2*y, x, 1]
+            sage: R(0).monomials()
+            []
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef slong length = nmod_mpoly_length(self._poly, R._ctx)
+        cdef slong i
+        cdef MPolynomial_zmod_flint m
+        result = []
+        for i in range(length):
+            m = R._new_element()
+            sig_on()
+            nmod_mpoly_get_term_monomial(m._poly, self._poly, i, R._ctx)
+            sig_off()
+            result.append(m)
+        return result
+
+    def constant_coefficient(self):
+        r"""
+        Return the constant coefficient of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: (3*x^2 - 2*y + 4).constant_coefficient()
+            4
+            sage: x.constant_coefficient()
+            0
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef ulong *exp
+        cdef ulong c
+        exp = <ulong *>sig_malloc(n * sizeof(ulong))
+        if exp == NULL:
+            raise MemoryError
+        try:
+            for i in range(n):
+                exp[i] = 0
+            c = nmod_mpoly_get_coeff_ui_ui(self._poly, exp, R._ctx)
+        finally:
+            sig_free(exp)
+        return R._base(c)
+
+    def monomial_coefficient(self, mon):
+        r"""
+        Return the coefficient of the monomial ``mon`` in this polynomial.
+
+        INPUT:
+
+        - ``mon`` -- a monomial in the same ring
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: f = 3*x^2*y - x*y + 5
+            sage: f.monomial_coefficient(x^2*y)
+            3
+            sage: f.monomial_coefficient(x*y)
+            6
+            sage: f.monomial_coefficient(R(1))
+            5
+            sage: f.monomial_coefficient(x)
+            0
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef MPolynomial_zmod_flint m
+        cdef ulong c
+        if isinstance(mon, MPolynomial_zmod_flint) and (<MPolynomial_zmod_flint>mon)._parent is R:
+            m = <MPolynomial_zmod_flint>mon
+        else:
+            m = <MPolynomial_zmod_flint>R(mon)
+        if nmod_mpoly_is_zero(m._poly, R._ctx):
+            raise ValueError("mon must not be equal to 0")
+        sig_on()
+        c = nmod_mpoly_get_coeff_ui_monomial(self._poly, m._poly, R._ctx)
+        sig_off()
+        return R._base(c)
+
+    def coefficient(self, degrees):
+        r"""
+        Return the coefficient of a monomial specified by ``degrees``.
+
+        INPUT:
+
+        - ``degrees`` -- a dictionary mapping generators to nonnegative
+          integers, or a tuple/list of nonnegative integers giving the
+          exponent of each variable
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: f = 3*x^2*y - x*y + 5
+            sage: f.coefficient({x: 2, y: 1})
+            3
+            sage: f.coefficient((2, 1))
+            3
+            sage: f.coefficient((0, 0))
+            5
+            sage: f.coefficient((1, 0))
+            0
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong i
+        cdef ulong *exp
+        cdef ulong c
+
+        if isinstance(degrees, dict):
+            names = R.variable_names()
+            d = [0] * n
+            for k, v in degrees.items():
+                key = str(k)
+                if key not in names:
+                    raise ValueError("{} is not a variable of {}".format(k, R))
+                d[names.index(key)] = int(v)
+            degrees = d
+        else:
+            degrees = list(degrees)
+            if len(degrees) != n:
+                raise ValueError("degrees must have length {}".format(n))
+
+        exp = <ulong *>sig_malloc(n * sizeof(ulong))
+        if exp == NULL:
+            raise MemoryError
+        try:
+            for i in range(n):
+                exp[i] = degrees[i]
+            c = nmod_mpoly_get_coeff_ui_ui(self._poly, exp, R._ctx)
+        finally:
+            sig_free(exp)
+        return R._base(c)
+
+    # ===== Leading term/coefficient/monomial =====
+
+    def lc(self):
+        r"""
+        Return the leading coefficient of this polynomial.
+
+        Returns 0 if this polynomial is zero.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint', order='lex')
+            sage: f = 3*x^2*y - x*y^3 + 5
+            sage: f.lc()
+            3
+            sage: R(0).lc()
+            0
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        if nmod_mpoly_is_zero(self._poly, R._ctx):
+            return R._base.zero()
+        return R._base(nmod_mpoly_get_term_coeff_ui(self._poly, 0, R._ctx))
+
+    def lm(self):
+        r"""
+        Return the leading monomial of this polynomial.
+
+        Returns 0 if this polynomial is zero.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint', order='lex')
+            sage: f = 3*x^2*y - x*y^3 + 5
+            sage: f.lm()
+            x^2*y
+            sage: R(0).lm()
+            0
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef MPolynomial_zmod_flint m
+        if nmod_mpoly_is_zero(self._poly, R._ctx):
+            return R._new_element()
+        m = R._new_element()
+        sig_on()
+        nmod_mpoly_get_term_monomial(m._poly, self._poly, 0, R._ctx)
+        sig_off()
+        return m
+
+    def lt(self):
+        r"""
+        Return the leading term of this polynomial.
+
+        Returns 0 if this polynomial is zero.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint', order='lex')
+            sage: f = 3*x^2*y - x*y^3 + 5
+            sage: f.lt()
+            3*x^2*y
+            sage: R(0).lt()
+            0
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef MPolynomial_zmod_flint t
+        if nmod_mpoly_is_zero(self._poly, R._ctx):
+            return R._new_element()
+        t = R._new_element()
+        sig_on()
+        nmod_mpoly_get_term(t._poly, self._poly, 0, R._ctx)
+        sig_off()
+        return t
+
+    def term_content(self):
+        r"""
+        Return the GCD of the (nonzero) terms of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: (6*x^2*y^2 - 4*x^3*y).term_content()
+            x^2*y
+            sage: R(0).term_content()
+            0
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef MPolynomial_zmod_flint result = R._new_element()
+        sig_on()
+        nmod_mpoly_term_content(result._poly, self._poly, R._ctx)
+        sig_off()
+        return result
+
+    # ===== Arithmetic =====
+
+    cpdef _add_(self, other):
+        r"""
+        Return the sum of this polynomial and ``other``.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: x + y
+            x + y
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef MPolynomial_zmod_flint res = self._new()
+        sig_on()
+        nmod_mpoly_add(res._poly, self._poly,
+                       (<MPolynomial_zmod_flint>other)._poly, R._ctx)
+        sig_off()
+        return res
+
+    cpdef _sub_(self, other):
+        r"""
+        Return the difference of this polynomial and ``other``.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: x - y
+            x + 6*y
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef MPolynomial_zmod_flint res = self._new()
+        sig_on()
+        nmod_mpoly_sub(res._poly, self._poly,
+                       (<MPolynomial_zmod_flint>other)._poly, R._ctx)
+        sig_off()
+        return res
+
+    cpdef _neg_(self):
+        r"""
+        Return the negation of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: -(x + y)
+            6*x + 6*y
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef MPolynomial_zmod_flint res = self._new()
+        sig_on()
+        nmod_mpoly_neg(res._poly, self._poly, R._ctx)
+        sig_off()
+        return res
+
+    cpdef _lmul_(self, Element scalar):
+        r"""
+        Return this polynomial multiplied by the scalar ``scalar``.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: 3 * x
+            3*x
+            sage: x * 3
+            3*x
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef MPolynomial_zmod_flint res = self._new()
+        cdef ulong c = <ulong>int(R._base(scalar))
+        sig_on()
+        nmod_mpoly_scalar_mul_ui(res._poly, self._poly, c, R._ctx)
+        sig_off()
+        return res
+
+    cpdef _mul_(self, other):
+        r"""
+        Return the product of this polynomial and ``other``.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: (x + 1) * (y - 1)
+            x*y + 6*x + y + 6
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef MPolynomial_zmod_flint res = self._new()
+        sig_on()
+        nmod_mpoly_mul(res._poly, self._poly,
+                       (<MPolynomial_zmod_flint>other)._poly, R._ctx)
+        sig_off()
+        return res
+
+    def __pow__(self, exp, mod):
+        r"""
+        Return this polynomial raised to the power ``exp``.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: (x + y)^3
+            x^3 + 3*x^2*y + 3*x*y^2 + y^3
+        """
+        if mod is not None:
+            raise NotImplementedError("modular exponentiation not supported")
+        if exp < 0:
+            raise ValueError("exponent must be non-negative")
+        cdef MPolynomial_zmod_flint self_ = self
+        cdef MPolynomialRing_zmod_flint R = self_._parent
+        cdef MPolynomial_zmod_flint res = self_._new()
+        cdef int ok
+        sig_on()
+        ok = nmod_mpoly_pow_ui(res._poly, self_._poly, <ulong>exp, R._ctx)
+        sig_off()
+        if not ok:
+            raise ArithmeticError("power failed (exponent too large?)")
+        return res
+
+    cpdef _richcmp_(self, other, int op):
+        r"""
+        Compare this polynomial with ``other``.
+
+        Only equality and inequality are supported.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: x == x
+            True
+            sage: x == y
+            False
+            sage: x != y
+            True
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef bint eq = nmod_mpoly_equal(
+            self._poly,
+            (<MPolynomial_zmod_flint>other)._poly,
+            R._ctx)
+        if op == Py_EQ:
+            return bool(eq)
+        if op == Py_NE:
+            return not eq
+        return NotImplemented
+
+    # ===== Division and related =====
+
+    def divides(self, other):
+        r"""
+        Return ``True`` if this polynomial divides ``other``.
+
+        This method requires the base ring to be a field (i.e., the modulus
+        to be prime).
+
+        INPUT:
+
+        - ``other`` -- a polynomial in the same ring
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: f = x^2 - y^2
+            sage: g = x - y
+            sage: g.divides(f)
+            True
+            sage: (x + 1).divides(f)
+            False
+            sage: R(0).divides(f)
+            False
+            sage: g.divides(R(0))
+            True
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        if not R._base.is_field():
+            raise NotImplementedError(
+                "divides over rings with composite characteristic is not implemented")
+        if self.is_zero():
+            return R(other).is_zero()
+        cdef MPolynomial_zmod_flint q = R._new_element()
+        cdef MPolynomial_zmod_flint b = R(other)
+        sig_on()
+        result = nmod_mpoly_divides(q._poly, b._poly, self._poly, R._ctx)
+        sig_off()
+        return bool(result)
+
+    def quo_rem(self, other):
+        r"""
+        Return the quotient and remainder of the division of this polynomial
+        by ``other``.
+
+        This method requires the base ring to be a field.
+
+        INPUT:
+
+        - ``other`` -- a nonzero polynomial in the same ring
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: f = x^2*y + 3*x - 1
+            sage: g = x*y - 1
+            sage: q, r = f.quo_rem(g)
+            sage: q * g + r == f
+            True
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        if not R._base.is_field():
+            raise NotImplementedError(
+                "quo_rem over rings with composite characteristic is not implemented")
+        cdef MPolynomial_zmod_flint q = R._new_element()
+        cdef MPolynomial_zmod_flint r = R._new_element()
+        cdef MPolynomial_zmod_flint b = R(other)
+        if b.is_zero():
+            raise ZeroDivisionError("cannot divide by zero")
+        sig_on()
+        nmod_mpoly_divrem(q._poly, r._poly, self._poly, b._poly, R._ctx)
+        sig_off()
+        return q, r
+
+    def gcd(self, other):
+        r"""
+        Return the greatest common divisor of this polynomial and ``other``.
+
+        Over a field, the result is monic.
+
+        INPUT:
+
+        - ``other`` -- a polynomial in the same ring
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: f = x^2 - y^2
+            sage: g = x - y
+            sage: f.gcd(g)
+            x + 6*y
+            sage: (2*x).gcd(4*y)
+            1
+            sage: f.gcd(R(0))
+            x^2 + 6*y^2
+            sage: R(0).gcd(R(0))
+            0
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef MPolynomial_zmod_flint result = R._new_element()
+        cdef MPolynomial_zmod_flint b = R(other)
+        sig_on()
+        ok = nmod_mpoly_gcd(result._poly, self._poly, b._poly, R._ctx)
+        sig_off()
+        if not ok:
+            raise ArithmeticError("GCD computation failed")
+        return result
+
+    def sqrt(self):
+        r"""
+        Return the square root of this polynomial if it is a perfect square,
+        otherwise raise a :class:`ValueError`.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: f = x^2 + 2*x*y + y^2
+            sage: f.sqrt()
+            x + y
+            sage: R(4).sqrt()
+            2
+            sage: x.sqrt()
+            Traceback (most recent call last):
+            ...
+            ValueError: x is not a perfect square
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef MPolynomial_zmod_flint result = R._new_element()
+        sig_on()
+        ok = nmod_mpoly_sqrt(result._poly, self._poly, R._ctx)
+        sig_off()
+        if not ok:
+            raise ValueError("{} is not a perfect square".format(self))
+        return result
+
+    def monic(self):
+        r"""
+        Return this polynomial divided by its leading coefficient.
+
+        This method requires the base ring to be a field.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: f = 3*x^2 + 2*y
+            sage: f.monic()
+            x^2 + 3*y
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        if not R._base.is_field():
+            raise NotImplementedError(
+                "monic over rings with composite characteristic is not implemented")
+        cdef MPolynomial_zmod_flint result = R._new_element()
+        sig_on()
+        nmod_mpoly_make_monic(result._poly, self._poly, R._ctx)
+        sig_off()
+        return result
+
+    # ===== Calculus =====
+
+    def _derivative(self, var):
+        r"""
+        Return the partial derivative of this polynomial with respect to
+        ``var``.
+
+        INPUT:
+
+        - ``var`` -- a generator of the parent ring (or its name)
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: f = 3*x^3*y^2 + 5*y^2 + 3*x + 2
+            sage: f._derivative(x)
+            2*x^2*y^2 + 3
+            sage: f._derivative(y)
+            6*x^3*y + 3*y
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef MPolynomial_zmod_flint result = R._new_element()
+        cdef slong var_idx
+        if var is None:
+            raise ValueError("you must specify the variable with respect to which to differentiate")
+        names = R.variable_names()
+        var_name = str(var)
+        if var_name not in names:
+            raise ValueError("{} is not a variable of {}".format(var, R))
+        var_idx = names.index(var_name)
+        sig_on()
+        nmod_mpoly_derivative(result._poly, self._poly, var_idx, R._ctx)
+        sig_off()
+        return result
+
+    def derivative(self, *args):
+        r"""
+        Return the (iterated) partial derivative of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: f = x^3 * y^2
+            sage: f.derivative(x)
+            3*x^2*y^2
+            sage: f.derivative(x, x)
+            6*x*y^2
+            sage: f.derivative(x, y)
+            6*x^2*y
+        """
+        result = self
+        for v in args:
+            result = result._derivative(v)
+        return result
+
+    # ===== Factorization =====
+
+    def factor(self):
+        r"""
+        Return the factorization of this polynomial.
+
+        This method requires the base ring to be a field.
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: f = (x^2 - y^2) * (x + 1)
+            sage: F = f.factor()
+            sage: F.unit() * prod(g^e for g, e in F) == f
+            True
+
+        TESTS::
+
+            sage: R(0).factor()
+            Traceback (most recent call last):
+            ...
+            ArithmeticError: factorization of 0 is not defined
+            sage: R(1).factor()
+            1
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        if not R._base.is_field():
+            raise NotImplementedError(
+                "factorization over rings with composite characteristic is not implemented")
+        if self.is_zero():
+            raise ArithmeticError("factorization of 0 is not defined")
+
+        cdef nmod_mpoly_factor_t fac
+        cdef nmod_mpoly_t base_poly
+        cdef MPolynomial_zmod_flint base
+        cdef slong i, length, exp
+        cdef int ok
+        cdef ulong constant
+
+        nmod_mpoly_factor_init(fac, R._ctx)
+        nmod_mpoly_init(base_poly, R._ctx)
+        factors = []
+        try:
+            sig_on()
+            ok = nmod_mpoly_factor(fac, self._poly, R._ctx)
+            sig_off()
+            if not ok:
+                raise ArithmeticError("factorization failed")
+            constant = nmod_mpoly_factor_get_constant_ui(fac, R._ctx)
+            length = nmod_mpoly_factor_length(fac, R._ctx)
+            for i in range(length):
+                nmod_mpoly_factor_get_base(base_poly, fac, i, R._ctx)
+                exp = nmod_mpoly_factor_get_exp_si(fac, i, R._ctx)
+                base = R._new_element()
+                sig_on()
+                nmod_mpoly_set(base._poly, base_poly, R._ctx)
+                sig_off()
+                factors.append((base, int(exp)))
+        finally:
+            nmod_mpoly_clear(base_poly, R._ctx)
+            nmod_mpoly_factor_clear(fac, R._ctx)
+
+        unit = R._base(constant)
+        return Factorization(factors, unit=unit, sort=False)
+
+    # ===== Resultant, discriminant =====
+
+    def resultant(self, other, variable=None):
+        r"""
+        Return the resultant of this polynomial and ``other`` with respect
+        to ``variable``.
+
+        If ``variable`` is not provided, the first variable of the ring is
+        used.
+
+        INPUT:
+
+        - ``other`` -- a polynomial in the same ring
+        - ``variable`` -- (optional) a generator of the ring
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: f = x^2 - y
+            sage: g = x - 1
+            sage: f.resultant(g)
+            6*y + 1
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef MPolynomial_zmod_flint result = R._new_element()
+        cdef MPolynomial_zmod_flint b = R(other)
+        cdef slong var_idx
+
+        if variable is None:
+            var_idx = 0
+        else:
+            names = R.variable_names()
+            var_name = str(variable)
+            if var_name not in names:
+                raise ValueError("{} is not a variable of {}".format(variable, R))
+            var_idx = names.index(var_name)
+
+        sig_on()
+        ok = nmod_mpoly_resultant(result._poly, self._poly, b._poly, var_idx, R._ctx)
+        sig_off()
+        if not ok:
+            raise ArithmeticError("resultant computation failed")
+        return result
+
+    def discriminant(self, variable):
+        r"""
+        Return the discriminant of this polynomial with respect to
+        ``variable``.
+
+        INPUT:
+
+        - ``variable`` -- a generator of the parent ring
+
+        EXAMPLES::
+
+            sage: R.<x,y> = PolynomialRing(GF(7), 'x,y', implementation='flint')
+            sage: f = x^2 + y*x + 1
+            sage: f.discriminant(x)
+            y^2 + 3
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef MPolynomial_zmod_flint result = R._new_element()
+        cdef slong var_idx
+        names = R.variable_names()
+        var_name = str(variable)
+        if var_name not in names:
+            raise ValueError("{} is not a variable of {}".format(variable, R))
+        var_idx = names.index(var_name)
+        sig_on()
+        ok = nmod_mpoly_discriminant(result._poly, self._poly, var_idx, R._ctx)
+        sig_off()
+        if not ok:
+            raise ArithmeticError("discriminant computation failed")
+        return result
+
+    # ===== Evaluation and substitution =====
+
+    def __call__(self, *args, **kwds):
+        r"""
+        Evaluate this polynomial at the given values.
+
+        Positional arguments are assigned to the variables in order. Keyword
+        arguments name variables explicitly. When all values are elements of
+        the base ring and all variables are assigned, the result is in the
+        base ring; otherwise the result is a polynomial in the same ring.
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(GF(7), 'x,y,z', implementation='flint')
+            sage: f = x^2 + y*z + 1
+            sage: f(1, 2, 3)
+            1
+            sage: f(1, 2, 3).parent()
+            Finite Field of size 7
+            sage: f(x, y, z) == f
+            True
+            sage: f(y, x, z)
+            y^2 + x*z + 1
+            sage: f(x=2)
+            y*z + 5
+            sage: f(x=1, y=2, z=3)
+            1
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong i
+        cdef ulong res_ui
+        cdef ulong *vals
+
+        if kwds and args:
+            raise TypeError("cannot mix positional and keyword arguments")
+
+        names = R.variable_names()
+        if args:
+            if len(args) != n:
+                raise TypeError("expected {} positional arguments, got {}".format(n, len(args)))
+            values = list(args)
+        else:
+            values = [None] * n
+            for k, v in kwds.items():
+                if k not in names:
+                    raise ValueError("{} is not a variable of {}".format(k, R))
+                values[names.index(k)] = v
+
+        # fast path: all values are in base ring and all assigned
+        scalar = all(v is not None and v in R._base for v in values)
+        if scalar:
+            vals = <ulong *>sig_malloc(n * sizeof(ulong))
+            if vals == NULL:
+                raise MemoryError
+            try:
+                for i in range(n):
+                    vals[i] = <ulong>int(R._base(values[i]))
+                sig_on()
+                res_ui = nmod_mpoly_evaluate_all_ui(self._poly, vals, R._ctx)
+                sig_off()
+            finally:
+                sig_free(vals)
+            return R._base(res_ui)
+
+        # general path: do substitution (possibly partial)
+        fixed = {}
+        for i in range(n):
+            if values[i] is not None:
+                fixed[names[i]] = values[i]
+        return self.subs(fixed)
+
+    def subs(self, fixed=None, **kw):
+        r"""
+        Substitute variables in this polynomial and return the result.
+
+        Each substitution value may be an element of the base ring or a
+        polynomial in the same ring. Variables not mentioned are left
+        unchanged.
+
+        INPUT:
+
+        - ``fixed`` -- (optional) dict mapping generators or variable names
+          to values
+        - ``**kw`` -- variable names as keyword arguments
+
+        EXAMPLES::
+
+            sage: R.<x,y,z> = PolynomialRing(GF(7), 'x,y,z', implementation='flint')
+            sage: f = x^2 + y^2 + z^2
+            sage: f.subs(x=1, y=2)
+            z^2 + 5
+            sage: f.subs({x: y + 1})
+            2*y^2 + z^2 + 2*y + 1
+            sage: f.subs(x=1, y=2, z=3)
+            0
+            sage: f.subs({x: y, y: x})
+            x^2 + y^2 + z^2
+        """
+        cdef MPolynomialRing_zmod_flint R = self._parent
+        cdef slong n = R._ngens
+        cdef slong i
+        cdef nmod_mpoly_struct **C
+        cdef MPolynomial_zmod_flint res
+
+        # build var_name → value mapping
+        sub = {}
+        if fixed is not None:
+            for k, v in fixed.items():
+                if isinstance(k, MPolynomial_zmod_flint):
+                    k = str(k)
+                sub[str(k)] = v
+        for k, v in kw.items():
+            sub[k] = v
+
+        # build list of substituting polynomials: one per variable
+        var_names = R.variable_names()
+        polys = []
+        for i in range(n):
+            name = var_names[i]
+            if name in sub:
+                v = sub[name]
+                if not isinstance(v, MPolynomial_zmod_flint):
+                    v = R(v)
+                polys.append(<MPolynomial_zmod_flint>v)
+            else:
+                polys.append(<MPolynomial_zmod_flint>R.gen(i))
+
+        # call nmod_mpoly_compose_nmod_mpoly
+        C = <nmod_mpoly_struct **>sig_malloc(n * sizeof(nmod_mpoly_struct *))
+        if C == NULL:
+            raise MemoryError
+        for i in range(n):
+            C[i] = &(<MPolynomial_zmod_flint>polys[i])._poly[0]
+        res = R._new_element()
+        sig_on()
+        ok = nmod_mpoly_compose_nmod_mpoly(res._poly, self._poly, C, R._ctx, R._ctx)
+        sig_off()
+        sig_free(C)
+        if not ok:
+            raise ArithmeticError("composition failed")
+        return res

--- a/src/sage/rings/polynomial/multi_polynomial_zmod_flint.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_zmod_flint.pyx
@@ -1703,6 +1703,10 @@ cdef class MPolynomial_zmod_flint(MPolynomial_flint_base):
         if kwds and args:
             raise TypeError("cannot mix positional and keyword arguments")
 
+        # allow f((a, b, c)) as a shortcut for f(a, b, c)
+        if len(args) == 1 and isinstance(args[0], (list, tuple)):
+            args = tuple(args[0])
+
         names = R.variable_names()
         if args:
             if len(args) != n:

--- a/src/sage/rings/polynomial/polynomial_integer_dense_flint.pyx
+++ b/src/sage/rings/polynomial/polynomial_integer_dense_flint.pyx
@@ -1873,3 +1873,317 @@ cdef class Polynomial_integer_dense_flint(Polynomial):
         sig_off()
 
         return res
+
+    @coerce_binop
+    def divides(self, Polynomial_integer_dense_flint other):
+        r"""
+        Return ``True`` if this polynomial divides ``other``.
+
+        EXAMPLES::
+
+            sage: R.<x> = ZZ[]
+            sage: f = x - 1
+            sage: g = x^3 - 1
+            sage: f.divides(g)
+            True
+            sage: f.divides(x + 1)
+            False
+            sage: R(0).divides(x)
+            False
+            sage: R(0).divides(R(0))
+            True
+            sage: f.divides(R(0))
+            True
+        """
+        cdef Polynomial_integer_dense_flint q
+        cdef int result
+        if self.is_zero():
+            return other.is_zero()
+        q = self._new()
+        sig_on()
+        result = fmpz_poly_divides(q._poly, other._poly, self._poly)
+        sig_off()
+        return bool(result)
+
+    def is_squarefree(self):
+        r"""
+        Return ``True`` if this polynomial is squarefree.
+
+        By convention, the zero polynomial is considered squarefree.
+
+        EXAMPLES::
+
+            sage: R.<x> = ZZ[]
+            sage: (x^2 - 1).is_squarefree()
+            True
+            sage: ((x - 1)^2).is_squarefree()
+            False
+            sage: R(1).is_squarefree()
+            True
+            sage: R(0).is_squarefree()
+            True
+        """
+        sig_on()
+        cdef bint result = fmpz_poly_is_squarefree(self._poly)
+        sig_off()
+        return bool(result)
+
+    def is_cyclotomic(self, certificate=False, algorithm=None):
+        r"""
+        Test whether this polynomial is a cyclotomic polynomial.
+
+        A *cyclotomic polynomial* is a monic, irreducible polynomial such that
+        all roots are roots of unity.
+
+        INPUT:
+
+        - ``certificate`` -- boolean (default: ``False``); if ``True``, return
+          ``0`` if not cyclotomic, otherwise return the positive integer ``n``
+          such that ``self`` is the ``n``-th cyclotomic polynomial
+        - ``algorithm`` -- ignored (kept for compatibility with the generic
+          method); FLINT's algorithm is always used
+
+        EXAMPLES::
+
+            sage: R.<x> = ZZ[]
+            sage: (x^2 + x + 1).is_cyclotomic()
+            True
+            sage: (x^2 + x + 1).is_cyclotomic(certificate=True)
+            3
+            sage: (x^2 - 1).is_cyclotomic()
+            False
+            sage: (x^2 - 1).is_cyclotomic(certificate=True)
+            0
+            sage: R(1).is_cyclotomic()
+            False
+        """
+        sig_on()
+        cdef ulong idx = fmpz_poly_is_cyclotomic(self._poly)
+        sig_off()
+        if certificate:
+            return Integer(idx)
+        return bool(idx)
+
+    def taylor_shift(self, c):
+        r"""
+        Return ``self(x + c)``, the Taylor shift of this polynomial by ``c``.
+
+        INPUT:
+
+        - ``c`` -- an integer
+
+        EXAMPLES::
+
+            sage: R.<x> = ZZ[]
+            sage: f = x^3 + 2*x - 1
+            sage: f.taylor_shift(1)
+            x^3 + 3*x^2 + 5*x + 2
+            sage: f.taylor_shift(1) == f(x + 1)
+            True
+            sage: f.taylor_shift(-2)
+            x^3 - 6*x^2 + 14*x - 13
+        """
+        cdef Polynomial_integer_dense_flint res = self._new()
+        cdef fmpz_t c_fmpz
+        cdef Integer cc = ZZ(c)
+        fmpz_init(c_fmpz)
+        fmpz_set_mpz(c_fmpz, cc.value)
+        sig_on()
+        fmpz_poly_taylor_shift(res._poly, self._poly, c_fmpz)
+        sig_off()
+        fmpz_clear(c_fmpz)
+        return res
+
+    def height(self):
+        r"""
+        Return the height of this polynomial, that is, the maximum of the
+        absolute values of the coefficients.
+
+        EXAMPLES::
+
+            sage: R.<x> = ZZ[]
+            sage: (3*x^2 - 7*x + 2).height()
+            7
+            sage: R(0).height()
+            0
+            sage: R(-5).height()
+            5
+        """
+        cdef fmpz_t h
+        cdef Integer result = Integer.__new__(Integer)
+        fmpz_init(h)
+        sig_on()
+        fmpz_poly_height(h, self._poly)
+        sig_off()
+        fmpz_get_mpz(result.value, h)
+        fmpz_clear(h)
+        return result
+
+    def bound_roots(self):
+        r"""
+        Return a nonnegative integer `B` such that every complex root `z` of
+        this polynomial satisfies `|z| \le B`.
+
+        EXAMPLES::
+
+            sage: R.<x> = ZZ[]
+            sage: B = ((x - 3) * (x + 5)).bound_roots()
+            sage: all(abs(r) <= B for r in [-5, 3])
+            True
+            sage: (x^2 - 2).bound_roots()
+            2
+            sage: R(7).bound_roots()
+            0
+        """
+        cdef fmpz_t b
+        cdef Integer result = Integer.__new__(Integer)
+        fmpz_init(b)
+        sig_on()
+        fmpz_poly_bound_roots(b, self._poly)
+        sig_off()
+        fmpz_get_mpz(result.value, b)
+        fmpz_clear(b)
+        return result
+
+    def num_real_roots(self):
+        r"""
+        Return the number of distinct real roots of this polynomial.
+
+        EXAMPLES::
+
+            sage: R.<x> = ZZ[]
+            sage: (x^2 - 1).num_real_roots()
+            2
+            sage: (x^2 + 1).num_real_roots()
+            0
+            sage: ((x - 1)^2 * (x + 2)).num_real_roots()
+            2
+            sage: ((x^2 - 2)*(x^2 - 3)).num_real_roots()
+            4
+            sage: R(0).num_real_roots()
+            Traceback (most recent call last):
+            ...
+            ValueError: number of real roots is not defined for the zero polynomial
+        """
+        if self.is_zero():
+            raise ValueError("number of real roots is not defined for the zero polynomial")
+        # FLINT requires the polynomial to be squarefree
+        cdef Polynomial_integer_dense_flint sf
+        if fmpz_poly_is_squarefree(self._poly):
+            sf = self
+        else:
+            sf = self._new()
+            sig_on()
+            fmpz_poly_divexact(sf._poly, self._poly,
+                               (<Polynomial_integer_dense_flint>self.gcd(self.derivative()))._poly)
+            sig_off()
+        sig_on()
+        cdef slong n = fmpz_poly_num_real_roots(sf._poly)
+        sig_off()
+        return Integer(n)
+
+    def nth_derivative(self, n):
+        r"""
+        Return the ``n``-th derivative of this polynomial.
+
+        INPUT:
+
+        - ``n`` -- a nonnegative integer
+
+        EXAMPLES::
+
+            sage: R.<x> = ZZ[]
+            sage: f = x^4 + 3*x^2 + 5
+            sage: f.nth_derivative(0) == f
+            True
+            sage: f.nth_derivative(1)
+            4*x^3 + 6*x
+            sage: f.nth_derivative(2)
+            12*x^2 + 6
+            sage: f.nth_derivative(4)
+            24
+            sage: f.nth_derivative(10)
+            0
+        """
+        if n < 0:
+            raise ValueError("n must be a nonnegative integer")
+        cdef Polynomial_integer_dense_flint res = self._new()
+        sig_on()
+        fmpz_poly_nth_derivative(res._poly, self._poly, <ulong>n)
+        sig_off()
+        return res
+
+    @coerce_binop
+    def compose_series(self, Polynomial_integer_dense_flint other, n):
+        r"""
+        Return the composition of this polynomial with ``other`` modulo `x^n`.
+
+        The polynomial ``other`` must have zero constant term so that the
+        composition is well-defined as a power series.
+
+        INPUT:
+
+        - ``other`` -- a polynomial with zero constant coefficient
+        - ``n`` -- a nonnegative integer
+
+        EXAMPLES::
+
+            sage: R.<x> = ZZ[]
+            sage: f = 1 + x + x^2
+            sage: g = x + x^3
+            sage: f.compose_series(g, 6)
+            2*x^4 + x^3 + x^2 + x + 1
+            sage: (1 + x).compose_series(x, 4)
+            x + 1
+
+        TESTS::
+
+            sage: f.compose_series(1 + x, 4)
+            Traceback (most recent call last):
+            ...
+            ValueError: other must have zero constant term
+        """
+        if n < 0:
+            raise ValueError("n must be a nonnegative integer")
+        if not other.is_zero() and fmpz_poly_length(other._poly) > 0:
+            # check constant term
+            if other[0] != 0:
+                raise ValueError("other must have zero constant term")
+        cdef Polynomial_integer_dense_flint res = self._new()
+        sig_on()
+        fmpz_poly_compose_series(res._poly, self._poly, other._poly, <slong>n)
+        sig_off()
+        return res
+
+    def power_sums(self, n):
+        r"""
+        Return the polynomial whose coefficients are the Newton power sums
+        of the roots of this polynomial, up to (but not including) order
+        ``n``.
+
+        If `r_1, \dots, r_d` are the roots of this polynomial (counted with
+        multiplicity), then the returned polynomial is
+        `\sum_{k=0}^{n-1} p_k x^k` where `p_k = \sum_i r_i^k`.
+
+        INPUT:
+
+        - ``n`` -- a nonnegative integer
+
+        EXAMPLES::
+
+            sage: R.<x> = ZZ[]
+            sage: f = (x - 1) * (x - 2) * (x + 3)
+            sage: f.power_sums(5)
+            98*x^4 - 18*x^3 + 14*x^2 + 3
+            sage: f.power_sums(0)
+            0
+        """
+        if n < 0:
+            raise ValueError("n must be a nonnegative integer")
+        if self.is_zero():
+            raise ValueError("power_sums is not defined for the zero polynomial")
+        cdef Polynomial_integer_dense_flint res = self._new()
+        sig_on()
+        fmpz_poly_power_sums(res._poly, self._poly, <slong>n)
+        sig_off()
+        return res

--- a/src/sage/rings/polynomial/polynomial_rational_flint.pyx
+++ b/src/sage/rings/polynomial/polynomial_rational_flint.pyx
@@ -2576,3 +2576,269 @@ cdef class Polynomial_rational_flint(Polynomial):
                 (d1 > d/2 and d1 < d-2 and d1.is_prime()):
                 return (2 if self.disc().is_square() else 1)
         return 0
+
+    @coerce_binop
+    def divides(self, Polynomial_rational_flint other):
+        r"""
+        Return ``True`` if this polynomial divides ``other``.
+
+        EXAMPLES::
+
+            sage: R.<x> = QQ[]
+            sage: f = x - 1
+            sage: g = x^3 - 1
+            sage: f.divides(g)
+            True
+            sage: f.divides(x + 1)
+            False
+            sage: R(0).divides(x)
+            False
+            sage: R(0).divides(R(0))
+            True
+            sage: f.divides(R(0))
+            True
+        """
+        cdef Polynomial_rational_flint q
+        cdef int result
+        if self.is_zero():
+            return other.is_zero()
+        q = self._new()
+        sig_str("FLINT exception")
+        result = fmpq_poly_divides(q._poly, other._poly, self._poly)
+        sig_off()
+        return bool(result)
+
+    def is_squarefree(self):
+        r"""
+        Return ``True`` if this polynomial is squarefree.
+
+        By convention, the zero polynomial is considered squarefree.
+
+        EXAMPLES::
+
+            sage: R.<x> = QQ[]
+            sage: (x^2 - 1).is_squarefree()
+            True
+            sage: ((x - 1)^2).is_squarefree()
+            False
+            sage: R(1).is_squarefree()
+            True
+            sage: R(0).is_squarefree()
+            True
+        """
+        sig_on()
+        cdef bint result = fmpq_poly_is_squarefree(self._poly)
+        sig_off()
+        return bool(result)
+
+    def is_monic(self):
+        r"""
+        Return ``True`` if this polynomial is monic.
+
+        A polynomial is monic if its leading coefficient is `1`.
+
+        EXAMPLES::
+
+            sage: R.<x> = QQ[]
+            sage: (x^2 + 1/2*x - 3).is_monic()
+            True
+            sage: (2*x^2 + x).is_monic()
+            False
+            sage: R(0).is_monic()
+            False
+            sage: R(1).is_monic()
+            True
+        """
+        return bool(fmpq_poly_is_monic(self._poly))
+
+    def content(self):
+        r"""
+        Return the content of this polynomial.
+
+        The content is the rational number whose absolute value is the
+        positive gcd of the numerators divided by the lcm of the
+        denominators of the coefficients; its sign is the sign of the
+        leading coefficient.
+
+        EXAMPLES::
+
+            sage: R.<x> = QQ[]
+            sage: (3*x^2 + 6*x - 9).content()
+            3
+            sage: (x/2 + 1/3).content()
+            1/6
+            sage: R(0).content()
+            0
+        """
+        cdef Rational result = Rational.__new__(Rational)
+        cdef fmpq_t c
+        fmpq_init(c)
+        sig_on()
+        fmpq_poly_content(c, self._poly)
+        sig_off()
+        fmpq_get_mpq(result.value, c)
+        fmpq_clear(c)
+        return result
+
+    def primitive_part(self):
+        r"""
+        Return the primitive part of this polynomial.
+
+        The primitive part is obtained by dividing by the content. The result
+        is a polynomial with integer coefficients (viewed as an element of
+        `\QQ[x]`).
+
+        EXAMPLES::
+
+            sage: R.<x> = QQ[]
+            sage: (3*x^2 - 6*x + 9).primitive_part()
+            x^2 - 2*x + 3
+            sage: (x/2 + 1/3).primitive_part()
+            3*x + 2
+            sage: R(0).primitive_part()
+            0
+        """
+        cdef Polynomial_rational_flint res = self._new()
+        sig_str("FLINT exception")
+        fmpq_poly_primitive_part(res._poly, self._poly)
+        sig_off()
+        return res
+
+    def nth_derivative(self, n):
+        r"""
+        Return the ``n``-th derivative of this polynomial.
+
+        INPUT:
+
+        - ``n`` -- a nonnegative integer
+
+        EXAMPLES::
+
+            sage: R.<x> = QQ[]
+            sage: f = x^4/24 + x^2/2 + 1
+            sage: f.nth_derivative(0) == f
+            True
+            sage: f.nth_derivative(1)
+            1/6*x^3 + x
+            sage: f.nth_derivative(2)
+            1/2*x^2 + 1
+            sage: f.nth_derivative(4)
+            1
+            sage: f.nth_derivative(10)
+            0
+        """
+        if n < 0:
+            raise ValueError("n must be a nonnegative integer")
+        cdef Polynomial_rational_flint res = self._new()
+        sig_str("FLINT exception")
+        fmpq_poly_nth_derivative(res._poly, self._poly, <ulong>n)
+        sig_off()
+        return res
+
+    @coerce_binop
+    def compose_series(self, Polynomial_rational_flint other, n):
+        r"""
+        Return the composition of this polynomial with ``other`` modulo
+        `x^n`.
+
+        The polynomial ``other`` must have zero constant term so that the
+        composition is well-defined as a power series.
+
+        INPUT:
+
+        - ``other`` -- a polynomial with zero constant coefficient
+        - ``n`` -- a nonnegative integer
+
+        EXAMPLES::
+
+            sage: R.<x> = QQ[]
+            sage: f = 1 + x/2 + x^2/3
+            sage: g = x - x^2
+            sage: f.compose_series(g, 4)
+            -2/3*x^3 - 1/6*x^2 + 1/2*x + 1
+            sage: (1 + x).compose_series(x, 4)
+            x + 1
+
+        TESTS::
+
+            sage: f.compose_series(1 + x, 4)
+            Traceback (most recent call last):
+            ...
+            ValueError: other must have zero constant term
+        """
+        if n < 0:
+            raise ValueError("n must be a nonnegative integer")
+        if other[0] != 0:
+            raise ValueError("other must have zero constant term")
+        cdef Polynomial_rational_flint res = self._new()
+        sig_str("FLINT exception")
+        fmpq_poly_compose_series(res._poly, self._poly, other._poly, <slong>n)
+        sig_off()
+        return res
+
+    def power_sums(self, n):
+        r"""
+        Return the polynomial whose coefficients are the Newton power sums
+        of the roots of this polynomial, up to (but not including) order
+        ``n``.
+
+        If `r_1, \dots, r_d` are the roots of this polynomial (counted with
+        multiplicity), then the returned polynomial is
+        `\sum_{k=0}^{n-1} p_k x^k` where `p_k = \sum_i r_i^k`.
+
+        INPUT:
+
+        - ``n`` -- a nonnegative integer
+
+        EXAMPLES::
+
+            sage: R.<x> = QQ[]
+            sage: f = (x - 1) * (x - 2) * (x + 1/2)
+            sage: f.power_sums(5)
+            273/16*x^4 + 71/8*x^3 + 21/4*x^2 + 5/2*x + 3
+            sage: f.power_sums(0)
+            0
+        """
+        if n < 0:
+            raise ValueError("n must be a nonnegative integer")
+        if self.is_zero():
+            raise ValueError("power_sums is not defined for the zero polynomial")
+        cdef Polynomial_rational_flint res = self._new()
+        sig_str("FLINT exception")
+        fmpq_poly_power_sums(res._poly, self._poly, <slong>n)
+        sig_off()
+        return res
+
+    def rescale(self, a):
+        r"""
+        Return the polynomial ``self(a * x)``.
+
+        INPUT:
+
+        - ``a`` -- a rational number
+
+        EXAMPLES::
+
+            sage: R.<x> = QQ[]
+            sage: f = x^3 - 2*x + 1
+            sage: f.rescale(2)
+            8*x^3 - 4*x + 1
+            sage: f.rescale(1/2)
+            1/8*x^3 - x + 1
+            sage: f.rescale(0)
+            1
+        """
+        cdef Rational aa = QQ(a)
+        # FLINT's fmpq_poly_rescale uses the convention 0^0 = 0; handle
+        # the a = 0 case manually so that the result is the constant term.
+        if aa.is_zero():
+            return self.parent()(self[0])
+        cdef Polynomial_rational_flint res = self._new()
+        cdef fmpq_t a_fmpq
+        fmpq_init(a_fmpq)
+        fmpq_set_mpq(a_fmpq, aa.value)
+        sig_str("FLINT exception")
+        fmpq_poly_rescale(res._poly, self._poly, a_fmpq)
+        sig_off()
+        fmpq_clear(a_fmpq)
+        return res

--- a/src/sage/rings/polynomial/polynomial_ring_constructor.py
+++ b/src/sage/rings/polynomial/polynomial_ring_constructor.py
@@ -909,6 +909,15 @@ def _multi_variate(base_ring, names, sparse=None, order='degrevlex', implementat
         else:
             implementation_names.update([None, "singular"])
 
+    if R is None and implementation == "flint":
+        from sage.rings.integer_ring import ZZ
+        if base_ring is not ZZ:
+            raise ValueError("FLINT multivariate polynomial implementation only supports ZZ as base ring")
+        from sage.rings.polynomial.multi_polynomial_integer_flint import (
+            MPolynomialRing_integer_flint,
+        )
+        R = MPolynomialRing_integer_flint(base_ring, n, names, order)
+
     if R is None and implementation is None:
         # Interpret implementation=None as implementation="generic"
         implementation = "generic"

--- a/src/sage/rings/polynomial/polynomial_ring_constructor.py
+++ b/src/sage/rings/polynomial/polynomial_ring_constructor.py
@@ -911,11 +911,17 @@ def _multi_variate(base_ring, names, sparse=None, order='degrevlex', implementat
 
     if R is None and implementation == "flint":
         from sage.rings.integer_ring import ZZ
+        from sage.rings.rational_field import QQ
         if base_ring is ZZ:
             from sage.rings.polynomial.multi_polynomial_integer_flint import (
                 MPolynomialRing_integer_flint,
             )
             R = MPolynomialRing_integer_flint(base_ring, n, names, order)
+        elif base_ring is QQ:
+            from sage.rings.polynomial.multi_polynomial_rational_flint import (
+                MPolynomialRing_rational_flint,
+            )
+            R = MPolynomialRing_rational_flint(base_ring, n, names, order)
         elif isinstance(base_ring, sage.rings.abc.IntegerModRing) or (
                 base_ring.is_finite() and base_ring.is_field()
                 and base_ring.characteristic() == base_ring.cardinality()):
@@ -926,7 +932,7 @@ def _multi_variate(base_ring, names, sparse=None, order='degrevlex', implementat
         else:
             raise ValueError(
                 "FLINT multivariate polynomial implementation only supports "
-                "ZZ or Z/nZ as base ring")
+                "ZZ, QQ, or Z/nZ as base ring")
 
     if R is None and implementation is None:
         # Interpret implementation=None as implementation="generic"

--- a/src/sage/rings/polynomial/polynomial_ring_constructor.py
+++ b/src/sage/rings/polynomial/polynomial_ring_constructor.py
@@ -911,12 +911,22 @@ def _multi_variate(base_ring, names, sparse=None, order='degrevlex', implementat
 
     if R is None and implementation == "flint":
         from sage.rings.integer_ring import ZZ
-        if base_ring is not ZZ:
-            raise ValueError("FLINT multivariate polynomial implementation only supports ZZ as base ring")
-        from sage.rings.polynomial.multi_polynomial_integer_flint import (
-            MPolynomialRing_integer_flint,
-        )
-        R = MPolynomialRing_integer_flint(base_ring, n, names, order)
+        if base_ring is ZZ:
+            from sage.rings.polynomial.multi_polynomial_integer_flint import (
+                MPolynomialRing_integer_flint,
+            )
+            R = MPolynomialRing_integer_flint(base_ring, n, names, order)
+        elif isinstance(base_ring, sage.rings.abc.IntegerModRing) or (
+                base_ring.is_finite() and base_ring.is_field()
+                and base_ring.characteristic() == base_ring.cardinality()):
+            from sage.rings.polynomial.multi_polynomial_zmod_flint import (
+                MPolynomialRing_zmod_flint,
+            )
+            R = MPolynomialRing_zmod_flint(base_ring, n, names, order)
+        else:
+            raise ValueError(
+                "FLINT multivariate polynomial implementation only supports "
+                "ZZ or Z/nZ as base ring")
 
     if R is None and implementation is None:
         # Interpret implementation=None as implementation="generic"

--- a/src/sage/rings/polynomial/polynomial_zmod_flint.pyx
+++ b/src/sage/rings/polynomial/polynomial_zmod_flint.pyx
@@ -1049,3 +1049,406 @@ cdef class Polynomial_zmod_flint(Polynomial_template):
     # polynomial_gf2x has modular_composition as the method name so here we
     # allow both
     modular_composition = compose_mod
+
+    @coerce_binop
+    def divides(self, Polynomial_zmod_flint other):
+        r"""
+        Return ``True`` if this polynomial divides ``other``.
+
+        EXAMPLES::
+
+            sage: R.<x> = GF(7)[]
+            sage: f = x - 1
+            sage: g = x^3 - 1
+            sage: f.divides(g)
+            True
+            sage: f.divides(x + 1)
+            False
+            sage: R(0).divides(x)
+            False
+            sage: R(0).divides(R(0))
+            True
+            sage: f.divides(R(0))
+            True
+
+        Also works over `\ZZ/n\ZZ` for composite ``n``::
+
+            sage: R.<x> = Zmod(15)[]
+            sage: (x - 1).divides(x^2 - 1)
+            True
+            sage: (x - 1).divides(x + 1)
+            False
+        """
+        cdef Polynomial_zmod_flint q
+        cdef int result
+        if self.is_zero():
+            return other.is_zero()
+        q = self._new()
+        sig_on()
+        result = nmod_poly_divides(&q.x, &other.x, &self.x)
+        sig_off()
+        return bool(result)
+
+    def is_squarefree(self):
+        r"""
+        Return ``True`` if this polynomial is squarefree.
+
+        A nonzero polynomial is squarefree if and only if it is coprime to its
+        derivative. By convention, the zero polynomial is considered
+        squarefree.
+
+        This method requires the base ring to be a field (i.e., the modulus
+        to be prime).
+
+        EXAMPLES::
+
+            sage: R.<x> = GF(7)[]
+            sage: (x^2 - 1).is_squarefree()
+            True
+            sage: ((x - 1)^2).is_squarefree()
+            False
+            sage: R(0).is_squarefree()
+            True
+            sage: R(1).is_squarefree()
+            True
+
+        TESTS::
+
+            sage: R.<x> = Zmod(6)[]
+            sage: (x^2 - 1).is_squarefree()
+            Traceback (most recent call last):
+            ...
+            NotImplementedError: squarefree test of polynomials over rings with composite characteristic is not implemented
+        """
+        if not self.base_ring().is_field():
+            raise NotImplementedError(
+                "squarefree test of polynomials over rings with composite characteristic is not implemented")
+        if self.is_zero():
+            return True
+        return self.gcd(self._derivative()).is_one() or self.gcd(self._derivative()).is_unit()
+
+    def _derivative(self, var=None):
+        r"""
+        Return the formal derivative of this polynomial.
+
+        INPUT:
+
+        - ``var`` -- (optional) must be either ``None`` or the unique
+          generator of the parent ring
+
+        EXAMPLES::
+
+            sage: R.<x> = GF(5)[]
+            sage: f = 3*x^3 + 4*x^2 + 2*x + 1
+            sage: f._derivative()
+            4*x^2 + 3*x + 2
+            sage: f._derivative(x)
+            4*x^2 + 3*x + 2
+            sage: f._derivative(x) == f.derivative()
+            True
+        """
+        if var is not None and var is not self._parent.gen():
+            raise ValueError("cannot differentiate with respect to {}".format(var))
+        cdef Polynomial_zmod_flint res = self._new()
+        sig_on()
+        nmod_poly_derivative(&res.x, &self.x)
+        sig_off()
+        return res
+
+    def integral(self):
+        r"""
+        Return the formal integral of this polynomial with constant term zero.
+
+        The coefficient of degree `k+1` in the result is the coefficient of
+        degree `k` in ``self`` divided by `k+1`. This requires `k+1` to be
+        invertible modulo the modulus for every nonzero coefficient.
+
+        EXAMPLES::
+
+            sage: R.<x> = GF(5)[]
+            sage: (x^2 + 3*x + 1).integral()
+            2*x^3 + 4*x^2 + x
+
+        TESTS::
+
+            sage: R.<x> = GF(5)[]
+            sage: (x^4).integral()
+            Traceback (most recent call last):
+            ...
+            ArithmeticError: integration not possible: leading exponent is not invertible
+        """
+        cdef unsigned long n = nmod_poly_modulus(&self.x)
+        cdef long deg = nmod_poly_degree(&self.x)
+        cdef long k
+        # ensure all required divisors are invertible
+        for k in range(1, deg + 2):
+            if nmod_poly_get_coeff_ui(&self.x, k - 1) != 0:
+                from sage.arith.misc import GCD
+                if GCD(k, n) != 1:
+                    raise ArithmeticError(
+                        "integration not possible: leading exponent is not invertible")
+        cdef Polynomial_zmod_flint res = self._new()
+        sig_on()
+        nmod_poly_integral(&res.x, &self.x)
+        sig_off()
+        return res
+
+    def discriminant(self):
+        r"""
+        Return the discriminant of this polynomial.
+
+        This method requires the base ring to be a field (i.e., the modulus
+        to be prime).
+
+        EXAMPLES::
+
+            sage: R.<x> = GF(7)[]
+            sage: (x^2 + x + 1).discriminant()
+            4
+            sage: (x^3 - x).discriminant()
+            4
+            sage: R(5).discriminant()
+            0
+
+        TESTS::
+
+            sage: R.<x> = Zmod(6)[]
+            sage: (x^2 + 1).discriminant()
+            Traceback (most recent call last):
+            ...
+            NotImplementedError: discriminant of polynomials over rings with composite characteristic is not implemented
+        """
+        if not self.base_ring().is_field():
+            raise NotImplementedError(
+                "discriminant of polynomials over rings with composite characteristic is not implemented")
+        sig_on()
+        cdef unsigned long d = nmod_poly_discriminant(&self.x)
+        sig_off()
+        return self.base_ring()(d)
+
+    def taylor_shift(self, c):
+        r"""
+        Return ``self(x + c)``, the Taylor shift of this polynomial by ``c``.
+
+        INPUT:
+
+        - ``c`` -- an element of the base ring (or coercible to it)
+
+        EXAMPLES::
+
+            sage: R.<x> = GF(7)[]
+            sage: f = x^3 + 2*x - 1
+            sage: f.taylor_shift(1)
+            x^3 + 3*x^2 + 5*x + 2
+            sage: f.taylor_shift(1) == f(x + 1)
+            True
+            sage: f.taylor_shift(3)
+            x^3 + 2*x^2 + x + 4
+
+        Also works over `\ZZ/n\ZZ` for composite ``n``::
+
+            sage: R.<x> = Zmod(10)[]
+            sage: (x^2 + x).taylor_shift(2)
+            x^2 + 5*x + 6
+        """
+        cdef unsigned long cc = <unsigned long>(int(self.base_ring()(c)))
+        cdef Polynomial_zmod_flint res = self._new()
+        sig_on()
+        nmod_poly_taylor_shift(&res.x, &self.x, cc)
+        sig_off()
+        return res
+
+    @coerce_binop
+    def compose_series(self, Polynomial_zmod_flint other, n):
+        r"""
+        Return the composition of this polynomial with ``other`` modulo `x^n`.
+
+        The polynomial ``other`` must have zero constant term so that the
+        composition is well-defined as a power series.
+
+        INPUT:
+
+        - ``other`` -- a polynomial with zero constant coefficient
+        - ``n`` -- a nonnegative integer
+
+        EXAMPLES::
+
+            sage: R.<x> = GF(7)[]
+            sage: f = 1 + x + x^2
+            sage: g = x + x^3
+            sage: f.compose_series(g, 6)
+            2*x^4 + x^3 + x^2 + x + 1
+            sage: (1 + x).compose_series(x, 4)
+            x + 1
+
+        TESTS::
+
+            sage: f.compose_series(1 + x, 4)
+            Traceback (most recent call last):
+            ...
+            ValueError: other must have zero constant term
+        """
+        if n < 0:
+            raise ValueError("n must be a nonnegative integer")
+        if not other.is_zero() and nmod_poly_get_coeff_ui(&other.x, 0) != 0:
+            raise ValueError("other must have zero constant term")
+        cdef Polynomial_zmod_flint res = self._new()
+        sig_on()
+        nmod_poly_compose_series(&res.x, &self.x, &other.x, <long>n)
+        sig_off()
+        return res
+
+    def power_sums(self, n):
+        r"""
+        Return the polynomial whose coefficients are the Newton power sums
+        of the roots of this polynomial, up to (but not including) order
+        ``n``.
+
+        If `r_1, \dots, r_d` are the roots of this polynomial (counted with
+        multiplicity), then the returned polynomial is
+        `\sum_{k=0}^{n-1} p_k x^k` where `p_k = \sum_i r_i^k`.
+
+        This method requires the base ring to be a field.
+
+        INPUT:
+
+        - ``n`` -- a nonnegative integer
+
+        EXAMPLES::
+
+            sage: R.<x> = GF(11)[]
+            sage: f = (x - 1) * (x - 2) * (x + 3)
+            sage: f.power_sums(5)
+            10*x^4 + 4*x^3 + 3*x^2 + 3
+            sage: f.power_sums(0)
+            0
+        """
+        if n < 0:
+            raise ValueError("n must be a nonnegative integer")
+        if self.is_zero():
+            raise ValueError("power_sums is not defined for the zero polynomial")
+        if not self.base_ring().is_field():
+            raise NotImplementedError(
+                "power_sums of polynomials over rings with composite characteristic is not implemented")
+        cdef Polynomial_zmod_flint res = self._new()
+        sig_on()
+        nmod_poly_power_sums(&res.x, &self.x, <long>n)
+        sig_off()
+        return res
+
+    def sqrt(self, extend=True):
+        r"""
+        Return the polynomial square root of this polynomial if it is a
+        perfect square in the polynomial ring; otherwise, raise a
+        :class:`ValueError`.
+
+        This method requires the base ring to be a field. The argument
+        ``extend`` is accepted for compatibility but the result, if it
+        exists, is always in the same polynomial ring.
+
+        INPUT:
+
+        - ``extend`` -- ignored (only kept for compatibility)
+
+        EXAMPLES::
+
+            sage: R.<x> = GF(7)[]
+            sage: f = (x^2 + 3*x + 1)^2
+            sage: f.sqrt()
+            x^2 + 3*x + 1
+            sage: R(4).sqrt()
+            2
+            sage: x.sqrt()
+            Traceback (most recent call last):
+            ...
+            ValueError: x is not a perfect square
+        """
+        if not self.base_ring().is_field():
+            raise NotImplementedError(
+                "sqrt of polynomials over rings with composite characteristic is not implemented")
+        cdef Polynomial_zmod_flint res = self._new()
+        cdef int ok
+        sig_on()
+        ok = nmod_poly_sqrt(&res.x, &self.x)
+        sig_off()
+        if not ok:
+            raise ValueError("{} is not a perfect square".format(self))
+        return res
+
+    @coerce_binop
+    def invmod(self, Polynomial_zmod_flint modulus):
+        r"""
+        Return the inverse of this polynomial modulo ``modulus``.
+
+        Raises a :class:`ValueError` if the inverse does not exist (i.e., if
+        this polynomial is not coprime to ``modulus``).
+
+        This method requires the base ring to be a field.
+
+        INPUT:
+
+        - ``modulus`` -- a polynomial in the same ring
+
+        EXAMPLES::
+
+            sage: R.<x> = GF(7)[]
+            sage: f = x + 1
+            sage: m = x^3 + x + 1
+            sage: g = f.invmod(m)
+            sage: (f * g) % m
+            1
+            sage: x.invmod(x^2)
+            Traceback (most recent call last):
+            ...
+            ValueError: x is not invertible modulo x^2
+        """
+        if not self.base_ring().is_field():
+            raise NotImplementedError(
+                "invmod of polynomials over rings with composite characteristic is not implemented")
+        cdef Polynomial_zmod_flint res = self._new()
+        cdef int ok
+        sig_on()
+        ok = nmod_poly_invmod(&res.x, &self.x, &modulus.x)
+        sig_off()
+        if not ok:
+            raise ValueError("{} is not invertible modulo {}".format(self, modulus))
+        return res
+
+    @coerce_binop
+    def remove(self, Polynomial_zmod_flint other):
+        r"""
+        Remove all occurrences of the factor ``other`` from this polynomial.
+
+        Returns a pair ``(k, q)`` where ``k`` is the largest nonnegative
+        integer such that ``other^k`` divides ``self``, and
+        ``q = self / other^k``.
+
+        This method requires the base ring to be a field and ``other`` to
+        have positive degree.
+
+        INPUT:
+
+        - ``other`` -- a polynomial in the same ring with positive degree
+
+        EXAMPLES::
+
+            sage: R.<x> = GF(7)[]
+            sage: f = (x - 2)^3 * (x + 1)
+            sage: f.remove(x - 2)
+            (3, x + 1)
+            sage: f.remove(x + 1)
+            (1, x^3 + x^2 + 5*x + 6)
+            sage: f.remove(x)
+            (0, x^4 + 2*x^3 + 6*x^2 + 4*x + 6)
+        """
+        if not self.base_ring().is_field():
+            raise NotImplementedError(
+                "remove of polynomials over rings with composite characteristic is not implemented")
+        if other.degree() <= 0:
+            raise ValueError("other must have positive degree")
+        cdef Polynomial_zmod_flint res = self._new()
+        sig_on()
+        nmod_poly_set(&res.x, &self.x)
+        cdef unsigned long k = nmod_poly_remove(&res.x, &other.x)
+        sig_off()
+        return Integer(k), res

--- a/tools/flint-autogen/flint/templates/types.pxd.template
+++ b/tools/flint-autogen/flint/templates/types.pxd.template
@@ -922,7 +922,7 @@ cdef extern from "flint_wrap.h":
     ctypedef fmpz_mpoly_ctx_struct fmpz_mpoly_ctx_t[1]
 
     ctypedef struct fmpq_mpoly_ctx_struct:
-        pass
+        fmpz_mpoly_ctx_t zctx
 
     ctypedef fmpq_mpoly_ctx_struct fmpq_mpoly_ctx_t[1]
 

--- a/tools/flint-autogen/flint/templates/types.pxd.template
+++ b/tools/flint-autogen/flint/templates/types.pxd.template
@@ -914,7 +914,7 @@ cdef extern from "flint_wrap.h":
     ctypedef mpoly_ctx_struct mpoly_ctx_t[1]
 
     ctypedef struct nmod_mpoly_ctx_struct:
-        pass
+        mpoly_ctx_t minfo
     ctypedef nmod_mpoly_ctx_struct nmod_mpoly_ctx_t[1]
 
     ctypedef struct fmpz_mpoly_ctx_struct:

--- a/tools/flint-autogen/flint/templates/types.pxd.template
+++ b/tools/flint-autogen/flint/templates/types.pxd.template
@@ -906,7 +906,11 @@ cdef extern from "flint_wrap.h":
         ORD_DEGREVLEX
 
     ctypedef struct mpoly_ctx_struct:
-        pass
+        slong nvars
+        slong nfields
+        ordering_t ord
+        int deg
+        int rev
     ctypedef mpoly_ctx_struct mpoly_ctx_t[1]
 
     ctypedef struct nmod_mpoly_ctx_struct:
@@ -914,7 +918,7 @@ cdef extern from "flint_wrap.h":
     ctypedef nmod_mpoly_ctx_struct nmod_mpoly_ctx_t[1]
 
     ctypedef struct fmpz_mpoly_ctx_struct:
-        pass
+        mpoly_ctx_t minfo
     ctypedef fmpz_mpoly_ctx_struct fmpz_mpoly_ctx_t[1]
 
     ctypedef struct fmpq_mpoly_ctx_struct:


### PR DESCRIPTION
# Expand the FLINT polynomial interface in Sage

This PR widens Sage's use of FLINT for polynomial arithmetic in three
directions: it adds three brand-new FLINT-backed multivariate polynomial
implementations (over `ZZ`, `QQ`, `Z/nZ`), exposes a broad set of
previously-unwrapped FLINT functions on the existing univariate FLINT
classes, and wires the new backends into a concrete consumer
(`ReedMullerPolynomialEncoder`) as a first proof of payoff.

## Summary of changes

### New: multivariate FLINT backends

Three new modules:

- `multi_polynomial_integer_flint.{pxd,pyx}` — `fmpz_mpoly` over `ZZ`
- `multi_polynomial_rational_flint.{pxd,pyx}` — `fmpq_mpoly` over `QQ`
- `multi_polynomial_zmod_flint.{pxd,pyx}` — `nmod_mpoly` over `Z/nZ`
  (and `GF(p)`)

All three are reachable via
`PolynomialRing(R, names, implementation='flint')`. They share a common
parent (`MPolynomial_flint` declared in `multi_polynomial.pxd`) and
implement the standard Sage multivariate API: arithmetic, comparison,
`monomial_coefficients` / `coefficients` / `monomials` / `exponents`,
leading term/monomial/coefficient, `degrees` / `total_degree`,
`variables`, `divides` / `quo_rem` / `gcd` / `sqrt`,
`_derivative` / `derivative` (and `integral` over `QQ`), `factor`,
`resultant` / `discriminant`, `subs` / `__call__`, plus copy/deepcopy/
pickle support.

Cross-backend conversion `R_libsingular(p_flint)` and
`R_flint(p_libsingular)` both work — libsingular's
`_element_constructor_` gained a generic `MPolynomial` fallback that
routes through `_mpoly_dict_recursive`.

### Template fix for opaque FLINT ctx structs

The auto-generated `src/sage/libs/flint/types.pxd` previously declared
`mpoly_ctx_struct`, `nmod_mpoly_ctx_struct` and `fmpq_mpoly_ctx_struct`
as opaque (`pass`), which made the sentinel pattern in
`__cinit__` / `__dealloc__` impossible. The template
`tools/flint-autogen/flint/templates/types.pxd.template` was updated
to expose `minfo` / `zctx`, and the generated file regenerated.

### Wider FLINT coverage on existing univariate classes

New methods on `Polynomial_integer_dense_flint` (`fmpz_poly`):
`divides`, `is_squarefree`, `is_cyclotomic` (with `certificate=True`),
`taylor_shift`, `height`, `bound_roots`, `num_real_roots`,
`nth_derivative`, `compose_series`, `power_sums`.

Similar additions on `Polynomial_rational_flint` (`fmpq_poly`):
`divides`, `is_squarefree`, `is_monic`, `content`, `primitive_part`,
`nth_derivative`, `compose_series`, `power_sums`, `rescale`.

And on `Polynomial_zmod_flint` (`nmod_poly`): `divides`,
`is_squarefree`, `_derivative`, `integral`, `discriminant`,
`taylor_shift`, `compose_series`, `power_sums`, `sqrt`, `invmod`,
`remove` (methods that require a prime modulus raise
`NotImplementedError` for composite ones).

### `ReedMullerPolynomialEncoder` gains a `poly_implementation` keyword

Passing `poly_implementation='flint'` makes the encoder build its
internal polynomial ring with the new backend. Benchmark numbers (see [benchmark_reed_muller.py](https://github.com/user-attachments/files/28840581/benchmark_reed_muller.py):

```
Reed-Muller(GF(5),  order=2, vars=3)  unencode:  32.4 ms → 1.4 ms   (~23x)
Reed-Muller(GF(7),  order=2, vars=4)  unencode: 4810 ms  → 30.8 ms (~156x)
Reed-Muller(GF(11), order=3, vars=3)  unencode: 1324 ms  → 13.2 ms (~100x)
Reed-Muller(GF(3),  order=2, vars=5)  unencode:  111.8 ms → 4.0 ms  (~28x)
```

Encoding (polynomial evaluation at every field point) is roughly on
par between backends; unencoding (multivariate Lagrange interpolation,
multiplication-dominated) is 20–150x faster on FLINT.

## Disclosure: AI involvement

This PR was developed in collaboration with **Anthropic's Claude**
(Claude Code, models Sonnet 4.6 and Opus 4.7). Claude wrote most of
the new Cython under direction from the author, ran the test suite
and benchmark loop, and helped triage compilation errors. Every
commit on this branch carries a `Co-Authored-By: Claude ...` trailer
to make the contribution explicit. The author reviewed all code,
made architectural decisions (class hierarchy, where to expose FLINT
struct fields, which methods to wrap), set the test policy, and
produced the benchmark interpretation. Doctest coverage is
comprehensive for the new code (~1500 new doctests, all passing) and
the pre-existing `multi_polynomial_libsingular.pyx` suite (1378
tests) was re-run after the cross-backend conversion change.