### PR TITLE
src/sage/interfaces/gap.py: increase some timeouts and sleep durations

### DIFF
--- a/src/sage/interfaces/gap.py
+++ b/src/sage/interfaces/gap.py
@@ -277,7 +277,7 @@ class Gap_generic(ExtraTabCompletion, Expect):
             ok
             sage: gap._expect.sendline()  # now we are out of sync
             1
-            sage: gap._synchronize()
+            sage: gap._synchronize(timeout=2)  # allow the CI more time
             sage: gap(123)
             123
         """
@@ -335,7 +335,7 @@ class Gap_generic(ExtraTabCompletion, Expect):
         # handler and input, if we don't wait a bit the result is
         # unpredictable.
         E.sendline(chr(3))
-        time.sleep(0.1)
+        time.sleep(0.2)
         E.sendline()
         try:
             # send a dummy command
@@ -352,11 +352,11 @@ class Gap_generic(ExtraTabCompletion, Expect):
             # either complete successfully (output "@n+<number>") or
             # return a "Syntax error: od expected@J@f +<number>"
             E.sendline()
-            time.sleep(0.1)
+            time.sleep(0.2)
             E.sendline('224433437;')
             E.expect(r'@[nf][@J\s>]*224433437', timeout=timeout)
             E.sendline()
-            time.sleep(0.1)
+            time.sleep(0.2)
             E.sendline('224433479;')
             E.expect(r'@[nf][@J\s>]*224433479', timeout=timeout)
             E.send(' ')


### PR DESCRIPTION
One test for _synchronize() is failing randomly on our CI (https://github.com/sagemath/sage/issues/37298). To reproduce the failure, two changes were required:

1. Force `_synchronize()` to time out by passing in a low timeout value.
2. Eliminate the `sleep(0.1)` calls in the `interrupt()` that happens when `_synchronize()` times out.

This puts the "real" issue in `interrupt()`, which can apparently do weird things if it does not wait long enough between commands. But to fix the CI issue, we make _two_ changes:

1. Change each `sleep(0.1)` to `sleep(0.2)` in `interrupt()`. This slows the method down if we need to retry a few times, but in exchange reduces the risk of mysterious errors.
2. Increase the `_synchronize()` timeout in the flaky doctest, to reduce the likelihood of a timeout and the need to `interrupt()` the interface in the first place.

Closes: https://github.com/sagemath/sage/issues/37298
