### PR TITLE
prepare for removing post-isomorphisms in elliptic-curve isogenies

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -1051,9 +1051,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
 
         sage: E = EllipticCurve(j=GF(7)(0))
         sage: phi = E.isogeny([E(0), E((0,1)), E((0,-1))]); phi
-        Composite morphism of degree 3:
-          From: Elliptic Curve defined by y^2 = x^3 + 1 over Finite Field of size 7
-          To:   Elliptic Curve defined by y^2 = x^3 + 1 over Finite Field of size 7
+        Isogeny of degree 3 from Elliptic Curve defined by y^2 = x^3 + 1 over Finite Field of size 7 to Elliptic Curve defined by y^2 = x^3 + 1 over Finite Field of size 7
         sage: phi2 = phi * phi; phi2
         Composite morphism of degree 9 = 3^2:
           From: Elliptic Curve defined by y^2 = x^3 + 1 over Finite Field of size 7

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -3213,7 +3213,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             sage: z2 = GF(71^2).gen()
             sage: E = EllipticCurve(j=57*z2+51)
             sage: E.isogeny(3*E.lift_x(0)).dual()
-            Composite morphism of degree 71 = 71*1^2:
+            Composite morphism of degree 71 = 71*1:
               From: Elliptic Curve defined by y^2 = x^3 + (32*z2+67)*x + (24*z2+37)
                     over Finite Field in z2 of size 71^2
               To:   Elliptic Curve defined by y^2 = x^3 + (41*z2+56)*x + (18*z2+42)
@@ -3234,7 +3234,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             sage: post = WeierstrassIsomorphism(phi.codomain(), (5,6,7,8))
             sage: phi = post * phi * pre
             sage: phi.dual()
-            Composite morphism of degree 213 = 71*3:
+            Composite morphism of degree 213 = 71*3*1:
               From: Elliptic Curve defined
                     by y^2 + 17*x*y + 45*y = x^3 + 30*x^2 + (6*z2+64)*x + (48*z2+65)
                     over Finite Field in z2 of size 71^2

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -537,9 +537,7 @@ def two_torsion_part(E, psi):
     return psi.gcd(psi_2)
 
 
