### PR TITLE
graphs: fix self-loop detection in chromatic_symmetric_function

### DIFF
--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -3757,6 +3757,18 @@ class Graph(GenericGraph):
             sage: e = SymmetricFunctions(ZZ).e()
             sage: e(graphs.CompleteGraph(5).chromatic_symmetric_function())
             120*e[5]
+
+        A graph with a loop has no proper coloring, so its chromatic symmetric
+        function is zero.  This must hold even for large vertex labels: with
+        the natural labeling ``0, 1, ..., n - 1`` a loop on a vertex labelled
+        above 256 has endpoints that are equal but distinct :class:`Integer`
+        objects, so they must be compared by value rather than identity::
+
+            sage: G = Graph(loops=True)
+            sage: G.add_vertices(range(258))
+            sage: G.add_edge(257, 257)
+            sage: G.chromatic_symmetric_function()                                  # needs sage.combinat sage.modules
+            0
         """
         from sage.combinat.sf.sf import SymmetricFunctions
         from sage.combinat.partition import _Partitions
@@ -3790,7 +3802,7 @@ class Graph(GenericGraph):
             u = find(dsf, e[0])
             v = find(dsf, e[1])
             # Terms cancel if edge creates a cycle.
-            if u is not v:
+            if u != v:
                 ret = summand(stack, dsf, sizes)
                 dsf[v] = u
                 sizes[u] += sizes[v]


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
### Title
graphs: fix self-loop detection in chromatic_symmetric_function

<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

### Description
`Graph.chromatic_symmetric_function()` could return a nonzero result for a graph containing a self-loop, even though a graph with a loop has no proper coloring and its chromatic symmetric function must be zero. The loop was detected by comparing the two endpoints of an edge with `is` (identity) rather than `==` (value). This is the same `is`-vs-`==` self-loop bug class as #42348 (fixed in `Graph.matching()`); this PR fixes the remaining occurrence.

### Reproducer
```python
sage: G = Graph(loops=True)
sage: G.add_vertices(range(258))
sage: G.add_edge(257, 257)
sage: G.chromatic_symmetric_function()        # nonzero before this PR
0                                             # correct after
```

A small loop (e.g. on vertex 2) does *not* trigger the bug — only large labels do (see root cause below), which is why it went unnoticed.

### Root cause
Two ingredients combine:

1. **Integer interning.** Sage caches `Integer` objects for `0..256`, so for small labels `u == v` happens to imply `u is v`. Labels `>= 256` are not cached, so two equal labels can be distinct objects (`u == v` but `u is not v`).

2. **Endpoint reconstruction under the natural labeling.** With the natural labeling `0, 1, ..., n - 1` the C graph backend stores no relabeling dictionary; an *unfiltered* edge iteration rebuilds each endpoint as a fresh `Integer` (`base/c_graph.pyx`, `_iterator_edges`, `vertices_case == 0`). So the two endpoints of a self-loop on a label `>= 256` are equal-but-distinct objects.

In `chromatic_symmetric_function`, the edges are taken unfiltered and the disjoint-set `find` helper returns its *argument* when the vertex is a root:

```python
def find(dsf, v):
    return v if dsf[v] is None else find(dsf, dsf[v])   # returns the passed object
...
u = find(dsf, e[0])
v = find(dsf, e[1])
if u is not v:        # two distinct objects for a loop  ->  True  ->  loop missed
```

So a self-loop is mistaken for an ordinary edge. Comparing by value (`u != v`) detects the loop correctly.

### Fix
A one-line change in `summand()`:
```diff
-            if u is not v:
+            if u != v:
```

plus a regression doctest using the natural labeling with a loop on vertex 257, which returns a nonzero result on the unfixed code and `0` after the fix.

### Audit of the wider `is`-on-vertices pattern in `src/sage/graphs/`
To make sure this was the only remaining genuine occurrence, I swept the whole graphs module for identity comparisons of vertex/edge endpoints. There are five such sites; only two are real bugs.

  | Site | Code | Verdict |
  |------|------|---------|
  | `graph.py` `chromatic_symmetric_function` | `if u is not v` | **bug — fixed here** |
  | `matching.py` `matching` | `if u is v` | bug — already fixed in #42348 |
  | `graph.py` `cores` | `v = y if x is u else x` | safe |
  | `generic_graph.py` `has_multiple_edges` | `if a is u / elif b is u` | safe |
  | `bipartite_graph.py` (bipartition helper) | `vertex_to_component[u] is vertex_to_component[v]` | safe — not a vertex comparison |

The discriminator is **where the compared object originates**, confirmed in `base/c_graph.pyx::_iterator_edges`:
- **Single-vertex-filtered** iteration (`edge_iterator(vertices=[u])`, `edges(vertices=u)`) reuses the caller's own query object verbatim for the matching endpoint (`v = vertices[0]`); only the *neighbor* is rebuilt via `vertex_label`. So `cores` and `has_multiple_edges` only ever `is`-compare a vertex against the very object they passed in — reliable at any label size. No failing test can be constructed for them, so they are left unchanged (changing them would be churn on a deliberate fast path).

- **Unfiltered** iteration (`self.edges(...)` with no `vertices=`) rebuilds *both* endpoints, so identity is unreliable for un-interned integer labels. This is exactly the path `chromatic_symmetric_function` (and the already-fixed `matching`) take.

- `bipartite_graph.py:1278` compares the two *component list objects*, not vertices: the algorithm keeps vertices of one component pointing at the same list, so `is` is the intended O(1) "same component?" test. Correct as-is.

Conclusion: `chromatic_symmetric_function` is the only remaining function in `src/sage/graphs/` affected by this bug class.

### Related
  - #42348 — fixed the same bug class in `Graph.matching()`.
  - (https://github.com/sagemath/sage/pull/40092#issuecomment-4678975802) — where this `is`-vs-`==` self-loop issue was originally reported.

cc: @dcoudert

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies
N/A

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


