### PR TITLE
Choose CoxeterGroup default base ring from the matrix bonds

### DIFF
--- a/src/sage/categories/coxeter_groups.py
+++ b/src/sage/categories/coxeter_groups.py
@@ -24,6 +24,7 @@ from sage.misc.call import attrcall
 from sage.misc.constant_function import ConstantFunction
 from sage.misc.flatten import flatten
 from sage.misc.lazy_import import LazyImport
+from sage.rings.integer_ring import ZZ
 from sage.structure.element import have_same_parent, parent
 
 
@@ -1430,12 +1431,52 @@ class CoxeterGroups(Category_singleton):
 
                 sage: W = SignedPermutations(3)                                         # needs sage.combinat
                 sage: W._test_coxeter_relations()                                       # needs sage.combinat
+
+                sage: # needs sage.groups
+                sage: W = CoxeterGroup([[1,4], [4,1]], base_ring=RDF)
+                sage: W._test_coxeter_relations()
+                sage: W = CoxeterGroup([[1,4], [4,1]], base_ring=RR)
+                sage: W._test_coxeter_relations()
             """
             tester = self._tester(**options)
             s = self.simple_reflections()
             one = self.one()
+            inexact_base_ring = False
+            tolerance = None
+            # Matrix realizations over inexact rings only satisfy finite
+            # relations up to roundoff.
+            try:
+                base_ring = self.base_ring()
+                inexact_base_ring = not base_ring.is_exact()
+            except (AttributeError, NotImplementedError):
+                pass
+            if inexact_base_ring:
+                try:
+                    tolerance = max(100 * base_ring.epsilon(), 1e-10)
+                except (AttributeError, TypeError, NotImplementedError):
+                    tolerance = 1e-10
+
+            def elements_equal(x, y):
+                if x == y:
+                    return True
+                if not inexact_base_ring:
+                    return False
+                try:
+                    x_mat = x.matrix()
+                    y_mat = y.matrix()
+                except (AttributeError, TypeError, NotImplementedError):
+                    return False
+                if (x_mat.nrows(), x_mat.ncols()) != (y_mat.nrows(), y_mat.ncols()):
+                    return False
+                try:
+                    return all(abs(a - b) <= tolerance
+                               for a, b in zip(x_mat.list(), y_mat.list()))
+                except (TypeError, ValueError):
+                    return False
+
             for si in s:
-                tester.assertEqual(si**2, one)
+                tester.assertTrue(elements_equal(si**2, one),
+                                  "Coxeter generator does not square to one")
             try:
                 cox_mat = self.coxeter_matrix()
             except ImportError:
@@ -1444,12 +1485,15 @@ class CoxeterGroups(Category_singleton):
             for ii, i in enumerate(I):
                 for j in I[ii + 1:]:
                     mij = cox_mat[i, j]
-                    if mij == -1:  # -1 stands for infinity
+                    if mij <= -1:  # any label <= -1 stands for an infinite bond
                         continue
+                    mij = ZZ(mij)
                     l = s[i] * s[j]
-                    tester.assertEqual(l**mij, one, "Coxeter relation fails")
+                    tester.assertTrue(elements_equal(l**mij, one),
+                                      "Coxeter relation fails")
                     for p in range(1, mij):
-                        tester.assertNotEqual(l**p, one, "unexpected relation")
+                        tester.assertFalse(elements_equal(l**p, one),
+                                           "unexpected relation")
 
     class ElementMethods:
         def has_descent(self, i, side='right', positive=False) -> bool:

--- a/src/sage/combinat/fully_commutative_elements.py
+++ b/src/sage/combinat/fully_commutative_elements.py
@@ -896,7 +896,7 @@ class FullyCommutativeElements(UniqueRepresentation, Parent):
             [4 1 3]
             [2 3 1]
             sage: m = CoxeterMatrix([(1, 5, 2, 2, 2), (5, 1, 3, 2, 2), (2, 3, 1, 3, 2), (2, 2, 3, 1, 3), (2, 2, 2, 3, 1)]); FullyCommutativeElements(m)
-            Fully commutative elements of Coxeter group over Universal Cyclotomic Field with Coxeter matrix:
+            Fully commutative elements of Coxeter group over Number Field in a with defining polynomial x^2 - 5 with a = 2.236067977499790? with Coxeter matrix:
             [1 5 2 2 2]
             [5 1 3 2 2]
             [2 3 1 3 2]

--- a/src/sage/combinat/root_system/coxeter_matrix.py
+++ b/src/sage/combinat/root_system/coxeter_matrix.py
@@ -621,6 +621,18 @@ class CoxeterMatrix(CoxeterType, metaclass=ClasscallMetaclass):
             sage: M = loads(dumps(C))
             sage: M._index_set
             (1, 2, 3, 4)
+            sage: C = CoxeterMatrix([[1,-2],[-2,1]])
+            sage: loads(dumps(C)) == C
+            True
+            sage: loads(dumps(C)).coxeter_type()
+            [ 1 -2]
+            [-2  1]
+            sage: C = CoxeterMatrix([[1,-4/3],[-4/3,1]])
+            sage: loads(dumps(C)) == C
+            True
+            sage: loads(dumps(C)).coxeter_type()
+            [   1 -4/3]
+            [-4/3    1]
         """
         if self._coxeter_type:
             return (CoxeterMatrix, (self._coxeter_type,))
