### PR TITLE
removing some "Python 2" old comments and code

### DIFF
--- a/src/sage/algebras/quantum_groups/representations.py
+++ b/src/sage/algebras/quantum_groups/representations.py
@@ -282,7 +282,7 @@ class AdjointRepresentation(CyclicRepresentation):
         sage: A
         V(-Lambda[0] + Lambda[4])
 
-    Sort the summands uniformly in Python 2 and Python 3::
+    Sort the summands uniformly::
 
         sage: A.print_options(sorting_key=lambda x: str(x))
         sage: v = A.an_element(); v

--- a/src/sage/arith/long.pxd
+++ b/src/sage/arith/long.pxd
@@ -387,10 +387,8 @@ cdef inline bint is_small_python_int(obj) noexcept:
     """
     Test whether Python object is a small Python integer.
 
-    Meaning that it can be converted to a C long. In Python 2,
-    this is equivalent to it being the ``int`` Python type. In Python
-    3, the ``int`` Python type has unlimited precision so we need to
-    check its range.
+    This means that it can be converted to a C long. In Python 3, the ``int``
+    Python type has unlimited precision so we need to check its range.
 
     EXAMPLES::
 

--- a/src/sage/categories/examples/sets_cat.py
+++ b/src/sage/categories/examples/sets_cat.py
@@ -166,7 +166,7 @@ class PrimeNumbers_Abstract(UniqueRepresentation, Parent):
         sage: P = Sets().example("inherits")
         sage: P = Sets().example("wrapper")
     """
-    def __init__(self):
+    def __init__(self) -> None:
         """
         TESTS::
 
@@ -174,7 +174,7 @@ class PrimeNumbers_Abstract(UniqueRepresentation, Parent):
         """
         Parent.__init__(self, category=Sets())
 
-    def _repr_(self):
+    def _repr_(self) -> str:
         """
         TESTS::
 
@@ -214,7 +214,7 @@ class PrimeNumbers_Abstract(UniqueRepresentation, Parent):
         """
         if i in self:
             return self._from_integer_(i)
-        raise ValueError("%s is not a prime number" % (i))
+        raise ValueError(f"{i} is not a prime number")
 
     @abstract_method
     def _from_integer_(self, i):
@@ -251,7 +251,7 @@ class PrimeNumbers_Abstract(UniqueRepresentation, Parent):
         assert i in self
         return self._from_integer_((Integer(i) + 1).next_prime())
 
-    def some_elements(self):
+    def some_elements(self) -> list:
         """
         Return some prime numbers.
 
@@ -269,7 +269,7 @@ class PrimeNumbers_Abstract(UniqueRepresentation, Parent):
         return res
 
     class Element(Element):
-        def is_prime(self):
+        def is_prime(self) -> bool:
             """
             Return whether ``self`` is a prime number.
 
@@ -296,8 +296,7 @@ class PrimeNumbers_Abstract(UniqueRepresentation, Parent):
 
             .. NOTE::
 
-                This method is not meant to implement the protocol iterator,
-                and thus not subject to Python 2 vs Python 3 incompatibilities.
+                This method is not meant to implement the protocol iterator.
             """
             return self.parent().next(self)
 

--- a/src/sage/data_structures/bitset_base.pyx
+++ b/src/sage/data_structures/bitset_base.pyx
@@ -49,13 +49,13 @@ cdef int bitset_from_str(bitset_t bits, object s, char zero=c'0', char one=c'1')
 
 cdef bitset_string(fused_bitset_t bits):
     """
-    Return a python string representing the bitset.
+    Return a Python string representing the bitset.
     """
     return bytes_to_str(bitset_bytes(bits))
 
 cdef bitset_bytes(fused_bitset_t bits):
     """
-    Return a python bytes object representing the bitset.
+    Return a Python bytes object representing the bitset.
     """
     cdef char* s = bitset_chars(NULL, bits)
     cdef object py_s

--- a/src/sage/data_structures/bitset_base.pyx
+++ b/src/sage/data_structures/bitset_base.pyx
@@ -55,11 +55,8 @@ cdef bitset_string(fused_bitset_t bits):
 
 cdef bitset_bytes(fused_bitset_t bits):
     """
