### PR TITLE
src/sage/modules/filtered_vector_space.py: handle random failure

### DIFF
--- a/src/sage/modules/filtered_vector_space.py
+++ b/src/sage/modules/filtered_vector_space.py
@@ -1218,8 +1218,8 @@ class FilteredVectorSpace_class(FreeModule_ambient_field):
             sage: D.degree()
             3
             sage: v = D.basis_matrix()[0]
-            sage: v[0]
-            1
+            sage: v[0] in [0,1]
+            True
 
             sage: while F.random_deformation(1/50).get_degree(2).matrix() == matrix([1, 0, 0]):
             ....:     pass


### PR DESCRIPTION
The doctest for a `random_deformation()` of a filtered vector space ultimately checks a randomly deformed singleton basis, expecting the first coordinate of its only constituent to be one after renormalization. So long as the first coordinate is non-zero, that is probably reliable, but if you are unlucky and deform your basis vector to (0,...), the zero is left alone. For example:

```python
sage: V = QQ^3

sage: V.span([V((2,3,4))])
Vector space of degree 3 and dimension 1 over Rational Field
Basis matrix:
[  1 3/2   2]

sage: V.span([V((0,3,4))])
Vector space of degree 3 and dimension 1 over Rational Field
Basis matrix:
[  0   1 4/3]
```

This is causing test failures in https://github.com/sagemath/sage/issues/41091. To fix it, we now check for both zero and one.
