### PR TITLE
gh-29516: Cross-link symbolic product documentation

### DIFF
--- a/src/sage/misc/functional.py
+++ b/src/sage/misc/functional.py
@@ -436,6 +436,17 @@ def symbolic_sum(expression, *args, **kwds):
 
       - ``'sympy'`` -- use SymPy
 
+    .. SEEALSO::
+
+        :func:`symbolic_prod` for symbolic products and
+        :func:`sage.misc.misc_c.prod` for products of iterable elements.
+
+    .. NOTE::
+
+        Although this function is named ``symbolic_sum``, it is available as
+        ``sum`` in the Sage global namespace. Without symbolic bounds, it
+        delegates to Python's built-in ``sum``.
+
     EXAMPLES::
 
         sage: k, n = var('k,n')                                                         # needs sage.symbolic
@@ -454,9 +465,9 @@ def symbolic_sum(expression, *args, **kwds):
 
     .. WARNING::
 
-        This function only works with symbolic expressions. To sum any
-        other objects like list elements or function return values,
-        please use python summation, see
+        This function only works with symbolic expressions. For other objects,
+        such as iterable elements or function return values, use Python's
+        built-in ``sum``.
         http://docs.python.org/library/functions.html#sum
 
         In particular, this does not work::
@@ -614,13 +625,42 @@ def symbolic_prod(expression, *args, **kwds):
 
     - ``hold`` -- boolean (default: ``False``); if ``True`` don't evaluate
 
-    This function is available as ``product`` in the Sage global namespace.
+
 
 
     .. SEEALSO::
 
+        :func:`symbolic_sum` for symbolic sums and
         :func:`sage.misc.misc_c.prod` for multiplying elements of an
         iterable.
+
+    .. NOTE::
+
+
+        Although this function is named ``symbolic_prod``, it is available as
+        ``product`` in the Sage global namespace.
+
+    .. WARNING::
+
+        This function only works with symbolic expressions. For products of
+        iterable elements or function return values, use
+        :func:`sage.misc.misc_c.prod`.
+
+        For example, this does not work::
+
+            sage: n = var('n')
+            sage: mylist = [1, 2, 3, 4, 5]
+            sage: product(mylist[n], n, 0, 3)
+            Traceback (most recent call last):
+            ...
+            TypeError: unable to convert n to an integer
+
+        Use ``prod`` instead::
+
+            sage: prod(mylist[n] for n in range(4))
+            24
+
+
 
     EXAMPLES::
 

--- a/src/sage/misc/functional.py
+++ b/src/sage/misc/functional.py
@@ -443,9 +443,8 @@ def symbolic_sum(expression, *args, **kwds):
 
     .. NOTE::
 
-        Although this function is named ``symbolic_sum``, it is available as
-        ``sum`` in the Sage global namespace. Without symbolic bounds, it
-        delegates to Python's built-in ``sum``.
+        This function is available as ``sum`` in the global namespace.
+        In the absence of bounds it delegates to Python's built-in ``sum``.
 
     EXAMPLES::
 

--- a/src/sage/misc/functional.py
+++ b/src/sage/misc/functional.py
@@ -439,7 +439,7 @@ def symbolic_sum(expression, *args, **kwds):
     .. SEEALSO::
 
         :func:`symbolic_prod` for symbolic products and
-        :func:`sage.misc.misc_c.prod` for products of iterable elements.
+        :func:`sage.misc.misc_c.prod` for products of iterables.
 
     .. NOTE::
 

--- a/src/sage/misc/functional.py
+++ b/src/sage/misc/functional.py
@@ -602,7 +602,7 @@ def symbolic_prod(expression, *args, **kwds):
 
     - ``a`` -- lower endpoint of the product
 
-    - ``b`` -- upper endpoint of the prduct
+    - ``b`` -- upper endpoint of the product
 
     - ``algorithm`` -- (default: ``'maxima'``)  one of
 
@@ -613,6 +613,14 @@ def symbolic_prod(expression, *args, **kwds):
       - ``'sympy'`` -- use SymPy
 
     - ``hold`` -- boolean (default: ``False``); if ``True`` don't evaluate
