### PR TITLE
Fix quadratic twist of 1728 in the supersingular case

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -220,7 +220,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
 
                     # Handle the case j=1728 and #K=3 mod 4 separately to ensure that
                     # twist is non-isomorphic if no input D was specified
-                    if char % 4 == 3 and K.degree() % 2 == 1 and self.j_invariant() == K(1728):
+                    if char % 4 == 3 and K.degree() % 2 == 1 and self.j_invariant() == 1728:
                         # Outside of characteristic 3 we have exactly two isomorphism classes,
                         # given by the parameters [1,0] and [D,0]
                         if char > 3:

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -220,11 +220,21 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
 
                     # Handle the case j=1728 and #K=3 mod 4 separately to ensure that
                     # twist is non-isomorphic if no input D was specified
-                    if char % 4 == 3 and char > 3 and K.degree() % 2 == 1 and self.j_invariant() == K(1728):
-                        E0 = EllipticCurve(K, [1,0])
-                        if self.is_isomorphic(E0, field=K):
-                            return EllipticCurve(K, [D,0])
-                        return E0
+                    if char % 4 == 3 and K.degree() % 2 == 1 and self.j_invariant() == K(1728):
+                        # Outside of characteristic 3 we have exactly two isomorphism classes,
+                        # given by the parameters [1,0] and [D,0]
+                        if char > 3:
+                            E0 = EllipticCurve(K, [1,0])
+                            if self.is_isomorphic(E0, field=K):
+                                return EllipticCurve(K, [D,0])
+                            return E0
+
+                        # Otherwise we are in characteristic 3; here the generic twisting does not
+                        # work exactly if the b-invariant b6 is zero. Note that b2 is zero here.
+                        b2, b4, b6, b8 = self.b_invariants()
+                        # E is isomorphic to [0,b2,0,8*b4,16*b6]
+                        if b6.is_zero():
+                            return EllipticCurve(K, [8*b4*D,0])
 
             else:
                 raise ValueError("twisting parameter D must be specified over infinite fields.")

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -188,6 +188,10 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
             sage: E = EllipticCurve(K, [1,0])
             sage: E.quadratic_twist().is_isomorphic(E)
             False
+            sage: F = GF(3^5, "a")
+            sage: E = EllipticCurve_from_j(F(1728))
+            sage: E.quadratic_twist().is_isomorphic(E)
+            False
         """
         K = self.base_ring()
         char = K.characteristic()
@@ -220,8 +224,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
                         E0 = EllipticCurve(K, [1,0])
                         if self.is_isomorphic(E0, field=K):
                             return EllipticCurve(K, [D,0])
-                        else:
-                            return E0
+                        return E0
 
             else:
                 raise ValueError("twisting parameter D must be specified over infinite fields.")

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -184,7 +184,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
             sage: E = EllipticCurve(GF(7), [0,6,0,8,0])
             sage: E.quadratic_twist().is_isomorphic(E)
             False
-            sage: K = GF(7^2, "i")
+            sage: K = GF(7^3, "i")
             sage: E = EllipticCurve(K, [1,0])
             sage: E.quadratic_twist().is_isomorphic(E)
             False
@@ -218,9 +218,9 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
                     while D.is_square():
                         D = K.random_element()
 
-                    # Handle the case j=1728 and char=3 mod 4 separately to ensure that
+                    # Handle the case j=1728 and #K=3 mod 4 separately to ensure that
                     # twist is non-isomorphic if no input D was specified
-                    if char % 4 == 3 and self.j_invariant() == K(1728):
+                    if char % 4 == 3 and char > 3 and K.degree() % 2 == 1 and self.j_invariant() == K(1728):
                         E0 = EllipticCurve(K, [1,0])
                         if self.is_isomorphic(E0, field=K):
                             return EllipticCurve(K, [D,0])

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -210,23 +210,15 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
                         while (x**2 + x + D).roots():
                             D *= a
                 else:
-                    # We could take a multiplicative generator but
-                    # that might be expensive to compute; otherwise
-                    # half the elements will do, and testing squares
-                    # is very fast.
-                    D = K.random_element()
-                    while D.is_square():
-                        D = K.random_element()
-
                     # Handle the case j=1728 and #K=3 mod 4 separately to ensure that
                     # twist is non-isomorphic if no input D was specified
                     if char % 4 == 3 and K.degree() % 2 == 1 and self.j_invariant() == 1728:
                         # Outside of characteristic 3 we have exactly two isomorphism classes,
-                        # given by the parameters [1,0] and [D,0]
+                        # given by the parameters [1,0] and [-1,0]
                         if char > 3:
                             E0 = EllipticCurve(K, [1,0])
                             if self.is_isomorphic(E0, field=K):
-                                return EllipticCurve(K, [D,0])
+                                return EllipticCurve(K, [-1,0])
                             return E0
 
                         # Otherwise we are in characteristic 3; here the generic twisting does not
@@ -234,8 +226,15 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
                         b2, b4, b6, b8 = self.b_invariants()
                         # E is isomorphic to [0,b2,0,8*b4,16*b6]
                         if b6.is_zero():
-                            return EllipticCurve(K, [8*b4*D,0])
+                            return EllipticCurve(K, [-8*b4,0])
 
+                    # We could take a multiplicative generator but
+                    # that might be expensive to compute; otherwise
+                    # half the elements will do, and testing squares
+                    # is very fast.
+                    D = K.random_element()
+                    while D.is_square():
+                        D = K.random_element()
             else:
                 raise ValueError("twisting parameter D must be specified over infinite fields.")
         else:

--- a/src/sage/schemes/elliptic_curves/ell_field.py
+++ b/src/sage/schemes/elliptic_curves/ell_field.py
@@ -173,6 +173,21 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
             sage: k2 = GF(p^2,'a')
             sage: E.change_ring(k2).is_isomorphic(Et.change_ring(k2))
             True
+
+        TESTS:
+
+        Check that :issue:`42403` is fixed, independently of model or base field::
+
+            sage: E = EllipticCurve(GF(7), [1,0])
+            sage: E.quadratic_twist().is_isomorphic(E)
+            False
+            sage: E = EllipticCurve(GF(7), [0,6,0,8,0])
+            sage: E.quadratic_twist().is_isomorphic(E)
+            False
+            sage: K = GF(7^2, "i")
+            sage: E = EllipticCurve(K, [1,0])
+            sage: E.quadratic_twist().is_isomorphic(E)
+            False
         """
         K = self.base_ring()
         char = K.characteristic()