-def _factored_isogeny_from_kernel_polynomial(E, kernel_polynomial,
-                                             codomain=None, model=None,
-                                             check=True):
+def _factored_isogeny_from_kernel_polynomial(E, kernel_polynomial, check=True):
     r"""
     Construct an isogeny from a kernel polynomial with both a nontrivial
     2-torsion part and another component, recursively extracting
@@ -591,25 +589,127 @@ def _factored_isogeny_from_kernel_polynomial(E, kernel_polynomial,
 
     psi_2tor = two_torsion_part(E, psi)
     if psi_2tor.degree() == 0:
-        return EllipticCurveIsogeny(E, psi, codomain=codomain, model=model,
-                                    check=check)
+        return EllipticCurveIsogeny(E, psi, check=check)
 
     psi_quotient = psi // psi_2tor
     if psi_quotient.degree() == 0:
-        return EllipticCurveIsogeny(E, psi_2tor, codomain=codomain,
-                                    model=model, check=check)
+        return EllipticCurveIsogeny(E, psi_2tor, check=check)
 
     phi_2tor = EllipticCurveIsogeny(E, psi_2tor, check=check)
     psi_image = phi_2tor.push_subgroup(psi_quotient)
-    phi_quotient = _factored_isogeny_from_kernel_polynomial(
-        phi_2tor.codomain(), psi_image, codomain=codomain, model=model,
-        check=check)
+    phi_quotient = _factored_isogeny_from_kernel_polynomial(phi_2tor.codomain(), psi_image, check=check)
     factored_isogeny = phi_quotient * phi_2tor
 
     if check and factored_isogeny.kernel_polynomial() != psi:
         raise ValueError(f"the polynomial {psi} does not define a finite subgroup of {E}")
 
     return factored_isogeny
+
+
+def _construct_isogeny(E, kernel=None, codomain=None, degree=None, model=None, check=True):
+    r"""
+    Wrapper around ``EllipticCurveIsogeny`` class to support old
+    constructor arguments.
+
+    EXAMPLES:
+
+    The following example shows how to specify an isogeny from domain
+    and codomain::
+
+        sage: from sage.schemes.elliptic_curves.ell_curve_isogeny import _construct_isogeny
+        sage: E = EllipticCurve('11a1')
+        sage: R.<x> = QQ[]
+        sage: f = x^2 - 21*x + 80
+        sage: phi = E.isogeny(f)
+        sage: E2 = phi.codomain()
+        sage: phi_s = _construct_isogeny(E, None, E2, 5); phi_s
+        Isogeny of degree 5
+         from Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
+           to Elliptic Curve defined by y^2 + y = x^3 - x^2 - 7820*x - 263580 over Rational Field
+        sage: phi_s == phi
+        True
+        sage: phi_s.rational_maps() == phi.rational_maps()
+        True
+
+    However, only cyclic normalized isogenies can be constructed this way.
+    The non-cyclic multiplication-by-`3` isogeny won't be found::
+
+        sage: from sage.schemes.elliptic_curves.ell_curve_isogeny import _construct_isogeny
+        sage: _construct_isogeny(E, None, codomain=E, degree=9)
+        Traceback (most recent call last):
+        ...
+        ValueError: the two curves are not linked by a cyclic normalized isogeny of degree 9
+
+    Non-normalized isogeny also won't be found::
+
+        sage: from sage.schemes.elliptic_curves.ell_curve_isogeny import _construct_isogeny
+        sage: _construct_isogeny(E2, None, codomain=E, degree=5)
+        Traceback (most recent call last):
+        ...
+        ValueError: the two curves are not linked by a cyclic normalized isogeny of degree 5
+        sage: phihat = phi.dual(); phihat
+        Isogeny of degree 5
+         from Elliptic Curve defined by y^2 + y = x^3 - x^2 - 7820*x - 263580
+              over Rational Field
+           to Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
+        sage: phihat.is_normalized()
+        False
+
+    Here an example of a construction of a endomorphisms with cyclic
+    kernel on a CM-curve::
+
+        sage: from sage.schemes.elliptic_curves.ell_curve_isogeny import _construct_isogeny
+        sage: K.<i> = NumberField(x^2 + 1)
+        sage: E = EllipticCurve(K, [1,0])
+        sage: RK.<X> = K[]
+        sage: f = X^2 - 2/5*i + 1/5
+        sage: phi = _construct_isogeny(E, f, codomain=E)
+        sage: phi.codomain() == phi.domain()
+        True
+        sage: phi.rational_maps()
+        (((4/25*i + 3/25)*x^5 + (4/5*i - 2/5)*x^3 - x)/(x^4 + (-4/5*i + 2/5)*x^2 + (-4/25*i - 3/25)),
+         ((11/125*i + 2/125)*x^6*y + (-23/125*i + 64/125)*x^4*y + (141/125*i + 162/125)*x^2*y + (3/25*i - 4/25)*y)/(x^6 + (-6/5*i + 3/5)*x^4 + (-12/25*i - 9/25)*x^2 + (2/125*i - 11/125)))
+    """
+    if not isinstance(E, EllipticCurve_generic):
+        raise ValueError("given E is not an elliptic curve")
+
+    # if the kernel is None, calculate the kernel polynomial
+    if kernel is None:
+        if codomain is None:
+            raise ValueError("at least one of kernel or codomain must be given")
+
+        if degree is None:
+            raise ValueError("degree must be given when specifying isogeny by domain and codomain")
+
+        pre_isom, _, _, _, kernel = compute_sequence_of_maps(E, codomain, degree)
+        kernel = kernel(pre_isom.x_rational_map())
+        kernel = E.base_ring()['x'](kernel)
+
+    try:
+        phi = EllipticCurveIsogeny(E, kernel=kernel, check=check)
+    except NotImplementedError:
+        phi = _factored_isogeny_from_kernel_polynomial(E, kernel, check=check)
+
+    if model is codomain is None:
+        return phi
+
+    oldE2 = phi._codomain
+
+    if model is not None:
+        if codomain is not None:
+            raise ValueError("cannot specify a codomain curve and model name simultaneously")
+
+        from sage.schemes.elliptic_curves.ell_field import compute_model
+        codomain = compute_model(oldE2, model)
+
+    else:  # codomain is not None
+        if not isinstance(codomain, EllipticCurve_generic):
+            raise ValueError("given codomain is not an elliptic curve")
+
+        if not oldE2.is_isomorphic(codomain):
+            raise ValueError("given codomain is not isomorphic to the computed codomain")
+
+    return oldE2.isomorphism_to(codomain) * phi
 
 
 class EllipticCurveIsogeny(EllipticCurveHom):
@@ -881,7 +981,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
         sage: f = x^2 - 21*x + 80
         sage: phi = E.isogeny(f)
         sage: E2 = phi.codomain()
-        sage: phi_s = EllipticCurveIsogeny(E, None, E2, 5); phi_s
+        sage: phi_s = E.isogeny(None, E2, 5); phi_s
         Isogeny of degree 5
          from Elliptic Curve defined by y^2 + y = x^3 - x^2 - 10*x - 20 over Rational Field
            to Elliptic Curve defined by y^2 + y = x^3 - x^2 - 7820*x - 263580 over Rational Field
@@ -1129,6 +1229,14 @@ class EllipticCurveIsogeny(EllipticCurveHom):
         self.__check = check
 
         self.__init_algebraic_structs(E)
+
+        if codomain is not None:
+            from sage.misc.superseded import deprecation
+            deprecation(42363, "the 'codomain' argument to the EllipticCurveIsogeny constructor is deprecated; use E.isogeny(...) instead of EllipticCurveIsogeny(E, ...)")
+
+        if model is not None:
+            from sage.misc.superseded import deprecation
+            deprecation(42363, f"the 'model' argument to the EllipticCurveIsogeny constructor is deprecated; use E.isogeny(..., codomain={model!r}, ...) instead of EllipticCurveIsogeny(E, ..., model={model!r}, ...)")
 
         # if the kernel is None and the codomain isn't, calculate the kernel polynomial
         if kernel is None and codomain is not None:
@@ -1437,7 +1545,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
 
             sage: E = EllipticCurve(GF(23), [0,0,0,1,0])
             sage: f = E.torsion_polynomial(3)/3
-            sage: phi = EllipticCurveIsogeny(E, f, E)
+            sage: phi = E.isogeny(f, codomain=E)
             sage: phi.rational_maps() == E.multiplication_by_m(3)
             False
             sage: negphi = -phi
@@ -1812,6 +1920,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             sage: E = EllipticCurve(j=GF(7)(1728))
             sage: E2 = EllipticCurve(GF(7), [0,0,0,5,0])
             sage: phi = EllipticCurveIsogeny(E, E((0,0)), E2); phi
+            doctest:warning ...
             Isogeny of degree 2
              from Elliptic Curve defined by y^2 = x^3 + x over Finite Field of size 7
                to Elliptic Curve defined by y^2 = x^3 + 5*x over Finite Field of size 7
@@ -1823,6 +1932,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
                to Elliptic Curve defined by y^2 = x^3 + 6*x over Finite Field of size 7
 
             sage: EllipticCurveIsogeny(E, E(0,0), model='montgomery')
+            doctest:warning ...
             Isogeny of degree 2
              from Elliptic Curve defined by y^2 = x^3 + x over Finite Field of size 7
                to Elliptic Curve defined by y^2 = x^3 + x^2 + x over Finite Field of size 7
@@ -1831,6 +1941,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             sage: E = EllipticCurve(j=1728)
             sage: f = x^3 - x
             sage: phi = EllipticCurveIsogeny(E, f, model='minimal'); phi
+            doctest:warning ...
             Isogeny of degree 4
              from Elliptic Curve defined by y^2 = x^3 - x over Rational Field
                to Elliptic Curve defined by y^2 = x^3 - x over Rational Field
@@ -3303,7 +3414,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
         E1 = self._codomain
         E2 = self._domain.change_weierstrass_model(u/F(d), 0, 0, 0)
 
-        phi_hat = EllipticCurveIsogeny(E1, None, E2, d)
+        phi_hat = _construct_isogeny(E1, None, E2, d)
         assert phi_hat.scaling_factor().is_one()
 
         for post_iso in E2.isomorphisms(self._domain):

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -27,7 +27,7 @@ from sage.schemes.elliptic_curves.ell_point import EllipticCurvePoint_field
 from sage.schemes.curves.projective_curve import ProjectivePlaneCurve_field
 
 from .constructor import EllipticCurve
-from .ell_curve_isogeny import EllipticCurveIsogeny, isogeny_codomain_from_kernel
+from .ell_curve_isogeny import EllipticCurveIsogeny, _construct_isogeny, isogeny_codomain_from_kernel
 from . import ell_generic
 
 
@@ -1904,7 +1904,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
             from sage.schemes.elliptic_curves.hom_composite import EllipticCurveHom_composite
             return EllipticCurveHom_composite(self, kernel, codomain=codomain, model=model, velu_sqrt_bound=velu_sqrt_bound)
         if algorithm == "traditional":
-            return EllipticCurveIsogeny(self, kernel, codomain, degree, model, check=check)
+            return _construct_isogeny(self, kernel, codomain, degree, model, check=check)
 
         if kernel is not None:
             # Check for multiple points or point of known order
@@ -1932,21 +1932,8 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
                 elif known_order:
                     from sage.schemes.elliptic_curves.hom_composite import EllipticCurveHom_composite
                     return EllipticCurveHom_composite(self, kernel, codomain=codomain, model=model, velu_sqrt_bound=velu_sqrt_bound)
-        try:
-            return EllipticCurveIsogeny(self, kernel, codomain, degree, model, check=check)
-        except NotImplementedError as err:
-            if kernel is None:
-                raise err
-            try:
-                from .ell_curve_isogeny import _factored_isogeny_from_kernel_polynomial
-                return _factored_isogeny_from_kernel_polynomial(self, kernel,
-                                                               codomain=codomain,
-                                                               model=model,
-                                                               check=check)
-            except NotImplementedError:
-                raise err
-        except AttributeError as e:
-            raise RuntimeError("Unable to construct isogeny: %s" % e)
+
+        return _construct_isogeny(self, kernel, codomain, degree, model, check=check)
 
     def isogeny_codomain(self, kernel):
         r"""

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -1899,7 +1899,15 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
             raise TypeError('cannot pass "degree" and "algorithm" parameters simultaneously')
         if algorithm == "velusqrt":
             from sage.schemes.elliptic_curves.hom_velusqrt import EllipticCurveHom_velusqrt
