### PR TITLE
Factor out runtime checks for build modules

### DIFF
--- a/src/sage/features/bliss.py
+++ b/src/sage/features/bliss.py
@@ -14,10 +14,9 @@ Features for testing the presence of ``bliss``
 # *****************************************************************************
 
 from sage.config import bliss_enabled
-from sage.features import PythonModule
-from sage.features.build_feature import BuildFeature
+from sage.features.build_feature import BuildModule
 
-class Bliss(BuildFeature):
+class Bliss(BuildModule):
     r"""
     A :class:`~sage.features.Feature` which describes whether the
     :mod:`sage.graphs.bliss` module is available in this installation
@@ -26,38 +25,36 @@ class Bliss(BuildFeature):
     EXAMPLES::
 
         sage: from sage.features.bliss import Bliss
-        sage: Bliss().require()  # needs bliss
+        sage: Bliss().is_present()  # needs bliss
+        FeatureTestResult('bliss', True)
+        sage: Bliss().is_present()  # needs !bliss
+        FeatureTestResult('bliss', False)
+
+    A runtime check. We only check the "present" case because, if
+    feature checks are _not_ deferred, the ``needs !bliss`` can be
+    satisfied (disabled at build time) at the same time we are able to
+    import a module that was installed for a previous build of sage::
+
+        sage: from sage.features.bliss import Bliss
+        sage: Bliss().is_present_at_runtime()  # needs bliss
+        FeatureTestResult('bliss', True)
+
     """
     _enabled_in_build = bliss_enabled
 
     def __init__(self):
         r"""
-        TESTS::
+        EXAMPLES::
 
             sage: from sage.features.bliss import Bliss
             sage: Bliss()
             Feature('bliss')
 
         """
+        module_name = "sage.graphs.bliss"
         super().__init__("bliss",
+                         module_name,
                          url='http://www.tcs.hut.fi/Software/bliss/')
