### PR TITLE
Update Homebrew formula for maxima, kenzo, and gap packages

### DIFF
--- a/build/pkgs/gap/distros/homebrew.txt
+++ b/build/pkgs/gap/distros/homebrew.txt
@@ -1,2 +1,2 @@
-# gap-system/gap/gap
-# commented out 2026-07-03, as it breaks doctesting without --debug, see #42471
+dimpase/gap/gap
+# a fixed fork for the broken for our purposes gap-system's tap (should have no Browse GAP package)

--- a/build/pkgs/kenzo/distros/homebrew.txt
+++ b/build/pkgs/kenzo/distros/homebrew.txt
@@ -1,0 +1,1 @@
+dimpase/tap/kenzo

--- a/build/pkgs/maxima/distros/homebrew.txt
+++ b/build/pkgs/maxima/distros/homebrew.txt
@@ -1,1 +1,1 @@
-maxima
+dimpase/tap/maxima-ecl


### PR DESCRIPTION
the Homebrew mainline maxima is not built with ecl, so it's totally useless for us.
The tap `dimpase/tap/maxima-ecl`, which replaces it in this PR, uses `ecl`, and also installs `maxima.fas`.

And to be done with Lisp, also added `dimpase/tap/kenzo`. (Also, re-added a fixed tap for GAP)

~To make the latter useful, it has to be linked from ecl,
and this can be done by setting ECLDIR to the right value; the latter is done in `.homebrew-build-env`,
so the latter needs to be re-sourced before trying this branch.~

You might need to `brew reinstall ecl` to update `ecl` to the latest patched version, which alleviated the need for extra hacks.

To check, start `ecl` and at the `ecl` prompt run
`(require :maxima)`, to verify this worked.






### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


