### PR TITLE
Make better use of the brial feature

### DIFF
--- a/src/sage/crypto/boolean_function.pyx
+++ b/src/sage/crypto/boolean_function.pyx
@@ -39,11 +39,6 @@ from sage.rings.polynomial.polynomial_element import Polynomial
 from sage.structure.richcmp cimport rich_to_bool
 from sage.structure.sage_object cimport SageObject
 
-try:
-    from sage.rings.polynomial.pbori.pbori import BooleanPolynomial
-except ImportError:
-    BooleanPolynomial = ()
-
 # for details about the implementation of hamming_weight (in .pxd),
 # walsh_hadamard transform, reed_muller transform, and a lot
 # more, see 'Matters computational' available on www.jjj.de.
@@ -283,6 +278,12 @@ cdef class BooleanFunction(SageObject):
             ...
             ValueError: the length of the truth table must be a power of 2
         """
+        from sage.features.brial import Brial
+        if Brial().is_present():
+            from sage.rings.polynomial.pbori.pbori import BooleanPolynomial
+        else:
+            BooleanPolynomial = ()
+
         cdef mp_bitcnt_t i
         if isinstance(x, str):
             L = ZZ(len(x))

--- a/src/sage/misc/citation.pyx
+++ b/src/sage/misc/citation.pyx
@@ -75,10 +75,6 @@ def get_systems(cmd):
         1/3*x^3
         sage: get_systems('integrate(x^2, x)')                                          # needs sage.symbolic
         ['Maxima', 'ginac']
-        sage: R.<x,y,z> = QQ[]
-        sage: I = R.ideal(x^2+y^2, z^2+y)
-        sage: get_systems('I.primary_decomposition()')
-        ['Singular']
     """
     import cProfile
     import pstats

--- a/src/sage/rings/polynomial/multi_polynomial_sequence.py
+++ b/src/sage/rings/polynomial/multi_polynomial_sequence.py
@@ -284,9 +284,10 @@ def PolynomialSequence(arg1, arg2=None, immutable=False, cr=False, cr_str=None):
         )
     """
     from sage.structure.element import Matrix
-    try:
+    from sage.features.brial import Brial
+    if Brial().is_present():
         from sage.rings.polynomial.pbori.pbori import BooleanMonomialMonoid
-    except ImportError:
+    else:
         BooleanMonomialMonoid = ()
 
     def is_ring(r):
@@ -1658,6 +1659,9 @@ class PolynomialSequence_gf2(PolynomialSequence_generic):
 
         if not isinstance(R, BooleanPolynomialRing_base):
             raise NotImplementedError("Only BooleanPolynomialRing's are supported.")
+
+        from sage.features.brial import Brial
+        Brial().require()
 
         from sage.rings.polynomial.pbori.ll import (eliminate, ll_encode,
                                                     ll_red_nf_redsb)

--- a/src/sage/rings/polynomial/pbori/PyPolyBoRi.py
+++ b/src/sage/rings/polynomial/pbori/PyPolyBoRi.py
@@ -10,6 +10,7 @@ AUTHOR:
 
     EXAMPLES::
 
+        sage: # needs brial
         sage: from sage.rings.polynomial.pbori.pbori import *
         sage: from sage.rings.polynomial.pbori.blocks import declare_ring
         sage: r=declare_ring(["x0","x1","x2","y0","y1","y2"], globals())
@@ -22,18 +23,21 @@ AUTHOR:
         sage: y0>y1*y2
         True
 
+        sage: # needs brial
         sage: r = r.clone(ordering=dlex)
         sage: r(x0) > r(x1)
         True
         sage: r(x0) > r(x1*x2)
         False
 
+        sage: # needs brial
         sage: r = r.clone(ordering=dp_asc)
         sage: r(x0) > r(x1)
         False
         sage: r(x0) > r(x1*x2)
         False
 
+        sage: # needs brial
         sage: r = r.clone(ordering=block_dlex, blocks=[3])
         sage: r(x0) > r(x1)
         True
@@ -42,6 +46,7 @@ AUTHOR:
         sage: r(x0) > r(y0*y1*y2)
         True
 
+        sage: # needs brial
         sage: r = r.clone(ordering=block_dp_asc)
         sage: r(x0) > r(x1)
         False
@@ -50,13 +55,16 @@ AUTHOR:
         sage: r(x0) > r(x1*x2)
         False
 
+        sage: # needs brial
         sage: r = r.clone(ordering=block_dp_asc, blocks=[3])
         sage: r(x0) > r(y0)
         True
 
+        sage: # needs brial
         sage: r(x0) > r(y0*y1)
         True
 
+        sage: # needs brial
         sage: r = r.clone(names=["z17", "z7"])
         sage: [r.variable(idx) for idx in range(3)]
         [z17, z7, x2]

--- a/src/sage/rings/polynomial/pbori/blocks.py
+++ b/src/sage/rings/polynomial/pbori/blocks.py
@@ -360,6 +360,7 @@ def declare_ring(blocks, context=None):
 
     EXAMPLES::
 
+        sage: # needs brial
         sage: from sage.rings.polynomial.pbori import *
         sage: declare_ring([Block("x",10),Block("y",5)],globals())
         Boolean PolynomialRing in x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, y0, y1, y2, y3, y4
@@ -410,6 +411,7 @@ def main_test():
     """
     EXAMPLES::
 
