### PR TITLE
gh-42398: add input verification to DyckWords._element_constructor_

### DIFF
--- a/src/sage/combinat/dyck_word.py
+++ b/src/sage/combinat/dyck_word.py
@@ -3382,10 +3382,25 @@ class DyckWords(UniqueRepresentation, Parent):
             [1, 1, 0, 1, 0, 0]
             sage: elt.parent() is D
             True
+            sage: D([x])
+            Traceback (most recent call last):
+            ...
+            ValueError: [x] is not an element of Complete Dyck words
+            sage: D([1, 1, 0])
+            Traceback (most recent call last):
+            ...
+            ValueError: [1, 1, 0] is not an element of Complete Dyck words
+            sage: DyckWords(2)([1, 0])
+            Traceback (most recent call last):
+            ...
+            ValueError: [1, 0] is not an element of Dyck words with 2 opening parentheses and 2 closing parentheses
         """
         if isinstance(word, DyckWord) and word.parent() is self:
             return word
-        return self.element_class(self, list(word))
+        word = list(word)
+        if word not in self:
+            raise ValueError("%s is not an element of %s" % (word, self))
+        return self.element_class(self, word)
 
     def __contains__(self, x) -> bool:
         r"""


### PR DESCRIPTION
### 📚 Description

Fixes #42398.

`DyckWords(...)(word)` previously wrapped `list(word)` in the element class
without any validation, so malformed input was silently accepted:

```python
sage: DyckWords()([x])
[x]
```

The input checking only lived in the top-level `DyckWord(...)` factory
(`__classcall_private__`), which the parent-call path bypasses. This PR adds
the missing check to `DyckWords._element_constructor_` by reusing the parent's
existing `__contains__`, raising `ValueError` on a non-member:

```python
sage: DyckWords()([x])
Traceback (most recent call last):
...
ValueError: [x] is not an element of Complete Dyck words
sage: DyckWords(2)([1, 0])
Traceback (most recent call last):
...
ValueError: [1, 0] is not an element of Dyck words with 2 opening parentheses and 2 closing parentheses
```

Validating against the specific parent (rather than the factory's generic
`is_a`) also catches wrong-size input. The hot construction paths
(`element_class`, iterators, `from_heights`, etc.) are untouched, so only the
public `D(x)` entry point pays the validation cost.

### 📝 Checklist

- [x] The title is concise and informative.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation builds.