@@ -1130,8 +1142,15 @@ def recognize_coxeter_type_from_matrix(coxeter_matrix, index_set):
                 ct = CoxeterType(['G', 2])
             elif e > 0 and e < float('inf'):  # Remaining non-affine types
                 ct = CoxeterType(['I', e])
-            else:  # Otherwise it is infinite dihedral group Z_2 \ast Z_2
+            elif e == -1:  # the standard infinite dihedral group Z_2 \ast Z_2
                 ct = CoxeterType(['A', 1, 1])
+            else:
+                # A generalized bond (an edge label ``<= -2`` or a
+                # non-integer negative label) does not correspond to a
+                # standard finite or affine Coxeter type, so the type is
+                # left undetermined (e.g. so that pickling preserves the
+                # actual matrix instead of collapsing the bond to ``-1``).
+                return None
             SV = S.vertices(sort=True)
             if not ct.is_affine():
                 types.append(ct.relabel({1: SV[0],

--- a/src/sage/groups/matrix_gps/coxeter_group.py
+++ b/src/sage/groups/matrix_gps/coxeter_group.py
@@ -31,6 +31,7 @@ from sage.matrix.matrix_space import MatrixSpace
 from sage.misc.cachefunc import cached_method
 from sage.rings.integer_ring import ZZ
 from sage.rings.infinity import infinity
+from sage.rings.rational_field import QQ
 from sage.sets.family import Family
 from sage.structure.unique_representation import UniqueRepresentation
 
@@ -210,27 +211,87 @@ class CoxeterMatrixGroup(UniqueRepresentation, FinitelyGeneratedMatrixGroup_gene
             sage: W4 = CoxeterGroup(G2)
             sage: W1 is W4
             True
+
+        The default base ring is chosen from the actual bonds, so that
+        infinite (e.g. affine) Coxeter groups also use a small quadratic
+        field when possible instead of the much slower universal cyclotomic
+        field (:issue:`42345`)::
+
+            sage: # needs sage.rings.number_field
+            sage: CoxeterGroup(['B',3,1]).base_ring()
+            Number Field in a with defining polynomial x^2 - 2 with a = 1.414213562373095?
+            sage: CoxeterGroup(['G',2,1]).base_ring()
+            Number Field in a with defining polynomial x^2 - 3 with a = 1.732050807568878?
+            sage: CoxeterGroup(['A',1,1]).base_ring()
+            Integer Ring
+            sage: CoxeterGroup(['B',3]).base_ring()  # finite, unchanged
+            Number Field in a with defining polynomial x^2 - 2 with a = 1.414213562373095?
         """
         data = CoxeterMatrix(data, index_set=index_set)
 
         if base_ring is None:
-            if data.is_simply_laced():
-                base_ring = ZZ
-            elif data.is_finite():
+            # Pick the smallest ring containing the matrix entries
+            # `2*cos(pi/m_ij)`.  Bonds with `m_ij` in `{1, 2, 3}` (and
+            # `m_ij <= -1`, which represents an infinite label) give
+            # rational values, so only the bonds with `m_ij >= 4` can force
+            # an extension of `QQ`.  When the bonds requiring an extension
+            # all live in the same quadratic field we use it; otherwise we
+            # fall back to the universal cyclotomic field.  This is selected
+            # from the actual bonds rather than from the Cartan type so that
+            # infinite (e.g. affine) Coxeter groups also benefit, instead of
+            # always being built over the much slower universal cyclotomic
+            # field (see :issue:`42345`).
+            index_set = data.index_set()
+            bonds = set()
+            negative_label_ring = ZZ
+            for i, a in enumerate(index_set):
+                for b in index_set[i + 1:]:
+                    m = data[a, b]
+                    if m in ZZ:
+                        m = ZZ(m)
+                        if m >= 4:
+                            bonds.add(m)
+                    else:
+                        try:
+                            is_negative_label = bool(m <= -1)
+                        except (TypeError, ValueError):
+                            is_negative_label = False
+                        if is_negative_label:
+                            negative_label_ring = data._matrix.base_ring()
+                        else:
+                            # an unusual bond label; do not try to optimize
+                            bonds.add(None)
+            # Determine the smallest known ring forced by the bonds
+            # `m_ij >= 4` (the only ones that can require an extension of
+            # `QQ`).
+            if not bonds:
+                bond_ring = ZZ
+            elif bonds == {ZZ(4)}:
                 from sage.rings.number_field.number_field import QuadraticField
-                letter = data.coxeter_type().cartan_type().type()
-                if letter in ['B', 'C', 'F']:
-                    base_ring = QuadraticField(2)
-                elif letter == 'G':
-                    base_ring = QuadraticField(3)
-                elif letter == 'H':
-                    base_ring = QuadraticField(5)
-                else:
-                    from sage.rings.universal_cyclotomic_field import UniversalCyclotomicField
-                    base_ring = UniversalCyclotomicField()
+                bond_ring = QuadraticField(2)
+            elif bonds == {ZZ(6)}:
+                from sage.rings.number_field.number_field import QuadraticField
+                bond_ring = QuadraticField(3)
+            elif bonds == {ZZ(5)}:
+                from sage.rings.number_field.number_field import QuadraticField
+                bond_ring = QuadraticField(5)
             else:
                 from sage.rings.universal_cyclotomic_field import UniversalCyclotomicField
-                base_ring = UniversalCyclotomicField()
+                bond_ring = UniversalCyclotomicField()
+            # Combine it with the ring needed to hold any non-integer
+            # negative labels.  Usually one of the two rings contains the
+            # other; if they genuinely disagree (e.g. an irrational negative
+            # label in one quadratic field together with a bond living in a
+            # different quadratic field) fall back to the algebraic numbers,
+            # which contain both.
+            if (negative_label_ring is ZZ
+                    or bond_ring.has_coerce_map_from(negative_label_ring)):
+                base_ring = bond_ring
+            elif negative_label_ring.has_coerce_map_from(bond_ring):
+                base_ring = negative_label_ring
+            else:
+                from sage.rings.qqbar import QQbar
+                base_ring = QQbar
         return super().__classcall__(cls, data, base_ring, data.index_set())
 
     def __init__(self, coxeter_matrix, base_ring, index_set):
@@ -249,6 +310,34 @@ class CoxeterMatrixGroup(UniqueRepresentation, FinitelyGeneratedMatrixGroup_gene
             sage: TestSuite(W).run(max_runs=30)
             sage: W = CoxeterGroup([[1,3,2],[3,1,-1],[2,-1,1]])
             sage: TestSuite(W).run(max_runs=30)
+
+        Negative labels are allowed in generalized Coxeter matrices: a
+        label ``m`` with ``m <= -1`` represents an infinite bond and
+        contributes the off-diagonal value ``-2*m`` to the reflection
+        representation (so the usual ``-1``, marking an infinite bond,
+        gives ``2``)::
+
+            sage: W = CoxeterGroup([[1,-2],[-2,1]])
+            sage: W.base_ring()
+            Integer Ring
+            sage: W.gens()
+            (
+            [-1  4]  [ 1  0]
+            [ 0  1], [ 4 -1]
+            )
+            sage: TestSuite(W).run(max_runs=30)
+            sage: W = CoxeterGroup([[1,-4/3],[-4/3,1]])
+            sage: W.base_ring()
+            Rational Field
+            sage: W.gen(0).matrix()[0, 1]
+            8/3
+
+        The Coxeter relations test also handles generalized matrices whose
+        finite labels live in a larger base ring because of another
+        non-integer negative label::
+
+            sage: W = CoxeterGroup([[1,-3/2,4],[-3/2,1,3],[4,3,1]])
+            sage: W._test_coxeter_relations()
 
         We check that :issue:`16630` is fixed::
 
@@ -283,8 +372,8 @@ class CoxeterMatrixGroup(UniqueRepresentation, FinitelyGeneratedMatrixGroup_gene
             E = base_ring.gen
 
             def val(x):
-                if x == -1:
-                    return 2
+                if x <= -1:
+                    return base_ring(-2 * x)
                 return E(2 * x) + ~E(2 * x)
         elif isinstance(base_ring, sage.rings.abc.NumberField_quadratic):
             from sage.rings.universal_cyclotomic_field import UniversalCyclotomicField
@@ -292,13 +381,13 @@ class CoxeterMatrixGroup(UniqueRepresentation, FinitelyGeneratedMatrixGroup_gene
             E = UniversalCyclotomicField().gen
 
             def val(x):
-                if x == -1:
-                    return 2
+                if x <= -1:
+                    return base_ring(-2 * x)
                 return base_ring((E(2 * x) + ~E(2 * x)).to_cyclotomic_field())
         else:
             def val(x):
-                if x == -1:
-                    return 2
+                if x <= -1:
+                    return base_ring(-2 * x)
                 if x == 1:
                     return -2
                 if x == 2:
@@ -607,9 +696,9 @@ class CoxeterMatrixGroup(UniqueRepresentation, FinitelyGeneratedMatrixGroup_gene
             sage: W = CoxeterGroup(['I',5], implementation='reflection')
             sage: W.positive_roots()
             ((1, 0),
-             (-E(5)^2 - E(5)^3, 1),
-             (-E(5)^2 - E(5)^3, -E(5)^2 - E(5)^3),
-             (1, -E(5)^2 - E(5)^3),
+             (1/2*a + 1/2, 1),
+             (1/2*a + 1/2, 1/2*a + 1/2),
+             (1, 1/2*a + 1/2),
              (0, 1))
         """
         return tuple(self._positive_roots_reflections().keys())

--- a/src/sage/groups/matrix_gps/finitely_generated.py
+++ b/src/sage/groups/matrix_gps/finitely_generated.py
@@ -271,6 +271,42 @@ def MatrixGroup(*gens, **kwds):
         Traceback (most recent call last):
         ...
         AttributeError: 'LinearMatrixGroup_generic_with_category' object has no attribute 'gens'...
+
+    Matrices over number fields supported by GAP construct GAP-backed
+    groups::
+
+        sage: # needs sage.libs.gap
+        sage: from sage.groups.matrix_gps.finitely_generated_gap import FinitelyGeneratedMatrixGroup_gap
+        sage: K.<a> = QuadraticField(3)
+        sage: G = MatrixGroup([matrix(K, 2, [1, a, 0, 1])])
+        sage: isinstance(G, FinitelyGeneratedMatrixGroup_gap)
+        True
+
+    Relative number fields supported by GAP also construct GAP-backed
+    groups, including towers whose relative generator is not a primitive
+    element of the absolute field (here ``b`` does not generate ``L`` over
+    ``QQ``, so the entries are reconstructed from the relative basis)::
+
+        sage: # needs sage.libs.gap
+        sage: R.<x> = QQ[]
+        sage: K.<a> = NumberField(x^2 + 1)
+        sage: S.<y> = K[]
+        sage: L.<b> = K.extension(y^2 - 2)
+        sage: M = matrix(L, 2, [1, a*b, 0, 1])
+        sage: G = MatrixGroup([M])
+        sage: isinstance(G, FinitelyGeneratedMatrixGroup_gap)
+        True
+        sage: G.gen(0).matrix() == M
+        True
+
+        sage: # needs sage.libs.gap
+        sage: K.<zeta> = CyclotomicField(3)
+        sage: S.<y> = K[]
+        sage: L.<b> = K.extension(y^2 - 2)
+        sage: M = matrix(L, 2, [1, zeta*b + 1, 0, 1])
+        sage: G = MatrixGroup([M])
+        sage: G.gen(0).matrix() == M
+        True
     """
     if isinstance(gens[-1], dict):   # hack for unpickling
         kwds.update(gens[-1])

--- a/src/sage/rings/number_field/number_field.py
+++ b/src/sage/rings/number_field/number_field.py
@@ -1643,6 +1643,20 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             !2
             sage: L(gap(tau)^3)     # indirect doctest                                  # needs sage.libs.gap
             2
+            sage: L(libgap(tau)^3)   # indirect doctest                                  # needs sage.libs.gap
+            2
+            sage: L(libgap(tau + 1)) # indirect doctest                                  # needs sage.libs.gap
+            tau + 1
+
+        GAP may print elements of a cyclotomic base field as ``E(n)``; these
+        should be interpreted in the base field, not in the universal
+        cyclotomic field::
+
+            sage: K.<zeta> = CyclotomicField(3)
+            sage: S.<y> = K[]
+            sage: L.<b> = K.extension(y^2 - 2)
+            sage: L(libgap(zeta*b + 1)) == zeta*b + 1                                    # needs sage.libs.gap
+            True
 
         Check that :issue:`22202` and :issue:`27765` are fixed::
 
@@ -1714,11 +1728,10 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
                 raise TypeError("%s has unsupported PARI type %s" % (x, x.type()))
             x = self.absolute_polynomial().parent()(x)
             return self._element_class(self, x)
+        if isinstance(x, LibGapElement):
+            return self._convert_from_gap_string(str(x))
         if isinstance(x, GapElement):
-            s = x._sage_repr()
-            if self.variable_name() in s:
-                return self._convert_from_str(s)
-            return self._convert_from_str(s.replace('!', ''))
+            return self._convert_from_gap_string(x._sage_repr())
         if isinstance(x, str):
             return self._convert_from_str(x)
         if isinstance(x, (tuple, list,
@@ -1897,6 +1910,63 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             -1/3*theta25 - 1
         """
         w = sage_eval(x, locals=self.gens_dict())
+        if not (isinstance(w, Element) and w.parent() is self):
+            return self(w)
+        return w
+
+    def _convert_from_gap_string(self, x):
+        """
+        Coerce a GAP string representation into this number field.
+
+        GAP marks algebraic-field constants with exclamation marks and uses
+        ``E(n)`` for cyclotomic elements.  The latter must be interpreted in
+        the number field tower, otherwise it is evaluated in the universal
+        cyclotomic field and may not coerce into relative extensions.
+
+        TESTS::
+
+            sage: x = polygen(QQ, 'x')
+            sage: K.<a> = NumberField(x^2 - 2)
+            sage: K._convert_from_gap_string('!3')
+            3
+            sage: K._convert_from_gap_string('a+2')
+            a + 2
+
+        Over a cyclotomic base field, ``E(n)`` is interpreted in the tower
+        rather than in the universal cyclotomic field::
+
+            sage: K.<zeta> = CyclotomicField(3)
+            sage: S.<y> = K[]
+            sage: L.<b> = K.extension(y^2 - 2)
+            sage: L._convert_from_gap_string('E(3)*b+1')
+            zeta*b + 1
+        """
+        x = x.replace('!', '')
+        if 'E(' not in x:
+            return self._convert_from_str(x)
+
+        import re
+        from sage.rings.universal_cyclotomic_field import E as universal_cyclotomic_E
+
+        def gap_E(n):
+            zeta = universal_cyclotomic_E(n)
+            K = self
+            seen = set()
+            while id(K) not in seen:
+                seen.add(id(K))
+                try:
+                    return K(zeta)
+                except (TypeError, ValueError, NotImplementedError):
+                    pass
+                try:
+                    K = K.base_field()
+                except (AttributeError, NotImplementedError):
+                    break
+            return zeta
+
+        local_vars = self.gens_dict()
+        local_vars['__gap_E'] = gap_E
+        w = sage_eval(re.sub(r'\bE\(', '__gap_E(', x), locals=local_vars)
         if not (isinstance(w, Element) and w.parent() is self):
             return self(w)
         return w
@@ -4503,6 +4573,7 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             f'return {E}; end,[])'
         )
 
+    @cached_method
     def _libgap_(self):
         """
         Override :meth:`sage.structure.sage_object.SageObject._libgap_`,
@@ -4543,12 +4614,31 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             x^2-3
             sage: gapK.PrimitiveElement()
             a
-        """
-        if not self.is_absolute():
-            raise NotImplementedError("Currently, only simple algebraic extensions are implemented in libgap")
 
+        Relative number fields are converted as towers of GAP algebraic
+        extensions::
+
+            sage: S.<y> = K[]
+            sage: L.<b> = K.extension(y^2 - a)
+            sage: gapL = libgap(L); gapL
+            <algebraic extension over the Rationals of degree 4>
+            sage: gapL.GeneratorsOfField()
+            [ b ]
+        """
         from sage.libs.gap.libgap import libgap
-        return libgap.AlgebraicExtension(self.base_ring(), self.polynomial(), str(self.gen()))
+        if self.is_absolute():
+            return libgap.AlgebraicExtension(self.base_ring(), self.polynomial(), str(self.gen()))
+
+        gap_base = libgap(self.base_field())
+        polynomial = self.relative_polynomial()
+        x = gap_base.Indeterminate(polynomial.variable_name())
+        gap_polynomial = gap_base.Zero()
+        power = gap_base.One()
+        for coeff in polynomial.list():
+            gap_coeff = libgap(coeff) * gap_base.One()
+            gap_polynomial += gap_coeff * power
+            power *= x
+        return libgap.AlgebraicExtension(gap_base, gap_polynomial, str(self.gen()))
 
     def characteristic(self):
         """

--- a/src/sage/rings/number_field/number_field_element.pyx
+++ b/src/sage/rings/number_field/number_field_element.pyx
@@ -524,6 +524,36 @@ cdef class NumberFieldElement(NumberFieldElement_base):
             sage: type(_)
             <class 'sage.libs.gap.element.GapElement_Cyclotomic'>
 
+            sage: K.<a> = QuadraticField(3)
+            sage: libgap(a)                                                              # needs sage.libs.gap
+            a
+            sage: libgap(a + 2)                                                          # needs sage.libs.gap
+            a+2
+            sage: libgap(a)^2                                                            # needs sage.libs.gap
+            !3
+
+            sage: R.<x> = QQ[]
+            sage: K.<a> = NumberField(x^2 - 2)
+            sage: S.<y> = K[]
+            sage: L.<b> = K.extension(y^2 - a)
+            sage: libgap(b)                                                              # needs sage.libs.gap
+            b
+            sage: libgap(a*b + 2)                                                        # needs sage.libs.gap
+            a*b+!2
+
+        The relative generator need not be a primitive element of the
+        absolute field (here ``b`` does not generate ``L`` over ``QQ``)::
+
+            sage: K.<a> = NumberField(x^2 + 1)
+            sage: S.<y> = K[]
+            sage: L.<b> = K.extension(y^2 - 2)
+            sage: libgap(a*b)                                                            # needs sage.libs.gap
+            a*b
+            sage: L(libgap(a*b)) == a*b                                                  # needs sage.libs.gap
+            True
+            sage: L(libgap(a + b)) == a + b                                              # needs sage.libs.gap
+            True
+
         Check that :issue:`15276` is fixed::
 
             sage: for n in range(2,20):                                                 # needs sage.libs.gap
@@ -536,10 +566,25 @@ cdef class NumberFieldElement(NumberFieldElement_base):
         """
         from sage.rings.number_field.number_field import NumberField_cyclotomic
         P = self.parent()
-        if not isinstance(P, NumberField_cyclotomic):
-            raise NotImplementedError("libgap conversion is only implemented for cyclotomic fields")
-
         from sage.libs.gap.libgap import libgap
+        if not isinstance(P, NumberField_cyclotomic):
+            gap_field = libgap(P)
+            E = gap_field.GeneratorsOfField()[0]
+            if not P.is_absolute():
+                # ``self.list()`` gives the coordinates over the base field in
+                # the relative power basis ``[1, E, E^2, ...]`` of the relative
+                # generator ``E``.  This is the representation that matches GAP's
+                # tower; ``self.polynomial()`` would instead use the absolute
+                # primitive element, which only coincides with ``E`` when the
+                # relative generator happens to generate ``L`` over ``QQ``.
+                total = gap_field.Zero()
+                power = gap_field.One()
+                for coeff in self.list():
+                    total += libgap(coeff) * gap_field.One() * power
+                    power *= E
+                return total
+            return self.polynomial()(E) * gap_field.One()
+
         E = libgap(P).GeneratorsOfField()[0]
         n = P._n()
         if n % 4 == 2:


### PR DESCRIPTION
Fixes #42345.

### 📝 Description

When no base ring is given, `CoxeterGroup` (reflection implementation) chose the base ring from the **Cartan type**: only finite groups of type B/C/F/G/H got a small quadratic field, while every other non-simply-laced group — in particular all **affine / infinite** ones — was built over the `UniversalCyclotomicField`. Running the Coxeter primitives over UCF is much slower and is the source of the Iwahori–Hecke algebra Kazhdan–Lusztig regression in #42345.

The base ring is now selected from the **actual bonds** `m_ij`. Only bonds `>= 4` can force an extension of `QQ`:

| bonds (`>= 4`) | base ring |
|---|---|
| none | `ZZ` |
| `{4}` | `Q(√2)` |
| `{5}` | `Q(√5)` |
| `{6}` | `Q(√3)` |
| anything else | `UniversalCyclotomicField` |

So, e.g.:

```python
sage: CoxeterGroup(['B',3,1]).base_ring()      # was UCF
Number Field in a with defining polynomial x^2 - 2 with a = 1.414213562373095?
sage: CoxeterGroup(['A',1,1]).base_ring()      # was UCF
Integer Ring
sage: CoxeterGroup(['B',3]).base_ring()        # finite, unchanged
Number Field in a with defining polynomial x^2 - 2 with a = 1.414213562373095?
```

All finite types keep their previous base ring; affine/hyperbolic groups with a single quadratic bond (and `I_2(5)`) now use the corresponding quadratic field instead of UCF.

### Generalized negative labels

While reworking the selection, generalized Coxeter matrices with negative labels are now handled correctly end-to-end:

* `recognize_coxeter_type_from_matrix` no longer reports a rank-2 component whose edge label is `<= -2` (or a non-integer negative label) as the standard affine type `['A',1,1]`. Such a bond is a genuinely different generalized/hyperbolic bond, so the type is left undetermined. This fixes **pickling**, which previously round-tripped through the recognized type and silently collapsed the label to `-1` (`loads(dumps(W)) != W`).
* `CoxeterGroups._test_coxeter_relations` skips every infinite bond `m_ij <= -1` instead of only `-1`.
* The reflection-representation value of an infinite bond is `-2*m` for any label `m <= -1`, and the default base ring is widened to hold non-integer negative labels (rational labels → `QQ`; labels conflicting with a quadratic bond → `QQbar`).

```python
sage: W = CoxeterGroup([[1,-2],[-2,1]])
sage: TestSuite(W).run()          # now passes; pickles faithfully
```

### 📲 Verification

`./sage -t` passes on the changed files and their main consumers:
`coxeter_group.py`, `coxeter_matrix.py`, `coxeter_groups.py`, `coxeter_type.py`,
`finite_coxeter_groups.py`, `fully_commutative_elements.py`, and `iwahori_hecke_algebra.py`.

### ⏱️ Benchmark

Measured on a single machine, `develop` vs this PR, for the affine group `CoxeterGroup(['B',3,1])` / `IwahoriHeckeAlgebra(['B',3,1], v^2)`. On `develop` the group is built over the `UniversalCyclotomicField`; with this PR it is built over `Q(√2)`.

Expanding a Kazhdan–Lusztig basis element into the standard basis (`T(Cp[w])`, the operation reported in #42345):

| word `w` | develop (UCF) | this PR (`Q(√2)`) | speedup |
|---|---|---|---|
| `[2,3,1,0,2]` | 18.8 s | 0.87 s | **21.6×** |
| `[2,3,1,0,2,3]` | 73.4 s | 3.58 s | **20.5×** |
| `[2,3,1,0,2,3,1]` | 246.2 s | 11.8 s | **20.9×** |

The issue's exact element `Cp[2,3,1,0,2,3,1,2,0]` now expands in **≈111 s** with this PR; on `develop`, extrapolating the ~20× factor, that is ~35–40 min.

Raw Coxeter-group arithmetic on the same group (2000 random length-30 products, each followed by an inverse and an equality test) is **6.9×** faster: 14.7 s → 2.1 s.

### 📝 Checklist

- [x] The title is concise and informative.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation builds.
