### PR TITLE
use other in richcmp arguments in  matrix/ folder

### DIFF
--- a/src/sage/matrix/matrix_cyclo_dense.pyx
+++ b/src/sage/matrix/matrix_cyclo_dense.pyx
@@ -770,14 +770,14 @@ cdef class Matrix_cyclo_dense(Matrix_dense):
         """
         return hash(self._matrix)
 
-    cpdef _richcmp_(self, right, int op):
+    cpdef _richcmp_(self, other, int op):
         """
         Implement comparison of two cyclotomic matrices with
         identical parents.
 
         INPUT:
 
-        - ``self``, ``right`` -- matrices with same parent
+        - ``self``, ``other`` -- matrices with same parent
 
         OUTPUT: boolean
 
@@ -805,7 +805,7 @@ cdef class Matrix_cyclo_dense(Matrix_dense):
             sage: A >= 2*A
             False
         """
-        return self._matrix._richcmp_((<Matrix_cyclo_dense>right)._matrix, op)
+        return self._matrix._richcmp_((<Matrix_cyclo_dense>other)._matrix, op)
 
     def __copy__(self):
         """

--- a/src/sage/matrix/matrix_dense.pyx
+++ b/src/sage/matrix/matrix_dense.pyx
@@ -54,7 +54,7 @@ cdef class Matrix_dense(matrix.Matrix):
         else:
             raise RuntimeError("unknown matrix version (=%s)" % version)
 
-    cpdef _richcmp_(self, right, int op):
+    cpdef _richcmp_(self, other, int op):
         """
         EXAMPLES::
 
@@ -82,13 +82,13 @@ cdef class Matrix_dense(matrix.Matrix):
             sage: M.transpose() == M
             False
         """
-        other = <Matrix_dense>right
+        m_other = <Matrix_dense>other
         cdef Py_ssize_t i, j
         # Parents are equal, so dimensions of self and other are equal
         for i in range(self._nrows):
             for j in range(self._ncols):
                 lij = self.get_unsafe(i, j)
-                rij = other.get_unsafe(i, j)
+                rij = m_other.get_unsafe(i, j)
                 r = richcmp_item(lij, rij, op)
                 if r is not NotImplemented:
                     return bool(r)

--- a/src/sage/matrix/matrix_gf2e_dense.pyx
+++ b/src/sage/matrix/matrix_gf2e_dense.pyx
@@ -704,7 +704,7 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
         """
         return self.__copy__()
 
-    cpdef _richcmp_(self, right, int op):
+    cpdef _richcmp_(self, other, int op):
         """
         EXAMPLES::
 
@@ -721,7 +721,7 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
         if self._nrows == 0 or self._ncols == 0:
             return rich_to_bool(op, 0)
         return rich_to_bool(op, mzed_cmp(self._entries,
-                                         (<Matrix_gf2e_dense>right)._entries))
+                                         (<Matrix_gf2e_dense>other)._entries))
 
     def __copy__(self):
         """

--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -1064,9 +1064,9 @@ cdef class Matrix_integer_dense(Matrix_dense):
         sig_off()
         return M
 
-    cpdef _richcmp_(self, right, int op):
+    cpdef _richcmp_(self, other, int op):
         r"""
-        Compare ``self`` with ``right``, examining entries in
+        Compare ``self`` with ``other``, examining entries in
         lexicographic (row major) ordering.
 
         EXAMPLES::
@@ -1086,14 +1086,11 @@ cdef class Matrix_integer_dense(Matrix_dense):
         sig_on()
         for i in range(self._nrows):
             for j in range(self._ncols):
-                k = fmpz_cmp(fmpz_mat_entry(self._matrix,i,j),
-                             fmpz_mat_entry((<Matrix_integer_dense>right)._matrix,i,j))
+                k = fmpz_cmp(fmpz_mat_entry(self._matrix, i, j),
+                             fmpz_mat_entry((<Matrix_integer_dense>other)._matrix, i, j))
                 if k:
                     sig_off()