@@ -198,6 +213,16 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
                     D = K.random_element()
                     while D.is_square():
                         D = K.random_element()
+
+                    # Handle the case j=1728 and char=3 mod 4 separately to ensure that
+                    # twist is non-isomorphic if no input D was specified
+                    if char % 4 == 3 and self.j_invariant() == K(1728):
+                        E0 = EllipticCurve(K, [1,0])
+                        if self.is_isomorphic(E0, field=K):
+                            return EllipticCurve(K, [D,0])
+                        else:
+                            return E0
+
             else:
                 raise ValueError("twisting parameter D must be specified over infinite fields.")
         else:
@@ -211,7 +236,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
 
         if char != 2:
             b2, b4, b6, b8 = self.b_invariants()
-            # E is isomorphic to  [0,b2,0,8*b4,16*b6]
+            # E is isomorphic to [0,b2,0,8*b4,16*b6]
             return EllipticCurve(K, [0, b2*D, 0, 8*b4*D**2, 16*b6*D**3])
 
         # now char==2
@@ -439,7 +464,7 @@ class EllipticCurve_field(ell_generic.EllipticCurve_generic, ProjectivePlaneCurv
 
             sage: # needs sage.rings.finite_rings
             sage: E1 = EllipticCurve_from_j(F(0))
-            sage: E2 = E1.quadratic_twist()
+            sage: E2 = E1.quadratic_twist(1)
             sage: D = E1.is_quadratic_twist(E2); D
             1
             sage: E1.is_isomorphic(E2)


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

This PR handles the quadratic twisting of any supersingular curve of $$j$$-invariant $$1728$$ separately to ensure that `.quadratic_twist()` always returns a non-isomorphic curve (when working over a finite field with unspecified input `D`). 

The two distinct isomorphism classes are given by $$E: y^2 = x^3 + x$$ and $$E': y^2 = x^3 + Dx$$ for a non-square $$D \in K$$ (which is computed in the method already; UPDATE: Since we only need to consider the case $$|K| \equiv 3 \bmod 4$$, we can take $$D = -1$$), so we simply check which one the curve `self` is not isomorphic to.

Also adjusted an example in `is_quadratic_twist` for consistency.

Fixes #42403.