-            return EllipticCurveHom_velusqrt(self, kernel, codomain=codomain, model=model)
+            phi = EllipticCurveHom_velusqrt(self, kernel)
+            if model is not None:
+                if codomain is not None:
+                    raise ValueError("cannot specify a codomain curve and model name simultaneously")
+                from sage.schemes.elliptic_curves.ell_field import compute_model
+                codomain = compute_model(phi.codomain(), model)
+            if codomain is not None:
+                phi = phi.codomain().isomorphism_to(codomain) * phi
+            return phi
         if algorithm == "factored":
             from sage.schemes.elliptic_curves.hom_composite import EllipticCurveHom_composite
             return EllipticCurveHom_composite(self, kernel, codomain=codomain, model=model, velu_sqrt_bound=velu_sqrt_bound)

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -1910,7 +1910,10 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
             return phi
         if algorithm == "factored":
             from sage.schemes.elliptic_curves.hom_composite import EllipticCurveHom_composite
-            return EllipticCurveHom_composite(self, kernel, codomain=codomain, model=model, velu_sqrt_bound=velu_sqrt_bound)
+            phi = EllipticCurveHom_composite(self, kernel, codomain=codomain, model=model, velu_sqrt_bound=velu_sqrt_bound)
+            if len(phi.factors()) == 1:
+                phi = phi.factors()[0]
+            return phi
         if algorithm == "traditional":
             return _construct_isogeny(self, kernel, codomain, degree, model, check=check)
 
@@ -1919,7 +1922,10 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
             kernel_is_list = isinstance(kernel, (list, tuple))
             if kernel_is_list and kernel[0] in self and len(kernel) > 1:
                 from sage.schemes.elliptic_curves.hom_composite import EllipticCurveHom_composite
-                return EllipticCurveHom_composite(self, kernel, codomain=codomain, model=model, velu_sqrt_bound=velu_sqrt_bound)
+                phi = EllipticCurveHom_composite(self, kernel, codomain=codomain, model=model, velu_sqrt_bound=velu_sqrt_bound)
+                if len(phi.factors()) == 1:
+                    phi = phi.factors()[0]
+                return phi
 
             if not kernel_is_list or (len(kernel) == 1 and kernel[0] in self):
                 # Single point on the curve; unpack the list for compatibility with velusqrt
@@ -1939,7 +1945,10 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
                     # Otherwise fall back to the standard case
                 elif known_order:
                     from sage.schemes.elliptic_curves.hom_composite import EllipticCurveHom_composite
-                    return EllipticCurveHom_composite(self, kernel, codomain=codomain, model=model, velu_sqrt_bound=velu_sqrt_bound)
+                    phi = EllipticCurveHom_composite(self, kernel, codomain=codomain, model=model, velu_sqrt_bound=velu_sqrt_bound)
+                    if len(phi.factors()) == 1:
+                        phi = phi.factors()[0]
+                    return phi
 
         return _construct_isogeny(self, kernel, codomain, degree, model, check=check)
 

--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -56,10 +56,10 @@ class EllipticCurveHom(Morphism):
             sage: P = E.lift_x(1)
             sage: E.isogeny(P)                        # indirect doctest
             Isogeny of degree 127 from Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field in z2 of size 257^2 to Elliptic Curve defined by y^2 = x^3 + 151*x + 22 over Finite Field in z2 of size 257^2
-            sage: E.isogeny(P, algorithm='factored')  # indirect doctest
-            Composite morphism of degree 127:
+            sage: E.isogeny(P, codomain=EllipticCurve(GF(257^2), [3,-30]), algorithm='factored')  # indirect doctest
+            Composite morphism of degree 127 = 127*1:
               From: Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field in z2 of size 257^2
