### PR TITLE
Use pytest for long cone tests

### DIFF
--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -4965,26 +4965,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: cones.trivial(0).discrete_complementarity_set()
             ()
 
-        TESTS:
-
-        A discrete complementarity set for the dual can be obtained by
-        switching components in a discrete complementarity set of the
-        original cone::
-
-            sage: K = random_cone(max_ambient_dim=6)
-            sage: dcs_dual = K.dual().discrete_complementarity_set()
-            sage: expected = tuple((x,s) for (s,x) in dcs_dual)
-            sage: actual = K.discrete_complementarity_set()
-            sage: sorted(actual) == sorted(expected)
-            True
-
-        The pairs in a discrete complementarity set are in fact
-        complementary::
-
-            sage: K = random_cone(max_ambient_dim=6)
-            sage: dcs = K.discrete_complementarity_set()
-            sage: sum((s*x).abs() for (x,s) in dcs)
-            0
         """
         # Return an immutable tuple instead of a mutable list because
         # the result will be cached.
@@ -5085,40 +5065,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             [0 0 1]
             ]
 
-        TESTS:
-
-        Every operator in a :meth:`lyapunov_like_basis` is Lyapunov-like
-        on the cone::
-
-            sage: K = random_cone(max_ambient_dim=8)
-            sage: LL = K.lyapunov_like_basis()
-            sage: all(L.is_lyapunov_like_on(K) for L in LL)
-            True
-
-        The Lyapunov-like transformations on a cone and its dual are
-        transposes of one another. However, there's no reason to expect
-        that one basis will consist of transposes of the other::
-
-            sage: K = random_cone(max_ambient_dim=8)
-            sage: LL1 = K.lyapunov_like_basis()
-            sage: LL2 = (L.transpose() for L in K.dual().lyapunov_like_basis())
-            sage: V = VectorSpace(K.lattice().base_field(), K.lattice_dim()^2)
-            sage: LL1_vecs = (V(m.list()) for m in LL1)
-            sage: LL2_vecs = (V(m.list()) for m in LL2)
-            sage: V.span(LL1_vecs) == V.span(LL2_vecs)
-            True
-
-        The space of all Lyapunov-like transformations is a Lie algebra
-        and should therefore be closed under the lie bracket::
-
-            sage: K = random_cone(max_ambient_dim=4)
-            sage: LL = K.lyapunov_like_basis()
-            sage: W = VectorSpace(K.lattice().base_field(), K.lattice_dim()**2)
-            sage: LL_W = W.span( W(m.list()) for m in LL )
-            sage: brackets = (W((L1*L2 - L2*L1).list()) for L1 in LL
-            ....:                                       for L2 in LL)
-            sage: all(b in LL_W for b in brackets)
-            True
         """
         # Matrices are not vectors in Sage, so we have to convert them
         # to vectors explicitly before we can find a basis. We need these
@@ -5250,93 +5196,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: K.lyapunov_rank()
             3
 
