### PR TITLE
Fix boolean evaluation of empty partitions

### DIFF
--- a/src/sage/combinat/partition.py
+++ b/src/sage/combinat/partition.py
@@ -6372,6 +6372,31 @@ class Partitions(UniqueRepresentation, Parent):
         else:
             Parent.__init__(self, category=FiniteEnumeratedSets())
 
+    def __bool__(self):
+        """
+        Return whether ``self`` should be treated as nonempty.
+
+        EXAMPLES::
+
+            sage: bool(Partitions(20, parts_in=[100]))
+            False
+            sage: bool(Partitions(20, parts_in=[1, 2]))
+            True
+            sage: bool(Partitions(-1))
+            False
+            sage: bool(Partitions(0, length=1))
+            False
+            sage: bool(Partitions(0, length=0))
+            True
+
+        Finite families are checked for emptiness; infinite families keep the
+        default truth value without trying to iterate through their elements::
+
+            sage: bool(Partitions())
+            True
+        """
+        return not self.is_finite() or not self.is_empty()
+
     Element = Partition
 
     # add options to class
@@ -8413,6 +8438,19 @@ class Partitions_with_constraints(IntegerListsLex):
 
     Element = Partition
     options = Partitions.options
+
+    def __bool__(self):
+        """
+        Return whether ``self`` contains at least one partition.
+
+        EXAMPLES::
+
+            sage: bool(Partitions(5, inner=[6]))
+            False
+            sage: bool(Partitions(5, inner=[2]))
+            True
+        """
+        return not self.is_empty()
 
     def __contains__(self, x):
         """


### PR DESCRIPTION
Fixes #42327

Empty finite `Partitions(...)` parents currently inherit `Parent.__bool__`, so they stay truthy even when `is_empty()` is true. For example, `Partitions(20, parts_in=[100])` and constrained finite parents such as `Partitions(5, inner=[6])` both evaluate to `True`.

This adds boolean evaluation for the finite partition parent paths that can already determine emptiness:

- `Partitions` checks finite parents with `is_empty()`, while keeping infinite families truthy without probing iteration
- `Partitions_with_constraints` returns `False` when the constrained family is empty

The infinite-family guard keeps `bool(Partitions())` cheap and avoids turning truth testing into an emptiness search for constrained infinite families.

Tests:

- `./sage -t src/sage/combinat/partition.py`
- `python -m py_compile src/sage/combinat/partition.py`
- `git diff --check`
- `uv run --frozen --only-group lint -- ruff check --config .github/workflows/ruff.toml --no-preview src/sage/combinat/partition.py`
- `uv run --frozen --only-group lint -- ruff check --config .github/workflows/ruff.toml --preview src/sage/combinat/partition.py`
- `uv run --frozen --only-group lint -- relint -c src/.relint.yml -- src/sage/combinat/partition.py`
- `uv run --frozen --only-group lint -- flake8 --select=RST src/sage/combinat/partition.py --config src/tox.ini`

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

None
