### PR TITLE
src/sage/libs/meson.build: special case for when libhomfly is disabled

### DIFF
--- a/src/sage/libs/meson.build
+++ b/src/sage/libs/meson.build
@@ -123,8 +123,19 @@ gc = dependency(
   required: not is_windows,
   disabler: true,
 )
-homfly = dependency('libhomfly', required: false, disabler: true)
-if not homfly.found()
+
+
+# This can go back to a simple
+#
+# dependency('libhomfly', required: get_option('libhomfly'), disabler: true)
+#
+# when the fallback is removed.
+homfly = dependency(
+  'libhomfly',
+  required: get_option('libhomfly').disabled() ? get_option('libhomfly') : false,
+  disabler: true,
+)
+if not homfly.found() and not get_option('libhomfly').disabled()
   # fallback for older versions without pkg-config
   homfly = cc.find_library(
     'homfly',


### PR DESCRIPTION
We try two methods of detecting libhomfly, and if the first succeeds, the magic

```
  required: get_option('libhomfly')
```

in the fallback doesn't work as intended (it is never reached). The no-pkgconfig fallback is not permanent, so for the time being, we add a special case and copy/paste a little.