+        sage: # needs brial
         sage: from sage.rings.polynomial.pbori.blocks import main_test
         sage: main_test()
         x(0)

--- a/src/sage/rings/polynomial/pbori/cnf.py
+++ b/src/sage/rings/polynomial/pbori/cnf.py
@@ -18,6 +18,7 @@ class CNFEncoder:
 
         TESTS::
 
+            sage: # needs brial
             sage: from sage.rings.polynomial.pbori import *
             sage: r = declare_ring(["x", "y", "z"], dict())
             sage: from sage.rings.polynomial.pbori.cnf import CNFEncoder
@@ -82,6 +83,7 @@ class CNFEncoder:
 
         TESTS::
 
+            sage: # needs brial
             sage: from sage.rings.polynomial.pbori import *
             sage: r = declare_ring(["x", "y", "z"], dict())
             sage: from sage.rings.polynomial.pbori.cnf import CNFEncoder
@@ -102,6 +104,7 @@ class CNFEncoder:
 
         TESTS::
 
+            sage: # needs brial
             sage: from sage.rings.polynomial.pbori import *
             sage: r = declare_ring(["x", "y", "z"], dict())
             sage: from sage.rings.polynomial.pbori.cnf import CNFEncoder
@@ -143,6 +146,7 @@ class CNFEncoder:
 
         TESTS::
 
+            sage: # needs brial
             sage: from sage.rings.polynomial.pbori import *
             sage: d = {}
             sage: r = declare_ring(["x", "y", "z"], d)
@@ -158,6 +162,7 @@ class CNFEncoder:
 
         TESTS::
 
+            sage: # needs brial
             sage: from sage.rings.polynomial.pbori import *
             sage: r = declare_ring(["x", "y", "z"], dict())
             sage: from sage.rings.polynomial.pbori.cnf import CNFEncoder
@@ -187,6 +192,7 @@ class CryptoMiniSatEncoder(CNFEncoder):
 
         TESTS::
 
+            sage: # needs brial
             sage: from sage.rings.polynomial.pbori import *
             sage: d=dict()
             sage: r = declare_ring(["x", "y", "z"], d)
@@ -221,6 +227,7 @@ class CryptoMiniSatEncoder(CNFEncoder):
 
         TESTS::
 
+            sage: # needs brial
             sage: from sage.rings.polynomial.pbori import *
             sage: r = declare_ring(["x", "y", "z"], dict())
             sage: from sage.rings.polynomial.pbori.cnf import CryptoMiniSatEncoder

--- a/src/sage/rings/polynomial/pbori/easy_polynomials.py
+++ b/src/sage/rings/polynomial/pbori/easy_polynomials.py
@@ -11,6 +11,7 @@ def easy_linear_polynomials(p):
 
     EXAMPLES::
 
+        sage: # needs brial
         sage: from sage.rings.polynomial.pbori.frontend import x
         sage: from sage.rings.polynomial.pbori.easy_polynomials import easy_linear_polynomials
         sage: easy_linear_polynomials(x(1)*x(2) + 1)
@@ -35,6 +36,7 @@ def easy_linear_polynomials_via_interpolation(p):
 
     TESTS::
 
+        sage: # needs brial
         sage: from sage.rings.polynomial.pbori.frontend import x
         sage: from sage.rings.polynomial.pbori.easy_polynomials import easy_linear_polynomials_via_interpolation
         sage: easy_linear_polynomials_via_interpolation(x(1)*x(2) + 1)

--- a/src/sage/rings/polynomial/pbori/fglm.py
+++ b/src/sage/rings/polynomial/pbori/fglm.py
@@ -20,6 +20,7 @@ def fglm(I, from_ring, to_ring):
 
     TESTS::
 
+        sage: # needs brial
         sage: from sage.rings.polynomial.pbori import *
         sage: from sage.rings.polynomial.pbori.PyPolyBoRi import OrderCode
         sage: from sage.rings.polynomial.pbori.fglm import fglm
@@ -44,6 +45,7 @@ def vars_real_divisors(monomial, monomial_set):
 
     EXAMPLES::
 
