### PR TITLE
Implement multisort (arity > 1) plethysm for lazy symmetric functions

### DIFF
--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -3648,7 +3648,9 @@ class Stream_plethysm(Stream_binary):
 
     Coefficients created outside the Sage preparser can be Python scalars::
 
-        sage: # needs sage.modules
+        sage: from sage.data_structures.stream import Stream_exact, Stream_plethysm
+        sage: p = SymmetricFunctions(QQ).p()
+        sage: f1 = Stream_exact([p[1]], order=1)
         sage: f0 = Stream_exact([int(1)])
         sage: r = Stream_plethysm(f0, f1, True, p); r[0]
         p[]
@@ -4053,7 +4055,6 @@ class Stream_plethysm_multi(Stream_inexact):
 
     EXAMPLES::
 
-        sage: # needs sage.modules
         sage: from sage.data_structures.stream import (Stream_exact,
         ....:     Stream_plethysm_multi)
         sage: p = SymmetricFunctions(QQ).p()
@@ -4076,7 +4077,6 @@ class Stream_plethysm_multi(Stream_inexact):
 
         TESTS::
 
-            sage: # needs sage.modules
             sage: from sage.data_structures.stream import (Stream_exact,
             ....:     Stream_function, Stream_plethysm_multi)
             sage: p = SymmetricFunctions(QQ).p()
@@ -4087,7 +4087,6 @@ class Stream_plethysm_multi(Stream_inexact):
             ....:                            p_outer=p2)
             sage: TestSuite(h).run(skip='_test_pickling')
 
-            sage: # needs sage.modules
             sage: f = Stream_function(
             ....:     lambda n: tensor([p[n], p[[]]]), True, 0)
             sage: g0 = Stream_exact([p[[]]])

--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -3679,11 +3679,7 @@ class Stream_plethysm(Stream_binary):
             sage: g = Stream_function(lambda n: s[n-1,1], True, 2)
             sage: h = Stream_plethysm(f, g, True, p)
         """
-        # A nonzero eventual constant means that the stream does not have
-        # finite support, so its ``_degree`` is not an upper bound for its
-        # support.
-        exact_f = (f if isinstance(f, Stream_exact) and not f._constant
-                   else None)
+        exact_f = f if isinstance(f, Stream_exact) else None
         if exact_f is not None:
             self._degree_f = f._degree
         else:
@@ -4094,8 +4090,7 @@ class Stream_plethysm_multi(Stream_inexact):
         if len(gs) != len(p_outer.tensor_factors()):
             raise ValueError("the number of arguments must match the outer tensor power")
 
-        exact_f = (f if isinstance(f, Stream_exact) and not f._constant
-                   else None)
+        exact_f = f if isinstance(f, Stream_exact) else None
         needs_prewarm = [g.is_uninitialized() and not g._approximate_order
                          for g in gs]
         if exact_f is not None:

--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -3678,6 +3678,15 @@ class Stream_plethysm(Stream_binary):
             sage: f = Stream_function(lambda n: s[n], True, 1)
             sage: g = Stream_function(lambda n: s[n-1,1], True, 2)
             sage: h = Stream_plethysm(f, g, True, p)
+
+            sage: # needs sage.modules
+            sage: from sage.data_structures.stream import (Stream_exact,
+            ....:     Stream_uninitialized)
+            sage: la = Partition([2]*8 + [1]*3)
+            sage: f = Stream_exact([p[la]], order=la.size())
+            sage: h = Stream_plethysm(f, Stream_uninitialized(0), True, p)
+            sage: sorted(h._powers)
+            [1, 2, 3, 4, 8]
         """
         exact_f = f if isinstance(f, Stream_exact) else None
         if exact_f is not None:
@@ -3726,7 +3735,8 @@ class Stream_plethysm(Stream_binary):
                 if not fk:
                     continue
                 for la, _ in _coerce_to_basis_over_base_ring(fk, p_f):
-                    self._cache_power(max(la.to_exp(), default=0))
+                    for m in la.to_exp():
+                        self._cache_power(m)
 
     @lazy_attribute
     def _approximate_order(self):
@@ -4065,7 +4075,8 @@ class Stream_plethysm_multi(Stream_inexact):
         TESTS::
 
             sage: from sage.data_structures.stream import (Stream_exact,
-            ....:     Stream_function, Stream_plethysm_multi)
+            ....:     Stream_function, Stream_plethysm_multi,
+            ....:     Stream_uninitialized)
             sage: p = SymmetricFunctions(QQ).p()
             sage: p2 = tensor([p, p])
             sage: f = Stream_exact([tensor([p[1], p[1]])], order=2)
@@ -4082,6 +4093,15 @@ class Stream_plethysm_multi(Stream_inexact):
             Traceback (most recent call last):
             ...
             ValueError: can only compute plethysm with a series of valuation 0 for symmetric functions of finite support
+
+            sage: la = Partition([2]*8 + [1]*3)
+            sage: f = Stream_exact([tensor([p[la], p[[]]])],
+            ....:                  order=la.size())
+            sage: u = Stream_uninitialized(0)
+            sage: h = Stream_plethysm_multi(f, (u, g), True, p,
+            ....:                            p_outer=p2)
+            sage: sorted(h._plethysms[0]._powers)
+            [1, 2, 3, 4, 8]
         """
         if p_outer is None:
             raise ValueError("the outer tensor powersum basis is required")
@@ -4130,7 +4150,8 @@ class Stream_plethysm_multi(Stream_inexact):
                     for h, mu, prewarm in zip(self._plethysms, la,
                                               needs_prewarm):
                         if prewarm:
-                            h._cache_power(max(mu.to_exp(), default=0))
+                            for m in mu.to_exp():
+                                h._cache_power(m)
 
     def __hash__(self):
         """

--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -3679,9 +3679,10 @@ class Stream_plethysm(Stream_binary):
             sage: g = Stream_function(lambda n: s[n-1,1], True, 2)
             sage: h = Stream_plethysm(f, g, True, p)
 
-            sage: # needs sage.modules
             sage: from sage.data_structures.stream import (Stream_exact,
+            ....:     Stream_plethysm,
             ....:     Stream_uninitialized)