+
+    This function is available as ``product`` in the Sage global namespace.
+
+
+    .. SEEALSO::
+
+        :func:`sage.misc.misc_c.prod` for multiplying elements of an
+        iterable.
 
     EXAMPLES::
 

--- a/src/sage/misc/functional.py
+++ b/src/sage/misc/functional.py
@@ -636,8 +636,8 @@ def symbolic_prod(expression, *args, **kwds):
     .. NOTE::
 
 
-        Although this function is named ``symbolic_prod``, it is available as
-        ``product`` in the Sage global namespace.
+        This function is available as ``product`` in the global namespace.
+        In the absence of bounds it delegates to :func:`sage.misc.misc_c.prod`.
 
     .. WARNING::
 

--- a/src/sage/misc/functional.py
+++ b/src/sage/misc/functional.py
@@ -466,7 +466,7 @@ def symbolic_sum(expression, *args, **kwds):
 
         This function only works with symbolic expressions. For other objects,
         such as iterable elements or function return values, use Python's
-        built-in ``sum``.
+        This function is intended for summations of symbolic expressions. However, if no bounds are given, the first argument is passed to python's built-in ``sum``:
         http://docs.python.org/library/functions.html#sum
 
         In particular, this does not work::

--- a/src/sage/misc/functional.py
+++ b/src/sage/misc/functional.py
@@ -624,9 +624,6 @@ def symbolic_prod(expression, *args, **kwds):
 
     - ``hold`` -- boolean (default: ``False``); if ``True`` don't evaluate
 
-
-
-
     .. SEEALSO::
 
         :func:`symbolic_sum` for symbolic sums and
@@ -634,7 +631,6 @@ def symbolic_prod(expression, *args, **kwds):
         iterable.
 
     .. NOTE::
-
 
         This function is available as ``product`` in the global namespace.
         In the absence of bounds it delegates to :func:`sage.misc.misc_c.prod`.
@@ -658,8 +654,6 @@ def symbolic_prod(expression, *args, **kwds):
 
             sage: prod(mylist[n] for n in range(4))
             24
-
-
 
     EXAMPLES::
 

--- a/src/sage/misc/functional.py
+++ b/src/sage/misc/functional.py
@@ -641,8 +641,8 @@ def symbolic_prod(expression, *args, **kwds):
 
     .. WARNING::
 
-        This function only works with symbolic expressions. For products of
-        iterable elements or function return values, use
+        This function is intended for products of symbolic expressions.
+        However, if no bounds are given, the first argument is passed to
         :func:`sage.misc.misc_c.prod`.
 
         For example, this does not work::

--- a/src/sage/misc/functional.py
+++ b/src/sage/misc/functional.py
@@ -464,9 +464,9 @@ def symbolic_sum(expression, *args, **kwds):
 
     .. WARNING::
 
-        This function only works with symbolic expressions. For other objects,
-        such as iterable elements or function return values, use Python's
-        This function is intended for summations of symbolic expressions. However, if no bounds are given, the first argument is passed to python's built-in ``sum``:
+        This function is intended for summations of symbolic expressions.
+        However, if no bounds are given, the first argument is passed to
+        python's built-in ``sum``:
         http://docs.python.org/library/functions.html#sum
 
         In particular, this does not work::

--- a/src/sage/misc/misc_c.pyx
+++ b/src/sage/misc/misc_c.pyx
@@ -81,7 +81,8 @@ def prod(x, z=None, Py_ssize_t recursion_cutoff=5):
 
     .. SEEALSO::
 
-        For the symbolic product function, see :func:`sage.calculus.calculus.symbolic_product`.
+        :func:`sage.misc.functional.symbolic_prod` for symbolic products and
+        :func:`sage.misc.functional.symbolic_sum` for symbolic sums.
 
     EXAMPLES::
 


### PR DESCRIPTION
## Description

This PR improves the documentation of `symbolic_prod` by:

* fixing the typo `prduct` to `product`;
* clarifying that the function is available as `product` in the Sage global namespace;
* adding cross-references to the iterable product and symbolic summation functions.

This is part of #29516.

## Testing

* `./sage -t src/sage/misc/functional.py`
* built and inspected the `reference/misc` HTML documentation