-    Return a python bytes string representing the bitset.
-
-    On Python 2 this is equivalent to bitset_string.
+    Return a python bytes object representing the bitset.
     """
-
     cdef char* s = bitset_chars(NULL, bits)
     cdef object py_s
     py_s = s

--- a/src/sage/plot/plot3d/index_face_set.pyx
+++ b/src/sage/plot/plot3d/index_face_set.pyx
@@ -95,8 +95,7 @@ cdef inline format_json_vertex(point_c P):
     return bytes_to_str(PyBytes_FromStringAndSize(ss, r))
 
 cdef inline format_json_face(face_c face):
-    s = "[{}]".format(",".join(str(face.vertices[i]) for i in range(face.n)))
-    return s
+    return "[{}]".format(",".join(str(face.vertices[i]) for i in range(face.n)))
 
 cdef inline format_obj_vertex(point_c P):
     cdef char ss[100]
@@ -875,20 +874,18 @@ cdef class IndexFaceSet(PrimitiveObject):
         if not self.global_texture:
             color_idx = ",".join('%r %r %r' % (fs[i].color.r, fs[i].color.g, fs[i].color.b)
                                  for i in range(self.fcount))
-            # Note: Don't use f-strings, since Sage on Python 2 still expects
-            # this to return a plain str instead of a unicode
-            return dedent("""
+            return dedent(f"""
                 <IndexedFaceSet solid='False' colorPerVertex='False' coordIndex='{coord_idx},-1'>
                   <Coordinate point='{points}'/>
                   <Color color='{color_idx}' />
                 </IndexedFaceSet>
-            """.format(coord_idx=coord_idx, points=points, color_idx=color_idx))
+            """)
 
-        return dedent("""
+        return dedent(f"""
             <IndexedFaceSet coordIndex='{coord_idx},-1'>
               <Coordinate point='{points}'/>
             </IndexedFaceSet>
-        """.format(coord_idx=coord_idx, points=points))
+        """)
 
     def bounding_box(self):
         r"""
@@ -1310,7 +1307,7 @@ cdef class IndexFaceSet(PrimitiveObject):
         opacity = float(self._extra_kwds.get('opacity', 1))
 
         if self.global_texture:
-            color_str = '"#{}"'.format(self.texture.hex_rgb())
+            color_str = f'"#{self.texture.hex_rgb()}"'
             json = ['{{"vertices":{}, "faces":{}, "color":{}, "opacity":{}}}'.format(
                     vertices_str, faces_str, color_str, opacity)]
         else:

--- a/src/sage/repl/rich_output/buffer.py
+++ b/src/sage/repl/rich_output/buffer.py
@@ -146,7 +146,7 @@ class OutputBuffer(SageObject):
         except PermissionError:
             pass
 
-    def _repr_(self):
+    def _repr_(self) -> str:
         """
         Return a string representation.
 
@@ -158,13 +158,13 @@ class OutputBuffer(SageObject):
             sage: OutputBuffer('test1234')
             buffer containing 8 bytes
         """
-        return 'buffer containing {0} bytes'.format(len(self.get()))
+        return f'buffer containing {len(self.get())} bytes'
 
     def get(self):
         """
         Return the buffer content.
 
-        OUTPUT: bytes; string in Python 2.x
+        OUTPUT: bytes
 
         EXAMPLES::
 
@@ -182,35 +182,15 @@ class OutputBuffer(SageObject):
                 self._data = f.read()
         return self._data
 
-    def get_unicode(self):
+    def get_str(self) -> str:
         """
-        Return the buffer content as string.
+        Return the buffer content as a ``str`` object.
 
-        OUTPUT:
+        This returns a unicode ``str`` with the buffer content
+        decoded from UTF-8.
 