+            sage: p = SymmetricFunctions(QQ).p()
             sage: la = Partition([2]*8 + [1]*3)
             sage: f = Stream_exact([p[la]], order=la.size())
             sage: h = Stream_plethysm(f, Stream_uninitialized(0), True, p)

--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -3565,10 +3565,7 @@ def _coerce_to_basis_over_base_ring(element, basis):
     :class:`CoefficientRing`.  Changing the base ring of ``basis`` before
     coercion preserves these undetermined coefficients.
     """
-    try:
-        element_base_ring = element.parent().base_ring()
-    except AttributeError:
-        return basis(element)
+    element_base_ring = element.parent().base_ring()
     if element_base_ring == basis.base_ring():
         return basis(element)
     base_ring = get_coercion_model().common_parent(basis.base_ring(),
@@ -3646,18 +3643,6 @@ class Stream_plethysm(Stream_binary):
         sage: r = Stream_plethysm(f0, f11, True, p); [r[n] for n in range(3)]
         [p[], 0, 0]
 
-    Coefficients created outside the Sage preparser can be Python scalars::
-
-        sage: from sage.data_structures.stream import Stream_exact, Stream_plethysm
-        sage: p = SymmetricFunctions(QQ).p()
-        sage: f1 = Stream_exact([p[1]], order=1)
-        sage: f0 = Stream_exact([int(1)])
-        sage: r = Stream_plethysm(f0, f1, True, p); r[0]
-        p[]
-        sage: g0 = Stream_exact([int(1)])
-        sage: r = Stream_plethysm(f1, g0, True, p); r[0]
-        p[]
-
     Check that degree one elements are treated in the correct way::
 
         sage: # needs sage.modules
@@ -3694,6 +3679,9 @@ class Stream_plethysm(Stream_binary):
             sage: g = Stream_function(lambda n: s[n-1,1], True, 2)
             sage: h = Stream_plethysm(f, g, True, p)
         """
+        # A nonzero eventual constant means that the stream does not have
+        # finite support, so its ``_degree`` is not an upper bound for its
+        # support.
         exact_f = (f if isinstance(f, Stream_exact) and not f._constant
                    else None)
         if exact_f is not None:
@@ -3730,9 +3718,10 @@ class Stream_plethysm(Stream_binary):
 
         # ``Stream_uninitialized._input_streams`` is a lazy snapshot, so all
         # powers that can contain undetermined coefficients must already exist
-        # when a finite outer function is applied to an undetermined argument
-        # of valuation zero.  Powers created later for a positive-valuation
-        # argument only involve previously determined coefficients.
+        # when an outer stream with finite support is applied to an
+        # undetermined argument of valuation zero.  Powers created later for a
+        # positive-valuation argument only involve previously determined
+        # coefficients.
         if (exact_f is not None
             and g.is_uninitialized()
             and not g._approximate_order):
@@ -3741,7 +3730,7 @@ class Stream_plethysm(Stream_binary):
                 if not fk:
                     continue
                 for la, _ in _coerce_to_basis_over_base_ring(fk, p_f):
-                    self._ensure_power(max(la.to_exp(), default=0))
+                    self._cache_power(max(la.to_exp(), default=0))
 
     @lazy_attribute
     def _approximate_order(self):
@@ -3822,11 +3811,13 @@ class Stream_plethysm(Stream_binary):
         if (c.parent() == self._basis.base_ring()
             and product.parent() == self._basis):
             return c * product
+        # This slower path is needed only when an implicit definition puts a
+        # coefficient or product over a temporary CoefficientRing.
         base_ring = get_coercion_model().common_parent(
             self._basis.base_ring(), c.parent(), product.parent().base_ring()
         )
         basis = self._basis.change_ring(base_ring)
-        return basis(product) * base_ring(c)
+        return base_ring(c) * basis(product)
 
     def compute_product(self, n, la):
         r"""
@@ -3941,7 +3932,7 @@ class Stream_plethysm(Stream_binary):
         except KeyError:
             pass
 
-        self._ensure_power(m)
+        self._cache_power(m)
         power_d = self._powers[m][d]
         # we have to check power_d for zero because it might be an
         # integer and not a symmetric function
@@ -3966,7 +3957,7 @@ class Stream_plethysm(Stream_binary):
             self._stretched_power_cache[key] = ret
         return ret
 
-    def _ensure_power(self, m):
+    def _cache_power(self, m):
         r"""
         Ensure that the cache contains the ``m``-th power of ``g``.
 
@@ -3979,7 +3970,7 @@ class Stream_plethysm(Stream_binary):
             sage: f = Stream_exact([p[1]], order=1)
             sage: g = Stream_function(lambda n: p[n], True, 1)
             sage: h = Stream_plethysm(f, g, True, p)
-            sage: h._ensure_power(16)
+            sage: h._cache_power(16)
             sage: sorted(h._powers)
             [1, 2, 4, 8, 16]
         """
@@ -3990,8 +3981,8 @@ class Stream_plethysm(Stream_binary):
 
         left = m // 2
         right = m - left
-        self._ensure_power(left)
-        self._ensure_power(right)
+        self._cache_power(left)
+        self._cache_power(right)
         # Preserve the sparsity policy of the parent.  A dense intermediate
         # stream would eagerly compute all preceding coefficients even when a
         # sparse parent requests only one coefficient.
@@ -4144,7 +4135,7 @@ class Stream_plethysm_multi(Stream_inexact):
                     for h, mu, prewarm in zip(self._plethysms, la,
                                               needs_prewarm):
                         if prewarm:
-                            h._ensure_power(max(mu.to_exp(), default=0))
+                            h._cache_power(max(mu.to_exp(), default=0))
 
     def __hash__(self):
         """

--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -110,7 +110,7 @@ from sage.rings.polynomial.infinite_polynomial_ring import InfinitePolynomialRin
 from sage.rings.polynomial.infinite_polynomial_element import InfinitePolynomial
 from sage.rings.fraction_field import FractionField_generic
 from sage.rings.fraction_field_element import FractionFieldElement
-from sage.misc.cachefunc import cached_method
+from sage.structure.element import get_coercion_model
 lazy_import('sage.combinat.sf.sfa', ['_variables_recursive', '_raise_variables'])
 
 