-
-    def is_present_at_runtime(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features import FeatureTestResult
-            sage: from sage.features.bliss import Bliss
-            sage: result = Bliss().is_present_at_runtime()
-            sage: isinstance(result, FeatureTestResult)
-            True
-            sage: result  # needs bliss
-            FeatureTestResult('bliss', True)
-
-        """
-        result = PythonModule("sage.graphs.bliss")._is_present()
-        result.feature = self
-        return result
 
 def all_features():
     return [Bliss()]

--- a/src/sage/features/brial.py
+++ b/src/sage/features/brial.py
@@ -3,11 +3,10 @@ Feature for testing the presence of (lib)brial
 """
 
 from sage.config import brial_enabled
-from sage.features import PythonModule
-from sage.features.build_feature import BuildFeature
+from sage.features.build_feature import BuildModule
 
 
-class Brial(BuildFeature):
+class Brial(BuildModule):
     r"""
     A :class:`sage.features.Feature` describing the presence of
     :mod:`sage.rings.polynomial.pbori`.
@@ -16,7 +15,7 @@ class Brial(BuildFeature):
     the presence and usability of libbrial -- a slightly more
     modern fork of PolyBoRi, which hopefully explains the name.
 
-    TESTS::
+    EXAMPLES::
 
         sage: from sage.features.brial import Brial
         sage: Brial().is_present()  # needs brial
@@ -24,42 +23,32 @@ class Brial(BuildFeature):
         sage: Brial().is_present()  # needs !brial
         FeatureTestResult('brial', False)
 
+    A runtime check. We only check the "present" case because, if
+    feature checks are _not_ deferred, the ``needs !brial`` can be
+    satisfied (disabled at build time) at the same time we are able to
+    import a module that was installed for a previous build of sage::
+
+        sage: from sage.features.brial import Brial
+        sage: Brial().is_present_at_runtime()  # needs brial
+        FeatureTestResult('brial', True)
+
     """
     _enabled_in_build = brial_enabled
 
     def __init__(self):
         r"""
-        TESTS::
+        EXAMPLES::
 
             sage: from sage.features.brial import Brial
-            sage: isinstance(Brial(), Brial)
-            True
-        """
-        super().__init__("brial", spkg="brial", type="standard")
-
-
-    def is_present_at_runtime(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features import FeatureTestResult
-            sage: from sage.features.brial import Brial
-            sage: brial = Brial()
-            sage: result = brial.is_present_at_runtime()
-            sage: isinstance(result, FeatureTestResult)
-            True
-            sage: result  # needs brial
-            FeatureTestResult('brial', True)
+            sage: Brial()
+            Feature('brial')
 
         """
-        # The build system installs the sage/rings/pbori source code
-        # even when brial support is disabled, so a naive import of
-        # that module will actually succeed. We check for a
-        # conditionally-compiled cython module instead.
-        cython_modname = "sage.rings.polynomial.pbori.pbori"
-        result = PythonModule(cython_modname)._is_present()
-        result.feature = self
-        return result
+        module_name = "sage.rings.polynomial.pbori.pbori"
+        super().__init__("brial",
+                         module_name,
+                         type="standard")
+
 
 def all_features():
     return [Brial()]

--- a/src/sage/features/build_feature.py
+++ b/src/sage/features/build_feature.py
@@ -133,3 +133,78 @@ class BuildFeature(Feature):
         # "False" to the config file.
         result = bool(self._enabled_in_build)
         return FeatureTestResult(self, result)
+
+
+class BuildModule(BuildFeature):
+    r"""
+    A :class:`~sage.features.Feature` indicating the presence of
+    a python (or cython) module, with explicit support from the build
+    system.
+
+    This subclass encapsulates the runtime import check that is
+    standard for most python and cython modules. Its constructor takes
+    a ``module_name`` parameter that (optionally) differs from the
+    name of the feature. It is this ``module_name`` that we actually
+    try to import when feature checks are deferred to runtime.
+    """
+    def __init__(self, name, module_name=None, **kwargs):
+        r"""
+        EXAMPLES::
+
+            sage: from sage.features.build_feature import BuildModule
+            sage: f = BuildModule("libgap", "sage.libs.gap.libgap")
+            sage: f._enabled_in_build = True
+            sage: f.is_present()
+            FeatureTestResult('libgap', True)
+
+        """
+        if module_name is None:
+            self._module_name = name
+        else:
+            self._module_name = module_name
+
+        super().__init__(name, **kwargs)
+
+    def is_present_at_runtime(self):
+        r"""
+        Check for the module at runtime.
+
+        This uses :func:`importlib.util.find_spec` rather than (say)
+        :func:`importlib.import_module` because we are only checking
+        for the _presence_ of the feature; if there's an error, then
+        so be it, but that doesn't mean that the feature is
+        nonexistent! Perhaps more importantly, this allows us to check
+        for the presence of a feature cheaply, without triggering a
+        module import. If the feature check performed the import,
+        doing a lazy import inside of ``if foo.is_present(): ...``
+        would be pointless.
+
+        TESTS::
+
+            sage: from sage.features.build_feature import BuildModule
+            sage: f = BuildModule("libgap", "sage.libs.gap.libgap")
+            sage: f.is_present_at_runtime()
+            FeatureTestResult('libgap', True)
+
+        ::
+
+            sage: from sage.features.build_feature import BuildModule
+            sage: f = BuildModule("sage.libs.nonexistent")
+            sage: f.is_present_at_runtime()
+            FeatureTestResult('sage.libs.nonexistent', False)
+
+        """
+        from importlib import import_module
+        result = True
+        msg = f"Successfully imported module `{self._module_name}`"
+
+        try:
+            import_module(self._module_name)
+        except ModuleNotFoundError:
+            result = False
+            msg = f"Module `{self._module_name}` not found"
+        except ImportError:
+            result = False
+            msg = f"Unable to import module `{self._module_name}`"
+
+        return FeatureTestResult(self, result, reason=msg)

--- a/src/sage/features/build_feature.py
+++ b/src/sage/features/build_feature.py
@@ -128,7 +128,6 @@ class BuildFeature(Feature):
         """
         if self.is_runtime_detectable():
             return self.is_present_at_runtime()
-        import sage.config
         # Wrap with bool() so that we can be lazy and use meson's
         # set10() rather than painstakingly writing "True" and
         # "False" to the config file.

--- a/src/sage/features/coxeter3.py
+++ b/src/sage/features/coxeter3.py
@@ -14,10 +14,9 @@ Features for testing the presence of ``coxeter3``
 # *****************************************************************************
 
 from sage.config import coxeter3_enabled
-from sage.features import PythonModule
-from sage.features.build_feature import BuildFeature
+from sage.features.build_feature import BuildModule
 
-class Coxeter3(BuildFeature):
+class Coxeter3(BuildModule):
     r"""
     A :class:`~sage.features.Feature` which describes whether the
     :mod:`sage.libs.coxeter3` module is available in this installation
@@ -26,43 +25,35 @@ class Coxeter3(BuildFeature):
     EXAMPLES::
 
         sage: from sage.features.coxeter3 import Coxeter3
-        sage: Coxeter3().require()  # needs coxeter3
+        sage: Coxeter3().is_present()  # needs coxeter3
+        FeatureTestResult('coxeter3', True)
+        sage: Coxeter3().is_present()  # needs !coxeter3
+        FeatureTestResult('coxeter3', False)
+
+    A runtime check. We only check the "present" case because, if
+    feature checks are _not_ deferred, the ``needs !coxeter3`` can be
+    satisfied (disabled at build time) at the same time we are able to
+    import a module that was installed for a previous build of sage::
+
+        sage: from sage.features.coxeter3 import Coxeter3
+        sage: Coxeter3().is_present_at_runtime()  # needs coxeter3
+        FeatureTestResult('coxeter3', True)
 
     """
     _enabled_in_build = coxeter3_enabled
 
     def __init__(self):
         r"""
-        TESTS::
+        EXAMPLES::
 
             sage: from sage.features.coxeter3 import Coxeter3
             sage: Coxeter3()
             Feature('coxeter3')
 
         """
-        super().__init__("coxeter3", spkg="coxeter3")
+        module_name = "sage.libs.coxeter3.coxeter"
+        super().__init__("coxeter3", module_name)
 
-    def is_present_at_runtime(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features import FeatureTestResult
-            sage: from sage.features.coxeter3 import Coxeter3
-            sage: result = Coxeter3().is_present_at_runtime()
-            sage: isinstance(result, FeatureTestResult)
-            True
-            sage: result  # needs coxeter3
-            FeatureTestResult('coxeter3', True)
-
-        """
-        # The build system installs the sage/libs/coxeter3 source code
-        # even when coxeter3 support is disabled, so a naive import of
-        # that module will actually succeed. We check for a
-        # conditionally-compiled cython module instead.
-        cython_modname = "sage.libs.coxeter3.coxeter"
-        result = PythonModule(cython_modname)._is_present()
-        result.feature = self
-        return result
 
 def all_features():
     return [Coxeter3()]

--- a/src/sage/features/libhomfly.py
+++ b/src/sage/features/libhomfly.py
@@ -3,16 +3,15 @@ Feature for testing the presence of libhomfly
 """
 
 from sage.config import libhomfly_enabled
-from sage.features import PythonModule
-from sage.features.build_feature import BuildFeature
+from sage.features.build_feature import BuildModule
 
 
-class Libhomfly(BuildFeature):
+class Libhomfly(BuildModule):
     r"""
     A :class:`sage.features.Feature` describing the presence of
     :mod:`sage.libs.homfly`, the interface to libhomfly.
 
-    TESTS::
+    EXAMPLES::
 
         sage: from sage.features.libhomfly import Libhomfly
         sage: Libhomfly().is_present()  # needs libhomfly
@@ -20,37 +19,31 @@ class Libhomfly(BuildFeature):
         sage: Libhomfly().is_present()  # needs !libhomfly
         FeatureTestResult('libhomfly', False)
 
+    A runtime check. We only check the "present" case because, if
+    feature checks are _not_ deferred, the ``needs !libhomfly`` can be
+    satisfied (disabled at build time) at the same time we are able to
+    import a module that was installed for a previous build of sage::
+
+        sage: from sage.features.libhomfly import Libhomfly
+        sage: Libhomfly().is_present_at_runtime()  # needs libhomfly
+        FeatureTestResult('libhomfly', True)
+
     """
     _enabled_in_build = libhomfly_enabled
 
     def __init__(self):
         r"""
-        TESTS::
+        EXAMPLES::
 
             sage: from sage.features.libhomfly import Libhomfly
-            sage: isinstance(Libhomfly(), Libhomfly)
-            True
+            sage: Libhomfly()
+            Feature('libhomfly')
 
         """
-        super().__init__('libhomfly', spkg='libhomfly', type='standard')
-
-    def is_present_at_runtime(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features import FeatureTestResult
-            sage: from sage.features.libhomfly import Libhomfly
-            sage: lhf = Libhomfly()
-            sage: result = lhf.is_present_at_runtime()
-            sage: isinstance(result, FeatureTestResult)
-            True
-            sage: result  # needs libhomfly
-            FeatureTestResult('libhomfly', True)
-
-        """
-        result = PythonModule("sage.libs.homfly")._is_present()
-        result.feature = self
-        return result
+        module_name = "sage.libs.homfly"
+        super().__init__('libhomfly',
+                         module_name,
+                         type='standard')
 
 
 def all_features():

--- a/src/sage/features/mcqd.py
+++ b/src/sage/features/mcqd.py
@@ -12,10 +12,9 @@ Features for testing the presence of ``mcqd``
 # *****************************************************************************
 
 from sage.config import mcqd_enabled
-from sage.features import PythonModule
-from sage.features.build_feature import BuildFeature
+from sage.features.build_feature import BuildModule
 
-class Mcqd(BuildFeature):
+class Mcqd(BuildModule):
     r"""
     A :class:`~sage.features.Feature` describing the presence of
     the :mod:`~sage.graphs.mcqd` module, which is the SageMath
@@ -26,37 +25,33 @@ class Mcqd(BuildFeature):
         sage: from sage.features.mcqd import Mcqd
         sage: Mcqd().is_present()  # needs mcqd
         FeatureTestResult('mcqd', True)
+        sage: Mcqd().is_present()  # needs !mcqd
+        FeatureTestResult('mcqd', False)
+
+    A runtime check. We only check the "present" case because, if
+    feature checks are _not_ deferred, the ``needs !mcqd`` can be
+    satisfied (disabled at build time) at the same time we are able to
+    import a module that was installed for a previous build of sage::
+
+        sage: from sage.features.mcqd import Mcqd
+        sage: Mcqd().is_present_at_runtime()  # needs mcqd
+        FeatureTestResult('mcqd', True)
 
     """
     _enabled_in_build = mcqd_enabled
 
     def __init__(self):
         """
-        TESTS::
+        EXAMPLES::
 
             sage: from sage.features.mcqd import Mcqd
-            sage: isinstance(Mcqd(), Mcqd)
-            True
+            sage: Mcqd()
+            Feature('mcqd')
 
         """
-        super().__init__("mcqd", spkg="mcqd")
+        module_name = "sage.graphs.mcqd"
+        super().__init__("mcqd", module_name)
 
-    def is_present_at_runtime(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features import FeatureTestResult
-            sage: from sage.features.mcqd import Mcqd
-            sage: result = Mcqd().is_present_at_runtime()
-            sage: isinstance(result, FeatureTestResult)
-            True
-            sage: result  # needs mcqd
-            FeatureTestResult('mcqd', True)
-
-        """
-        result = PythonModule("sage.graphs.mcqd")._is_present()
-        result.feature = self
-        return result
 
 def all_features():
     return [Mcqd()]

--- a/src/sage/features/meataxe.py
+++ b/src/sage/features/meataxe.py
@@ -13,10 +13,9 @@ Feature for testing the presence of ``meataxe``
 # *****************************************************************************
 
 from sage.config import meataxe_enabled
-from sage.features import PythonModule
-from sage.features.build_feature import BuildFeature
+from sage.features.build_feature import BuildModule
 
-class Meataxe(BuildFeature):
+class Meataxe(BuildModule):
     r"""
     A :class:`~sage.features.Feature` describing the presence of
     the Sage modules that depend on the :ref:`meataxe <spkg_meataxe>`
@@ -27,38 +26,33 @@ class Meataxe(BuildFeature):
         sage: from sage.features.meataxe import Meataxe
         sage: Meataxe().is_present()  # needs meataxe
         FeatureTestResult('meataxe', True)
+        sage: Meataxe().is_present()  # needs !meataxe
+        FeatureTestResult('meataxe', False)
+
+    A runtime check. We only check the "present" case because, if
+    feature checks are _not_ deferred, the ``needs !meataxe`` can be
+    satisfied (disabled at build time) at the same time we are able to
+    import a module that was installed for a previous build of sage::
+
+        sage: from sage.features.meataxe import Meataxe
+        sage: Meataxe().is_present_at_runtime()  # needs meataxe
+        FeatureTestResult('meataxe', True)
 
     """
     _enabled_in_build = meataxe_enabled
 
     def __init__(self):
         r"""
-        TESTS::
+        EXAMPLES::
 
             sage: from sage.features.meataxe import Meataxe
-            sage: isinstance(Meataxe(), Meataxe)
-            True
+            sage: Meataxe()
+            Feature('meataxe')
 
         """
-        super().__init__("meataxe", spkg="meataxe")
+        module_name = "sage.matrix.matrix_gfpn_dense"
+        super().__init__("meataxe", module_name)
 
-    def is_present_at_runtime(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features import FeatureTestResult
-            sage: from sage.features.meataxe import Meataxe
-            sage: result = Meataxe().is_present_at_runtime()
-            sage: isinstance(result, FeatureTestResult)
-            True
-            sage: result  # needs meataxe
-            FeatureTestResult('meataxe', True)
-
-        """
-        modname = "sage.matrix.matrix_gfpn_dense"
-        result = PythonModule(modname)._is_present()
-        result.feature = self
-        return result
 
 def all_features():
     return [Meataxe()]

--- a/src/sage/features/rankwidth.py
+++ b/src/sage/features/rankwidth.py
@@ -13,11 +13,9 @@ Feature for the rank-width graph decomposition
 # ****************************************************************************
 
 from sage.config import rankwidth_enabled
-from sage.features import PythonModule
-from sage.features.build_feature import BuildFeature
+from sage.features.build_feature import BuildModule
 
-
-class RankWidth(BuildFeature):
+class RankWidth(BuildModule):
     r"""
     A :class:`~sage.features.Feature` indicating whether or not the
     rank-width graph decomposition is available.
@@ -35,6 +33,15 @@ class RankWidth(BuildFeature):
         sage: RankWidth().is_present()  # needs !rankwidth
         FeatureTestResult('rankwidth', False)
 
+    A runtime check. We only check the "present" case because, if
+    feature checks are _not_ deferred, the ``needs !rankwidth`` can be
+    satisfied (disabled at build time) at the same time we are able to
+    import a module that was installed for a previous build of sage::
+
+        sage: from sage.features.rankwidth import RankWidth
+        sage: RankWidth().is_present_at_runtime()  # needs rankwidth
+        FeatureTestResult('rankwidth', True)
+
     """
     _enabled_in_build = rankwidth_enabled
 
@@ -47,26 +54,12 @@ class RankWidth(BuildFeature):
             Feature('rankwidth')
 
         """
-        super().__init__("rankwidth", spkg="rw", type="standard")
+        module_name = "sage.graphs.graph_decompositions.rankwidth"
+        super().__init__("rankwidth",
+                         module_name,
+                         spkg="rw",
+                         type="standard")
 
-    def is_present_at_runtime(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features import FeatureTestResult
-            sage: from sage.features.rankwidth import RankWidth
-            sage: rw = RankWidth()
-            sage: result = rw.is_present_at_runtime()
-            sage: isinstance(result, FeatureTestResult)
-            True
-            sage: result  # needs rankwidth
-            FeatureTestResult('rankwidth', True)
-
-        """
-        cython_modname = "sage.graphs.graph_decompositions.rankwidth"
-        result = PythonModule(cython_modname)._is_present()
-        result.feature = self
-        return result
 
 def all_features():
     return [RankWidth()]

--- a/src/sage/features/sirocco.py
+++ b/src/sage/features/sirocco.py
@@ -14,10 +14,9 @@ Features for testing the presence of ``sirocco``
 # *****************************************************************************
 
 from sage.config import sirocco_enabled
-from sage.features import PythonModule
-from sage.features.build_feature import BuildFeature
+from sage.features.build_feature import BuildModule
 
-class Sirocco(BuildFeature):
+class Sirocco(BuildModule):
     r"""
     A :class:`~sage.features.Feature` which describes whether the
     :mod:`sage.libs.sirocco` module is available in this installation
@@ -26,38 +25,35 @@ class Sirocco(BuildFeature):
     EXAMPLES::
 
         sage: from sage.features.sirocco import Sirocco
-        sage: Sirocco().require()  # needs sirocco
+        sage: Sirocco().is_present()  # needs sirocco
+        FeatureTestResult('sirocco', True)
+        sage: Sirocco().is_present()  # needs !sirocco
+        FeatureTestResult('sirocco', False)
+
+    A runtime check. We only check the "present" case because, if
+    feature checks are _not_ deferred, the ``needs !sirocco`` can be
+    satisfied (disabled at build time) at the same time we are able to
+    import a module that was installed for a previous build of sage::
+
+        sage: from sage.features.sirocco import Sirocco
+        sage: Sirocco().is_present_at_runtime()  # needs sirocco
+        FeatureTestResult('sirocco', True)
 
     """
     _enabled_in_build = sirocco_enabled
 
     def __init__(self):
         r"""
-        TESTS::
+        EXAMPLES::
 
             sage: from sage.features.sirocco import Sirocco
             sage: Sirocco()
             Feature('sirocco')
 
         """
-        super().__init__("sirocco", spkg="sirocco")
+        module_name = "sage.libs.sirocco"
+        super().__init__("sirocco", module_name, spkg="sirocco")
 
-    def is_present_at_runtime(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features import FeatureTestResult
-            sage: from sage.features.sirocco import Sirocco
-            sage: result = Sirocco().is_present_at_runtime()
-            sage: isinstance(result, FeatureTestResult)
-            True
-            sage: result  # needs sirocco
-            FeatureTestResult('sirocco', True)
-
-        """
-        result = PythonModule("sage.libs.sirocco")._is_present()
-        result.feature = self
-        return result
 
 def all_features():
     return [Sirocco()]

--- a/src/sage/features/tdlib.py
+++ b/src/sage/features/tdlib.py
@@ -13,44 +13,45 @@ Features for testing the presence of ``tdlib``
 # *****************************************************************************
 
 from sage.config import tdlib_enabled
-from sage.features import PythonModule
-from sage.features.build_feature import BuildFeature
+from sage.features.build_feature import BuildModule
 
-class Tdlib(BuildFeature):
+class Tdlib(BuildModule):
     r"""
     A :class:`~sage.features.Feature` describing the presence of
-    the SageMath interface to the :ref:`tdlib <spkg_tdlib>` library.
+    the SageMath interface to the treedec (formerly tdlib) library.
+
+    EXAMPLES::
+
+        sage: from sage.features.tdlib import Tdlib
+        sage: Tdlib().is_present()  # needs tdlib
+        FeatureTestResult('tdlib', True)
+        sage: Tdlib().is_present()  # needs !tdlib
+        FeatureTestResult('tdlib', False)
+
+    A runtime check. We only check the "present" case because, if
+    feature checks are _not_ deferred, the ``needs !tdlib`` can be
+    satisfied (disabled at build time) at the same time we are able to
+    import a module that was installed for a previous build of sage::
+
+        sage: from sage.features.tdlib import Tdlib
+        sage: Tdlib().is_present_at_runtime()  # needs tdlib
+        FeatureTestResult('tdlib', True)
+
     """
     _enabled_in_build = tdlib_enabled
 
     def __init__(self):
         r"""
-        TESTS::
+        EXAMPLES::
 
             sage: from sage.features.tdlib import Tdlib
-            sage: isinstance(Tdlib(), Tdlib)
-            True
+            sage: Tdlib()
+            Feature('tdlib')
 
         """
-        super().__init__("tdlib", spkg="tdlib")
+        module_name = "sage.graphs.graph_decompositions.tdlib"
+        super().__init__("tdlib", module_name, spkg="tdlib")
 
-    def is_present_at_runtime(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features import FeatureTestResult
-            sage: from sage.features.tdlib import Tdlib
-            sage: result = Tdlib().is_present_at_runtime()
-            sage: isinstance(result, FeatureTestResult)
-            True
-            sage: result  # needs tdlib
-            FeatureTestResult('tdlib', True)
-
-        """
-        modname = "sage.graphs.graph_decompositions.tdlib"
-        result = PythonModule(modname)._is_present()
-        result.feature = self
-        return result
 
 def all_features():
     return [Tdlib()]


### PR DESCRIPTION
To keep things simple at first, I copy & pasted a bunch of `is_present_at_runtime()` checks for cython modules. These are essentially all the same: try an import, and catch the error if one happens.

This PR adds a subclass to simplify that, and converts the existing build features. Omitting doctests, this reduces our existing features to a few lines:

```python
# meson.options
option('foo', type: 'feature', value: 'auto', description: 'Interface to foo')
```

```python
# src/sage/config.py.in
foo_enabled = @FOO_ENABLED@
```

```python
# src/sage/libs/meson.build
foo = dependency('libfoo', required: get_option('foo'), disabler: true)
conf_data.set10('FOO_ENABLED', foo.found())
```

```python
# src/sage/features/foo.py
from sage.config import foo_enabled
from sage.features.build_feature import BuildModule

class Foo(BuildModule):
    _enabled_in_build = foo_enabled
    def __init__(self):
        super().__init__("foo", "sage.libs.foo")
```