-                    if k < 0:
-                        return rich_to_bool(op, -1)
-                    else:
-                        return rich_to_bool(op, 1)
+                    return rich_to_bool(op, -1 if k < 0 else 1)
         sig_off()
         return rich_to_bool(op, 0)
 

--- a/src/sage/matrix/matrix_mod2_dense.pyx
+++ b/src/sage/matrix/matrix_mod2_dense.pyx
@@ -1570,17 +1570,17 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
             A.subdivide(col_divs, row_divs)
         return A
 
-    cpdef _richcmp_(self, right, int op):
+    cpdef _richcmp_(self, other, int op):
         """
-        Compare ``self`` with ``right``.
+        Compare ``self`` with ``other``.
 
         While equality and
         inequality are clearly defined, ``<`` and ``>`` are not.  For
-        those first the matrix dimensions of ``self`` and ``right``
+        those first the matrix dimensions of ``self`` and ``other``
         are compared. If these match then ``<`` means that there is a
         position smallest (i,j) in ``self`` where ``self[i,j]`` is
-        zero but ``right[i,j]`` is one. This (i,j) is smaller than the
-        (i,j) if ``self`` and ``right`` are exchanged for the
+        zero but ``other[i,j]`` is one. This (i,j) is smaller than the
+        (i,j) if ``self`` and ``other`` are exchanged for the
         comparison.
 
         EXAMPLES::
@@ -1601,7 +1601,7 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
         if self._nrows == 0 or self._ncols == 0:
             return rich_to_bool(op, 0)
         return rich_to_bool(op, mzd_cmp(self._entries,
-                                        (<Matrix_mod2_dense>right)._entries))
+                                        (<Matrix_mod2_dense>other)._entries))
 
     def augment(self, right, subdivide=False):
         r"""

--- a/src/sage/matrix/matrix_modn_dense_template.pxi
+++ b/src/sage/matrix/matrix_modn_dense_template.pxi
@@ -997,7 +997,7 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
         sig_off()
         return M
 
-    cpdef _richcmp_(self, right, int op):
+    cpdef _richcmp_(self, other, int op):
         r"""
         Compare two dense matrices over `\Z/n\Z`.
 
@@ -1037,7 +1037,7 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
             False
         """
         cdef Py_ssize_t i
-        cdef celement* other_ent = (<Matrix_modn_dense_template>right)._entries
+        cdef celement* other_ent = (<Matrix_modn_dense_template>other)._entries
         sig_on()
         for i in range(self._nrows * self._ncols):
             if self._entries[i] < other_ent[i]:

--- a/src/sage/matrix/matrix_rational_dense.pyx
+++ b/src/sage/matrix/matrix_rational_dense.pyx
@@ -510,7 +510,7 @@ cdef class Matrix_rational_dense(Matrix_dense):
         sig_off()
         return ans
 
-    cpdef _richcmp_(self, right, int op):
+    cpdef _richcmp_(self, other, int op):
         r"""
         TESTS::
 
@@ -543,12 +543,9 @@ cdef class Matrix_rational_dense(Matrix_dense):
         for i in range(self._nrows):
             for j in range(self._ncols):
                 k = fmpq_cmp(fmpq_mat_entry(self._matrix, i, j),
-                             fmpq_mat_entry((<Matrix_rational_dense> right)._matrix, i, j))
+                             fmpq_mat_entry((<Matrix_rational_dense> other)._matrix, i, j))
                 if k:
-                    if k > 0:
-                        return rich_to_bool(op, 1)
-                    else:
-                        return rich_to_bool(op, -1)
+                    return rich_to_bool(op, 1 if k > 0 else -1)
         return rich_to_bool(op, 0)
 
     cdef _vector_times_matrix_(self, Vector v):


### PR DESCRIPTION
as another step towards uniformity in using `_richcmp_(self, other, op)` everywhere

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.