@@ -2015,7 +2015,13 @@ class Stream_uninitialized(Stream):
                         c = retract(subs(c, var, val))
                         if c.parent() is not self._base_ring:
                             good = m - i0 - 1
-                elif c.parent() == self._U:
+                elif c.parent() == self._PF:
+                    c = retract(subs(c, var, val))
+                    if c.parent() is not self._base_ring:
+                        good = m - i0 - 1
+                elif (hasattr(c, 'map_coefficients')
+                      and hasattr(c.parent(), 'base_ring')
+                      and c.parent().base_ring() == self._PF):
                     c = c.map_coefficients(lambda e: subs(e, var, val))
                     try:
                         c = c.map_coefficients(lambda e: retract(e), self._base_ring)
@@ -3551,6 +3557,25 @@ class Stream_cauchy_compose(Stream_binary):
                             if (l := self._left[k]))
 
 
+def _coerce_to_basis_over_base_ring(element, basis):
+    r"""
+    Coerce ``element`` to ``basis`` over its current base ring.
+
+    Implicitly defined streams temporarily have coefficients over a
+    :class:`CoefficientRing`.  Changing the base ring of ``basis`` before
+    coercion preserves these undetermined coefficients.
+    """
+    try:
+        element_base_ring = element.parent().base_ring()
+    except AttributeError:
+        return basis(element)
+    if element_base_ring == basis.base_ring():
+        return basis(element)
+    base_ring = get_coercion_model().common_parent(basis.base_ring(),
+                                                   element_base_ring)
+    return basis.change_ring(base_ring)(element)
+
+
 class Stream_plethysm(Stream_binary):
     r"""
     Return the plethysm of ``f`` composed by ``g``.
@@ -3621,6 +3646,16 @@ class Stream_plethysm(Stream_binary):
         sage: r = Stream_plethysm(f0, f11, True, p); [r[n] for n in range(3)]
         [p[], 0, 0]
 
+    Coefficients created outside the Sage preparser can be Python scalars::
+
+        sage: # needs sage.modules
+        sage: f0 = Stream_exact([int(1)])
+        sage: r = Stream_plethysm(f0, f1, True, p); r[0]
+        p[]
+        sage: g0 = Stream_exact([int(1)])
+        sage: r = Stream_plethysm(f1, g0, True, p); r[0]
+        p[]
+
     Check that degree one elements are treated in the correct way::
 
         sage: # needs sage.modules
@@ -3657,7 +3692,9 @@ class Stream_plethysm(Stream_binary):
             sage: g = Stream_function(lambda n: s[n-1,1], True, 2)
             sage: h = Stream_plethysm(f, g, True, p)
         """
-        if isinstance(f, Stream_exact):
+        exact_f = (f if isinstance(f, Stream_exact) and not f._constant
+                   else None)
+        if exact_f is not None:
             self._degree_f = f._degree
         else:
             self._degree_f = None
@@ -3670,19 +3707,39 @@ class Stream_plethysm(Stream_binary):
         else:
             self._basis = ring
         self._p = p
-        g = Stream_map_coefficients(g, lambda x: p(x), is_sparse)
-        self._powers = [g]  # a cache for the powers of g in the powersum basis
+        g = Stream_map_coefficients(
+            g, lambda x: _coerce_to_basis_over_base_ring(x, p), is_sparse
+        )
+        self._powers = {1: g}  # powers of g in the powersum basis
+        self._stretched_power_cache = {}
         R = self._basis.base_ring()
         self._degree_one = _variables_recursive(R, include=include, exclude=exclude)
 
         if HopfAlgebrasWithBasis(R).TensorProducts() in p.categories():
             self._tensor_power = len(p._sets)
             p_f = p._sets[0]
-            f = Stream_map_coefficients(f, lambda x: p_f(x), is_sparse)
         else:
             self._tensor_power = None
-            f = Stream_map_coefficients(f, lambda x: p(x), is_sparse)
+            p_f = p
+        f = Stream_map_coefficients(
+            f, lambda x: _coerce_to_basis_over_base_ring(x, p_f), is_sparse
+        )
         super().__init__(f, g, is_sparse)
+
+        # ``Stream_uninitialized._input_streams`` is a lazy snapshot, so all
+        # powers that can contain undetermined coefficients must already exist
+        # when a finite outer function is applied to an undetermined argument
+        # of valuation zero.  Powers created later for a positive-valuation
+        # argument only involve previously determined coefficients.
+        if (exact_f is not None
+            and g.is_uninitialized()
+            and not g._approximate_order):
+            for k in range(exact_f._approximate_order, exact_f._degree):
+                fk = exact_f[k]
+                if not fk:
+                    continue
+                for la, _ in _coerce_to_basis_over_base_ring(fk, p_f):
+                    self._ensure_power(max(la.to_exp(), default=0))
 
     @lazy_attribute
     def _approximate_order(self):
@@ -3735,20 +3792,39 @@ class Stream_plethysm(Stream_binary):
              3*s[1, 1, 1, 1] + 2*s[2, 1, 1] + s[2, 2] + s[3, 1] + s[4],
              4*s[1, 1, 1, 1, 1] + 4*s[2, 1, 1, 1] + 2*s[2, 2, 1] + 2*s[3, 1, 1] + s[3, 2] + s[4, 1] + s[5]]
         """
-        if not n:  # special case of 0
-            if self._right[0]:
-                assert self._degree_f is not None, "the plethysm with a lazy symmetric function of valuation 0 is defined only for symmetric functions of finite support"
-                K = self._degree_f
-            else:
-                K = 1
+        if self._right[0]:
+            assert self._degree_f is not None, "the plethysm with a lazy symmetric function of valuation 0 is defined only for symmetric functions of finite support"
+            K = self._degree_f
         else:
             K = n + 1
 
-        return sum((c * self.compute_product(n, la)
-                    for k in range(self._left._approximate_order, K)
-                    if self._left[k]  # necessary, because it might be int(0)
-                    for la, c in self._left[k]),
-                   self._basis.zero())
+        ret = None
+        for k in range(self._left._approximate_order, K):
+            fk = self._left[k]
+            if not fk:
+                continue
+            for la, c in fk:
+                product = self.compute_product(n, la)
+                if product:
+                    term = self._coefficient_times_product(c, product)
+                    ret = term if ret is None else ret + term
+        return self._basis.zero() if ret is None else ret
+
+    def _coefficient_times_product(self, c, product):
+        """
+        Multiply ``product`` by ``c`` over their common base ring.
+
+        The common base ring can be a temporary :class:`CoefficientRing`
+        while an implicit definition is being solved.
+        """
+        if (c.parent() == self._basis.base_ring()
+            and product.parent() == self._basis):
+            return c * product
+        base_ring = get_coercion_model().common_parent(
+            self._basis.base_ring(), c.parent(), product.parent().base_ring()
+        )
+        basis = self._basis.change_ring(base_ring)
+        return basis(product) * base_ring(c)
 
     def compute_product(self, n, la):
         r"""