-        Lyapunov rank is invariant under :meth:`dual` [RNPA2011]_::
-
-            sage: K = Cone([(2,2,4), (-1,9,0), (2,0,6)])
-            sage: K.lyapunov_rank() == K.dual().lyapunov_rank()
-            True
-
-        TESTS:
-
-        Lyapunov rank should be additive on a product of proper cones
-        [RNPA2011]_::
-
-            sage: K1 = random_cone(max_ambient_dim=6,
-            ....:                  strictly_convex=True,
-            ....:                  solid=True)
-            sage: K2 = random_cone(max_ambient_dim=6,
-            ....:                  strictly_convex=True,
-            ....:                  solid=True)
-            sage: K = K1.cartesian_product(K2)
-            sage: K.lyapunov_rank() == K1.lyapunov_rank() + K2.lyapunov_rank()
-            True
-
-        Lyapunov rank should be invariant under a linear isomorphism
-        [Or2017]_::
-
-            sage: K1 = random_cone(max_ambient_dim=8)
-            sage: n = K1.lattice_dim()
-            sage: A = random_matrix(QQ, n, algorithm='unimodular')
-            sage: K2 = Cone((A*r for r in K1), lattice=K1.lattice())
-            sage: K1.lyapunov_rank() == K2.lyapunov_rank()
-            True
-
-        Lyapunov rank should be invariant under :meth:`dual` [RNPA2011]_::
-
-            sage: K = random_cone(max_ambient_dim=8)
-            sage: K.lyapunov_rank() == K.dual().lyapunov_rank()
-            True
-
-        The Lyapunov rank of a proper polyhedral cone in a non-trivial
-        `n`-dimensional space can be any number between `1` and `n`
-        inclusive, excluding `n-1` [GT2014]_::
-
-            sage: K = random_cone(max_ambient_dim=8,
-            ....:                 min_rays=1,
-            ....:                 strictly_convex=True,
-            ....:                 solid=True)
-            sage: b = K.lyapunov_rank()
-            sage: n = K.lattice_dim()
-            sage: 1 <= b <= n
-            True
-            sage: b == n-1
-            False
-
-        No polyhedral closed convex cone in `n` dimensions has Lyapunov
-        rank `n-1` [Or2017]_::
-
-            sage: K = random_cone(max_ambient_dim=8)
-            sage: K.lyapunov_rank() == K.lattice_dim() - 1
-            False
-
-        The calculation of the Lyapunov rank of an improper cone can
-        be reduced to that of a proper cone [Or2017]_::
-
-            sage: K = random_cone(max_ambient_dim=8)
-            sage: K_SP = K.solid_restriction().strict_quotient()
-            sage: l = K.lineality()
-            sage: c = K.codim()
-            sage: actual = K.lyapunov_rank()
-            sage: expected = K_SP.lyapunov_rank() + K.dim()*(l + c) + c**2
-            sage: actual == expected
-            True
-
-        The Lyapunov rank of a cone is the length of a
-        :meth:`lyapunov_like_basis` for it::
-
-            sage: K = random_cone(max_ambient_dim=8)
-            sage: K.lyapunov_rank() == len(K.lyapunov_like_basis())
-            True
-
-        A "perfect" cone has Lyapunov rank `n` or more in `n`
-        dimensions. We can make any cone perfect by adding a slack
-        variable::
-
-            sage: K = random_cone(max_ambient_dim=8)
-            sage: L = ToricLattice(K.lattice_dim() + 1)
-            sage: K = Cone([r.list() + [0] for r in K], lattice=L)
-            sage: K.lyapunov_rank() >= K.lattice_dim()
-            True
         """
         # The solid_restriction() and strict_quotient() methods
         # already check if the cone is solid or strictly convex, so we
@@ -5681,77 +5540,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         TESTS:
 
-        A random positive operator should send a random element of one
-        cone into the other cone::
-
-            sage: K1 = random_cone(max_ambient_dim=3)
-            sage: K2 = random_cone(max_ambient_dim=3)
-            sage: pi_gens = K1.positive_operators_gens(K2)
-            sage: L = ToricLattice(K1.lattice_dim() * K2.lattice_dim())
-            sage: pi_cone = Cone((g.list() for g in pi_gens),
-            ....:                lattice=L,
-            ....:                check=False)
-            sage: P = matrix(K2.lattice_dim(),
-            ....:            K1.lattice_dim(),
-            ....:            pi_cone.random_element(QQ).list())
-            sage: K2.contains(P*K1.random_element(ring=QQ))
-            True
-
-        The lineality space of the dual of the positive operators
-        can be computed from the lineality spaces of the cone and
-        its dual [Or2018b]_::
-
-            sage: K = random_cone(max_ambient_dim=3)
-            sage: pi_gens = K.positive_operators_gens()
-            sage: L = ToricLattice(K.lattice_dim()**2)
-            sage: pi_cone = Cone((g.list() for g in pi_gens),
-            ....:                lattice=L,
-            ....:                check=False)
-            sage: actual = pi_cone.dual().linear_subspace()
-            sage: U1 = [vector((s.tensor_product(x)).list())
-            ....:       for x in K.lines()
-            ....:       for s in K.dual()]
-            sage: U2 = [vector((s.tensor_product(x)).list())
-            ....:       for x in K
-            ....:       for s in K.dual().lines()]
-            sage: expected = pi_cone.lattice().vector_space().span(U1+U2)
-            sage: actual == expected
-            True
-
-        The lineality of the dual of the positive operators is known
-        from its lineality space [Or2018b]_::
-
-            sage: K = random_cone(max_ambient_dim=3)
-            sage: n = K.lattice_dim()
-            sage: m = K.dim()
-            sage: l = K.lineality()
-            sage: pi_gens = K.positive_operators_gens()
-            sage: L = ToricLattice(n**2)
-            sage: pi_cone = Cone((g.list() for g in pi_gens),
-            ....:                lattice=L,
-            ....:                check=False)
-            sage: actual = pi_cone.dual().lineality()
-            sage: expected = l*(m - l) + m*(n - m)
-            sage: actual == expected
-            True
-
-        The dimension of the positive operators on a cone depends on the
-        dimension and lineality of that cone [Or2018b]_::
-
-            sage: K = random_cone(max_ambient_dim=3)
-            sage: n = K.lattice_dim()
-            sage: m = K.dim()
-            sage: l = K.lineality()
-            sage: pi_gens = K.positive_operators_gens()
-            sage: L = ToricLattice(n**2)
-            sage: pi_cone = Cone((g.list() for g in pi_gens),
-            ....:                lattice=L,
-            ....:                check=False)
-            sage: actual = pi_cone.dim()
-            sage: expected = n**2 - l*(m - l) - (n - m)*m
-            sage: actual == expected
-            True
-
         The trivial cone, full space, and half-plane all give rise to the
         expected dimensions [Or2018b]_::
 
@@ -5780,21 +5568,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: pi_cone = Cone((g.list() for g in pi_gens),
             ....:                check=False)
             sage: pi_cone.dim() == 3
-            True
-
-        The lineality of the positive operators follows from the
-        description of its generators [Or2018b]_::
-
-            sage: K = random_cone(max_ambient_dim=3)
-            sage: n = K.lattice_dim()
-            sage: pi_gens = K.positive_operators_gens()
-            sage: L = ToricLattice(n**2)
-            sage: pi_cone = Cone((g.list() for g in pi_gens),
-            ....:                lattice=L,
-            ....:                check=False)
-            sage: actual = pi_cone.lineality()
-            sage: expected = n**2 - K.dim()*K.dual().dim()
-            sage: actual == expected
             True
 
         The trivial cone, full space, and half-plane all give rise to
@@ -5826,113 +5599,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: pi_cone.lineality() == 2
             True
 
-        A cone is proper if and only if its positive operators form a
-        proper cone [Or2018b]_::
-
-            sage: K = random_cone(max_ambient_dim=3)
-            sage: pi_gens = K.positive_operators_gens()
-            sage: L = ToricLattice(K.lattice_dim()**2)
-            sage: pi_cone = Cone((g.list() for g in pi_gens),
-            ....:                lattice=L,
-            ....:                check=False)
-            sage: K.is_proper() == pi_cone.is_proper()
-            True
-
-        The positive operators on a permuted cone can be obtained by
-        conjugation::
-
-            sage: K = random_cone(max_ambient_dim=3)
-            sage: L = ToricLattice(K.lattice_dim()**2)
-            sage: p = SymmetricGroup(K.lattice_dim()).random_element().matrix()
-            sage: pK = Cone((p*k for k in K), K.lattice(), check=False)
-            sage: pi_gens = pK.positive_operators_gens()
-            sage: actual = Cone((g.list() for g in pi_gens),
-            ....:               lattice=L,
-            ....:               check=False)
-            sage: pi_gens = K.positive_operators_gens()
-            sage: expected = Cone(((p*g*p.inverse()).list() for g in pi_gens),
-            ....:                 lattice=L,
-            ....:                 check=False)
-            sage: actual.is_equivalent(expected)
-            True
-
-        An operator is positive from one cone to another if and only if
-        its adjoint is positive from the dual of the second cone to the
-        dual of the first::
-
-            sage: K1 = random_cone(max_ambient_dim=3)
-            sage: K2 = random_cone(max_ambient_dim=3)
-            sage: F = K1.lattice().vector_space().base_field()
-            sage: n = K1.lattice_dim()
-            sage: m = K2.lattice_dim()
-            sage: L = ToricLattice(n*m)
-            sage: W = VectorSpace(F, n*m)
-            sage: pi_gens = K1.positive_operators_gens(K2)
-            sage: pi_fwd = Cone((g.list() for g in pi_gens),
-            ....:                lattice=L,
-            ....:                check=False)
-            sage: pi_gens = K2.dual().positive_operators_gens(K1.dual())
-            sage: pi_back = Cone((g.list() for g in pi_gens),
-            ....:                lattice=L,
-            ....:                check=False)
-            sage: M_fwd = MatrixSpace(F, m, n)
-            sage: M_back = MatrixSpace(F, n, m)
-            sage: L = M_fwd(pi_fwd.random_element(ring=QQ).list())
-            sage: pi_back.contains(W(L.transpose().list()))
-            True
-            sage: L = M_back(pi_back.random_element(ring=QQ).list())
-            sage: pi_fwd.contains(W(L.transpose().list()))
-            True
-
-        The Lyapunov rank of the positive operators is the product of
-        the Lyapunov ranks of the associated cones if both are proper
-        [Or2018a]_::
-
-            sage: K1 = random_cone(max_ambient_dim=3,
-            ....:                  strictly_convex=True,
-            ....:                  solid=True)
-            sage: K2 = random_cone(max_ambient_dim=3,
-            ....:                  strictly_convex=True,
-            ....:                  solid=True)
-            sage: pi_gens = K1.positive_operators_gens(K2)
-            sage: L = ToricLattice(K1.lattice_dim() * K2.lattice_dim())
-            sage: pi_cone = Cone((g.list() for g in pi_gens),
-            ....:                lattice=L,
-            ....:                check=False)
-            sage: beta1 = K1.lyapunov_rank()
-            sage: beta2 = K2.lyapunov_rank()
-            sage: pi_cone.lyapunov_rank() == beta1*beta2
-            True
-
-        Lyapunov-like operators on a proper polyhedral positive operator
-        cone can be computed from the Lyapunov-like operators on the cones
-        with respect to which the operators are positive [Or2018a]_::
-
-            sage: K1 = random_cone(max_ambient_dim=3,
-            ....:                  strictly_convex=True,
-            ....:                  solid=True)
-            sage: K2 = random_cone(max_ambient_dim=3,
-            ....:                  strictly_convex=True,
-            ....:                  solid=True)
-            sage: pi_gens = K1.positive_operators_gens(K2)
-            sage: F = K1.lattice().base_field()
-            sage: m = K1.lattice_dim()
-            sage: n = K2.lattice_dim()
-            sage: L = ToricLattice(m*n)
-            sage: M1 = MatrixSpace(F, m, m)
-            sage: M2 = MatrixSpace(F, n, n)
-            sage: tps = (M2(s.list()).tensor_product(M1(x.list()))
-            ....:        for x in K1.dual().lyapunov_like_basis()
-            ....:        for s in K2.lyapunov_like_basis())
-            sage: W = VectorSpace(F, (m**2)*(n**2))
-            sage: expected = span(F, (W(x.list()) for x in tps))
-            sage: pi_cone = Cone((g.list() for g in pi_gens),
-            ....:                lattice=L,
-            ....:                check=False)
-            sage: LL_pi = pi_cone.lyapunov_like_basis()
-            sage: actual = span(F, (W(x.list()) for x in LL_pi))
-            sage: actual == expected
-            True
         """
         if K2 is None:
             K2 = self