+        sage: # needs brial
         sage: from sage.rings.polynomial.pbori.pbori import *
         sage: from sage.rings.polynomial.pbori.PyPolyBoRi import OrderCode
         sage: dp_asc = OrderCode.dp_asc
@@ -71,6 +73,7 @@ def m_k_plus_one(completed_elements, variables):
 
     EXAMPLES::
 
+        sage: # needs brial
         sage: from sage.rings.polynomial.pbori.pbori import *
         sage: from sage.rings.polynomial.pbori.PyPolyBoRi import OrderCode
         sage: from sage.rings.polynomial.pbori.fglm import m_k_plus_one

--- a/src/sage/rings/polynomial/pbori/frontend.py
+++ b/src/sage/rings/polynomial/pbori/frontend.py
@@ -5,6 +5,7 @@ a given context.
 
 EXAMPLES::
 
+    sage: # needs brial
     sage: from sage.rings.polynomial.pbori.frontend import x
     sage: x(0)
     x(0)
@@ -19,6 +20,9 @@ EXAMPLES::
     sage: x(9999) + x(9999)
     0
 
+::
+
+    sage: # needs brial
     sage: from sage.rings.polynomial.pbori.frontend import x, polybori_start
     sage: context = dict(globals())
     sage: polybori_start(context)

--- a/src/sage/rings/polynomial/pbori/gbcore.py
+++ b/src/sage/rings/polynomial/pbori/gbcore.py
@@ -308,6 +308,7 @@ def variety_size_from_gb(I):
     """
     TESTS::
 
+        sage: # needs brial
         sage: from sage.rings.polynomial.pbori import Ring, Monomial, Polynomial
         sage: from sage.rings.polynomial.pbori.gbcore import variety_size_from_gb
         sage: r = Ring(100)
@@ -360,6 +361,7 @@ def other_ordering_pre(I, option_set, kwds):
     """
     TESTS::
 
+        sage: # needs brial
         sage: from sage.rings.polynomial.pbori.blocks import declare_ring
         sage: r = declare_ring(['x0', 'x1', 'x2', 'x3', 'x4'], globals())
         sage: id = [x1*x3 + x1 + x2*x3 + x3 + x4, x0*x3 + x0 + x1*x2 + x2 + 1,  x1*x3 + x1*x4 + x3*x4 + x4 + 1, x0*x2 + x0*x4 + x1 + x3 + x4]

--- a/src/sage/rings/polynomial/pbori/ll.py
+++ b/src/sage/rings/polynomial/pbori/ll.py
@@ -203,6 +203,7 @@ class RingMap:
 
     TESTS::
 
+        sage: # needs brial
         sage: from sage.rings.polynomial.pbori.pbori import *
         sage: from sage.rings.polynomial.pbori.blocks import declare_ring, Block
         sage: to_ring = declare_ring([Block("x", 10)], globals())
@@ -231,6 +232,7 @@ class RingMap:
 
         TESTS::
 
+            sage: # needs brial
             sage: from sage.rings.polynomial.pbori.pbori import *
             sage: from sage.rings.polynomial.pbori.blocks import declare_ring, Block
             sage: to_ring = declare_ring([Block("x", 10)], globals())
@@ -271,6 +273,7 @@ class RingMap:
 
         TESTS::
 
+            sage: # needs brial
             sage: from sage.rings.polynomial.pbori.pbori import *
             sage: from sage.rings.polynomial.pbori.blocks import declare_ring, Block
             sage: to_ring = declare_ring([Block("x", 10)], globals())
@@ -288,6 +291,7 @@ class RingMap:
 
         EXAMPLES::
 
+            sage: # needs brial
             sage: from sage.rings.polynomial.pbori.pbori import *
             sage: from sage.rings.polynomial.pbori.blocks import declare_ring, Block
             sage: to_ring = declare_ring([Block("x", 10)], globals())

--- a/src/sage/rings/polynomial/pbori/nf.py
+++ b/src/sage/rings/polynomial/pbori/nf.py
@@ -93,6 +93,7 @@ def multiply_polynomials(l, ring):
 
     TESTS::
 
+        sage: # needs brial
         sage: from sage.rings.polynomial.pbori import *
         sage: r = Ring(1000)
         sage: x = r.variable
@@ -638,6 +639,7 @@ def normal_form(poly, ideal, reduced=True):
 
     TESTS::
 
+        sage: # needs brial
         sage: from sage.rings.polynomial.pbori import declare_ring, normal_form
         sage: r=declare_ring(['x','y'], globals())
         sage: normal_form(x+y, [y],reduced=True)