@@ -3821,7 +3897,6 @@ class Stream_plethysm(Stream_binary):
 
         return ret
 
-    @cached_method
     def stretched_power_restrict_degree(self, i, m, d):
         r"""
         Return the degree ``d*i`` part of ``p([i]*m)(g)`` in
@@ -3858,29 +3933,69 @@ class Stream_plethysm(Stream_binary):
             sage: A == B                        # long time
             True
         """
-        # TODO: we should do lazy binary powering here
-        while len(self._powers) < m:
-            # TODO: possibly we always want a dense cache here?
-            self._powers.append(Stream_cauchy_mul(self._powers[-1],
-                                                  self._powers[0],
-                                                  self._is_sparse))
-        power_d = self._powers[m-1][d]
+        key = (i, m, d)
+        try:
+            return self._stretched_power_cache[key]
+        except KeyError:
+            pass
+
+        self._ensure_power(m)
+        power_d = self._powers[m][d]
         # we have to check power_d for zero because it might be an
         # integer and not a symmetric function
-        if power_d:
-            # _raise_variables(c, i, self._degree_one) cannot vanish
-            # because i is positive and c is nonzero
-            if self._tensor_power is None:
-                terms = {mon.stretch(i):
-                         _raise_variables(c, i, self._degree_one)
-                         for mon, c in power_d}
-            else:
-                terms = {tuple(mu.stretch(i) for mu in mon):
-                         _raise_variables(c, i, self._degree_one)
-                         for mon, c in power_d}
-            return self._basis(self._p.element_class(self._p, terms))
+        if not power_d:
+            return self._basis.zero()
 
-        return self._basis.zero()
+        base_ring = power_d.parent().base_ring()
+        # _raise_variables(c, i, self._degree_one) cannot vanish
+        # because i is positive and c is nonzero
+        if self._tensor_power is None:
+            terms = {mon.stretch(i):
+                     base_ring(_raise_variables(c, i, self._degree_one))
+                     for mon, c in power_d}
+        else:
+            terms = {tuple(mu.stretch(i) for mu in mon):
+                     base_ring(_raise_variables(c, i, self._degree_one))
+                     for mon, c in power_d}
+        p = self._p.change_ring(base_ring)
+        basis = self._basis.change_ring(base_ring)
+        ret = basis(p.element_class(p, terms))
+        if not isinstance(base_ring, CoefficientRing):
+            self._stretched_power_cache[key] = ret
+        return ret
+
+    def _ensure_power(self, m):
+        r"""
+        Ensure that the cache contains the ``m``-th power of ``g``.
+
+        Only the powers needed for a balanced multiplication tree are
+        created::
+
+            sage: from sage.data_structures.stream import (Stream_exact,
+            ....:     Stream_function, Stream_plethysm)
+            sage: p = SymmetricFunctions(QQ).p()
+            sage: f = Stream_exact([p[1]], order=1)
+            sage: g = Stream_function(lambda n: p[n], True, 1)
+            sage: h = Stream_plethysm(f, g, True, p)
+            sage: h._ensure_power(16)
+            sage: sorted(h._powers)
+            [1, 2, 4, 8, 16]
+        """
+        if m <= 1:
+            return
+        if m in self._powers:
+            return
+
+        left = m // 2
+        right = m - left
+        self._ensure_power(left)
+        self._ensure_power(right)
+        # Preserve the sparsity policy of the parent.  A dense intermediate
+        # stream would eagerly compute all preceding coefficients even when a
+        # sparse parent requests only one coefficient.
+        self._powers[m] = Stream_cauchy_mul(self._powers[left],
+                                            self._powers[right],
+                                            self._is_sparse)
 
     def input_streams(self):
         r"""
@@ -3896,7 +4011,8 @@ class Stream_plethysm(Stream_binary):
             sage: g = Stream_function(lambda n: s[n-1,1], True, 2)
             sage: h = Stream_plethysm(f, g, True, p)
             sage: h.input_streams()
-            [<sage.data_structures.stream.Stream_map_coefficients object at ...>]
+            [<sage.data_structures.stream.Stream_map_coefficients object at ...>,
+             <sage.data_structures.stream.Stream_map_coefficients object at ...>]
             sage: [h[i] for i in range(1, 5)]
             [0,
              1/2*p[1, 1] - 1/2*p[2],
@@ -3904,9 +4020,261 @@ class Stream_plethysm(Stream_binary):
              1/4*p[1, 1, 1, 1] + 1/4*p[2, 2] - 1/2*p[4]]
             sage: h.input_streams()
             [<sage.data_structures.stream.Stream_map_coefficients object at ...>,
+             <sage.data_structures.stream.Stream_map_coefficients object at ...>,
              <sage.data_structures.stream.Stream_cauchy_mul object at ...>]
         """
