### PR TITLE
Update gfan version check to allow beta versions

### DIFF
--- a/build/pkgs/gfan/spkg-configure.m4
+++ b/build/pkgs/gfan/spkg-configure.m4
@@ -2,7 +2,7 @@ SAGE_SPKG_CONFIGURE(
     [gfan], [
         AC_CACHE_CHECK([for gfan >= 0.6.2], [ac_cv_path_GFAN], [
         AC_PATH_PROGS_FEATURE_CHECK([GFAN_VERSION], [gfan_version], [
-            gfan_version=`$ac_path_GFAN_VERSION | $SED -n '/^gfan/s/gfan//p'`
+            gfan_version=`$ac_path_GFAN_VERSION | $SED -n '/^gfan/s/gfan//p' | $SED -n '/beta/s///p'`
             AS_IF([test -n "$gfan_version"], [
                 AX_COMPARE_VERSION([$gfan_version], [ge], [0.6.2], [
                     ac_cv_path_GFAN_VERSION="$ac_path_GFAN_VERSION"


### PR DESCRIPTION
the latest gfan has version 0.8beta, and this fix allows its usage (e.g. from the Homebrew tap)

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


