### PR TITLE
fix MILP formulation in `edge_disjoint_spanning_trees`

### DIFF
--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -7513,6 +7513,14 @@ class GenericGraph(GenericGraph_pyx):
             Traceback (most recent call last):
             ...
             ValueError: algorithm must be None or "MILP" for directed graphs
+
+        Check that the issue raised in :issue:`42257` on the MILP formulation on
+        complete directed graphs of order 3 is fixed::
+
+            sage: clique = digraphs.Complete
+            sage: [len(clique(k).edge_disjoint_spanning_trees(k - 1, algorithm='MILP'))
+            ....:  for k in range(1, 8)]
+            [0, 1, 2, 3, 4, 5, 6]
         """
         self._scream_if_not_simple()
         from sage.categories.sets_cat import EmptySetError
@@ -7587,8 +7595,9 @@ class GenericGraph(GenericGraph_pyx):
 
             # We use the Miller-Tucker-Zemlin subtour elimination constraints
             # combined with the Desrosiers-Langevin strengthening constraints
+            # (only when n is large enough to avoid corner cases).
             for u, v in D.edge_iterator(labels=False):
-                if D.has_edge(v, u):
+                if n > 3 and D.has_edge(v, u):
                     # DL
                     p.add_constraint(pos[u, c] + (n - 1)*edge[(u, v), c] + (n - 3)*edge[(v, u), c]
                                      <= pos[v, c] + n - 2)


### PR DESCRIPTION
As raised in https://github.com/sagemath/sage/pull/42257#issuecomment-4723691288, the MILP formulation of `edge_disjoint_spanning_trees` is incorrect for the complete directed graph of order 3. It fails to find the 2 edge disjoint spanning trees. It is working well for larger digraphs.
This is a side effect of the Desrosiers-Langevin strengthening constraints on small digraphs. This PR avoids its use on (di)graphs of order $\leq 3$.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