-        return self._powers
+        return [self._left] + list(self._powers.values())
+
+
+class Stream_plethysm_multi(Stream_inexact):
+    r"""
+    Return the multisort plethysm of ``f`` composed with ``gs``.
+
+    The coefficients of ``f`` belong to a tensor product of symmetric
+    function algebras.  For a powersum monomial
+    `p_{\lambda_1} \mathbin{\#} \cdots \mathbin{\#} p_{\lambda_r}`, this
+    stream computes the product
+    `p_{\lambda_1}(g_1) \cdots p_{\lambda_r}(g_r)`.
+
+    The individual factors are computed by :class:`Stream_plethysm`, so
+    its powersum conversion, power caches, and degree restriction logic
+    are shared by all powersum monomials involving the same argument.
+
+    INPUT:
+
+    - ``f`` -- a :class:`Stream`
+    - ``gs`` -- tuple of :class:`Stream` objects
+    - ``is_sparse`` -- boolean
+    - ``p`` -- the powersum basis containing the coefficients of ``gs``
+    - ``ring`` -- (default: ``None``) the ring the result should be in;
+      by default ``p``
+    - ``p_outer`` -- the tensor powersum basis containing the
+      coefficients of ``f``
+
+    EXAMPLES::
+
+        sage: # needs sage.modules
+        sage: from sage.data_structures.stream import (Stream_exact,
+        ....:     Stream_plethysm_multi)
+        sage: p = SymmetricFunctions(QQ).p()
+        sage: p2 = tensor([p, p])
+        sage: X = tensor([p[1], p[[]]])
+        sage: Y = tensor([p[[]], p[1]])
+        sage: f = Stream_exact([X + Y], order=1)
+        sage: g = Stream_exact([p[1]], order=1)
+        sage: h = Stream_plethysm_multi(f, (g, g), True, p, p,
+        ....:                            p_outer=p2)
+        sage: [h[n] for n in range(3)]
+        [0, 2*p[1], 0]
+        sage: len(h.input_streams())
+        3
+    """
+
+    def __init__(self, f, gs, is_sparse, p, ring=None, p_outer=None):
+        r"""
+        Initialize ``self``.
+
+        TESTS::
+
+            sage: # needs sage.modules
+            sage: from sage.data_structures.stream import (Stream_exact,
+            ....:     Stream_function, Stream_plethysm_multi)
+            sage: p = SymmetricFunctions(QQ).p()
+            sage: p2 = tensor([p, p])
+            sage: f = Stream_exact([tensor([p[1], p[1]])], order=2)
+            sage: g = Stream_exact([p[1]], order=1)
+            sage: h = Stream_plethysm_multi(f, (g, g), True, p,
+            ....:                            p_outer=p2)
+            sage: TestSuite(h).run(skip='_test_pickling')
+
+            sage: # needs sage.modules
+            sage: f = Stream_function(
+            ....:     lambda n: tensor([p[n], p[[]]]), True, 0)
+            sage: g0 = Stream_exact([p[[]]])
+            sage: Stream_plethysm_multi(f, (g0, g), True, p,
+            ....:                        p_outer=p2)
+            Traceback (most recent call last):
+            ...
+            ValueError: can only compute plethysm with a series of valuation 0 for symmetric functions of finite support
+        """
+        if p_outer is None:
+            raise ValueError("the outer tensor powersum basis is required")
+
+        gs = tuple(gs)
+        if len(gs) != len(p_outer.tensor_factors()):
+            raise ValueError("the number of arguments must match the outer tensor power")
+
+        exact_f = (f if isinstance(f, Stream_exact) and not f._constant
+                   else None)
+        needs_prewarm = [g.is_uninitialized() and not g._approximate_order
+                         for g in gs]
+        if exact_f is not None:
+            self._degree_f = f._degree
+        else:
+            self._degree_f = None
+
+        if (self._degree_f is None
+            and any(g._true_order and not g._approximate_order for g in gs)):
+            raise ValueError("can only compute plethysm with a series of valuation 0 for symmetric functions of finite support")
+
+        self._basis = p if ring is None else ring
+        self._left = Stream_map_coefficients(
+            f,
+            lambda x: _coerce_to_basis_over_base_ring(x, p_outer),
+            is_sparse,
+        )
+        self._arguments = gs
+
+        R = self._basis.base_ring()
+        if HopfAlgebrasWithBasis(R).TensorProducts() in p.categories():
+            p_factor = p._sets[0]
+        else:
+            p_factor = p
+        unit = Stream_exact([p_factor.one()])
+        self._plethysms = tuple(Stream_plethysm(unit, g, is_sparse, p,
+                                                self._basis)
+                                for g in gs)
+        super().__init__(is_sparse, False)
+
+        if exact_f is not None and any(needs_prewarm):
+            for k in range(exact_f._approximate_order, exact_f._degree):
+                fk = exact_f[k]
+                if not fk:
+                    continue
+                for la, _ in _coerce_to_basis_over_base_ring(fk, p_outer):
+                    for h, mu, prewarm in zip(self._plethysms, la,
+                                              needs_prewarm):
+                        if prewarm:
+                            h._ensure_power(max(mu.to_exp(), default=0))
+
+    def __hash__(self):
+        """
+        Return the hash of ``self``.
+        """
+        return hash((type(self), self._left, self._arguments))
+
+    def __eq__(self, other):
+        """
+        Return whether ``self`` and ``other`` are known to be equal.
+        """
+        return (isinstance(other, type(self))
+                and self._left == other._left
+                and self._arguments == other._arguments)
+
+    def is_uninitialized(self):
+        """
+        Return whether an input stream is uninitialized.
+        """
+        return (self._left.is_uninitialized()
+                or any(g.is_uninitialized() for g in self._arguments))
+
+    @lazy_attribute
+    def _approximate_order(self):
+        """
+        Return a lower bound for the order of ``self``.
+        """
+        order = self._left._approximate_order
+        if not order:
+            return ZZ.zero()
+        return order * min(g._approximate_order for g in self._arguments)
+
+    def get_coefficient(self, n):
+        r"""
+        Return the ``n``-th coefficient of ``self``.
+
+        INPUT:
+
+        - ``n`` -- integer; the degree of the coefficient
+        """
+        if any(h._right[0] for h in self._plethysms):
+            assert self._degree_f is not None, "the plethysm with a lazy symmetric function of valuation 0 is defined only for symmetric functions of finite support"
+            stop = self._degree_f
+        else:
+            stop = n + 1
+
+        ret = None
+        for k in range(self._left._approximate_order, stop):
+            fk = self._left[k]
+            if not fk:
+                continue
+            for la, c in fk:
+                product = self.compute_product(n, tuple(la))
+                if product:
+                    term = self._plethysms[0]._coefficient_times_product(
+                        c, product
+                    )
+                    ret = term if ret is None else ret + term
+        return self._basis.zero() if ret is None else ret
+
+    def compute_product(self, n, la):
+        r"""
+        Return the degree ``n`` part of
+        `\prod_i p_{\lambda_i}(g_i)`.
+
+        INPUT:
+
+        - ``n`` -- integer; the degree of the coefficient
+        - ``la`` -- tuple of partitions `\lambda_i`
+        """
+        return self._compute_product(n, tuple(la), 0, {})
+
+    def _compute_product(self, n, la, i, cache):
+        """
+        Recursively compute a Cauchy product of plethysm factors.
+
+        The cache is local to one coefficient computation.  In particular,
+        it must not retain undetermined coefficients across calls.
+        """
+        key = (n, i)
+        try:
+            return cache[key]
+        except KeyError:
+            pass
+
+        if i == len(la):
+            if n:
+                ret = self._basis.zero()
+            else:
+                ret = self._basis.one()
+            cache[key] = ret
+            return ret
+
+        mu = la[i]
+        if not mu:
+            ret = self._compute_product(n, la, i + 1, cache)
+            cache[key] = ret
+            return ret
+
+        orders = [self._plethysms[j]._right._approximate_order * sum(la[j])
+                  for j in range(i, len(la)) if la[j]]
+        if n < sum(orders):
+            ret = self._basis.zero()
+            cache[key] = ret
+            return ret
+
+        order = orders[0]
+        remaining_order = sum(orders[1:])
+        ret = self._basis.zero()
+        for k in range(order, n - remaining_order + 1):
+            left = self._plethysms[i].compute_product(k, mu)
+            if not left:
+                continue
+            right = self._compute_product(n - k, la, i + 1, cache)
+            if right:
+                ret += left * right
+        cache[key] = ret
+        return ret
+
+    def input_streams(self):
+        r"""
+        Return the streams used to compute the coefficients of ``self``.
+
+        This includes the outer stream and all cached powers maintained by
+        the per-argument :class:`Stream_plethysm` objects.
+        """
+        return ([self._left]
+                + [stream for h in self._plethysms
+                   for stream in h._powers.values()])
 
 
 #####################################################################

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -6975,6 +6975,26 @@ class LazySymmetricFunction(LazyCompletionGradedAlgebraElement):
             0
             sage: (3+f)(0, 0)                                                           # needs sage.modules
             3