@@ -6126,48 +5792,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         TESTS:
 
-        The cross-positive property is possessed by every cross-positive
-        operator::
-
-            sage: K = random_cone(max_ambient_dim=3)
-            sage: cp_gens = K.cross_positive_operators_gens()
-            sage: all(L.is_cross_positive_on(K) for L in cp_gens)
-            True
-
-        The lineality space of the cone of cross-positive operators is
-        the space of Lyapunov-like operators [Or2018b]_::
-
-            sage: K = random_cone(max_ambient_dim=3)
-            sage: L = ToricLattice(K.lattice_dim()**2)
-            sage: cp_gens = K.cross_positive_operators_gens()
-            sage: cp_cone = Cone((g.list() for g in cp_gens),
-            ....:                lattice=L,
-            ....:                check=False)
-            sage: ll_basis = (vector(l.list())
-            ....:             for l in K.lyapunov_like_basis())
-            sage: lls = L.vector_space().span(ll_basis)
-            sage: cp_cone.linear_subspace() == lls
-            True
-
-        The lineality spaces of the duals of the positive and cross-
-        positive operator cones are equal. From this it follows that
-        the dimensions of the cross-positive operator cone and positive
-        operator cone are equal [Or2018b]_::
-
-            sage: K = random_cone(max_ambient_dim=3)
-            sage: pi_dual = K._positive_operators_dual(K)
-            sage: pi_cone = pi_dual.dual()
-            sage: cp_gens = K.cross_positive_operators_gens()
-            sage: L = ToricLattice(K.lattice_dim()**2)
-            sage: cp_cone = Cone((g.list() for g in cp_gens),
-            ....:                lattice=L,
-            ....:                check=False)
-            sage: pi_cone.dim() == cp_cone.dim()
-            True
-            sage: cp_dual = cp_cone.dual()
-            sage: pi_dual.linear_subspace() == cp_dual.linear_subspace()
-            True
-
         The trivial cone, full space, and half-plane all give rise to
         the expected dimensions [Or2018b]_::
 
@@ -6197,47 +5821,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: cp_cone.dim() == 3
             True
 
-        The cross-positive operators of a permuted cone can be obtained by
-        conjugation::
-
-            sage: K = random_cone(max_ambient_dim=3)
-            sage: L = ToricLattice(K.lattice_dim()**2)
-            sage: p = SymmetricGroup(K.lattice_dim()).random_element().matrix()
-            sage: pK = Cone((p*k for k in K), K.lattice(), check=False)
-            sage: cp_gens = pK.cross_positive_operators_gens()
-            sage: actual = Cone((g.list() for g in cp_gens),
-            ....:               lattice=L,
-            ....:               check=False)
-            sage: cp_gens = K.cross_positive_operators_gens()
-            sage: expected = Cone(((p*g*p.inverse()).list() for g in cp_gens),
-            ....:                 lattice=L,
-            ....:                 check=False)
-            sage: actual.is_equivalent(expected)
-            True
-
-        An operator is cross-positive on a cone if and only if its
-        adjoint is cross-positive on the dual of that cone [Or2018b]_::
-
-            sage: K = random_cone(max_ambient_dim=3)
-            sage: F = K.lattice().vector_space().base_field()
-            sage: n = K.lattice_dim()
-            sage: L = ToricLattice(n**2)
-            sage: W = VectorSpace(F, n**2)
-            sage: cp_gens = K.cross_positive_operators_gens()
-            sage: cp_cone = Cone((g.list() for g in cp_gens),
-            ....:                lattice=L,
-            ....:                check=False)
-            sage: cp_gens = K.dual().cross_positive_operators_gens()
-            sage: cp_star = Cone((g.list() for g in cp_gens),
-            ....:                lattice=L,
-            ....:                check=False)
-            sage: M = MatrixSpace(F, n)
-            sage: L = M(cp_cone.random_element(ring=QQ).list())
-            sage: cp_star.contains(W(L.transpose().list()))
-            True
-            sage: L = M(cp_star.random_element(ring=QQ).list())
-            sage: cp_cone.contains(W(L.transpose().list()))
-            True
         """
         # Compute the desired cone from its dual...
         cp_cone = self._cross_positive_operators_dual().dual()
@@ -6281,14 +5864,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         - [BP1994]_
         - [Or2018b]_
 
-        TESTS:
-
-        The Z-property is possessed by every Z-operator::
-
-            sage: K = random_cone(max_ambient_dim=3)
-            sage: Z_gens = K.Z_operators_gens()
-            sage: all(L.is_Z_operator_on(K) for L in Z_gens)
-            True
         """
         return [ -cp for cp in self.cross_positive_operators_gens() ]
 

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -5499,6 +5499,66 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         # explicit conversion, we return ``0`` when we have no rays.
         return L(sum(terms))
 