-              To:   Elliptic Curve defined by y^2 = x^3 + 151*x + 22 over Finite Field in z2 of size 257^2
+              To:   Elliptic Curve defined by y^2 = x^3 + 3*x + 227 over Finite Field in z2 of size 257^2
             sage: E.isogeny(P, algorithm='velusqrt')  # indirect doctest
             Elliptic-curve isogeny (using square-root Vélu) of degree 127:
               From: Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field in z2 of size 257^2

--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -132,9 +132,7 @@ class EllipticCurveHom(Morphism):
             ret = other._composition_impl(self, other)
 
         if ret is NotImplemented:
-            from sage.schemes.elliptic_curves.hom_composite import (
-                EllipticCurveHom_composite,
-            )
+            from sage.schemes.elliptic_curves.hom_composite import EllipticCurveHom_composite
             ret = EllipticCurveHom_composite.from_factors([other, self])
 
         return ret

--- a/src/sage/schemes/elliptic_curves/hom_composite.py
+++ b/src/sage/schemes/elliptic_curves/hom_composite.py
@@ -368,7 +368,7 @@ class EllipticCurveHom_composite(EllipticCurveHom):
         ::
 
             sage: EllipticCurveHom_composite(E, E.lift_x(3), codomain=E)
-            Composite morphism of degree 20 = 2^2*5:
+            Composite morphism of degree 20 = 2^2*5*1:
               From: Elliptic Curve defined by y^2 = x^3 + x over Finite Field of size 19
               To:   Elliptic Curve defined by y^2 = x^3 + x over Finite Field of size 19
 
@@ -409,10 +409,7 @@ class EllipticCurveHom_composite(EllipticCurveHom):
             if not isinstance(codomain, EllipticCurve_generic):
                 raise ValueError(f'not an elliptic curve: {codomain}')
             iso = self._phis[-1].codomain().isomorphism_to(codomain)
-            if hasattr(self._phis[-1], '_set_post_isomorphism'):
-                self._phis[-1]._set_post_isomorphism(iso)
-            else:
-                self._phis.append(iso)
+            self._phis.append(iso)
 
         self._phis = tuple(self._phis)  # make immutable
         self.__perform_inheritance_housekeeping()
@@ -486,7 +483,7 @@ class EllipticCurveHom_composite(EllipticCurveHom):
             sage: EllipticCurveHom_composite.from_factors(phi.factors()) == phi
             True
         """
-        maps = tuple(maps)
+        maps = list(maps)
         if not maps and E is None:
             raise ValueError('need either factors or domain')
         if E is None:
@@ -500,13 +497,21 @@ class EllipticCurveHom_composite(EllipticCurveHom):
             E = phi.codomain()
 
         if not maps:
-            maps = (identity_morphism(E),)
+            maps = [identity_morphism(E)]
 
         if len(maps) == 1 and not strict:
             return maps[0]
 
+        if not strict:
+            i = 0
+            while i < len(maps) - 1:
+                if type(maps[i]) is type(maps[i+1]) is WeierstrassIsomorphism:
+                    maps[i] = maps[i+1] * maps[i]
+                    del maps[i+1]
+                i += 1
+
         result = cls.__new__(cls)
-        result._phis = maps
+        result._phis = tuple(maps)  # immutable
         result.__perform_inheritance_housekeeping()
         return result
 
@@ -656,7 +661,7 @@ class EllipticCurveHom_composite(EllipticCurveHom):
               To:   Elliptic Curve defined by y^2 + (I+1)*x*y = x^3 + I*x^2 + (-3331/4)*x + (-142593/8*I)
                     over Number Field in I with defining polynomial x^2 + 1 with I = 1*I
             sage: iso2 * EllipticCurveHom_composite.from_factors([phi, psi]) # indirect doctest
-            Composite morphism of degree 16 = 4^2:
+            Composite morphism of degree 16 = 4^2*1:
               From: Elliptic Curve defined by y^2 + (I+1)*x*y = x^3 + I*x^2 + (-4)*x + (-6*I)
                     over Number Field in I with defining polynomial x^2 + 1 with I = 1*I
               To:   Elliptic Curve defined by y^2 + (I+1)*x*y = x^3 + I*x^2 + (-4)*x + (-6*I)
@@ -676,14 +681,12 @@ class EllipticCurveHom_composite(EllipticCurveHom):
         """
         if isinstance(left, EllipticCurveHom_composite):
             if isinstance(right, EllipticCurveHom_composite):
-                return EllipticCurveHom_composite.from_factors(right.factors() + left.factors())
+                return EllipticCurveHom_composite.from_factors(right.factors() + left.factors(), strict=False)
             if isinstance(right, EllipticCurveHom):
-                return EllipticCurveHom_composite.from_factors((right,) + left.factors())
+                return EllipticCurveHom_composite.from_factors((right,) + left.factors(), strict=False)
         if isinstance(right, EllipticCurveHom_composite):
-            if isinstance(left, WeierstrassIsomorphism) and hasattr(right.factors()[-1], '_set_post_isomorphism'):  # XXX bit of a hack
-                return EllipticCurveHom_composite.from_factors(right.factors()[:-1] + (left * right.factors()[-1],), strict=False)
             if isinstance(left, EllipticCurveHom):
-                return EllipticCurveHom_composite.from_factors(right.factors() + (left,))
+                return EllipticCurveHom_composite.from_factors(right.factors() + (left,), strict=False)
         return NotImplemented
 
     @staticmethod

--- a/src/sage/schemes/elliptic_curves/hom_composite.py
+++ b/src/sage/schemes/elliptic_curves/hom_composite.py
@@ -456,7 +456,7 @@ class EllipticCurveHom_composite(EllipticCurveHom):
           always return an :class:`EllipticCurveHom_composite` object,
           else may return another :class:`EllipticCurveHom` type
 
-        OUTPUT: the composite of ``maps``
+        OUTPUT: the composition of ``maps``
 
         EXAMPLES::
 
