### PR TITLE
graphs/matching: fix loop detection in edge filtering

### DIFF
--- a/src/sage/graphs/matching.py
+++ b/src/sage/graphs/matching.py
@@ -1194,6 +1194,18 @@ def matching(G, value_only=False, algorithm='Edmonds',
         sage: sorted(m)                                                             # needs sage.networkx
         [(0, 3, 3), (1, 2, 6)]
 
+    Self-loops are filtered out before the matching is computed, so they do
+    not affect the result.  This holds for vertices with any integer label,
+    including labels above 256, which CPython does not cache as identical
+    objects (so the loop filter must compare endpoints by value, not by
+    identity)::
+
+        sage: G = Graph([(300, 300), (300, 301), (302, 303)], loops=True)
+        sage: G.matching(value_only=True, algorithm='Edmonds')                      # needs networkx
+        2
+        sage: G.matching(value_only=True, algorithm='LP')                           # needs sage.numerical.mip
+        2
+
     TESTS:
 
     If ``algorithm`` is set to anything different from ``'Edmonds'`` or
@@ -1215,7 +1227,7 @@ def matching(G, value_only=False, algorithm='Edmonds',
     W = {}
     L = {}
     for u, v, l in G.edge_iterator():
-        if u is v:
+        if u == v:
             continue
         fuv = frozenset((u, v))
         if fuv not in L or (use_edge_labels and W[fuv] < weight(l)):


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

This fixes a pre-existing bug in `Graph.matching()`: a graph with a self-loop on an integer-labelled vertex above 256 raises `ValueError: not enough values to unpack (expected 2, got 1) instead of returning a matching.`

The edge filter skipped loops with an identity test, u is v, which only catches loops whose endpoints are the same Python object. CPython does not cache integers above 256, so a loop on such a vertex slips through the filter and its frozenset collapses to a single element, which then fails to unpack in the Edmonds and LP branches with a ValueError.

Compare endpoints by value, `u == v`, and add a regression test on a graph with a self-loop on a vertex labelled above 256.
Reproducer on develop:

```python
sage: G = Graph([(300, 300), (300, 301)], loops=True)
sage: G.matching(value_only=True, algorithm='Edmonds')
...
ValueError: not enough values to unpack (expected 2, got 1)
```

With this PR it returns 1. The regression doctest checks the result against both the Edmonds and LP algorithms.

:memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

  - [x] The title is concise and informative.
  - [x] The description explains in detail what this PR is about.
  - [x] I have linked a relevant issue or discussion.
  - [x] I have created tests covering the changes.
  - [x] I have updated the documentation and checked the documentation preview.

  :hourglass: Dependencies

  <!-- List all open PRs that this PR logically depends on. For example, -->
  <!-- - #12345: short description why this is a dependency -->
  <!-- - #34567: ... -->

This issue was reported in https://github.com/sagemath/sage/pull/40092#issuecomment-4678975802.
cc: @dcoudert 