--- a/src/sage/rings/polynomial/pbori/parallel.py
+++ b/src/sage/rings/polynomial/pbori/parallel.py
@@ -51,6 +51,7 @@ def to_fast_pickable(l) -> list:
 
     EXAMPLES::
 
+        sage: # needs brial
         sage: from sage.rings.polynomial.pbori import Ring, Polynomial
         sage: from sage.rings.polynomial.pbori.parallel import to_fast_pickable, from_fast_pickable
         sage: r = Ring(1000)
@@ -129,6 +130,7 @@ def from_fast_pickable(l, r) -> list:
 
     EXAMPLES::
 
+        sage: # needs brial
         sage: from sage.rings.polynomial.pbori import Ring
         sage: from sage.rings.polynomial.pbori.parallel import from_fast_pickable
         sage: r = Ring(1000)
@@ -284,6 +286,7 @@ def groebner_basis_first_finished(I, *l):
 
     EXAMPLES::
 
+        sage: # needs brial
         sage: from sage.rings.polynomial.pbori.PyPolyBoRi import Ring
         sage: r = Ring(1000)
         sage: ideal = [r.variable(1)*r.variable(2)+r.variable(2)+r.variable(1)]

--- a/src/sage/rings/polynomial/pbori/pbori.pyx
+++ b/src/sage/rings/polynomial/pbori/pbori.pyx
@@ -2,6 +2,7 @@
 # distutils: library_dirs = M4RI_LIBDIR LIBPNG_LIBDIR
 # distutils: include_dirs = M4RI_INCDIR LIBPNG_INCDIR
 # distutils: extra_compile_args = M4RI_CFLAGS
+# sage.doctest: needs brial
 r"""
 Boolean Polynomials
 

--- a/src/sage/rings/polynomial/pbori/randompoly.py
+++ b/src/sage/rings/polynomial/pbori/randompoly.py
@@ -19,6 +19,7 @@ def gen_random_poly(ring, l, deg, vars_set, seed=123):
 
     EXAMPLES::
 
+        sage: # needs brial
         sage: from sage.rings.polynomial.pbori.PyPolyBoRi import Ring, Variable
         sage: from sage.rings.polynomial.pbori.randompoly import gen_random_poly
         sage: r = Ring(16)
@@ -61,6 +62,7 @@ def sparse_random_system(ring, number_of_polynomials, variables_per_polynomial,
 
     TESTS::
 
+        sage: # needs brial
         sage: from sage.rings.polynomial.pbori import Ring, groebner_basis
         sage: r = Ring(10)
         sage: from sage.rings.polynomial.pbori.randompoly import sparse_random_system
@@ -96,6 +98,7 @@ def sparse_random_system_data_file_content(number_of_variables, **kwds):
     r"""
     TESTS::
 
+        sage: # needs brial
         sage: from sage.rings.polynomial.pbori.randompoly import sparse_random_system_data_file_content
         sage: sparse_random_system_data_file_content(10, number_of_polynomials=5, variables_per_polynomial=3, degree=2, random_seed=int(123))
         "declare_ring(['x'+str(i) for in range(10)])\nideal=\\\n[...]\n\n"

--- a/src/sage/structure/sequence.py
+++ b/src/sage/structure/sequence.py
@@ -295,12 +295,13 @@ def Sequence(x, universe=None, check=True, immutable=False, cr=False, cr_str=Non
     from sage.rings.polynomial.multi_polynomial_ring import MPolynomialRing_base
     from sage.rings.polynomial.multi_polynomial_sequence import PolynomialSequence
     from sage.rings.quotient_ring import QuotientRing_nc
-    try:
+    from sage.features.brial import Brial
+    if Brial().is_present():
         # pbori (brial) is optional, so to keep the isinstance() below
         # working as intended in its absence, we set it equal to the
         # other type that isinstance() is checking for.
         from sage.rings.polynomial.pbori.pbori import BooleanMonomialMonoid
-    except ImportError:
+    else:
         BooleanMonomialMonoid = MPolynomialRing_base
 
     if isinstance(universe, (MPolynomialRing_base, BooleanMonomialMonoid)) or (isinstance(universe, QuotientRing_nc) and isinstance(universe.cover_ring(), MPolynomialRing_base)):


### PR DESCRIPTION
Some more progress towards a brial-less installation:

* Add `needs brial` tags under sage/rings/polynomial/pbori.
* Replace some manual `try import .. catch ImportError` blocks with the brial feature.
* Add `Brial().require()` in one method that is going to use it anyway, to improve the error message if it isn't there.
* Delete one newly-failing example in `get_systems()`. The documentation for this function says that it can fail with both false positives and false negatives... so, uh, cool.

This should get the doctests to pass, but pytest will still fail when it tries to import any modules that themselves import from brial at the top level.