@@ -497,18 +497,43 @@ class EllipticCurveHom_composite(EllipticCurveHom):
             E = phi.codomain()
 
         if not maps:
-            maps = [identity_morphism(E)]
-
-        if len(maps) == 1 and not strict:
-            return maps[0]
+            maps = identity_morphism(E),
 
         if not strict:
+            # flatten nested compositions
             i = 0
-            while i < len(maps) - 1:
-                if type(maps[i]) is type(maps[i+1]) is WeierstrassIsomorphism:
-                    maps[i] = maps[i+1] * maps[i]
-                    del maps[i+1]
-                i += 1
+            while i < len(maps):
+                if isinstance(maps[i], EllipticCurveHom_composite):
+                    maps[i:i+1] = maps[i].factors()
+                else:
+                    i += 1
+
+            # collect scalars
+            from sage.schemes.elliptic_curves.hom_scalar import EllipticCurveHom_scalar
+            scalars = []
+            i = 0
+            while i < len(maps):
+                if isinstance(maps[i], EllipticCurveHom_scalar):
+                    scalars.append(maps[i]._m)
+                    del maps[i]
+                else:
+                    i += 1
+            if scalars:
+                maps.append(E.scalar_multiplication(prod(scalars)))
+
+            # fold isomorphisms and Frobenius isogenies
+            from sage.schemes.elliptic_curves.weierstrass_morphism import WeierstrassIsomorphism
+            from sage.schemes.elliptic_curves.hom_frobenius import EllipticCurveHom_frobenius
+            for typ in (WeierstrassIsomorphism, EllipticCurveHom_frobenius):
+                i = 0
+                while i < len(maps) - 1:
+                    if isinstance(maps[i], typ) and isinstance(maps[i+1], typ):
+                        maps[i:i+2] = maps[i+1] * maps[i],
+                    else:
+                        i += 1
+
+            if len(maps) == 1:
+                return maps[0]
 
         result = cls.__new__(cls)
         result._phis = tuple(maps)  # immutable
@@ -661,7 +686,7 @@ class EllipticCurveHom_composite(EllipticCurveHom):
               To:   Elliptic Curve defined by y^2 + (I+1)*x*y = x^3 + I*x^2 + (-3331/4)*x + (-142593/8*I)
                     over Number Field in I with defining polynomial x^2 + 1 with I = 1*I
             sage: iso2 * EllipticCurveHom_composite.from_factors([phi, psi]) # indirect doctest
-            Composite morphism of degree 16 = 4^2*1:
+            Composite morphism of degree 16 = 2^2*4*1:
               From: Elliptic Curve defined by y^2 + (I+1)*x*y = x^3 + I*x^2 + (-4)*x + (-6*I)
                     over Number Field in I with defining polynomial x^2 + 1 with I = 1*I
               To:   Elliptic Curve defined by y^2 + (I+1)*x*y = x^3 + I*x^2 + (-4)*x + (-6*I)
@@ -680,13 +705,9 @@ class EllipticCurveHom_composite(EllipticCurveHom):
                     over Number Field in I with defining polynomial x^2 + 1 with I = 1*I
         """
         if isinstance(left, EllipticCurveHom_composite):
-            if isinstance(right, EllipticCurveHom_composite):
-                return EllipticCurveHom_composite.from_factors(right.factors() + left.factors(), strict=False)
-            if isinstance(right, EllipticCurveHom):
-                return EllipticCurveHom_composite.from_factors((right,) + left.factors(), strict=False)
+            return EllipticCurveHom_composite.from_factors((right,) + left.factors(), E=right.domain(), strict=False)
         if isinstance(right, EllipticCurveHom_composite):
-            if isinstance(left, EllipticCurveHom):
-                return EllipticCurveHom_composite.from_factors(right.factors() + (left,), strict=False)
+            return EllipticCurveHom_composite.from_factors(right.factors() + (left,), E=right.domain(), strict=False)
         return NotImplemented
 
     @staticmethod

--- a/src/sage/schemes/elliptic_curves/hom_fractional.py
+++ b/src/sage/schemes/elliptic_curves/hom_fractional.py
@@ -34,7 +34,7 @@ Division by an integer::
     sage: phi.degree()
     105
     sage: phi.to_isogeny_chain()
-    Composite morphism of degree 105 = 1*3*5*7:
+    Composite morphism of degree 105 = 1*3*5*7*1:
       From: Elliptic Curve defined by y^2 = x^3 + 418*x over Finite Field of size 419
       To:   Elliptic Curve defined by y^2 = x^3 + 418*x over Finite Field of size 419
 
@@ -339,7 +339,7 @@ class EllipticCurveHom_fractional(EllipticCurveHom):
             sage: endo.degree()
             105
             sage: endo.to_isogeny_chain()
-            Composite morphism of degree 105 = 1*3*5*7:
+            Composite morphism of degree 105 = 1*3*5*7*1:
               From: Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 419^2
               To:   Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 419^2
             sage: endo.to_isogeny_chain() == endo

--- a/src/sage/schemes/elliptic_curves/hom_frobenius.py
+++ b/src/sage/schemes/elliptic_curves/hom_frobenius.py
@@ -124,7 +124,7 @@ TESTS::
        From: Elliptic Curve defined by y^2 = x^3 + (12*z5^4+14*z5^3+z5^2+4*z5+13)*x + 1 over Finite Field in z5 of size 17^5
        To:   Elliptic Curve defined by y^2 = x^3 + z5*x + 1 over Finite Field in z5 of size 17^5]
     sage: prod(fs[::-1])
-    Composite morphism of degree 1419857 = 17^5:
+    Frobenius endomorphism of degree 1419857 = 17^5:
       From: Elliptic Curve defined by y^2 = x^3 + z5*x + 1 over Finite Field in z5 of size 17^5
       To:   Elliptic Curve defined by y^2 = x^3 + z5*x + 1 over Finite Field in z5 of size 17^5
 
@@ -308,6 +308,28 @@ class EllipticCurveHom_frobenius(EllipticCurveHom):
                 f'\n  To:   {self._codomain}'
 
     # EllipticCurveHom methods
+
+    @staticmethod
+    def _composition_impl(left, right):
+        r"""
+        Helper method to compose other elliptic-curve morphisms with
+        :class:`EllipticCurveHom_frobenius` objects. Called by
+        :meth:`EllipticCurveHom._composition_`.
+
+        TESTS::
+
+            sage: F.<t> = GF((11, 23), modulus = [9,1,8] + [0]*20 + [1])
+            sage: E = EllipticCurve([1, t])
+            sage: phi = E.frobenius_isogeny(6)
+            sage: psi = phi.codomain().frobenius_isogeny(7)
+            sage: psi * phi
+            Frobenius isogeny of degree 34522712143931 = 11^13:
+              From: Elliptic Curve defined by y^2 = x^3 + x + t over Finite Field in t of size 11^23
+              To:   Elliptic Curve defined by y^2 = x^3 + x + (7*t^22+7*t^21+5*t^18+8*t^17+2*t^16+8*t^15+3*t^14+5*t^13+4*t^12+3*t^11+9*t^10+3*t^9+6*t^8+4*t^7+7*t^6+8*t^5+9*t^4+4*t^3+5*t^2+2*t+10) over Finite Field in t of size 11^23
+        """
+        if isinstance(left, EllipticCurveHom_frobenius) and isinstance(right, EllipticCurveHom_frobenius):
+            return EllipticCurveHom_frobenius(right._domain, left._n + right._n)
+        return NotImplemented
 
     def rational_maps(self):
         """