+
+        Check composition of a lazy symmetric function with more than
+        one alphabet::
+
+            sage: p = SymmetricFunctions(QQ).p()
+            sage: T = tensor([p, p])
+            sage: L = LazySymmetricFunctions(T)
+            sage: X = tensor([p[1], p[[]]])
+            sage: Y = tensor([p[[]], p[1]])
+            sage: L(X + Y)(L(X), L(Y))
+            (p[]#p[1]+p[1]#p[]) + O^7
+            sage: L(X + Y)(2, 3)
+            5
+            sage: L(tensor([p[2], p[1]]))(2, 3)
+            6
+            sage: f = 1 / (1 - L(X))
+            sage: f(1, L(Y))
+            Traceback (most recent call last):
+            ...
+            ValueError: can only compose with a positive valuation series
         """
         fP = parent(self)
         if len(args) != fP._arity:
@@ -7003,6 +7023,7 @@ class LazySymmetricFunction(LazyCompletionGradedAlgebraElement):
                 return P(f.leading_coefficient())
             return P.zero()
 
+        from sage.rings.lazy_series_ring import LazySymmetricFunctions
         if len(args) == 1:
             g = args[0]
             if (isinstance(self._coeff_stream, Stream_exact)
@@ -7021,7 +7042,6 @@ class LazySymmetricFunction(LazyCompletionGradedAlgebraElement):
             if isinstance(g, LazySymmetricFunction):
                 R = P._laurent_poly_ring
             else:
-                from sage.rings.lazy_series_ring import LazySymmetricFunctions
                 R = g.parent()
                 P = LazySymmetricFunctions(R)
                 g = P(g)
@@ -7048,7 +7068,93 @@ class LazySymmetricFunction(LazyCompletionGradedAlgebraElement):
             )
             return P.element_class(P, coeff_stream)
 
-        raise NotImplementedError("only implemented for arity 1")
+        f_is_polynomial = (isinstance(self._coeff_stream, Stream_exact)
+                           and not self._coeff_stream._constant)
+        fR = fP._laurent_poly_ring
+        ps = tensor([B.realization_of().p() for B in fR.tensor_factors()])
+        ps_factors = ps.tensor_factors()
+        if not isinstance(P, LazySymmetricFunctions):
+            try:
+                P = LazySymmetricFunctions(P)
+            except ValueError:
+                if not f_is_polynomial:
+                    raise ValueError("can only compose with a positive "
+                                     "valuation series") from None
+                args = [P(g) for g in args]
+                ret = P.zero()
+                for k in range(self._coeff_stream._approximate_order,
+                               self._coeff_stream._degree):
+                    fk = self[k]
+                    if not fk:
+                        continue
+                    for la, c in ps(fk):
+                        ret += P(c) * prod((ps_factors[i][mu](args[i])
+                                            for i, mu in enumerate(la)),
+                                           P.one())
+                return ret
+        args = [P(g) for g in args]
+        R = P._laurent_poly_ring
+
+        if not f_is_polynomial:
+            for g in args:
+                if isinstance(g._coeff_stream, Stream_zero):
+                    continue
+                if g._coeff_stream._approximate_order == 0:
+                    if not g._coeff_stream.is_uninitialized() and g[0]:
+                        raise ValueError("can only compose with a positive "
+                                         "valuation series")
+                    g._coeff_stream._approximate_order = 1
+
+        one = P.one()
+        ps_cache = {}
+        plethysm_cache = {}
+        product_cache = {}
+
+        def coefficient_in_powersum(k):
+            try:
+                return ps_cache[k]
+            except KeyError:
+                ret = ps(self[k])
+                ps_cache[k] = ret
+                return ret
+
+        def plethysm_factor(i, la):
+            key = (i, la)
+            try:
+                return plethysm_cache[key]
+            except KeyError:
+                ret = P(ps_factors[i][la](args[i]))
+                plethysm_cache[key] = ret
+                return ret
+
+        def plethysm_product(la):
+            key = tuple(la)
+            try:
+                return product_cache[key]
+            except KeyError:
+                ret = prod((plethysm_factor(i, mu)
+                            for i, mu in enumerate(key)), one)
+                product_cache[key] = ret
+                return ret
+
+        def coefficient(n):
+            if f_is_polynomial and any(g._coeff_stream._approximate_order == 0 and g[0]
+                                       for g in args):
+                stop = self._coeff_stream._degree
+            else:
+                stop = n + 1
+
+            ret = R.zero()
+            for k in range(self._coeff_stream._approximate_order, stop):
+                fk = self[k]
+                if not fk:
+                    continue
+                for la, c in coefficient_in_powersum(k):
+                    ret += c * plethysm_product(la)[n]
+            return ret
+
+        coeff_stream = Stream_function(coefficient, P.is_sparse(), 0)
+        return P.element_class(P, coeff_stream)
 
     plethysm = __call__
 

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -7026,6 +7026,18 @@ class LazySymmetricFunction(LazyCompletionGradedAlgebraElement):
             sage: A[:5]
             [p[], 2*p[1], 2*p[1, 1], 4*p[1, 1, 1], 10*p[1, 1, 1, 1]]
 
+        Every multiplicity used by an exact outer function is registered
+        before an implicit-definition dependency snapshot is taken::
+
+            sage: la = Partition([2]*8 + [1]*3)
+            sage: F = S(p[la])
+            sage: A = S.undefined(valuation=0)
+            sage: equation = A - S(QQ(15)/16) - z - F(A) / 16
+            sage: S.define_implicitly([(A, [p[[]]])], [equation])
+            sage: _ = A[:6]
+            sage: (A - S(QQ(15)/16) - z - F(A) / 16)[:6]
+            []
+
         All homogeneous parts of an exact outer function can contribute when
         the argument has a nonzero constant term::
 

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -6986,6 +6986,11 @@ class LazySymmetricFunction(LazyCompletionGradedAlgebraElement):
             sage: Y = tensor([p[[]], p[1]])
             sage: L(X + Y)(L(X), L(Y))
             (p[]#p[1]+p[1]#p[]) + O^7
+            sage: r = L(X + Y)(p[1], p[1])
+            sage: r
+            2*p[1]
+            sage: r.parent() is p
+            True
             sage: L(X + Y)(2, 3)
             5
             sage: L(tensor([p[2], p[1]]))(2, 3)
@@ -7074,24 +7079,28 @@ class LazySymmetricFunction(LazyCompletionGradedAlgebraElement):
         ps = tensor([B.realization_of().p() for B in fR.tensor_factors()])
         ps_factors = ps.tensor_factors()
         if not isinstance(P, LazySymmetricFunctions):
-            try:
-                P = LazySymmetricFunctions(P)
-            except ValueError:
-                if not f_is_polynomial:
-                    raise ValueError("can only compose with a positive "
-                                     "valuation series") from None
+            if f_is_polynomial:
                 args = [P(g) for g in args]
                 ret = P.zero()
                 for k in range(self._coeff_stream._approximate_order,
-                               self._coeff_stream._degree):
+                    self._coeff_stream._degree):
                     fk = self[k]
                     if not fk:
                         continue
                     for la, c in ps(fk):
-                        ret += P(c) * prod((ps_factors[i][mu](args[i])
-                                            for i, mu in enumerate(la)),
-                                           P.one())
+                        ret += P(c) * prod(
+                           (ps_factors[i][mu](args[i])
+                            for i, mu in enumerate(la)),
+                            P.one(),
+                        )
                 return ret
+
+            try:
+                P = LazySymmetricFunctions(P)
+            except ValueError:
+                raise ValueError(
+                    "can only compose with a positive valuation series"
+                ) from None
         args = [P(g) for g in args]
         R = P._laurent_poly_ring
 

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -262,6 +262,7 @@ from sage.data_structures.stream import (
     Stream_dirichlet_convolve,
     Stream_dirichlet_invert,
     Stream_plethysm,
+    Stream_plethysm_multi,
     Stream_pseudo_diff_mul
 )
 
@@ -6985,7 +6986,7 @@ class LazySymmetricFunction(LazyCompletionGradedAlgebraElement):
             sage: X = tensor([p[1], p[[]]])
             sage: Y = tensor([p[[]], p[1]])
             sage: L(X + Y)(L(X), L(Y))
-            (p[]#p[1]+p[1]#p[]) + O^7
+            (p[]#p[1]+p[1]#p[]) + O^8
             sage: r = L(X + Y)(p[1], p[1])
             sage: r
             2*p[1]
@@ -7000,6 +7001,51 @@ class LazySymmetricFunction(LazyCompletionGradedAlgebraElement):
             Traceback (most recent call last):
             ...
             ValueError: can only compose with a positive valuation series
+
+        Check that argument streams remain visible to implicit definitions::
+
+            sage: S = LazySymmetricFunctions(p)
+            sage: H = L(tensor([p[1], p[1]]))
+            sage: z = S(p[1])
+            sage: A = S.undefined(valuation=1)
+            sage: S.define_implicitly([A], [A - z - H(A, z)])
+            sage: A[:5]
+            [p[1], p[1, 1], p[1, 1, 1], p[1, 1, 1, 1]]
+
+        Undetermined coefficients in the outer stream and in arguments with
+        nonzero constant term remain in the solver's temporary base ring::
+
+            sage: A = S.undefined(valuation=1)
+            sage: S.define_implicitly([A], [A - z - A(z) / 2])
+            sage: A[:4]
+            [2*p[1], 0, 0]
+            sage: F = S(p[1, 1])
+            sage: A = S.undefined(valuation=0)
+            sage: S.define_implicitly([(A, [p[[]]])],
+            ....:     [A - S(QQ(3)/4) - z - F(A) / 4])
+            sage: A[:5]
+            [p[], 2*p[1], 2*p[1, 1], 4*p[1, 1, 1], 10*p[1, 1, 1, 1]]
+
+        All homogeneous parts of an exact outer function can contribute when
+        the argument has a nonzero constant term::
+
+            sage: g = S(lambda n: p[[]] if n == 0 else
+            ....:       (p[1] if n == 1 else 0), valuation=0)
+            sage: S(p[[1]*5])(g)[:3]
+            [p[], 5*p[1], 10*p[1, 1]]
+
+        The same temporary-base-ring handling applies in the multisort case::
+
+            sage: F = L(tensor([p[[1]*8], p[[]]]))
+            sage: A = S.undefined(valuation=0)
+            sage: S.define_implicitly([(A, [p[[]]])],
+            ....:     [A - S(QQ(15)/16) - z - F(A, z) / 16])
+            sage: A[:5]
+            [p[], 2*p[1], 14*p[1, 1], 252*p[1, 1, 1], 5530*p[1, 1, 1, 1]]
+            sage: A = L.undefined(valuation=1)
+            sage: L.define_implicitly([A], [A - L(X) - A(L(Y), L(X)) / 2])
+            sage: A[:3]
+            [2/3*p[] # p[1] + 4/3*p[1] # p[], 0]
         """
         fP = parent(self)
         if len(args) != fP._arity:
@@ -7083,7 +7129,7 @@ class LazySymmetricFunction(LazyCompletionGradedAlgebraElement):
                 args = [P(g) for g in args]
                 ret = P.zero()
                 for k in range(self._coeff_stream._approximate_order,
-                    self._coeff_stream._degree):
+                               self._coeff_stream._degree):
                     fk = self[k]
                     if not fk:
                         continue