+    def _positive_operators_dual(self, K2):
+        r"""
+        Return the dual cone of the positive operators from
+        ``self`` to ``K2`` under the matrix <-> long-vector
+        isometry.
+
+        In :meth:`positive_operators_gens` we compute the cone of
+        positive operators from ``self`` to ``K2`` by taking the
+        dual of a dual. This method computes the latter dual. Matrices
+        cannot generate cones in Sage, so long vectors are used as
+        proxies in this step. The matrix <-> long-vector map is an
+        isometry, so everything works out the same in the end.
+
+        The intermediate dual cone of long vectors turns out to be
+        useful in at least one doctest, so it has been factored out
+        for efficiency.
+
+        REFERENCES:
+
+        - [Or2018b]_
+
+        EXAMPLES:
+
+        On the nonnegative orthant, the positive operators are the
+        (self-dual) cone of nonnegative matrices, which in long-vector
+        form is just a (bigger) nonnegative orthant::
+
+            sage: K = cones.nonnegative_orthant(3)
+            sage: J = K._positive_operators_dual(K)
+            sage: J.is_equivalent(cones.nonnegative_orthant(9))
+            True
+
+        """
+        # Matrices are not vectors in Sage, so we have to convert them
+        # to vectors explicitly before we can find a basis. We need these
+        # two values to construct the appropriate "long vector" space.
+        F = self.lattice().base_field()
+        n = self.lattice_dim()
+        m = K2.lattice_dim()
+
+        tensor_products = ( s.tensor_product(x) for x in self
+                                                for s in K2.dual() )
+
+        # Convert those tensor products to long vectors.
+        W = VectorSpace(F, n*m)
+        vectors = ( W(tp.list()) for tp in tensor_products )
+
+        check = True
+        if self.is_proper() and K2.is_proper():
+            # All of the generators involved are extreme vectors and
+            # therefore minimal. If this cone is neither solid nor
+            # strictly convex, then the tensor product of ``s`` and ``x``
+            # is the same as that of ``-s`` and ``-x``. However, as a
+            # /set/, ``tensor_products`` may still be minimal.
+            check = False
+
+        # Create the dual cone of the positive operators, expressed as
+        # long vectors.
+        return Cone(vectors, ToricLattice(W.dimension()), check=check)
+
     def positive_operators_gens(self, K2=None):
         r"""
         Compute minimal generators of the positive operators on this cone.
@@ -5877,37 +5937,14 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         if K2 is None:
             K2 = self
 
-        # Matrices are not vectors in Sage, so we have to convert them
-        # to vectors explicitly before we can find a basis. We need these
-        # two values to construct the appropriate "long vector" space.
+        # Create cone of positive operators, expressed as long
+        # vectors.
+        pi_cone = self._positive_operators_dual(K2).dual()
+
+        # And finally convert its rays back to matrix representations.
         F = self.lattice().base_field()
         n = self.lattice_dim()
         m = K2.lattice_dim()
-
-        tensor_products = ( s.tensor_product(x) for x in self
-                                                for s in K2.dual() )
-
-        # Convert those tensor products to long vectors.
-        W = VectorSpace(F, n*m)
-        vectors = ( W(tp.list()) for tp in tensor_products )
-
-        check = True
-        if self.is_proper() and K2.is_proper():
-            # All of the generators involved are extreme vectors and
-            # therefore minimal. If this cone is neither solid nor
-            # strictly convex, then the tensor product of ``s`` and ``x``
-            # is the same as that of ``-s`` and ``-x``. However, as a
-            # /set/, ``tensor_products`` may still be minimal.
-            check = False
-
-        # Create the dual cone of the positive operators, expressed as
-        # long vectors.
-        pi_dual = Cone(vectors, ToricLattice(W.dimension()), check=check)
-
-        # Now compute the desired cone from its dual...
-        pi_cone = pi_dual.dual()
-
-        # And finally convert its rays back to matrix representations.
         M = MatrixSpace(F, m, n)
         return [ M(v.list()) for v in pi_cone ]
 
@@ -6118,20 +6155,17 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         operator cone are equal [Or2018b]_::
 
             sage: K = random_cone(max_ambient_dim=3)
-            sage: pi_gens = K.positive_operators_gens()
+            sage: pi_dual = K._positive_operators_dual(K)
+            sage: pi_cone = pi_dual.dual()
             sage: cp_gens = K.cross_positive_operators_gens()
             sage: L = ToricLattice(K.lattice_dim()**2)
-            sage: pi_cone = Cone((g.list() for g in pi_gens),
-            ....:                lattice=L,
-            ....:                check=False)
             sage: cp_cone = Cone((g.list() for g in cp_gens),
             ....:                lattice=L,
             ....:                check=False)
             sage: pi_cone.dim() == cp_cone.dim()
             True
-            sage: pi_star = pi_cone.dual()
-            sage: cp_star = cp_cone.dual()
-            sage: pi_star.linear_subspace() == cp_star.linear_subspace()
+            sage: cp_dual = cp_cone.dual()
+            sage: pi_dual.linear_subspace() == cp_dual.linear_subspace()
             True
 
         The trivial cone, full space, and half-plane all give rise to

--- a/src/sage/geometry/cone_test.py
+++ b/src/sage/geometry/cone_test.py
@@ -1,0 +1,638 @@
+import pytest
+
+from itertools import chain
+from sage.geometry.cone import Cone, random_cone
+from sage.geometry.toric_lattice import ToricLattice
+from sage.groups.perm_gps.permgroup_named import SymmetricGroup
+from sage.matrix.constructor import matrix
+from sage.matrix.matrix_space import MatrixSpace
+from sage.modules.free_module import VectorSpace
+from sage.symbolic.ring import SR
+
+
+def _gen_ops_test_cones():
+    r"""
+    Generate two cones that are suitable for testing (cross)
+    positive, Lyapunov-like, and Z-operators.
+
+    This extends :meth:`sage.geomtry.cone.random_cone` by choosing
+    conservative parameters, and by rejecting any cone that looks too
+    complicated for these methods to be computed in a reasonable
+    amount of time. We generate two cones simultaneously because,
+    while the cross-positive, Lyapunov-like, and Z-operators are
+    defined on a single cone, the regular (non-cross) positive
+    operators involve *two*.  We need to ensure that the various
+    combinations are all computationally feasible; "success" is thus a
+    property of the pair.
+    """
+    J2 = random_cone(max_ambient_dim=5, max_rays=10)
+    J3 = random_cone(max_ambient_dim=5, max_rays=10)
+
+    J2_dual = J2.dual()
+    J3_dual = J3.dual()
+
+    worst_dim = J2.dim() * max(J2_dual.dim(), J3_dual.dim())
+    worst_npairs = J2.nrays() * max(J2_dual.nrays(), J2_dual.nrays())
+
+    # How many pairs is too many pairs, in a given dimension? Note
+    # that the maximum ambient dimension for both cones is 5, so there
+    # are only a few cases to worry about.  "Too many" means that with
+    # Cone(..., check=True), constructing the cone of operators itself
+    # will be slow. The numbers below were obtained by hand.
+    #
+    # (product of dimensions => max number of ray pairs)
+    limits = {
+        9: 250,
+        12: 100,
+        15: 45,
+        16: 36,
+        20: 32,
+        25: 30,
+    }
+    if not J2.is_proper() or not J3.is_proper():
+        # When both J2 and J3 are proper, check=False gets used.
+        if worst_dim in limits:
+            # Ignore really low-dimensional cases.
+            if worst_npairs >= limits[worst_dim]:
+                return _gen_ops_test_cones()
+
+
+    # Monkey patch both dual() methods with the already-computed
+    # (cached) values, so we don't have recompute them later.
+    J2_dual_meth = lambda s: J2_dual
+    J3_dual_meth = lambda s: J3_dual
+    J2.dual = J2_dual_meth.__get__(J2)
+    J3.dual = J3_dual_meth.__get__(J3)
+
+    # We _also_ need to check that the dual we're going to take a dual
+    # of is not too complicated: the complexity of dual() is bad in
+    # general. It's also not easy to predict... so we are pretty much
+    # guessing here.
+    J2_J2_pi_dual = J2._positive_operators_dual(J2)
+    J2_J3_pi_dual = J2._positive_operators_dual(J3)
+
+    worst_nrays = max(J2_J2_pi_dual.nrays(), J2_J3_pi_dual.nrays())
+    if worst_dim in limits and (worst_nrays >= limits[worst_dim]):
+        # Again: do not expect this comparison to mean anything.
+        # It's a bound; it's better than nothing.
+        return _gen_ops_test_cones()
+
+    # If we've made it this far, we monkey-patch cache a few more
+    # intermediate results, starting with the posops-duals that
+    # we already have handy. Note that there are two of them! The
+    # tests had better not involve any others.
+    def J2_pi_dual_method(s,o):
+        if o is J2:
+            return J2_J2_pi_dual
+        return J2_J3_pi_dual  # "o" must be J3
+
+    J2._positive_operators_dual = J2_pi_dual_method.__get__(J2)
+
+    # Do the same for the dual of the cross-positive operators, but note
+    # in this case that there is no "other" argument; the cross-positive
+    # operators are on a single cone.
+    J2_cp_dual = J2._cross_positive_operators_dual()
+    J2_cp_dual_method = lambda s: J2_cp_dual
+    J2._cross_positive_operators_dual = J2_cp_dual_method.__get__(J2)
+
+    return (J2,J3)
+
+@pytest.fixture
+def K():
+    r"""
+    The baseline random cone fixture, meant to be used in tests
+    that do not explode computationally.
+    """
+    return random_cone(max_ambient_dim=12, max_rays=15)
+
+@pytest.fixture
+def P():
+    r"""
+    Like :func:`K`, but guaranteed to be proper.
+    """
+    return random_cone(max_ambient_dim=12,
+                       max_rays=15,
+                       solid=True,
+                       strictly_convex=True)
+
+@pytest.fixture
+def J():
+    r"""
+    Another :func:`K`, for tests that require two cones of a
+    similar nature.
+
+    """
+    return random_cone(max_ambient_dim=12, max_rays=15)
+
+@pytest.fixture
+def Q():
+    r"""
+    Like :func:`J`, but guaranteed to be proper.
+    """
+    return random_cone(max_ambient_dim=12,
+                       max_rays=15,
+                       solid=True,
+                       strictly_convex=True)
+
+@pytest.fixture
+def K2_and_K3():
+    return _gen_ops_test_cones()
+
+@pytest.fixture
+def K2(K2_and_K3):
+    r"""
+    Cone (1 of 2) used to test positive, cross-positive,
+    Lyapunov-like, and Z-operators.
+    """
+    return K2_and_K3[0]
+
+@pytest.fixture
+def K3(K2_and_K3):
+    r"""
+    Cone (2 of 2) used to test positive, cross-positive, Lyapunov-like,
+    and Z-operators. Used mainly for positive operators tests, where
+    two different cones can be involved.
+    """
+    return K2_and_K3[1]
+
+@pytest.fixture
+def K2_cp_gens(K2):
+    return K2.cross_positive_operators_gens()
+
+@pytest.fixture
+def K2_cp_cone(K2, K2_cp_gens):
+    L = ToricLattice(K2.lattice_dim()**2)
+    return Cone((g.list() for g in K2_cp_gens),
+                lattice=L,
+                check=False)
+
+@pytest.fixture
+def K2_posops_gens(K2):
+    return K2.positive_operators_gens()
+
+@pytest.fixture
+def K2_K3_posops_gens(K2, K3):
+    return K2.positive_operators_gens(K3)
+
+@pytest.fixture
+def K2_posops_cone(K2, K2_posops_gens):
+    L = ToricLattice(K2.lattice_dim()**2)
+    return Cone((g.list() for g in K2_posops_gens),
+                lattice=L,
+                check=False)
+
+@pytest.fixture
+def K2_K3_posops_cone(K2, K3, K2_K3_posops_gens):
+    L = ToricLattice(K2.lattice_dim()*K3.lattice_dim())
+    return Cone((g.list() for g in K2_K3_posops_gens),
+                lattice=L,
+                check=False)
+
+@pytest.fixture
+def K2_ll_basis(K2):
+    return K2.lyapunov_like_basis()
+
+@pytest.mark.longlong
+def test_is_cross_positive(K2, K2_cp_gens):
+    r"""
+    The cross-positive property is possessed by every
+    cross-positive operator.
+    """
+    F = K2.lattice().base_field()
+    n = K2.lattice_dim()
+
+    # Check over SR, too.
+    assert all(A.is_cross_positive_on(K2) for A in K2_cp_gens)
+    assert all(A.change_ring(SR).is_cross_positive_on(K2) for A in K2_cp_gens)
+
+    # The identity matrix is always cross-positive.
+    assert matrix.identity(F, n).is_cross_positive_on(K2)
+
+    # The zero matrix is always cross-positive.
+    assert matrix.zero(F, n).is_cross_positive_on(K2)
+
+@pytest.mark.longlong
+def test_is_Z_operator(K2, K2_cp_gens):
+    r"""
+    The Z property is possessed by every Z-operator.
+    """
+    F = K2.lattice().base_field()
+    n = K2.lattice_dim()
+
+    # Obviously cheating, but the Z_operators_gens() method is simple
+    # enough to justify faking it here; otherwise we'd have to
+    # recompute the cross-positive gens that we already have cached.
+    Z_gens = [ -cp for cp in K2_cp_gens ]
+
+    # Check over SR, too.
+    assert all(A.is_Z_operator_on(K2) for A in Z_gens)
+    assert all(A.change_ring(SR).is_Z_operator_on(K2) for A in Z_gens)
+
+    # The identity matrix is always a Z-operator.
+    assert matrix.identity(F, n).is_Z_operator_on(K2)
+
+    # The zero matrix is always a Z-operator.
+    assert matrix.zero(F, n).is_Z_operator_on(K2)
+
+@pytest.mark.longlong
+def test_is_positive(K2, K3, K2_K3_posops_gens):
+    r"""
+    Every positive operator is positive.
+    """
+    F = K2.lattice().base_field()
+    m = K2.lattice_dim()
+    n = K3.lattice_dim()
+
+    # Check over SR, too.
+    assert all(A.is_positive_operator_on(K2,K3) for A in K2_K3_posops_gens)
+    assert all(A.change_ring(SR).is_positive_operator_on(K2,K3)
+               for A in K2_K3_posops_gens)
+
+    # The identity matrix is a positive-operator on every cone.
+    assert matrix.identity(F, m).is_positive_operator_on(K2)
+
+    # The zero matrix is always a positive operator.
+    assert matrix.zero(F, n, m).is_positive_operator_on(K2, K3)
+
+@pytest.mark.longlong
+def test_is_lyapunov_like(K2, K2_ll_basis):
+    r"""
+    Every Lyapunov-like operator is Lyapunov-like.
+    """
+    F = K2.lattice().base_field()
+    n = K2.lattice_dim()
+
+    # Check over SR, too.
+    assert all(A.is_lyapunov_like_on(K2) for A in K2_ll_basis)
+    assert all(A.change_ring(SR).is_lyapunov_like_on(K2)
+               for A in K2_ll_basis)
+
+    # The identity matrix is always Lyapunov-like.
+    assert matrix.identity(F, n).is_lyapunov_like_on(K2)
+
+    # The zero matrix is always Lyapunov-like.
+    assert matrix.zero(F, n).is_lyapunov_like_on(K2)
+
+@pytest.mark.longlong
+def test_lyapunov_like_is_plus_minus_Z(K2):
+    r"""
+    A matrix is Lyapunov-like on a cone if and only if both the
+    matrix and its negation are cross-positive (or Z) on the cone.
+    """
+    R = K2.lattice().base_field()
+    A = matrix.random(R, K2.lattice_dim())
+    actual = A.is_lyapunov_like_on(K2)
+    expected = all( B.is_cross_positive_on(K2) for  B in (A, -A) )
+    assert actual == expected
+
+@pytest.mark.longlong
+def test_cross_positive_linspace(K2, K2_cp_cone, K2_ll_basis):
+    r"""
+    The lineality space of the cone of cross-positive operators is
+    the space of Lyapunov-like operators [Or2018b]_.
+    """
+    L = ToricLattice(K2.lattice_dim()**2)
+    V = L.vector_space()
+    long_basis = (V(l.list()) for l in K2_ll_basis)
+    lls = V.span(long_basis)
+    assert K2_cp_cone.linear_subspace() == lls
+
+@pytest.mark.longlong
+def test_cross_positive_permutation(K2, K2_cp_gens):
+    r"""
+    The cross-positive operators of a permuted cone can be
+    obtained by conjugation.
+    """
+    L = ToricLattice(K2.lattice_dim()**2)
+    p = SymmetricGroup(K2.lattice_dim()).random_element().matrix()
+    pK2 = Cone((p*k for k in K2), K2.lattice(), check=False)
+    actual = Cone((g.list() for g in pK2.cross_positive_operators_gens()),
+                  lattice=L,
+                  check=False)
+    expected = Cone(((p*g*p.inverse()).list() for g in K2_cp_gens),
+                    lattice=L,
+                    check=False)
+    assert actual.is_equivalent(expected)
+
+@pytest.mark.longlong
+def test_cross_positive_adjoint(K2, K2_cp_cone):
+    r"""
+    An operator is cross-positive on a cone if and only if its
+    adjoint is cross-positive on the dual of that cone [Or2018b]_.
+    """
+    n = K2.lattice_dim()
+    L = ToricLattice(n**2)
+    F = K2.lattice().base_field()
+    M = MatrixSpace(F, n)
+    W = L.vector_space()
+
+    dual_gens = K2.dual().cross_positive_operators_gens()
+    cp_star = Cone((g.list() for g in dual_gens),
+                   lattice=L,
+                   check=False)
+
+    A = M(K2_cp_cone.random_element(ring=F).list())
+    assert cp_star.contains(W(A.transpose().list()))
+
+    A = M(cp_star.random_element(ring=F).list())
+    assert K2_cp_cone.contains(W(A.transpose().list()))
+
+@pytest.mark.longlong
+def test_cross_positive_dim(K2, K2_cp_cone, K2_posops_cone):
+    r"""
+    The lineality spaces of the duals of the positive and cross-
+    positive operator cones are equal. From this it follows that
+    the dimensions of the cross-positive operator cone and positive
+    operator cone are equal [Or2018b]_.
+    """
+    pi_star = K2._positive_operators_dual(K2)
+    cp_star = K2._cross_positive_operators_dual()
+
+    assert pi_star.linear_subspace() == cp_star.linear_subspace()
+    assert K2_posops_cone.dim() == K2_cp_cone.dim()
+
+@pytest.mark.longlong
+def test_posops_dual_linspace(K2):
+    r"""
+    The lineality space of the dual of the positive operators
+    can be computed from the lineality spaces of the cone and
+    its dual [Or2018b]_.
+    """
+    pi_dual = K2._positive_operators_dual(K2)
+    V = pi_dual.lattice().vector_space()
+    actual = pi_dual.linear_subspace()
+    U1 = ( V((s.tensor_product(x)).list())
+           for x in K2.lines()
+           for s in K2.dual() )
+    U2 = ( V((s.tensor_product(x)).list())
+           for x in K2
+           for s in K2.dual().lines() )
+    expected = V.span(chain(U1,U2))
+    assert actual == expected
+
+@pytest.mark.longlong
+def test_posops_dual_lineality(K2):
+    r"""
+    The lineality of the dual of the positive operators is known
+    from the lineality space of the original [Or2018b]_.
+    """
+    n = K2.lattice_dim()
+    m = K2.dim()
+    l = K2.lineality()
+    actual = K2._positive_operators_dual(K2).lineality()
+    expected = l*(m - l) + m*(n - m)
+    assert actual == expected
+
+@pytest.mark.longlong
+def test_posops_dimension(K2, K2_posops_cone):
+    r"""
+    The dimension of the positive operators on a cone depends on the
+    dimension and lineality of that cone [Or2018b]_.
+    """
+    n = K2.lattice_dim()
+    m = K2.dim()
+    l = K2.lineality()
+    actual = K2_posops_cone.dim()
+    expected = n**2 - l*(m - l) - (n - m)*m
+    assert actual == expected
+
+@pytest.mark.longlong
+def test_posops_lineality_from_gens(K2, K2_posops_cone):
+    r"""
+    The lineality of the positive operators follows from the
+    description of its generators [Or2018b]_.
+    """
+    n = K2.lattice_dim()
+    actual = K2_posops_cone.lineality()
+    expected = n**2 - K2.dim()*K2.dual().dim()
+    assert actual == expected
+
+@pytest.mark.longlong
+def test_posops_proper(K2, K2_posops_cone):
+    r"""
+    A cone is proper if and only if its positive operators form a
+    proper cone [Or2018b]_.
+    """
+    assert K2.is_proper() == K2_posops_cone.is_proper()
+
+@pytest.mark.longlong
+def test_posops_on_element(K2, K3, K2_K3_posops_cone):
+    r"""
+    A random positive operator should send a random element of one
+    cone into the other cone.
+    """
+    F = K2.lattice().base_field()
+    P = matrix(K3.lattice_dim(),
+               K2.lattice_dim(),
+               K2_K3_posops_cone.random_element(F).list())
+    assert K3.contains(P*K2.random_element(ring=F))
+
+@pytest.mark.longlong
+def test_posops_permutation(K2, K2_posops_gens):
+    r"""
+    The positive operators on a permuted cone can be obtained by
+    conjugation.
+    """
+    L = ToricLattice(K2.lattice_dim()**2)
+    p = SymmetricGroup(K2.lattice_dim()).random_element().matrix()
+    pK = Cone((p*k for k in K2), K2.lattice(), check=False)
+    actual = Cone((g.list() for g in pK.positive_operators_gens()),
+                  lattice=L,
+                  check=False)
+    expected = Cone(((p*g*p.inverse()).list() for g in K2_posops_gens),
+                    lattice=L,
+                    check=False)
+    assert actual.is_equivalent(expected)
+
+@pytest.mark.longlong
+def test_posops_adjoint(K2, K3, K2_K3_posops_cone):
+    r"""
+    An operator is positive from one cone to another if and only if
+    its adjoint is positive from the dual of the second cone to the
+    dual of the first.
+    """
+    F = K2.lattice().base_field()
+    n = K2.lattice_dim()
+    m = K3.lattice_dim()
+    L = ToricLattice(n*m)
+    W = L.vector_space()
+    M_fwd = MatrixSpace(F, m, n)
+    M_back = MatrixSpace(F, n, m)
+
+    pi_fwd = K2_K3_posops_cone
+    pi_back_gens = K3.dual().positive_operators_gens(K2.dual())
+    pi_back = Cone((g.list() for g in pi_back_gens),
+                   lattice=L,
+                   check=False)
+
+    A = M_fwd(pi_fwd.random_element(ring=F).list())
+    assert pi_back.contains(W(A.transpose().list()))
+    A = M_back(pi_back.random_element(ring=F).list())
+    assert pi_fwd.contains(W(A.transpose().list()))
+
+@pytest.mark.longlong
+def test_posops_lyapunov_rank(K2, K3, K2_K3_posops_cone):
+    r"""
+    The Lyapunov rank of the positive operators is the product of
+    the Lyapunov ranks of the associated cones if both are proper
+    [Or2018a]_.
+    """
+    if not K2_K3_posops_cone.is_proper():
+        return
+
+    beta1 = K2.lyapunov_rank()
+    beta2 = K3.lyapunov_rank()
+    assert K2_K3_posops_cone.lyapunov_rank() == beta1*beta2
+
+@pytest.mark.longlong
+def test_posops_LL(K2, K3, K2_K3_posops_cone):
+    r"""
+    Lyapunov-like operators on a proper polyhedral positive operator
+    cone can be computed from the Lyapunov-like operators on the cones
+    with respect to which the operators are positive [Or2018a]_.
+    """
+    if not K2_K3_posops_cone.is_proper():
+        return
+
+    F = K2.lattice().base_field()
+    m = K2.lattice_dim()
+    n = K3.lattice_dim()
+    M1 = MatrixSpace(F, m)
+    M2 = MatrixSpace(F, n)
+    W = VectorSpace(F, (m**2)*(n**2))
+
+    tps = (M2(s.list()).tensor_product(M1(x.list()))
+           for x in K2.dual().lyapunov_like_basis()
+           for s in K3.lyapunov_like_basis())
+    expected = W.span( W(x.list()) for x in tps )
+    LL_pi = K2_K3_posops_cone.lyapunov_like_basis()
+    actual = W.span( W(x.list()) for x in LL_pi )
+    assert actual == expected
+
+@pytest.mark.longlong
+def test_lyapunov_like_adjoint(K2, K2_ll_basis):
+    r"""
+    The Lyapunov-like transformations on a cone and its dual are
+    transposes of one another. However, there's no reason to expect
+    that one basis will consist of transposes of the other.
+    """
+    F = K2.lattice().base_field()
+    V = VectorSpace(F, K2.lattice_dim()**2)
+    LL2 = (A.transpose() for A in K2.dual().lyapunov_like_basis())
+    LL1_vecs = (V(m.list()) for m in K2_ll_basis)
+    LL2_vecs = (V(m.list()) for m in LL2)
+    assert V.span(LL1_vecs) == V.span(LL2_vecs)
+
+@pytest.mark.longlong
+def test_LL_closed_under_lie_bracket(K2, K2_ll_basis):
+    r"""
+    The space of all Lyapunov-like transformations is a Lie algebra
+    and should therefore be closed under the lie bracket.
+    """
+    W = VectorSpace(K2.lattice().base_field(), K2.lattice_dim()**2)
+    LL_W = W.span( W(m.list()) for m in K2_ll_basis )
+    brackets = (W((A1*A2 - A2*A1).list()) for A1 in K2_ll_basis
+                                          for A2 in K2_ll_basis)
+    assert all(b in LL_W for b in brackets)
+
+@pytest.mark.long
+def test_lyapunov_rank_of_direct_sum(P, Q):
+    r"""
+    Lyapunov rank should be additive on a product of proper cones
+    [RNPA2011]_.
+    """
+    PQ = P.cartesian_product(Q)
+    assert PQ.lyapunov_rank() == P.lyapunov_rank() + Q.lyapunov_rank()
+
+@pytest.mark.long
+def test_lyapunov_rank_automorphism_invariance(K):
+    r"""
+    Lyapunov rank should be invariant under a linear isomorphism
+    [Or2017]_.
+    """
+    F = K.lattice().base_field()
+    n = K.lattice_dim()
+    A = matrix.random(F, n, algorithm='unimodular')
+    AK = Cone((A*r for r in K), lattice=K.lattice())
+    assert K.lyapunov_rank() == AK.lyapunov_rank()
+
+@pytest.mark.long
+def test_lyapunov_rank_dual_invariance(K):
+    r"""
+    Lyapunov rank should be invariant under
+    :meth:`sage.geometry.cone.ConvexRationalPolyhedralCone.dual`
+    [RNPA2011]_.
+    """
+    assert K.lyapunov_rank() == K.dual().lyapunov_rank()
+
+@pytest.mark.long
+def test_lyapunov_rank_valid_range(K, P):
+    r"""
+    The Lyapunov rank of a proper polyhedral cone in a
+    non-trivial `n`-dimensional space can be any number between `1`
+    and `n` inclusive, excluding `n-1` [GT2014]_. No polyhedral closed
+    convex cone in `n` dimensions (proper or otherwise) has Lyapunov
+    rank `n-1` [Or2017]_.
+    """
+    b = P.lyapunov_rank()
+    n = P.lattice_dim()
+    if not P.is_trivial():
+        # The paper overlooks the trivial case!
+        assert 1 <= b <= n
+    assert b != n-1
+
+    assert K.lyapunov_rank() != K.lattice_dim()-1
+
+@pytest.mark.long
+def test_lyapunov_rank_from_proper_subcone(K):
+    r"""
+    The calculation of the Lyapunov rank of an improper cone can
+    be reduced to that of a proper cone [Or2017]_.
+    """
+    K_SP = K.solid_restriction().strict_quotient()
+    l = K.lineality()
+    c = K.codim()
+    actual = K.lyapunov_rank()
+    expected = K_SP.lyapunov_rank() + K.dim()*(l + c) + c**2
+    assert actual == expected
+
+@pytest.mark.long
+def test_lyapunov_rank_agrees_with_naive_definition(K):
+    r"""
+    The Lyapunov rank of a cone is the length of a
+    :meth:`sage.geometry.cone.ConvexRationalPolyhedralCone.lyapunov_like_basis`
+    for it.
+    """
+    assert K.lyapunov_rank() == len(K.lyapunov_like_basis())
+
+@pytest.mark.long
+def test_lyapunov_rank_of_perfect_cone(K):
+    r"""
+    A "perfect" cone has Lyapunov rank `n` or more in `n`
+    dimensions. We can make any cone perfect by adding a slack
+    variable.
+    """
+    L = ToricLattice(K.lattice_dim() + 1)
+    K_perf = Cone([r.list() + [0] for r in K], lattice=L)
+    assert K_perf.lyapunov_rank() >= K_perf.lattice_dim()
+
+@pytest.mark.long
+def test_discrete_complementarity_set_of_dual(K):
+    r"""
+    A discrete complementarity set for the dual can be obtained by
+    switching components in a discrete complementarity set of the
+    original cone.
+    """
+    dcs_dual = K.dual().discrete_complementarity_set()
+    expected = tuple((x,s) for (s,x) in dcs_dual)
+    actual = K.discrete_complementarity_set()
+    assert sorted(actual) == sorted(expected)
+
+@pytest.mark.long
+def test_discrete_complementarity_set_is_complementary(K):
+    r"""
+    The pairs in a discrete complementarity set are in fact
+    complementary.
+    """
+    dcs = K.discrete_complementarity_set()
+    assert sum((s*x).abs() for (x,s) in dcs) == 0

--- a/src/sage/geometry/meson.build
+++ b/src/sage/geometry/meson.build
@@ -3,6 +3,7 @@ py.install_sources(
   'abc.pyx',
   'all.py',
   'cone.py',
+  'cone_test.py',
   'cone_catalog.py',
   'cone_critical_angles.py',
   'convex_set.py',

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -18250,34 +18250,6 @@ cdef class Matrix(Matrix1):
 
         TESTS:
 
-        The identity matrix is always a positive operator::
-
-            sage: K = random_cone(max_ambient_dim=8)
-            sage: R = K.lattice().vector_space().base_ring()
-            sage: L = identity_matrix(R, K.lattice_dim())
-            sage: L.is_positive_operator_on(K)
-            True
-
-        The zero matrix is always a positive operator::
-
-            sage: K = random_cone(max_ambient_dim=8)
-            sage: R = K.lattice().vector_space().base_ring()
-            sage: L = zero_matrix(R, K.lattice_dim())
-            sage: L.is_positive_operator_on(K)
-            True
-
-        Everything in ``K1.positive_operators_gens(K2)`` should be
-        positive on ``K1`` with respect to ``K2``, even if we make
-        the underlying ring symbolic (the usual case is tested by
-        the ``positive_operators_gens`` method)::
-
-            sage: K1 = random_cone(max_ambient_dim=5, max_rays=15)
-            sage: K2 = random_cone(max_ambient_dim=5, max_rays=15)
-            sage: results = ( L.change_ring(SR).is_positive_operator_on(K1, K2)
-            ....:             for L in K1.positive_operators_gens(K2) )
-            sage: all(results)                  # long time
-            True
-
         Technically we could test this, but for now only closed convex cones
         are supported as our ``K1`` and ``K2`` arguments::
 
@@ -18400,33 +18372,6 @@ cdef class Matrix(Matrix1):
 
         TESTS:
 
-        The identity matrix is always cross-positive::
-
-            sage: K = random_cone(max_ambient_dim=8)
-            sage: R = K.lattice().vector_space().base_ring()
-            sage: L = identity_matrix(R, K.lattice_dim())
-            sage: L.is_cross_positive_on(K)
-            True
-
-        The zero matrix is always cross-positive::
-
-            sage: K = random_cone(max_ambient_dim=8)
-            sage: R = K.lattice().vector_space().base_ring()
-            sage: L = zero_matrix(R, K.lattice_dim())
-            sage: L.is_cross_positive_on(K)
-            True
-
-        Everything in ``K.cross_positive_operators_gens()`` should be
-        cross-positive on ``K``, even if we make the underlying ring
-        symbolic (the usual case is tested by the
-        ``cross_positive_operators_gens`` method)::
-
-            sage: K = random_cone(max_ambient_dim=5, max_rays=15)
-            sage: results = ( L.change_ring(SR).is_cross_positive_on(K)
-            ....:             for L in K.cross_positive_operators_gens() )
-            sage: all(results)                  # long time
-            True
-
         Technically we could test this, but for now only closed convex cones
         are supported as our ``K`` argument::
 
@@ -18538,31 +18483,6 @@ cdef class Matrix(Matrix1):
 
         TESTS:
 
-        The identity matrix is always a Z-operator::
-
-            sage: K = random_cone(max_ambient_dim=8)
-            sage: R = K.lattice().vector_space().base_ring()
-            sage: L = identity_matrix(R, K.lattice_dim())
-            sage: L.is_Z_operator_on(K)
-            True
-
-        The zero matrix is always a Z-operator::
-
-            sage: K = random_cone(max_ambient_dim=8)
-            sage: R = K.lattice().vector_space().base_ring()
-            sage: L = zero_matrix(R, K.lattice_dim())
-            sage: L.is_Z_operator_on(K)
-            True
-
-        Everything in ``K.Z_operators_gens()`` should be a Z-operator on
-        ``K``, , even if we make the underlying ring symbolic (the usual
-        case is tested by the ``Z_operators_gens`` method)::
-
-            sage: K = random_cone(max_ambient_dim=5, max_rays=15)                       # needs sage.geometry.polyhedron
-            sage: all(L.change_ring(SR).is_Z_operator_on(K)     # long time             # needs sage.geometry.polyhedron sage.symbolic
-            ....:     for L in K.Z_operators_gens())
-            True
-
         Technically we could test this, but for now only closed convex cones
         are supported as our ``K`` argument::
 
@@ -18654,32 +18574,6 @@ cdef class Matrix(Matrix1):
 
         TESTS:
 
-        The identity matrix is always Lyapunov-like::
-
-            sage: K = random_cone(max_ambient_dim=8)
-            sage: R = K.lattice().vector_space().base_ring()
-            sage: L = identity_matrix(R, K.lattice_dim())
-            sage: L.is_lyapunov_like_on(K)
-            True
-
-        The zero matrix is always Lyapunov-like::
-
-            sage: K = random_cone(max_ambient_dim=8)
-            sage: R = K.lattice().vector_space().base_ring()
-            sage: L = zero_matrix(R, K.lattice_dim())
-            sage: L.is_lyapunov_like_on(K)
-            True
-
-        Everything in ``K.lyapunov_like_basis()`` should be
-        Lyapunov-like on ``K``, even if we make the underlying ring
-        symbolic (the usual case is tested by the
-        ``lyapunov_like_basis`` method)::
-
-            sage: K = random_cone(max_ambient_dim=5, max_rays=15)                       # needs sage.geometry.polyhedron
-            sage: all(L.change_ring(SR).is_lyapunov_like_on(K)  # long time             # needs sage.geometry.polyhedron sage.symbolic
-            ....:     for L in K.lyapunov_like_basis())
-            True
-
         Technically we could test this, but for now only closed convex cones
         are supported as our ``K`` argument::
 
@@ -18709,17 +18603,6 @@ cdef class Matrix(Matrix1):
             sage: L.is_lyapunov_like_on(K)
             True
 
-        A matrix is Lyapunov-like on a cone if and only if both the
-        matrix and its negation are cross-positive on the cone::
-
-            sage: K = random_cone(max_ambient_dim=5, max_rays=15)
-            sage: R = K.lattice().vector_space().base_ring()
-            sage: L = random_matrix(R, K.lattice_dim())
-            sage: actual = L.is_lyapunov_like_on(K)             # long time
-            sage: expected = (L.is_cross_positive_on(K) and     # long time
-            ....:             (-L).is_cross_positive_on(K))
-            sage: actual == expected                            # long time
-            True
         """
         import sage.geometry.abc
 


### PR DESCRIPTION
We get "random" failures sometimes due to a complicated cone method being called on an unusually complicated random cone. Given the unpredictability and complexity of some (intermediate) methods, fixing this is not as easy as just starting with a simpler cone (since to be 100%, we'd have to start with something trivial).

Most of the problem is with the methods that construct operators on or between cones, since this takes you into "dimension squared." To address the root of the problem, we move most tests for these methods to pytest. This lets us cache much more aggressively, and even monkey-patch methods on the fly. In particular this lets us run and check intermediate results without having to worry about computing them twice.

This supersedes https://github.com/sagemath/sage/pull/42256 (but thank you for fixing the CI in the meantime).