-        String. Unicode in Python 2.x. Raises a :exc:`UnicodeEncodeError`
-        if the data is not valid utf-8.
-
-        EXAMPLES::
-
-            sage: from sage.repl.rich_output.buffer import OutputBuffer
-            sage: OutputBuffer('test1234').get().decode('ascii')
-            'test1234'
-            sage: OutputBuffer('test1234').get_unicode()
-            'test1234'
-        """
-        return self.get().decode('utf-8')
-
-    def get_str(self):
-        """
-        Return the buffer content as a ``str`` object for the current Python
-        version.
-
-        That is, returns a Python 2-style encoding-agnostic ``str`` on Python
-        2, and returns a unicode ``str`` on Python 3 with the buffer content
-        decoded from UTF-8.  In other words, this is equivalent to
-        ``OutputBuffer.get`` on Python 2 and ``OutputBuffer.get_unicode`` on
-        Python 3.  This is useful in some cases for cross-compatible code.
+        This raises a :exc:`UnicodeEncodeError` if the data is not
+        valid UTF-8.
 
         OUTPUT: a ``str`` object
 
@@ -224,8 +204,18 @@ class OutputBuffer(SageObject):
             sage: c = OutputBuffer('été').get_str()
             sage: type(c) is str
             True
+
+        TESTS::
+
+            sage: from sage.repl.rich_output.buffer import OutputBuffer
+            sage: OutputBuffer('test1234').get().decode('ascii')
+            'test1234'
+            sage: OutputBuffer('test1234').get_unicode()
+            'test1234'
         """
-        return self.get_unicode()
+        return self.get().decode('utf-8')
+
+    get_unicode = get_str
 
     def filename(self, ext=None):
         """

--- a/src/sage/repl/rich_output/output_basic.py
+++ b/src/sage/repl/rich_output/output_basic.py
@@ -258,7 +258,7 @@ class OutputUnicodeArt(OutputBase):
             sage: from sage.repl.rich_output.output_catalog import OutputUnicodeArt
             sage: OutputUnicodeArt.example()
             OutputUnicodeArt container
-            sage: print(OutputUnicodeArt.example().unicode_art.get_unicode())
+            sage: print(OutputUnicodeArt.example().unicode_art.get_str())
             ⎛-11   0   1⎞
             ⎜  3  -1   0⎟
             ⎝ -1  -1   0⎠
@@ -282,7 +282,7 @@ class OutputUnicodeArt(OutputBase):
             ⎜  3  -1   0⎟
             ⎝ -1  -1   0⎠
         """
-        print(self.unicode_art.get_unicode())
+        print(self.unicode_art.get_str())
 
 
 class OutputLatex(OutputBase):

--- a/src/sage/repl/rich_output/output_browser.py
+++ b/src/sage/repl/rich_output/output_browser.py
@@ -82,9 +82,9 @@ class OutputHtml(OutputBase):
             sage: rich_output.print_to_stdout()
             <div>Hello World!</div>
         """
-        print(self.html.get_unicode())
+        print(self.html.get_str())
 
-    def with_html_tag(self):
+    def with_html_tag(self) -> str:
         r"""
         Return the HTML code surrounded by ``<html>`` tag.
 
@@ -99,4 +99,4 @@ class OutputHtml(OutputBase):
             sage: rich_output.with_html_tag()
             '<html><div>Hello World!</div></html>'
         """
-        return '<html>{0}</html>'.format(self.html.get_unicode())
+        return '<html>{0}</html>'.format(self.html.get_str())

--- a/src/sage/structure/sequence.py
+++ b/src/sage/structure/sequence.py
@@ -559,14 +559,6 @@ class Sequence_generic(SageObject, list):
 
         return list.__getitem__(self, n)
 
-    # We have to define the *slice functions as long as Sage uses Python 2.*
-    # otherwise the inherited *slice functions from list are called
-    def __getslice__(self, i, j):
-        return self.__getitem__(slice(i, j))
-
-    def __setslice__(self, i, j, value):
-        return self.__setitem__(slice(i, j), value)
-
     def append(self, x):
         """
         EXAMPLES::


### PR DESCRIPTION
in various places, we update the doc by removing allusions to Python 2

Also set `get_unicode` to be an alias of `get_str`

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.