@@ -7114,55 +7160,19 @@ class LazySymmetricFunction(LazyCompletionGradedAlgebraElement):
                                          "valuation series")
                     g._coeff_stream._approximate_order = 1
 
-        one = P.one()
-        ps_cache = {}
-        plethysm_cache = {}
-        product_cache = {}
-
-        def coefficient_in_powersum(k):
-            try:
-                return ps_cache[k]
-            except KeyError:
-                ret = ps(self[k])
-                ps_cache[k] = ret
-                return ret
-
-        def plethysm_factor(i, la):
-            key = (i, la)
-            try:
-                return plethysm_cache[key]
-            except KeyError:
-                ret = P(ps_factors[i][la](args[i]))
-                plethysm_cache[key] = ret
-                return ret
-
-        def plethysm_product(la):
-            key = tuple(la)
-            try:
-                return product_cache[key]
-            except KeyError:
-                ret = prod((plethysm_factor(i, mu)
-                            for i, mu in enumerate(key)), one)
-                product_cache[key] = ret
-                return ret
-
-        def coefficient(n):
-            if f_is_polynomial and any(g._coeff_stream._approximate_order == 0 and g[0]
-                                       for g in args):
-                stop = self._coeff_stream._degree
-            else:
-                stop = n + 1
-
-            ret = R.zero()
-            for k in range(self._coeff_stream._approximate_order, stop):
-                fk = self[k]
-                if not fk:
-                    continue
-                for la, c in coefficient_in_powersum(k):
-                    ret += c * plethysm_product(la)[n]
-            return ret
-
-        coeff_stream = Stream_function(coefficient, P.is_sparse(), 0)
+        if P._arity == 1:
+            target_ps = R.realization_of().p()
+        else:
+            target_ps = tensor([B.realization_of().p()
+                                for B in R.tensor_factors()])
+        coeff_stream = Stream_plethysm_multi(
+            self._coeff_stream,
+            tuple(g._coeff_stream for g in args),
+            P.is_sparse(),
+            target_ps,
+            R,
+            p_outer=ps,
+        )
         return P.element_class(P, coeff_stream)
 
     plethysm = __call__

