### PR TITLE
Corrected definition of height function to fix issue with multimodular echelonization over QQ.

### DIFF
--- a/src/sage/matrix/matrix_rational_dense.pyx
+++ b/src/sage/matrix/matrix_rational_dense.pyx
@@ -1290,9 +1290,9 @@ cdef class Matrix_rational_dense(Matrix_dense):
 
     def height(self):
         """
-        Return the height of this matrix, which is the maximum of the
-        absolute values of all numerators and denominators of entries in
-        this matrix.
+        Return the height of this matrix, which is the least common
+        multiple of the absolute values of all numerators and
+        denominators of entries in this matrix.
 
         OUTPUT: integer
 
@@ -1318,15 +1318,15 @@ cdef class Matrix_rational_dense(Matrix_dense):
         cdef Py_ssize_t i, j
         sig_on()
         fmpz_init(x)
-        fmpz_zero(h)
+        fmpz_one(h)
         for i in range(self._nrows):
             for j in range(self._ncols):
                 fmpz_abs(x, fmpq_mat_entry_num(self._matrix, i, j))
-                if fmpz_cmp(h, x) < 0:
-                    fmpz_set(h, x)
+                if not fmpz_is_zero(x) and fmpz_cmp(h, x) != 0:
+                    fmpz_lcm(h, h, x)
                 fmpz_abs(x, fmpq_mat_entry_den(self._matrix, i, j))
-                if fmpz_cmp(h, x) < 0:
-                    fmpz_set(h, x)
+                if not fmpz_is_zero(x) and fmpz_cmp(h, x) != 0:
+                    fmpz_lcm(h, h, x)
         fmpz_clear(x)
         sig_off()
         return 0

--- a/src/sage/matrix/matrix_rational_sparse.pyx
+++ b/src/sage/matrix/matrix_rational_sparse.pyx
@@ -426,19 +426,19 @@ cdef class Matrix_rational_sparse(Matrix_sparse):
     cdef int mpz_height(self, mpz_t height) except -1:
         cdef mpz_t x, h
         mpz_init(x)
-        mpz_init_set_si(h, 0)
+        mpz_init_set_si(h, 1)
         cdef Py_ssize_t i, j
         sig_on()
         for i from 0 <= i < self._nrows:
             for j from 0 <= j < self._matrix[i].num_nonzero:
                 mpq_get_num(x, self._matrix[i].entries[j])
                 mpz_abs(x, x)
-                if mpz_cmp(h,x) < 0:
-                    mpz_set(h,x)
+                if mpz_cmp(h,x) != 0:
+                    mpz_lcm(h,h,x)
                 mpq_get_den(x, self._matrix[i].entries[j])
                 mpz_abs(x, x)
-                if mpz_cmp(h,x) < 0:
-                    mpz_set(h,x)
+                if mpz_cmp(h,x) != 0:
+                    mpz_lcm(h,h,x)
         sig_off()
         mpz_set(height, h)
         mpz_clear(h)


### PR DESCRIPTION

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

This PR fixes a bug in the multimodular row echelon form algorithm for matrices over QQ by redefining the `height()` functions for dense and sparse matrices to compute the least common denominator of the nonzero numerators and denominators of the matrix entries, rather than the maximum of the absolute values. Fixes #42411.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