--- a/src/sage/schemes/elliptic_curves/hom_frobenius.py
+++ b/src/sage/schemes/elliptic_curves/hom_frobenius.py
@@ -60,11 +60,11 @@ Computing the dual of Frobenius is supported as well::
     sage: E = EllipticCurve([GF(17^6).gen(), 0])
     sage: pi = EllipticCurveHom_frobenius(E)
     sage: pihat = pi.dual(); pihat
-    Isogeny of degree 17
-     from Elliptic Curve defined by y^2 = x^3 + (15*z6^5+5*z6^4+8*z6^3+12*z6^2+11*z6+7)*x
-          over Finite Field in z6 of size 17^6
-       to Elliptic Curve defined by y^2 = x^3 + z6*x
-          over Finite Field in z6 of size 17^6
+    Composite morphism of degree 17 = 17*1:
+      From: Elliptic Curve defined by y^2 = x^3 + (15*z6^5+5*z6^4+8*z6^3+12*z6^2+11*z6+7)*x
+            over Finite Field in z6 of size 17^6
+      To:   Elliptic Curve defined by y^2 = x^3 + z6*x
+            over Finite Field in z6 of size 17^6
     sage: pihat.is_separable()
     True
     sage: pihat * pi == EllipticCurveHom_scalar(E,17)   # known bug -- #6413

--- a/src/sage/schemes/elliptic_curves/hom_frobenius.py
+++ b/src/sage/schemes/elliptic_curves/hom_frobenius.py
@@ -160,7 +160,7 @@ from sage.schemes.elliptic_curves.ell_generic import EllipticCurve_generic
 from sage.schemes.elliptic_curves.constructor import EllipticCurve
 
 from sage.schemes.elliptic_curves.hom import EllipticCurveHom, find_post_isomorphism
-from sage.schemes.elliptic_curves.ell_curve_isogeny import EllipticCurveIsogeny
+from sage.schemes.elliptic_curves.ell_curve_isogeny import _construct_isogeny
 from sage.schemes.elliptic_curves.hom_composite import EllipticCurveHom_composite
 from sage.schemes.elliptic_curves.hom_scalar import EllipticCurveHom_scalar
 
@@ -493,7 +493,7 @@ class EllipticCurveHom_frobenius(EllipticCurveHom):
             Phis = []
             for _ in range(self._n):
                 Ep = EllipticCurve([a**self._p for a in E.a_invariants()])
-                Phis.append(EllipticCurveIsogeny(Ep, ker, codomain=E))
+                Phis.append(_construct_isogeny(Ep, ker, codomain=E))
                 E, ker = Ep, ker.map_coefficients(lambda c: c**self._p)
             Phi = EllipticCurveHom_composite.from_factors(Phis[::-1], self._codomain)
 

