### PR TITLE
update sageinspect.sage_getdoc to return the docstring unchanged

### DIFF
--- a/src/sage/misc/cachefunc.pyx
+++ b/src/sage/misc/cachefunc.pyx
@@ -905,7 +905,6 @@ cdef class CachedFunction():
             sage: I = P * [x,y]
             sage: from sage.misc.sageinspect import sage_getdoc
             sage: print(sage_getdoc(I.groebner_basis))  # indirect doctest
-            WARNING: the enclosing module is marked...
                Return the reduced Groebner basis of this ideal.
             ...
 

--- a/src/sage/misc/sageinspect.py
+++ b/src/sage/misc/sageinspect.py
@@ -2156,7 +2156,6 @@ def sage_getdoc(obj, obj_name='', embedded=False):
         return ''
     r = sage_getdoc_original(obj)
     s = sage.misc.sagedoc.format(r, embedded=embedded)
-    f = sage_getfile(obj)
 
     # Fix object naming
     if obj_name != '':

--- a/src/sage/misc/sageinspect.py
+++ b/src/sage/misc/sageinspect.py
@@ -2157,13 +2157,6 @@ def sage_getdoc(obj, obj_name='', embedded=False):
     r = sage_getdoc_original(obj)
     s = sage.misc.sagedoc.format(r, embedded=embedded)
     f = sage_getfile(obj)
-    if f and os.path.exists(f):
-        from sage.doctest.control import skipfile
-        skip = skipfile(f)
-        if isinstance(skip, str):
-            warn = """WARNING: the enclosing module is marked '{}',
-so doctests may not pass.""".format(skip)
-            s = warn + "\n\n" + s
 
     # Fix object naming
     if obj_name != '':


### PR DESCRIPTION
Currently, `function?` may end up with a string that has a `WARNING:` added to the front if the enclosing module is marked as having certain dependencies. The warning is just about doctests not passing, but a user mainly wants to see documentation when using `?` -- rarely would they be interested in checking if all doctests pass (particularly, at that point doctests aren't run at all and it is quite difficult to run doctests at that point in the first place).
We remove the addition of the warning here.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [X] The title is concise and informative.
- [X] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [X] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


