### PR TITLE
Added special case generating series methods for Hadamard and Arithmetic products

### DIFF
--- a/src/sage/rings/lazy_species.py
+++ b/src/sage/rings/lazy_species.py
@@ -1753,7 +1753,6 @@ class ArithmeticProductSpeciesElement(LazyCombinatorialSpeciesElement):
         self._other = G
 
     def generating_series(self):
-
         r"""
         Return the (exponential) generating series of ``self``.
 
@@ -1763,7 +1762,15 @@ class ArithmeticProductSpeciesElement(LazyCombinatorialSpeciesElement):
             sage: E = L.Sets()
             sage: Ep = E.restrict(1)
             sage: Ep.arithmetic_product(Ep).generating_series()
-            X + X^2 + 1/3*X^3 + 1/3*X^4 + 1/60*X^5 + 61/360*X^6 
+            X + X^2 + 1/3*X^3 + 1/3*X^4 + 1/60*X^5 + 61/360*X^6 + O(X^7)
+
+        We check Example 2.2 from [MM2008]_::
+
+            sage: L.<X> = LazyCombinatorialSpecies(QQ)
+            sage: C = L.Cycles()
+            sage: Lp = X/(1 - X)
+            sage: C.arithmetic_product(Lp).generating_series()
+            X + 3/2*X^2 + 4/3*X^3 + 7/4*X^4 + 6/5*X^5 + 2*X^6 + O(X^7)
         """
         f = self._left.generating_series()
         g = self._other.generating_series()
@@ -1816,8 +1823,8 @@ class HadamardProductSpeciesElement(LazyCombinatorialSpeciesElement):
             1 + X + 1/2*X^2 + 1/6*X^3 + 1/24*X^4 + 1/120*X^5 + 1/720*X^6 + O(X^7)
 
             sage: C = L.Cycles()
-            sage: C.hadamard_product(C).generating_series().truncate(7)
-            X + 1/2*X^2 + 2/3*X^3 + 3/2*X^4 + 24/5*X^5 + 20*X^6
+            sage: C.hadamard_product(C).generating_series()
+            X + 1/2*X^2 + 2/3*X^3 + 3/2*X^4 + 24/5*X^5 + 20*X^6 + O(X^7)
         """
         f = self._left.generating_series()
         g = self._other.generating_series()

--- a/src/sage/rings/lazy_species.py
+++ b/src/sage/rings/lazy_species.py
@@ -1752,6 +1752,31 @@ class ArithmeticProductSpeciesElement(LazyCombinatorialSpeciesElement):
         self._left = F
         self._other = G
 
+    def generating_series(self):
+
+        r"""
+        Return the (exponential) generating series of ``self``.
+
+        EXAMPLES::
+
+            sage: L = LazyCombinatorialSpecies(QQ, "X")
+            sage: E = L.Sets()
+            sage: Ep = E.restrict(1)
+            sage: Ep.arithmetic_product(Ep).generating_series().truncate(7)
+            X + X^2 + 1/3*X^3 + 1/3*X^4 + 1/60*X^5 + 61/360*X^6 
+        """
+
+        f = self._left.generating_series()
+        g = self._other.generating_series()
+        zero = f.parent().base_ring().zero()
+
+        def coefficient(n):
+            if not n:
+                return zero
+            return sum((f[d] * g[n // d] for d in divisors(n)), zero)
+
+        return f.parent()(coefficient)
+
 
 class HadamardProductSpeciesElement(LazyCombinatorialSpeciesElement):
     def __init__(self, left, other):
@@ -1779,6 +1804,29 @@ class HadamardProductSpeciesElement(LazyCombinatorialSpeciesElement):
         super().__init__(P, coeff_stream)
         self._left = left
         self._other = other
+
+    def generating_series(self):
+        r"""
+        Return the (exponential) generating series of ``self``.
+
+        EXAMPLES::
+
+            sage: L = LazyCombinatorialSpecies(QQ, "X")
+            sage: E = L.Sets()
+            sage: E.hadamard_product(E).generating_series()
+            1 + X + 1/2*X^2 + 1/6*X^3 + 1/24*X^4 + 1/120*X^5 + 1/720*X^6 + O(X^7)
+
+            sage: C = L.Cycles()
+            sage: C.hadamard_product(C).generating_series().truncate(7)
+            X + 1/2*X^2 + 2/3*X^3 + 3/2*X^4 + 24/5*X^5 + 20*X^6
+        """
+        f = self._left.generating_series()
+        g = self._other.generating_series()
+
+        def coefficient(n):
+            return factorial(n) * f[n] * g[n]
+
+        return f.parent()(coefficient)
 
 
 class LazyCombinatorialSpecies(LazyCompletionGradedAlgebra):

--- a/src/sage/rings/lazy_species.py
+++ b/src/sage/rings/lazy_species.py
@@ -1765,7 +1765,6 @@ class ArithmeticProductSpeciesElement(LazyCombinatorialSpeciesElement):
             sage: Ep.arithmetic_product(Ep).generating_series().truncate(7)
             X + X^2 + 1/3*X^3 + 1/3*X^4 + 1/60*X^5 + 61/360*X^6 
         """
-
         f = self._left.generating_series()
         g = self._other.generating_series()
         zero = f.parent().base_ring().zero()

--- a/src/sage/rings/lazy_species.py
+++ b/src/sage/rings/lazy_species.py
@@ -1762,7 +1762,7 @@ class ArithmeticProductSpeciesElement(LazyCombinatorialSpeciesElement):
             sage: L = LazyCombinatorialSpecies(QQ, "X")
             sage: E = L.Sets()
             sage: Ep = E.restrict(1)
-            sage: Ep.arithmetic_product(Ep).generating_series().truncate(7)
+            sage: Ep.arithmetic_product(Ep).generating_series()
             X + X^2 + 1/3*X^3 + 1/3*X^4 + 1/60*X^5 + 61/360*X^6 
         """
         f = self._left.generating_series()


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->


Coefficients of Hadamard product and Arithmetic product of single sort species admit neat closed forms. I implemented generating series methods for these operations following other sample generating series methods.



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