--- a/src/sage/schemes/elliptic_curves/hom_scalar.py
+++ b/src/sage/schemes/elliptic_curves/hom_scalar.py
@@ -260,7 +260,6 @@ class EllipticCurveHom_scalar(EllipticCurveHom):
             NotImplemented
         """
         if isinstance(self, EllipticCurveHom_scalar) and isinstance(other, EllipticCurveHom_scalar):
-            assert self._domain == other._domain
             return EllipticCurveHom_scalar(self._domain, self._m * other._m)
         return NotImplemented
 

--- a/src/sage/schemes/elliptic_curves/hom_sum.py
+++ b/src/sage/schemes/elliptic_curves/hom_sum.py
@@ -224,7 +224,7 @@ class EllipticCurveHom_sum(EllipticCurveHom):
             sage: endo.degree()
             420
             sage: endo.to_isogeny_chain()
-            Composite morphism of degree 420 = 4*1*3*5*7:
+            Composite morphism of degree 420 = 4*1*3*5*7*1:
               From: Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 419^2
               To:   Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 419^2
 
@@ -245,7 +245,7 @@ class EllipticCurveHom_sum(EllipticCurveHom):
             sage: m2 = E.scalar_multiplication(2)
             sage: m3 = E.scalar_multiplication(3)
             sage: (m2 - m3).to_isogeny_chain()
-            Composite morphism of degree 1 = 1^2:
+            Composite morphism of degree 1:
               From: Elliptic Curve defined by y^2 + x*y = x^3 + x^2 + 180*x + 17255 over Rational Field
               To:   Elliptic Curve defined by y^2 + x*y = x^3 + x^2 + 180*x + 17255 over Rational Field
             sage: (m2 - m3).rational_maps()

--- a/src/sage/schemes/elliptic_curves/hom_sum.py
+++ b/src/sage/schemes/elliptic_curves/hom_sum.py
@@ -210,7 +210,7 @@ class EllipticCurveHom_sum(EllipticCurveHom):
             sage: E = EllipticCurve(GF(101), [5,5])
             sage: phi = E.isogenies_prime_degree(7)[0]
             sage: (phi + phi).to_isogeny_chain()
-            Composite morphism of degree 28 = 4*1*7:
+            Composite morphism of degree 28 = 1*7*4:
               From: Elliptic Curve defined by y^2 = x^3 + 5*x + 5 over Finite Field of size 101
               To:   Elliptic Curve defined by y^2 = x^3 + 29*x + 51 over Finite Field of size 101
 
@@ -224,7 +224,7 @@ class EllipticCurveHom_sum(EllipticCurveHom):
             sage: endo.degree()
             420
             sage: endo.to_isogeny_chain()
-            Composite morphism of degree 420 = 4*1*3*5*7*1:
+            Composite morphism of degree 420 = 1*3*5*7*1*4:
               From: Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 419^2
               To:   Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 419^2
 
@@ -245,9 +245,8 @@ class EllipticCurveHom_sum(EllipticCurveHom):
             sage: m2 = E.scalar_multiplication(2)
             sage: m3 = E.scalar_multiplication(3)
             sage: (m2 - m3).to_isogeny_chain()
-            Composite morphism of degree 1:
-              From: Elliptic Curve defined by y^2 + x*y = x^3 + x^2 + 180*x + 17255 over Rational Field
-              To:   Elliptic Curve defined by y^2 + x*y = x^3 + x^2 + 180*x + 17255 over Rational Field
+            Elliptic-curve endomorphism of Elliptic Curve defined by y^2 + x*y = x^3 + x^2 + 180*x + 17255 over Rational Field
+              Via:  (u,r,s,t) = (-1, 0, -1, 0)
             sage: (m2 - m3).rational_maps()
             (x, -x - y)
 
@@ -500,8 +499,8 @@ class EllipticCurveHom_sum(EllipticCurveHom):
             sage: E = EllipticCurve(GF(101), [5,5])
             sage: phi = E.isogenies_prime_degree(7)[0]
             sage: (phi + phi).rational_maps()
-            ((31*x^28 + 4*x^27 + 40*x^26 + ... + 3*x^2 + 19*x - 27)/(23*x^27 + 16*x^26 + 9*x^25 + ... - 43*x^2 - 22*x + 37),
-             (-3*x^42*y + 32*x^41*y + 16*x^40*y + ... - 27*x^2*y + 18*x*y - 42*y)/(-24*x^42 - 47*x^41 - 12*x^40 + ... + 18*x^2 - 48*x + 18))
+            ((x^28 + 49*x^27 - 15*x^26 + ... - 47*x^2 - 17*x + 24),
+             (8*x^42*y - 18*x^41*y - 9*x^40*y - ... - 29*x^2*y - 48*x*y + 11*y)/(-37*x^42 - 43*x^41 + 32*x^40 + ... - 48*x^2 + 27*x - 48))
 
         ALGORITHM: :meth:`to_isogeny_chain`.
         """

--- a/src/sage/schemes/elliptic_curves/hom_velusqrt.py
+++ b/src/sage/schemes/elliptic_curves/hom_velusqrt.py
@@ -49,15 +49,15 @@ and must therefore be equal *up to post-isomorphism*::
     sage: sum(iso * psi == phi for iso in isos)
     1
 