--- a/src/sage/rings/lazy_species.py
+++ b/src/sage/rings/lazy_species.py
@@ -1599,6 +1599,13 @@ class CompositionSpeciesElement(LazyCombinatorialSpeciesElementGeneratingSeriesM
             sage: F = E(E.restrict(1))
             sage: F.cycle_index_series()[5]
             h[2, 2, 1] - h[3, 1, 1] + 3*h[3, 2] + 2*h[4, 1] + 2*h[5]
+
+            sage: L.<X, Y> = LazyCombinatorialSpecies(QQ)
+            sage: F = (X + Y)(X, Y)
+            sage: F.cycle_index_series()[1]
+            p[] # p[1] + p[1] # p[]
+            sage: F.isotype_generating_series()
+            (X+Y) + O(X,Y)^7
         """
         return self._left.cycle_index_series()(*[G.cycle_index_series() for G in self._args])
 


### PR DESCRIPTION
### Description

`LazySymmetricFunction.__call__` previously raised

```python
NotImplementedError: only implemented for arity 1
```

when a lazy symmetric function over a tensor basis was composed with several arguments. This prevented multisort `CompositionSpeciesElement` objects from computing their cycle index series, as reported in #42331.

This PR implements multisort plethysm `f(g_1, ..., g_r)` when `f` belongs to a tensor product of `r` symmetric function algebras.

- `Stream_plethysm_multi` delegates each sort to `Stream_plethysm`, sharing powersum conversion, degree restriction, stretched powers, and coefficient caches.
- Finite outer functions composed with exact arguments retain exact results.
- Lazy and implicitly defined arguments are supported, including temporary coefficient rings and nonzero constant terms when the outer function has finite support.
- Powers of argument streams are built with a lazy balanced multiplication tree, avoiding the previous linear chain for high multiplicities.
- Scalar arguments, zero arguments, tensor-valued targets, and the positive-valuation requirement for infinite outer functions remain consistent with the arity-1 behavior.

### Performance

The balanced power cache was compared with the previous linear cache when requesting one high-degree coefficient:

| Multiplicity | Degree | Linear cache | Balanced cache | Speedup | Cached nodes / depth |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 32 | 48 | 77.14 ms | 10.41 ms | 7.41x | 32 / 31 -> 6 / 5 |
| 64 | 80 | 147.84 ms | 12.47 ms | 11.85x | 64 / 63 -> 7 / 6 |
| 80 | 100 | 298.96 ms | 21.58 ms | 13.85x | 80 / 79 -> 8 / 7 |

The ordinary arity-1 positive-valuation case remained effectively unchanged at 5.44 ms versus 5.47 ms, a 0.65% difference.

As a result, multisort composition now works through the same stream machinery as ordinary plethysm, and `cycle_index_series()` works for multisort `CompositionSpeciesElement` objects.

Fixes #42331.