-Just like
-:class:`~sage.schemes.elliptic_curves.ell_curve_isogeny.EllipticCurveIsogeny`,
-the constructor supports a ``model`` keyword argument::
+By constructing an :class:`EllipticCurveHom_velusqrt` object through
+the `:meth:`EllipticCurve_field.isogeny` method, a ``model`` keyword
+can be used to specify the shape of the codomain curve::
 
     sage: E = EllipticCurve(GF(6666679), [1,1])
     sage: K = E(9091, 517864)
-    sage: phi = EllipticCurveHom_velusqrt(E, K, model='montgomery')
+    sage: phi = E.isogeny(K, model='montgomery', algorithm='velusqrt')
     sage: phi
-    Elliptic-curve isogeny (using square-root Vélu) of degree 2999:
+    Composite morphism of degree 2999 = 2999*1:
       From: Elliptic Curve defined by y^2 = x^3 + x + 1 over Finite Field of size 6666679
       To:   Elliptic Curve defined by y^2 = x^3 + 1559358*x^2 + x over Finite Field of size 6666679
 
@@ -699,12 +699,12 @@ class EllipticCurveHom_velusqrt(EllipticCurveHom):
               From: Elliptic Curve defined by y^2 = x^3 + x over Finite Field of size 419
               To:   Elliptic Curve defined by y^2 = x^3 + 301*x + 86 over Finite Field of size 419
             sage: E2 = EllipticCurve(GF(419), [0,6,0,385,42])
-            sage: EllipticCurveHom_velusqrt(E, K, codomain=E2)
-            Elliptic-curve isogeny (using square-root Vélu) of degree 105:
+            sage: E.isogeny(K, codomain=E2, algorithm='velusqrt')
+            Composite morphism of degree 105 = 105*1:
               From: Elliptic Curve defined by y^2 = x^3 + x over Finite Field of size 419
               To:   Elliptic Curve defined by y^2 = x^3 + 6*x^2 + 385*x + 42 over Finite Field of size 419
-            sage: EllipticCurveHom_velusqrt(E, K, model='montgomery')
-            Elliptic-curve isogeny (using square-root Vélu) of degree 105:
+            sage: E.isogeny(K, model='montgomery', algorithm='velusqrt')
+            Composite morphism of degree 105 = 105*1:
               From: Elliptic Curve defined by y^2 = x^3 + x over Finite Field of size 419
               To:   Elliptic Curve defined by y^2 = x^3 + 6*x^2 + x over Finite Field of size 419
 
@@ -767,7 +767,14 @@ class EllipticCurveHom_velusqrt(EllipticCurveHom):
         self._domain = E
         self._compute_codomain(model=model)
 
+        if model is not None:
+            from sage.misc.superseded import deprecation
+            deprecation(42363, "the 'model' argument to the EllipticCurveHom_velusqrt constructor is deprecated; use E.isogeny(..., codomain={model!r}, ..., algorithm='velusqrt') instead of EllipticCurveHom_velusqrt(E, ..., model={model!r}, ...)")
+
         if codomain is not None:
+            from sage.misc.superseded import deprecation
+            deprecation(42363, "the 'codomain' argument to the EllipticCurveHom_velusqrt constructor is deprecated; use E.isogeny(..., algorithm='velusqrt') instead of EllipticCurveHom_velusqrt(E, ...)")
+
             self._post_iso = self._codomain.isomorphism_to(codomain) * self._post_iso
             self._codomain = codomain
 
@@ -932,9 +939,9 @@ class EllipticCurveHom_velusqrt(EllipticCurveHom):
             sage: from sage.schemes.elliptic_curves.hom_velusqrt import EllipticCurveHom_velusqrt
             sage: E = EllipticCurve(GF(71), [0,5,0,1,0])
             sage: K = E(4, 19)
-            sage: phi = EllipticCurveHom_velusqrt(E, K, model='montgomery')
+            sage: phi = E.isogeny(K, model='montgomery', algorithm='velusqrt')
             sage: phi
-            Elliptic-curve isogeny (using square-root Vélu) of degree 19:
+            Composite morphism of degree 19 = 19*1:
               From: Elliptic Curve defined by y^2 = x^3 + 5*x^2 + x over Finite Field of size 71
               To:   Elliptic Curve defined by y^2 = x^3 + 40*x^2 + x over Finite Field of size 71
             sage: phi(K)
@@ -946,7 +953,7 @@ class EllipticCurveHom_velusqrt(EllipticCurveHom):
             sage: phi(E(0,0))
             (0 : 0 : 1)
             sage: phi(E(7,13))
-            (70 : 31 : 1)
+            (70 : ... : 1)
 
         TESTS::
 
@@ -1255,8 +1262,8 @@ class EllipticCurveHom_velusqrt(EllipticCurveHom):
 
             sage: E = EllipticCurve(GF(101^2), [1, 1, 1, 1, 1])
             sage: K = (E.cardinality() // 11) * E.gens()[0]
-            sage: phi = E.isogeny(K, algorithm='velusqrt', model='montgomery'); phi
-            Elliptic-curve isogeny (using square-root Vélu) of degree 11:
+            sage: phi = E.isogeny(K, model='montgomery', algorithm='velusqrt'); phi
+            Composite morphism of degree 11 = 11*1:
               From: Elliptic Curve defined by y^2 + x*y + y = x^3 + x^2 + x + 1 over Finite Field in z2 of size 101^2
               To:   Elliptic Curve defined by y^2 = x^3 + 61*x^2 + x over Finite Field in z2 of size 101^2
             sage: phi.scaling_factor()
@@ -1342,8 +1349,8 @@ class EllipticCurveHom_velusqrt(EllipticCurveHom):
 
             sage: E = EllipticCurve(GF(101^2), [1, 1, 1, 1, 1])
             sage: K = (E.cardinality() // 11) * E.gens()[0]
-            sage: phi = E.isogeny(K, algorithm='velusqrt', model='montgomery'); phi
-            Elliptic-curve isogeny (using square-root Vélu) of degree 11:
+            sage: phi = E.isogeny(K, model='montgomery', algorithm='velusqrt'); phi
+            Composite morphism of degree 11 = 11*1:
               From: Elliptic Curve defined by y^2 + x*y + y = x^3 + x^2 + x + 1 over Finite Field in z2 of size 101^2
               To:   Elliptic Curve defined by y^2 = x^3 + 61*x^2 + x over Finite Field in z2 of size 101^2
             sage: phi(E.lift_x(42)).x()

--- a/src/sage/schemes/elliptic_curves/hom_velusqrt.py
+++ b/src/sage/schemes/elliptic_curves/hom_velusqrt.py
@@ -1150,7 +1150,7 @@ class EllipticCurveHom_velusqrt(EllipticCurveHom):
               From: Elliptic Curve defined by y^2 = x^3 + (8*z2+70)*x + (3*z2+49) over Finite Field in z2 of size 71^2
               To:   Elliptic Curve defined by y^2 = x^3 + (41*z2+56)*x + (18*z2+42) over Finite Field in z2 of size 71^2
             sage: E.isogeny(E.lift_x(0), algorithm='velusqrt').dual()
-            Composite morphism of degree 213 = 71*3:
+            Composite morphism of degree 213 = 71*3*1:
               From: Elliptic Curve defined by y^2 = x^3 + (50*z2+61)*x + (22*z2+25) over Finite Field in z2 of size 71^2
               To:   Elliptic Curve defined by y^2 = x^3 + (41*z2+56)*x + (18*z2+42) over Finite Field in z2 of size 71^2
         """

--- a/src/sage/schemes/elliptic_curves/hom_velusqrt.py
+++ b/src/sage/schemes/elliptic_curves/hom_velusqrt.py
@@ -1163,8 +1163,7 @@ class EllipticCurveHom_velusqrt(EllipticCurveHom):
         F = self._raw_domain.base_ring()
         from sage.schemes.elliptic_curves.weierstrass_morphism import WeierstrassIsomorphism
         isom = ~WeierstrassIsomorphism(self._raw_domain, (~F(self._degree), 0, 0, 0))
-        from sage.schemes.elliptic_curves.ell_curve_isogeny import EllipticCurveIsogeny
-        phi = EllipticCurveIsogeny(self._raw_codomain, None, isom.domain(), self._degree)
+        phi = self._raw_codomain.isogeny(kernel=None, codomain=isom.domain(), degree=self._degree)
         return ~self._pre_iso * isom * phi * ~self._post_iso
 
     @cached_method


### PR DESCRIPTION
Follow-up to #41537: Given that we now have `EllipticCurveHom_composite`, it no longer makes sense for individual `EllipticCurveHom` children to inline their own implementation of post-compositions with isomorphisms.

Mainly, we deprecate the old constructor arguments, instructing users to use higher-level wrappers around the `EllipticCurveHom` machinery instead.