### PR TITLE
Fix incorrect multimodular echelon form for matrices with denominators

### DIFF
--- a/src/sage/matrix/matrix_rational_dense.pyx
+++ b/src/sage/matrix/matrix_rational_dense.pyx
@@ -1926,6 +1926,13 @@ cdef class Matrix_rational_dense(Matrix_dense):
             sage: E.echelon_form(algorithm='multimodular') is E
             True
 
+        This holds even if a copy was cached while the matrix was still
+        mutable::
+
+            sage: A.set_immutable()
+            sage: A.echelon_form(algorithm='flint') is A
+            True
+
         ::
 
             sage: B = matrix(QQ, [[1, 2], [3, 4]])
@@ -1954,15 +1961,17 @@ cdef class Matrix_rational_dense(Matrix_dense):
             pivots = self.fetch('pivots')
             if pivots is None:
                 raise RuntimeError('in_echelon_form set but not pivots')
-        x = self.fetch(label)
-        if x is not None:
-            return x
-
         if in_echelon_form and self.is_immutable():
             # ``self`` is its own echelon form and cannot drift away from it.
+            # This takes precedence over an equal copy cached under ``label``
+            # back when ``self`` was still mutable.
             self.cache(label, self)
             self.cache('rank', len(pivots))
             return self
+
+        x = self.fetch(label)
+        if x is not None:
+            return x
 
         E = self.__copy__()
         if in_echelon_form:

--- a/src/sage/matrix/matrix_rational_dense.pyx
+++ b/src/sage/matrix/matrix_rational_dense.pyx
@@ -1032,6 +1032,83 @@ cdef class Matrix_rational_dense(Matrix_dense):
         self.cache('clear_denom', X)
         return X
 
+    def _clear_denom_rowwise(self):
+        r"""
+        Clear denominators independently in each row, divide out its content,
+        and return the resulting integer matrix together with its height.
+
+        Scaling rows independently preserves the row space over `\QQ` and can
+        produce much smaller entries than using one global denominator.
+
+        TESTS::
+
+            sage: A = matrix(QQ, [[-1/2, 1/3], [1/5, 1/7]])
+            sage: B, height = A._clear_denom_rowwise()
+            sage: B
+            [-3  2]
+            [ 7  5]
+            sage: height
+            7
+            sage: A._clear_denom()[0].height()
+            105
+            sage: B.change_ring(QQ).echelon_form() == A.echelon_form()
+            True
+            sage: matrix(QQ, [[2/101, 2/103]])._clear_denom_rowwise()
+            ([103 101], 103)
+        """
+        cdef Py_ssize_t i, j
+        cdef Matrix_integer_dense B
+        cdef fmpz *entry
+        cdef fmpz_t absolute, content, denom, height
+        cdef Integer H = Integer.__new__(Integer)
+
+        from sage.matrix.matrix_space import MatrixSpace
+        MZ = MatrixSpace(ZZ, self._nrows, self._ncols, sparse=False)
+        B = Matrix_integer_dense.__new__(Matrix_integer_dense, MZ,
+                                        None, None, None)
+
+        fmpz_init(absolute)
+        fmpz_init(content)
+        fmpz_init(denom)
+        fmpz_init(height)
+        try:
+            sig_on()
+            try:
+                fmpz_zero(height)
+                for i in range(self._nrows):
+                    fmpz_one(denom)
+                    fmpz_zero(content)
+                    for j in range(self._ncols):
+                        fmpz_lcm(denom, denom,
+                                 fmpq_mat_entry_den(self._matrix, i, j))
+                    for j in range(self._ncols):
+                        entry = fmpz_mat_entry(B._matrix, i, j)
+                        fmpz_divexact(
+                            entry, denom,
+                            fmpq_mat_entry_den(self._matrix, i, j))
+                        fmpz_mul(
+                            entry, entry,
+                            fmpq_mat_entry_num(self._matrix, i, j))
+                        fmpz_gcd(content, content, entry)
+                    if not fmpz_is_zero(content):
+                        for j in range(self._ncols):
+                            entry = fmpz_mat_entry(B._matrix, i, j)
+                            fmpz_divexact(entry, entry, content)
+                    for j in range(self._ncols):
+                        entry = fmpz_mat_entry(B._matrix, i, j)
+                        fmpz_abs(absolute, entry)
+                        if fmpz_cmp(absolute, height) > 0:
+                            fmpz_set(height, absolute)
+            finally:
+                sig_off()
+            fmpz_get_mpz(H.value, height)
+        finally:
+            fmpz_clear(height)
+            fmpz_clear(denom)
+            fmpz_clear(content)
+            fmpz_clear(absolute)
+        return B, H
+
     def charpoly(self, var='x', algorithm=None):
         r"""
         Return the characteristic polynomial of this matrix.
@@ -1797,19 +1874,82 @@ cdef class Matrix_rational_dense(Matrix_dense):
             ....:     ech_multi = m.echelon_form('multimodular'); m._clear_cache()
             ....:     ech_class = m.echelon_form('classical')
             ....:     assert ech_flint == ech_padic == ech_multi == ech_class
+
+        Check that multimodular options are forwarded to :meth:`echelonize`::
+
+            sage: import sage.matrix.misc as matrix_misc
+            sage: original = matrix_misc.matrix_rational_echelon_form_multimodular
+            sage: received = []
+            sage: def wrapper(A, height_guess=None, proof=None):
+            ....:     received.append((height_guess, proof))
+            ....:     return original(A, height_guess=height_guess, proof=proof)
+            sage: matrix_misc.matrix_rational_echelon_form_multimodular = wrapper
+            sage: try:
+            ....:     A = matrix(QQ, [[1, 2]])
+            ....:     flint_result = A.echelon_form(algorithm='flint')
+            ....:     result = A.echelon_form(
+            ....:         algorithm='multimodular', height_guess=37, proof=False)
+            ....: finally:
+            ....:     matrix_misc.matrix_rational_echelon_form_multimodular = original
+            sage: flint_result == result == matrix(QQ, [[1, 2]])
+            True
+            sage: received
+            [(37, False)]
+
+        In-place echelonization must still produce an immutable result from
+        this method, while preserving cache-corruption detection::
+
+            sage: A = matrix(QQ, [[1, 2], [3, 4]])
+            sage: A.echelonize(algorithm='flint')
+            sage: E = A.echelon_form(algorithm='flint')
+            sage: (A.is_mutable(), E.is_mutable(), E is A, E == A)
+            (True, False, False, True)
+            sage: E is A.echelon_form(algorithm='flint')
+            True
+            sage: B = matrix(QQ, [[1, 2], [3, 4]])
+            sage: B.echelonize(algorithm='flint')
+            sage: _ = B.echelon_form(algorithm='flint')
+            sage: del B._cache['echelon_form']
+            sage: B.echelon_form(algorithm='flint')
+            Traceback (most recent call last):
+            ...
+            RuntimeError: in_echelon_form set but not echelon_form
+            sage: C = matrix(QQ, [[1, 2], [3, 4]])
+            sage: C.echelonize(algorithm='flint')
+            sage: _ = C.echelon_form(algorithm='flint')
+            sage: del C._cache['pivots']
+            sage: C.echelon_form(algorithm='flint')
+            Traceback (most recent call last):
+            ...
+            RuntimeError: in_echelon_form set but not pivots
         """
-        x = self.fetch('echelon_form')
+        cdef Matrix_rational_dense E
+        label = 'echelon_form_%s' % algorithm
+        in_echelon_form = self.fetch('in_echelon_form')
+        if in_echelon_form:
+            if self.fetch('echelon_form') is None:
+                raise RuntimeError('in_echelon_form set but not echelon_form')
+            pivots = self.fetch('pivots')
+            if pivots is None:
+                raise RuntimeError('in_echelon_form set but not pivots')
+        x = self.fetch(label)
         if x is not None:
             return x
-        if self.fetch('in_echelon_form'):
-            raise RuntimeError('in_echelon_form set but not echelon_form')
 
         E = self.__copy__()
-        E.echelonize(algorithm)
+        if in_echelon_form:
+            E.cache('in_echelon_form', True)
+            E.cache('echelon_form', E)
+            E.cache('pivots', pivots)
+            E.cache('rank', len(pivots))
+        else:
+            E.echelonize(algorithm=algorithm, height_guess=height_guess,
+                         proof=proof, **kwds)
+            pivots = E.pivots()
         E.set_immutable()
-        self.cache('echelon_form', E)
-        self.cache('pivots', E.pivots())
-        self.cache('rank', len(E.pivots()))
+        self.cache(label, E)
+        self.cache('pivots', pivots)
+        self.cache('rank', len(pivots))
         return E
 
     def _echelonize_flint(self, algorithm: str):
@@ -2062,8 +2202,8 @@ cdef class Matrix_rational_dense(Matrix_dense):
            - ``None`` -- (default) use default algorithm for computing Echelon
              forms
 
-           - 'multimodular': much better if the answers
-             factors have small height
+           - ``'multimodular'`` -- can be effective when the answer factors
+             have small height
 
         - ``height_guess`` -- positive integer; only used by
           the multimodular algorithm
@@ -2078,13 +2218,11 @@ cdef class Matrix_rational_dense(Matrix_dense):
 
            IMPORTANT: If you expect that the subspaces in the answer
            are spanned by vectors with small height coordinates, use
-           algorithm='multimodular' and height_guess=1; this is
-           potentially much faster than the default. If you know for a
-           fact the answer will be very small, use
-           algorithm='multimodular', height_guess=bound on height,
-           proof=False.
-
-        You can get very very fast decomposition with proof=False.
+           ``algorithm='multimodular'`` and a tight ``height_guess``.  This can
+           make the multimodular algorithm faster than the default.  Setting
+           ``proof=False`` with an explicit ``height_guess`` attempts
+           reconstruction earlier, but is not guaranteed to improve
+           performance.
 
         EXAMPLES::
 
@@ -2129,8 +2267,8 @@ cdef class Matrix_rational_dense(Matrix_dense):
         - ``echelon_algorithm`` -- an optional algorithm to be passed to the
           method ``echelon_form``
 
-        - ``'multimodular'`` -- use this if the answers have
-          small height
+        - ``'multimodular'`` -- can be effective when the answers have small
+          height
 
         - ``**kwds`` -- passed on to echelon function
 
@@ -2138,10 +2276,11 @@ cdef class Matrix_rational_dense(Matrix_dense):
 
            IMPORTANT: If you expect that the subspaces in the answer are
            spanned by vectors with small height coordinates, use
-           algorithm='multimodular' and height_guess=1; this is potentially
-           much faster than the default. If you know for a fact the answer
-           will be very small, use algorithm='multimodular',
-           height_guess=bound on height, proof=False
+           ``algorithm='multimodular'`` and a tight ``height_guess``.  This can
+           make the multimodular algorithm faster than the default.  Setting
+           ``proof=False`` with an explicit ``height_guess`` attempts
+           reconstruction earlier, but is not guaranteed to improve
+           performance.
 
         OUTPUT:
 
@@ -2259,10 +2398,8 @@ cdef class Matrix_rational_dense(Matrix_dense):
 
 #          IMPORTANT NOTE:
 #          If you expect that the subspaces in the answer are spanned by vectors
-#          with small height coordinates, use algorithm='multimodular' and
-#          height_guess=1; this is potentially much faster than the default.
-#          If you know for a fact the answer will be very small, use
-#             algorithm='multimodular', height_guess=bound on height, proof=False
+#          with small height coordinates, use algorithm='multimodular' and a
+#          tight height_guess. This can make the multimodular algorithm faster.
 
 #          OUTPUT:
 #              Sequence -- list of tuples (V,g), where V is a subspace

--- a/src/sage/matrix/matrix_rational_dense.pyx
+++ b/src/sage/matrix/matrix_rational_dense.pyx
@@ -1709,13 +1709,16 @@ cdef class Matrix_rational_dense(Matrix_dense):
 
           - ``'classical'``: just clear each column using Gauss elimination.
 
-        - ``height_guess``, ``**kwds`` -- all passed to the
-          ``'multimodular'`` algorithm; ignored by other algorithms
+        - ``height_guess`` -- passed to the ``'multimodular'`` algorithm;
+          ignored by other algorithms
 
         - ``proof`` -- boolean or ``None`` (default: None, see
           proof.linear_algebra or sage.structure.proof). Passed to the
           ``'multimodular'`` algorithm. Note that the Sage global default is
           ``proof=True``.
+
+        - ``**kwds`` -- ignored; accepted for compatibility with the generic
+          :meth:`~sage.matrix.matrix2.Matrix.echelonize`
 
         EXAMPLES::
 
@@ -1801,7 +1804,7 @@ cdef class Matrix_rational_dense(Matrix_dense):
         if algorithm in ('flint', 'flint:classical', 'flint:multimodular', 'flint:fflu'):
             pivots = self._echelonize_flint(algorithm)
         elif algorithm == 'multimodular':
-            pivots = self._echelonize_multimodular(height_guess, proof, **kwds)
+            pivots = self._echelonize_multimodular(height_guess, proof)
         elif algorithm == 'classical':
             pivots = self._echelon_in_place_classical()
         elif algorithm == 'padic':
@@ -1896,6 +1899,14 @@ cdef class Matrix_rational_dense(Matrix_dense):
             sage: received
             [(37, False)]
 
+        Keyword arguments that the multimodular algorithm does not understand
+        are ignored, as they are by the other algorithms::
+
+            sage: matrix(QQ, [[1, 2], [3, 4]]).echelon_form(
+            ....:     algorithm='multimodular', cutoff=0)
+            [1 0]
+            [0 1]
+
         In-place echelonization must still produce an immutable result from
         this method, while preserving cache-corruption detection::
 
@@ -1906,6 +1917,17 @@ cdef class Matrix_rational_dense(Matrix_dense):
             (True, False, False, True)
             sage: E is A.echelon_form(algorithm='flint')
             True
+
+        An immutable matrix that is already in echelon form is its own echelon
+        form, and is not copied::
+
+            sage: E.echelon_form(algorithm='flint') is E
+            True
+            sage: E.echelon_form(algorithm='multimodular') is E
+            True
+
+        ::
+
             sage: B = matrix(QQ, [[1, 2], [3, 4]])
             sage: B.echelonize(algorithm='flint')
             sage: _ = B.echelon_form(algorithm='flint')
@@ -1935,6 +1957,12 @@ cdef class Matrix_rational_dense(Matrix_dense):
         x = self.fetch(label)
         if x is not None:
             return x
+
+        if in_echelon_form and self.is_immutable():
+            # ``self`` is its own echelon form and cannot drift away from it.
+            self.cache(label, self)
+            self.cache('rank', len(pivots))
+            return self
 
         E = self.__copy__()
         if in_echelon_form:

--- a/src/sage/matrix/matrix_rational_sparse.pyx
+++ b/src/sage/matrix/matrix_rational_sparse.pyx
@@ -633,8 +633,17 @@ cdef class Matrix_rational_sparse(Matrix_sparse):
             True
             sage: matrix(QQ, [[2/101, 2/103]], sparse=True)._clear_denom_rowwise()
             ([103 101], 103)
+
+        Entries that are stored but zero do not become stored entries of the
+        result::
+
+            sage: A = matrix(QQ, [[1, 2], [3, 4]], sparse=True)
+            sage: A.set_row_to_multiple_of_row(0, 1, 0)
+            sage: B, height = A._clear_denom_rowwise()
+            sage: B.nonzero_positions()
+            [(1, 0), (1, 1)]
         """
-        cdef Py_ssize_t i, j
+        cdef Py_ssize_t i, j, k, num_nonzero
         cdef Matrix_integer_sparse B
         cdef mpq_vector *source_row
         cdef mpz_vector *target_row
@@ -655,41 +664,52 @@ cdef class Matrix_rational_sparse(Matrix_sparse):
                 source_row = &self._matrix[i]
                 mpz_set_ui(content, 0)
                 mpz_set_ui(denom, 1)
+                num_nonzero = 0
                 for j in range(source_row.num_nonzero):
                     sig_check()
-                    mpz_lcm(denom, denom,
-                            mpq_denref(source_row.entries[j]))
+                    if mpq_sgn(source_row.entries[j]):
+                        num_nonzero += 1
+                        mpz_lcm(denom, denom,
+                                mpq_denref(source_row.entries[j]))
 
                 # Allocate and initialize a complete replacement row before
                 # changing B.  This keeps every row structurally valid if
-                # allocation or a later signal raises an exception.
-                mpz_vector_init(
-                    &new_row, self._ncols, source_row.num_nonzero)
+                # allocation or a later signal raises an exception.  A stored
+                # entry of ``self`` may be zero, and those must not be stored
+                # in B.
+                mpz_vector_init(&new_row, self._ncols, num_nonzero)
+                k = 0
                 for j in range(source_row.num_nonzero):
-                    new_row.positions[j] = source_row.positions[j]
+                    if mpq_sgn(source_row.entries[j]):
+                        new_row.positions[k] = source_row.positions[j]
+                        k += 1
                 target_row = &B._matrix[i]
                 mpz_vector_clear(target_row)
                 target_row[0] = new_row
 
+                k = 0
                 for j in range(source_row.num_nonzero):
                     sig_check()
+                    if not mpq_sgn(source_row.entries[j]):
+                        continue
                     mpz_divexact(
-                        target_row.entries[j], denom,
+                        target_row.entries[k], denom,
                         mpq_denref(source_row.entries[j]))
                     mpz_mul(
-                        target_row.entries[j], target_row.entries[j],
+                        target_row.entries[k], target_row.entries[k],
                         mpq_numref(source_row.entries[j]))
-                    mpz_gcd(content, content, target_row.entries[j])
+                    mpz_gcd(content, content, target_row.entries[k])
+                    k += 1
 
                 if mpz_sgn(content):
-                    for j in range(source_row.num_nonzero):
+                    for k in range(num_nonzero):
                         sig_check()
-                        mpz_divexact(target_row.entries[j],
-                                     target_row.entries[j], content)
-                for j in range(source_row.num_nonzero):
+                        mpz_divexact(target_row.entries[k],
+                                     target_row.entries[k], content)
+                for k in range(num_nonzero):
                     sig_check()
-                    if mpz_cmpabs(target_row.entries[j], height.value) > 0:
-                        mpz_abs(height.value, target_row.entries[j])
+                    if mpz_cmpabs(target_row.entries[k], height.value) > 0:
+                        mpz_abs(height.value, target_row.entries[k])
         finally:
             mpz_clear(denom)
             mpz_clear(content)
@@ -705,8 +725,10 @@ cdef class Matrix_rational_sparse(Matrix_sparse):
 
         INPUT:
 
-        - ``height_guess``, ``proof``, ``**kwds`` -- all passed to the multimodular
-          algorithm; ignored by the `p`-adic algorithm
+        - ``height_guess``, ``proof`` -- passed to the multimodular algorithm
+
+        - ``**kwds`` -- ignored; accepted for compatibility with the generic
+          :meth:`~sage.matrix.matrix2.Matrix.echelonize`
 
         OUTPUT:
 
@@ -740,7 +762,7 @@ cdef class Matrix_rational_sparse(Matrix_sparse):
             return  # already known to be in echelon form
         self.check_mutability()
 
-        pivots = self._echelonize_multimodular(height_guess, proof, **kwds)
+        pivots = self._echelonize_multimodular(height_guess, proof)
 
         self.cache('in_echelon_form', True)
         self.cache('echelon_form', self)
@@ -752,8 +774,10 @@ cdef class Matrix_rational_sparse(Matrix_sparse):
         """
         INPUT:
 
-        - ``height_guess``, ``proof``, ``**kwds`` -- all passed to the multimodular
-          algorithm; ignored by the `p`-adic algorithm
+        - ``height_guess``, ``proof`` -- passed to the multimodular algorithm
+
+        - ``**kwds`` -- ignored; accepted for compatibility with the generic
+          :meth:`~sage.matrix.matrix2.Matrix.echelon_form`
 
         OUTPUT: ``self`` is no in reduced row echelon form
 
@@ -809,9 +833,9 @@ cdef class Matrix_rational_sparse(Matrix_sparse):
         return E
 
     # Multimodular echelonization algorithms
-    def _echelonize_multimodular(self, height_guess=None, proof=None, **kwds):
+    def _echelonize_multimodular(self, height_guess=None, proof=None):
         cdef Matrix_rational_sparse E
-        E, pivots = self._echelon_form_multimodular(height_guess, proof=proof, **kwds)
+        E, pivots = self._echelon_form_multimodular(height_guess, proof=proof)
         self.clear_cache()
         # Swap the data of E and self (effectively moving E to self)
         self._matrix, E._matrix = E._matrix, self._matrix

--- a/src/sage/matrix/matrix_rational_sparse.pyx
+++ b/src/sage/matrix/matrix_rational_sparse.pyx
@@ -24,7 +24,7 @@ TESTS::
 #                  http://www.gnu.org/licenses/
 #*****************************************************************************
 
-from cysignals.signals cimport sig_on, sig_off
+from cysignals.signals cimport sig_check, sig_on, sig_off
 from cysignals.memory cimport check_calloc, sig_free
 
 from sage.data_structures.binary_search cimport *
@@ -615,10 +615,90 @@ cdef class Matrix_rational_sparse(Matrix_sparse):
         mpz_clear(t)
         return A, D
 
+    def _clear_denom_rowwise(self):
+        r"""
+        Clear denominators independently in each row, divide out its content,
+        and return the resulting integer matrix together with its height.
+
+        TESTS::
+
+            sage: A = matrix(QQ, [[0, 0], [1/2, 1/3]], sparse=True)
+            sage: B, height = A._clear_denom_rowwise()
+            sage: B
+            [0 0]
+            [3 2]
+            sage: (height, B.is_sparse())
+            (3, True)
+            sage: B.change_ring(QQ).echelon_form() == A.echelon_form()
+            True
+            sage: matrix(QQ, [[2/101, 2/103]], sparse=True)._clear_denom_rowwise()
+            ([103 101], 103)
+        """
+        cdef Py_ssize_t i, j
+        cdef Matrix_integer_sparse B
+        cdef mpq_vector *source_row
+        cdef mpz_vector *target_row
+        cdef mpz_vector new_row
+        cdef mpz_t content, denom
+        cdef Integer height = Integer.__new__(Integer)
+
+        MZ = sage.matrix.matrix_space.MatrixSpace(
+            ZZ, self._nrows, self._ncols, sparse=True)
+        B = MZ.element_class(MZ, None, False, False)
+
+        mpz_set_ui(height.value, 0)
+        mpz_init(content)
+        mpz_init(denom)
+        try:
+            for i in range(self._nrows):
+                sig_check()
+                source_row = &self._matrix[i]
+                mpz_set_ui(content, 0)
+                mpz_set_ui(denom, 1)
+                for j in range(source_row.num_nonzero):
+                    sig_check()
+                    mpz_lcm(denom, denom,
+                            mpq_denref(source_row.entries[j]))
+
+                # Allocate and initialize a complete replacement row before
+                # changing B.  This keeps every row structurally valid if
+                # allocation or a later signal raises an exception.
+                mpz_vector_init(
+                    &new_row, self._ncols, source_row.num_nonzero)
+                for j in range(source_row.num_nonzero):
+                    new_row.positions[j] = source_row.positions[j]
+                target_row = &B._matrix[i]
+                mpz_vector_clear(target_row)
+                target_row[0] = new_row
+
+                for j in range(source_row.num_nonzero):
+                    sig_check()
+                    mpz_divexact(
+                        target_row.entries[j], denom,
+                        mpq_denref(source_row.entries[j]))
+                    mpz_mul(
+                        target_row.entries[j], target_row.entries[j],
+                        mpq_numref(source_row.entries[j]))
+                    mpz_gcd(content, content, target_row.entries[j])
+
+                if mpz_sgn(content):
+                    for j in range(source_row.num_nonzero):
+                        sig_check()
+                        mpz_divexact(target_row.entries[j],
+                                     target_row.entries[j], content)
+                for j in range(source_row.num_nonzero):
+                    sig_check()
+                    if mpz_cmpabs(target_row.entries[j], height.value) > 0:
+                        mpz_abs(height.value, target_row.entries[j])
+        finally:
+            mpz_clear(denom)
+            mpz_clear(content)
+        return B, height
+
     ################################################
     # Echelon form
     ################################################
-    def echelonize(self, height_guess=None, proof=True, **kwds):
+    def echelonize(self, height_guess=None, proof=None, **kwds):
         """
         Transform the matrix ``self`` into reduced row echelon form
         in place.
@@ -668,7 +748,7 @@ cdef class Matrix_rational_sparse(Matrix_sparse):
         self.cache('rank', len(pivots))
 
     def echelon_form(self, algorithm='default',
-                     height_guess=None, proof=True, **kwds):
+                     height_guess=None, proof=None, **kwds):
         """
         INPUT:
 
@@ -689,6 +769,31 @@ cdef class Matrix_rational_sparse(Matrix_sparse):
             [      0       1       0  -5/157]
             [      0       0       1 238/157]
             [      0       0       0       0]
+
+        TESTS:
+
+        ``proof`` defaults to ``None``, so that the global
+        ``proof.linear_algebra`` flag is honoured just as it is for dense
+        matrices::
+
+            sage: import sage.matrix.misc as matrix_misc
+            sage: original = matrix_misc.matrix_rational_echelon_form_multimodular
+            sage: received = []
+            sage: def wrapper(A, height_guess=None, proof=None):
+            ....:     received.append(proof)
+            ....:     return original(A, height_guess=height_guess, proof=proof)
+            sage: matrix_misc.matrix_rational_echelon_form_multimodular = wrapper
+            sage: try:
+            ....:     a = matrix(QQ, [[1/2, 1/3]], sparse=True)
+            ....:     default = a.echelon_form()
+            ....:     forced = matrix(QQ, [[1/2, 1/3]], sparse=True).echelon_form(
+            ....:         proof=True)
+            ....: finally:
+            ....:     matrix_misc.matrix_rational_echelon_form_multimodular = original
+            sage: received
+            [None, True]
+            sage: default == forced == matrix(QQ, [[1, 2/3]])
+            True
         """
         label = 'echelon_form_%s' % algorithm
         x = self.fetch(label)
@@ -704,7 +809,7 @@ cdef class Matrix_rational_sparse(Matrix_sparse):
         return E
 
     # Multimodular echelonization algorithms
-    def _echelonize_multimodular(self, height_guess=None, proof=True, **kwds):
+    def _echelonize_multimodular(self, height_guess=None, proof=None, **kwds):
         cdef Matrix_rational_sparse E
         E, pivots = self._echelon_form_multimodular(height_guess, proof=proof, **kwds)
         self.clear_cache()
@@ -712,7 +817,7 @@ cdef class Matrix_rational_sparse(Matrix_sparse):
         self._matrix, E._matrix = E._matrix, self._matrix
         return pivots
 
-    def _echelon_form_multimodular(self, height_guess=None, proof=True):
+    def _echelon_form_multimodular(self, height_guess=None, proof=None):
         """
         Return reduced row-echelon form using a multi-modular
         algorithm.  Does not change ``self``.
@@ -720,7 +825,8 @@ cdef class Matrix_rational_sparse(Matrix_sparse):
         INPUT:
 
         - ``height_guess`` -- integer or ``None``
-        - ``proof`` -- boolean (default: ``True``)
+        - ``proof`` -- boolean or ``None`` (default: ``None``, see
+          ``proof.linear_algebra`` or ``sage.structure.proof``)
         """
         from sage.matrix.misc import matrix_rational_echelon_form_multimodular
         cdef Matrix E

--- a/src/sage/matrix/misc.pyx
+++ b/src/sage/matrix/misc.pyx
@@ -562,7 +562,7 @@ def matrix_rational_echelon_form_multimodular(Matrix self, height_guess=None, pr
         sage: A = matrix(QQ, [[46337, 19453]], sparse=True)
         sage: expected = A.dense_matrix().echelon_form(algorithm='flint')
         sage: A.echelon_form(algorithm='multimodular',
-        ....:                height_guess=46337, proof=False) == expected
+        ....:                height_guess=46336, proof=False) == expected
         True
 
     Check both ends of the optimized sparse prime range.  A target reached

--- a/src/sage/matrix/misc.pyx
+++ b/src/sage/matrix/misc.pyx
@@ -11,6 +11,7 @@ from sage.ext.mod_int cimport *
 from sage.libs.gmp.mpq cimport *
 from sage.libs.gmp.mpz cimport *
 from sage.misc.lazy_import import LazyImport
+from sage.misc.lazy_string import lazy_string
 from sage.misc.verbose import verbose
 from sage.modules.vector_integer_sparse cimport *
 from sage.modules.vector_modn_sparse cimport *
@@ -180,6 +181,91 @@ def matrix_integer_sparse_rational_reconstruction(Matrix_integer_sparse A, Integ
     return R
 
 
+def _multimodular_echelon_progress(p, prod, M):
+    """
+    Return a progress message for modular echelon form.
+
+    TESTS::
+
+        sage: from sage.matrix.misc import _multimodular_echelon_progress
+        sage: _multimodular_echelon_progress(7, 10, 100)
+        'echelon modulo p=7 (66.67% done)'
+    """
+    return "echelon modulo p=%s (%.2f%% done)" % (
+        p, 100*float(len(str(prod))) / len(str(M)))
+
+
+def _multimodular_echelon_next_modulus(M, prod):
+    r"""
+    Return the target modulus to use after a failed reconstruction attempt.
+
+    ``M`` grows geometrically, but the result always exceeds ``prod``: a
+    retry must buy at least one new prime, otherwise the next pass would
+    reconstruct from the very same primes and fail in the same way.
+
+    TESTS::
+
+        sage: from sage.matrix.misc import _multimodular_echelon_next_modulus
+        sage: _multimodular_echelon_next_modulus(2^60, 2^61) == 2^73
+        True
+
+    Growth alone can leave ``M`` behind ``prod``; then take the smallest
+    modulus that requires another prime::
+
+        sage: _multimodular_echelon_next_modulus(2, 10^6)
+        1000001
+    """
+    M = M << (M.bit_length() // 5 + 1)
+    if M <= prod:
+        M = prod + 1
+    return M
+
+
+def _multimodular_echelon_candidate_has_shape(Matrix E, pivots):
+    r"""
+    Return whether ``E`` has reduced-echelon shape for ``pivots``.
+
+    This checks the structural invariant used by the exact row-space
+    certificate in :func:`matrix_rational_echelon_form_multimodular`.
+
+    TESTS::
+
+        sage: from sage.matrix.misc import _multimodular_echelon_candidate_has_shape
+        sage: _multimodular_echelon_candidate_has_shape(
+        ....:     matrix(QQ, [[0, 1]]), (1,))
+        True
+        sage: _multimodular_echelon_candidate_has_shape(
+        ....:     matrix(QQ, [[46337, 1]], sparse=True), (1,))
+        False
+        sage: _multimodular_echelon_candidate_has_shape(
+        ....:     matrix(QQ, [[1, 2], [0, 1]]), (0, 1))
+        False
+        sage: _multimodular_echelon_candidate_has_shape(
+        ....:     matrix(QQ, [[0, 1], [1, 0]]), (1, 0))
+        False
+    """
+    cdef Py_ssize_t i, j, pivot
+    cdef Py_ssize_t r = len(pivots)
+    if (r > E.nrows()
+            or any(pivot < 0 or pivot >= E.ncols() for pivot in pivots)
+            or any(pivots[i] >= pivots[i + 1] for i in range(r - 1))):
+        return False
+    if (not E[r:].is_zero()
+            or not E[:r].matrix_from_columns(pivots).is_one()):
+        return False
+    if E.is_sparse():
+        for i, j in E.nonzero_positions(copy=False):
+            if i < r and j < pivots[i]:
+                return False
+    else:
+        for i in range(r):
+            pivot = pivots[i]
+            for j in range(pivot):
+                if not E.get_is_zero_unsafe(i, j):
+                    return False
+    return True
+
+
 def matrix_rational_echelon_form_multimodular(Matrix self, height_guess=None, proof=None):
     """
     Return reduced row-echelon form using a multi-modular
@@ -189,10 +275,17 @@ def matrix_rational_echelon_form_multimodular(Matrix self, height_guess=None, pr
 
     INPUT:
 
-    - ``height_guess`` -- integer or ``None``
+    - ``height_guess`` -- integer or ``None``; an estimate for `H(dE)`, where
+      `E` is the output echelon form and `d` is its denominator
     - ``proof`` -- boolean or ``None`` (default: ``None``, see
       ``proof.linear_algebra`` or ``sage.structure.proof``). Note that the
-      global Sage default is proof=True
+      global Sage default is proof=True.  With ``proof=False``, the algorithm
+      uses an explicitly supplied ``height_guess`` to attempt reconstruction
+      early and checks each candidate first with the usual height certificate;
+      if that fails, it checks the reduced-echelon shape and an exact row-space
+      identity.  The early attempt can reduce the number of modular images
+      when the output is much smaller than the input, but failed
+      reconstructions and the exact check can also make it slower
 
     OUTPUT: a pair consisting of a matrix in echelon form and a tuple of pivot
     positions.
@@ -205,35 +298,42 @@ def matrix_rational_echelon_form_multimodular(Matrix self, height_guess=None, pr
 
     Given Matrix A with n columns (self).
 
-     0. Rescale input matrix A to have integer entries.  This does
-        not change echelon form and makes reduction modulo lots of
-        primes significantly easier if there were denominators.
-        Henceforth we assume A has integer entries.
+     0. Rescale each row of the input matrix A independently to a primitive
+        integer row.  This does not change echelon form and makes reduction
+        modulo lots of primes significantly easier if there were
+        denominators.  Henceforth we assume A has integer entries.
 
-     1. Let c be a guess for the height of the echelon form.  E.g.,
-        c=1000, e.g., if matrix is very sparse and application is to
-        computing modular symbols.
+     1. Let c be a guess for H(dE), where E is the output echelon form
+        and d is its denominator.  E.g., c=1000 if the matrix is very
+        sparse and the application is to computing modular symbols.
 
-     2. Let M = n * c * H(A) + 1,
-        where n is the number of columns of A.
+     2. Let M = n * c * H(A) + 1, where n is the number of columns of A.
+        If ``proof=False`` and c was supplied explicitly, start instead with
+        M = c + 1 in order to attempt rational reconstruction earlier.
 
      3. List primes p_1, p_2, ..., such that the product of
         the p_i is at least M.
 
      4. Try to compute the rational reconstruction CRT echelon form
         of A mod the product of the p_i.  If rational
-        reconstruction fails, compute 1 more echelon forms mod the
-        next prime, and attempt again.  Make sure to keep the
+        reconstruction fails, compute more echelon forms modulo subsequent
+        primes, and attempt again.  Make sure to keep the
         result of CRT on the primes from before, so we don't have
         to do that computation again.  Let E be this matrix.
 
-     5. Compute the denominator d of E.
-        Attempt to prove that result is correct by checking that
+     5. Compute the denominator d of E.  Attempt to prove that the result is
+        correct by checking that
 
               H(d*E)*ncols(A)*H(A) < (prod of reduction primes)
 
-        where H denotes the height.   If this fails, do step 4 with
-        a few more primes.
+        where H denotes the height.  With ``proof=False``, if this certificate
+        fails, check the exact identity
+
+              d*A = A[:, P] * (d*E)[:r]
+
+        where P is the tuple of r pivot columns, after explicitly checking
+        that E has reduced-echelon shape for P.  If the applicable check
+        fails, do step 4 with more primes.
 
     EXAMPLES::
 
@@ -305,29 +405,178 @@ def matrix_rational_echelon_form_multimodular(Matrix self, height_guess=None, pr
         sage: t = walltime(t)  # long time
         sage: (t < 10, t)  # long time
         (True, ...)
+
+    TESTS:
+
+    Check that the correctness bound accounts for the integer matrix obtained
+    after clearing denominators (:issue:`42411`)::
+
+        sage: entries = [[1000001000, -1/501000500, 3], [1, -1, 1]]
+        sage: expected = matrix(QQ, entries).echelon_form(algorithm='flint')
+        sage: matrix(QQ, entries).echelon_form(algorithm='multimodular') == expected
+        True
+        sage: matrix(QQ, entries, sparse=True).echelon_form() == expected
+        True
+
+    An early reconstruction is checked exactly even when the standard
+    validity bound is disabled::
+
+        sage: output_height = (expected.denominator() * expected).height()
+        sage: matrix(QQ, entries, sparse=True).echelon_form(
+        ....:     height_guess=output_height, proof=False) == expected
+        True
+
+    First calibrate the instrumentation on a case that needs the exact
+    fallback, then check that the inexpensive height certificate bypasses
+    it::
+
+        sage: import sage.matrix.misc as matrix_misc
+        sage: A = matrix(QQ, [[10^6, 1, 0], [10^6 - 1, 1, 0]])
+        sage: expected = A.echelon_form(algorithm='flint')
+        sage: original_shape_check = matrix_misc._multimodular_echelon_candidate_has_shape
+        sage: shape_checks = []
+        sage: def count_shape_check(*args):
+        ....:     shape_checks.append(None)
+        ....:     return original_shape_check(*args)
+        sage: matrix_misc._multimodular_echelon_candidate_has_shape = count_shape_check
+        sage: try:
+        ....:     D = 43*53*61
+        ....:     fallback = matrix(QQ, [[D, D/43, D/53, D/61, 0],
+        ....:                            [0,    0,    0,    0, 1]], sparse=True)
+        ....:     fallback_expected = fallback.dense_matrix().echelon_form(
+        ....:         algorithm='flint')
+        ....:     fallback_result = fallback.echelon_form(
+        ....:         algorithm='multimodular', height_guess=1, proof=False)
+        ....:     hook_is_active = bool(shape_checks)
+        ....:     shape_checks.clear()
+        ....:     result = A.__copy__().echelon_form(
+        ....:         algorithm='multimodular', proof=False)
+        ....: finally:
+        ....:     matrix_misc._multimodular_echelon_candidate_has_shape = original_shape_check
+        sage: (result == expected, fallback_result == fallback_expected)
+        (True, True)
+        sage: (hook_is_active, shape_checks)
+        (True, [])
+
+    A premature rational reconstruction is rejected by the exact check even
+    when ``proof=False``::
+
+        sage: A = matrix(QQ, 2, 3,
+        ....:            [-17, 4/5, 25/13, -2/3, 19/5, -17/11], sparse=True)
+        sage: expected = A.dense_matrix().echelon_form(algorithm='flint')
+        sage: output_height = (expected.denominator() * expected).height()
+        sage: A.echelon_form(algorithm='multimodular',
+        ....:                height_guess=output_height, proof=False) == expected
+        True
+
+    The full identity is necessary.  Rational reconstruction may reuse a
+    shared denominator, so even a pivot residue of one need not reconstruct
+    as one::
+
+        sage: N = ZZ(499)
+        sage: C = matrix(QQ, [[1, 1/7, 1/11, 1/13, 0],
+        ....:                 [0,   0,    0,    0, 1]])
+        sage: L = matrix(ZZ, 2, 5, [x % N for x in C.list()], sparse=True)
+        sage: candidate = L.rational_reconstruction(N)
+        sage: candidate[1, 4]
+        3/1001
+        sage: B0 = matrix(ZZ, [[1001, 143, 91, 77, 0],
+        ....:                  [   0,   0,  0,  0, 1]], sparse=True)
+        sage: d = candidate.denominator()
+        sage: dE = (d*candidate).change_ring(ZZ)
+        sage: P = (0, 4); nonpivots = (1, 2, 3)
+        sage: (d * B0.matrix_from_columns(nonpivots)
+        ....:  == B0.matrix_from_columns(P)
+        ....:     * dE.matrix_from_columns(nonpivots))
+        True
+        sage: d*B0 == B0.matrix_from_columns(P) * dE
+        False
+
+    This situation can occur in the multimodular algorithm itself.  The first
+    sparse reduction prime is 46337, and the following shared denominator is
+    congruent to 8 modulo that prime::
+
+        sage: D = 43*53*61
+        sage: A = matrix(QQ, [[D, D/43, D/53, D/61, 0],
+        ....:                 [0,    0,    0,    0, 1]], sparse=True)
+        sage: expected = A.dense_matrix().echelon_form(algorithm='flint')
+        sage: A.echelon_form(algorithm='multimodular',
+        ....:                height_guess=1, proof=False) == expected
+        True
+
+    An exact row-space check also rejects a reconstruction obtained only from
+    bad-pivot primes::
+
+        sage: A = matrix(QQ, [[46337, 19453]], sparse=True)
+        sage: expected = A.dense_matrix().echelon_form(algorithm='flint')
+        sage: A.echelon_form(algorithm='multimodular',
+        ....:                height_guess=46337, proof=False) == expected
+        True
+
+    Check that independent row scaling keeps the performance-critical bound
+    small when rows have distinct denominators.  Counting calls to
+    ``previous_prime`` avoids a timing-dependent test::
+
+        sage: import sage.matrix.misc as matrix_misc
+        sage: denominators = [next_prime(10^4 + 100*i) for i in range(80)]
+        sage: entries = {(i, i): 1/q for i, q in enumerate(denominators)}
+        sage: entries.update({(i, 119): 1 for i in range(80)})
+        sage: A = matrix(QQ, 80, 120, entries)
+        sage: expected = matrix(QQ, 80, 120)
+        sage: for i, q in enumerate(denominators):
+        ....:     expected[i, i] = 1
+        ....:     expected[i, 119] = q
+        sage: original_previous_prime = matrix_misc.previous_prime
+        sage: def run(proof):
+        ....:     primes = []
+        ....:     def count_previous_prime(p):
+        ....:         primes.append(p)
+        ....:         return original_previous_prime(p)
+        ....:     matrix_misc.previous_prime = count_previous_prime
+        ....:     try:
+        ....:         result = A.__copy__().echelon_form(
+        ....:             algorithm='multimodular', proof=proof)
+        ....:     finally:
+        ....:         matrix_misc.previous_prime = original_previous_prime
+        ....:     return result, len(primes)
+        sage: proved, proved_primes = run(True)
+        sage: unproved, unproved_primes = run(False)
+        sage: proved == unproved == expected
+        True
+        sage: all(0 < count < 10
+        ....:     for count in (proved_primes, unproved_primes))
+        True
     """
     if proof is None:
         from sage.structure.proof.proof import get_flag
         proof = get_flag(proof, "linear_algebra")
 
     verbose("Multimodular echelon algorithm on %s x %s matrix" % (self._nrows, self._ncols), caller_name="multimod echelon")
-    cdef Matrix E
+    cdef Matrix E, dE
+    cdef bint default_height_guess = height_guess is None
     if self._nrows == 0 or self._ncols == 0:
         return self, ()
 
-    B, _ = self._clear_denom()
+    B, height = self._clear_denom_rowwise()
+    if not height:
+        return self.parent()(0), ()
 
-    height = self.height()
     if height_guess is None:
+        # Base the heuristic on the primitive integer matrix actually used by
+        # the modular computation, so denominator clearing is accounted for.
         height_guess = 10000000*(height+100)
     tm = verbose("height_guess = %s" % height_guess, level=2, caller_name="multimod echelon")
 
     cdef Integer M
     from sage.arith.misc import integer_floor as floor
-    if proof:
+    if proof or default_height_guess:
+        # The modular computation is done with denominators cleared, so H(A)
+        # in the reconstruction bound is the height of this integer matrix.
         M = floor(max(1, self._ncols * height_guess * height + 1))
     else:
-        M = floor(max(1, height_guess + 1))
+        # An explicit height guess opts into early reconstruction.  Each
+        # candidate is checked below.
+        M = floor(max(2, height_guess + 1))
 
     if self.is_sparse():
         from sage.matrix.matrix_modn_sparse import MAX_MODULUS
@@ -347,10 +596,11 @@ def matrix_rational_echelon_form_multimodular(Matrix self, height_guess=None, pr
             problem = problem + 1
             if problem > 50:
                 verbose("echelon multi-modular possibly not converging?", caller_name="multimod echelon")
-            t = verbose("echelon modulo p=%s (%.2f%% done)" % (
-                       p, 100*float(len(str(prod))) / len(str(M))), level=2, caller_name="multimod echelon")
+            t = verbose(lazy_string(_multimodular_echelon_progress,
+                                    p, prod, M),
+                        level=2, caller_name="multimod echelon")
 
-            # We use denoms=False, since we made self integral by calling clear_denom above.
+            # We use denoms=False, since the rows of B are integral.
             A = B._mod_int(p)
             t = verbose("time to reduce matrix mod p:",t, level=2, caller_name="multimod echelon")
             A.echelonize()
@@ -391,6 +641,8 @@ def matrix_rational_echelon_form_multimodular(Matrix self, height_guess=None, pr
                 Y.append(lifts[p])
                 prod = prod * X[i].base_ring().order()
         verbose("finished comparing pivots", level=2, t=t, caller_name="multimod echelon")
+        if prod < M:
+            continue
         try:
             if not Y:
                 raise ValueError("not enough primes")
@@ -411,20 +663,36 @@ def matrix_rational_echelon_form_multimodular(Matrix self, height_guess=None, pr
             verbose('rational reconstruction completed', t, level=2, caller_name="multimod echelon")
         except ValueError as msg:
             verbose(msg, level=2)
-            verbose("Not enough primes to do CRT lift; redoing with several more primes.", level=2, caller_name="multimod echelon")
-            M <<= M.bit_length() // 5 + 1
+            verbose("Not enough primes to do CRT lift; redoing with more "
+                    "primes.", level=2,
+                    caller_name="multimod echelon")
+            M = _multimodular_echelon_next_modulus(M, prod)
             continue
 
-        if not proof:
-            verbose("Not checking validity of result (since proof=False).", level=2, caller_name="multimod echelon")
-            break
-        d   = E.denominator()
-        hdE = int((d*E).height())
+        d = E.denominator()
+        dE = d*E
+        hdE = int(dE.height())
         if hdE * self.ncols() * height < prod:
-            verbose("Validity of result checked.", level=2, caller_name="multimod echelon")
+            verbose("Validity checked using the height bound.", level=2,
+                    caller_name="multimod echelon")
             break
+
+        if not proof:
+            r = len(best_pivots)
+            if _multimodular_echelon_candidate_has_shape(E, best_pivots):
+                dE_integer = dE[:r].change_ring(B.base_ring())
+                if d*B == B.matrix_from_columns(best_pivots) * dE_integer:
+                    verbose("Validity of early reconstruction checked.",
+                            level=2, caller_name="multimod echelon")
+                    break
+            verbose("Early reconstruction failed the row-space check; "
+                    "trying more primes.", level=2,
+                    caller_name="multimod echelon")
+            M = _multimodular_echelon_next_modulus(M, prod)
+            continue
+
         verbose("Validity failed; trying again with more primes.", level=2, caller_name="multimod echelon")
-        M <<= M.bit_length() // 5 + 1
+        M = _multimodular_echelon_next_modulus(M, prod)
     #end while
     verbose("total time",tm, level=2, caller_name="multimod echelon")
     return E, tuple(best_pivots)

--- a/src/sage/matrix/misc.pyx
+++ b/src/sage/matrix/misc.pyx
@@ -4,7 +4,7 @@ Misc matrix algorithms
 
 from cysignals.signals cimport sig_check
 
-from sage.arith.misc import CRT_basis, previous_prime
+from sage.arith.misc import CRT_basis, next_prime, previous_prime
 from sage.arith.rational_reconstruction cimport mpq_rational_reconstruction
 from sage.data_structures.binary_search cimport *
 from sage.ext.mod_int cimport *
@@ -195,6 +195,40 @@ def _multimodular_echelon_progress(p, prod, M):
         p, 100*float(len(str(prod))) / len(str(M)))
 
 
+_sparse_prime_product_cache = {}
+
+
+def _sparse_prime_product(max_modulus):
+    r"""
+    Return the product of all primes below ``max_modulus``, cached.
+
+    This is the largest modulus the optimized sparse modular backend can
+    reach, so it is what decides whether that backend can finish a given
+    reconstruction at all.  It depends on nothing but ``max_modulus``, hence
+    the cache: recomputing it costs about a millisecond, which would dominate
+    the echelon form of a small matrix.
+
+    TESTS::
+
+        sage: from sage.matrix.misc import _sparse_prime_product
+        sage: _sparse_prime_product(10)
+        210
+        sage: _sparse_prime_product(10) is _sparse_prime_product(10)
+        True
+        sage: from sage.matrix.matrix_modn_sparse import MAX_MODULUS
+        sage: _sparse_prime_product(MAX_MODULUS).nbits()
+        66444
+    """
+    cached = _sparse_prime_product_cache.get(max_modulus)
+    if cached is not None:
+        return cached
+    from sage.arith.misc import prime_range
+    from sage.misc.misc_c import prod as product
+    cached = Integer(product(prime_range(max_modulus)))
+    _sparse_prime_product_cache[max_modulus] = cached
+    return cached
+
+
 def _multimodular_echelon_next_modulus(M, prod):
     r"""
     Return the target modulus to use after a failed reconstruction attempt.
@@ -281,14 +315,24 @@ def matrix_rational_echelon_form_multimodular(Matrix self, height_guess=None, pr
       ``proof.linear_algebra`` or ``sage.structure.proof``). Note that the
       global Sage default is proof=True.  With ``proof=False``, the algorithm
       uses an explicitly supplied ``height_guess`` to attempt reconstruction
-      early and checks each candidate first with the usual height certificate;
-      if that fails, it checks the reduced-echelon shape and an exact row-space
-      identity.  The early attempt can reduce the number of modular images
-      when the output is much smaller than the input, but failed
+      early, subject to backend fallback, and checks each candidate first with
+      the usual height certificate; if that fails, it checks the
+      reduced-echelon shape and an exact row-space identity.  The early
+      attempt can reduce the number of modular images when the output is much
+      smaller than the input, but failed
       reconstructions and the exact check can also make it slower
 
     OUTPUT: a pair consisting of a matrix in echelon form and a tuple of pivot
     positions.
+
+    .. NOTE::
+
+        A sparse input that is already close to dense, and wide enough that
+        its echelon form can be far taller than itself, is delegated to dense
+        FLINT: the optimized sparse modular backend is capped at small moduli
+        and cannot always reach the required prime product.  The result is
+        still returned sparse, but ``height_guess`` and ``proof`` have no
+        effect on that path, since FLINT is exact.
 
     ALGORITHM:
 
@@ -312,7 +356,15 @@ def matrix_rational_echelon_form_multimodular(Matrix self, height_guess=None, pr
         M = c + 1 in order to attempt rational reconstruction earlier.
 
      3. List primes p_1, p_2, ..., such that the product of
-        the p_i is at least M.
+        the p_i is at least M.  Sparse matrices ordinarily start with the
+        primes supported by the optimized sparse modular backend.  If M
+        already exceeds the product of that complete finite range, start
+        genuinely sparse inputs directly with larger primes and generic
+        sparse matrices; otherwise switch to those matrices if the optimized
+        range is exhausted later.  When a wide input is already at least
+        three-quarters dense and a heuristic based on the target and a
+        Hadamard bound indicates that the complete optimized prime range may
+        be insufficient, use dense FLINT instead.
 
      4. Try to compute the rational reconstruction CRT echelon form
         of A mod the product of the p_i.  If rational
@@ -513,6 +565,81 @@ def matrix_rational_echelon_form_multimodular(Matrix self, height_guess=None, pr
         ....:                height_guess=46337, proof=False) == expected
         True
 
+    Check both ends of the optimized sparse prime range.  A target reached
+    only after using the final prime must be reconstructed immediately; if
+    the target is still not reached, the computation continues with generic
+    sparse matrices over larger primes::
+
+        sage: import sage.matrix.misc as matrix_misc
+        sage: import sage.matrix.matrix_modn_sparse as modn_sparse
+        sage: original_max_modulus = modn_sparse.MAX_MODULUS
+        sage: original_previous_prime = matrix_misc.previous_prime
+        sage: original_next_prime = matrix_misc.next_prime
+        sage: previous_prime_inputs = []
+        sage: next_prime_inputs = []
+        sage: def record_previous_prime(p):
+        ....:     previous_prime_inputs.append(p)
+        ....:     return original_previous_prime(p)
+        sage: def record_next_prime(p, proof=None):
+        ....:     next_prime_inputs.append(
+        ....:         (p > modn_sparse.MAX_MODULUS, proof))
+        ....:     return original_next_prime(p, proof=proof)
+        sage: modn_sparse.MAX_MODULUS = 4
+        sage: matrix_misc.previous_prime = record_previous_prime
+        sage: matrix_misc.next_prime = record_next_prime
+        sage: try:
+        ....:     A = matrix(QQ, [[1, 10, 0]], sparse=True)
+        ....:     expected = A.dense_matrix().echelon_form(algorithm='flint')
+        ....:     continued = A.echelon_form(
+        ....:         algorithm='multimodular', height_guess=1, proof=False)
+        ....:     continuation_trace = (list(previous_prime_inputs),
+        ....:                           list(next_prime_inputs))
+        ....:     previous_prime_inputs.clear()
+        ....:     next_prime_inputs.clear()
+        ....:     direct_input = matrix(QQ, [[1, 10, 0]], sparse=True)
+        ....:     direct = direct_input.echelon_form(
+        ....:         algorithm='multimodular', height_guess=8, proof=False)
+        ....:     direct_trace = (list(previous_prime_inputs),
+        ....:                     list(next_prime_inputs))
+        ....:     previous_prime_inputs.clear()
+        ....:     next_prime_inputs.clear()
+        ....:     dense_input = [[1, 1, 1], [1, 0, 1]]
+        ....:     dense_fallback = matrix(QQ, dense_input,
+        ....:                             sparse=True).echelon_form(
+        ....:         algorithm='multimodular', height_guess=1, proof=True)
+        ....:     dense_trace = (list(previous_prime_inputs),
+        ....:                    list(next_prime_inputs))
+        ....:     previous_prime_inputs.clear()
+        ....:     next_prime_inputs.clear()
+        ....:     early = matrix(QQ, dense_input, sparse=True).echelon_form(
+        ....:         algorithm='multimodular', height_guess=1, proof=False)
+        ....:     early_trace = (list(previous_prime_inputs),
+        ....:                    list(next_prime_inputs))
+        ....:     previous_prime_inputs.clear()
+        ....:     next_prime_inputs.clear()
+        ....:     boundary = matrix(QQ, [[1, 1]], sparse=True).echelon_form(
+        ....:         algorithm='multimodular', height_guess=2, proof=True)
+        ....:     boundary_trace = (list(previous_prime_inputs),
+        ....:                       list(next_prime_inputs))
+        ....: finally:
+        ....:     matrix_misc.next_prime = original_next_prime
+        ....:     matrix_misc.previous_prime = original_previous_prime
+        ....:     modn_sparse.MAX_MODULUS = original_max_modulus
+        sage: (continued == expected, continued.is_sparse(),
+        ....:  continuation_trace)
+        (True, True, ([5, 3], [(True, True)]))
+        sage: (direct == expected, direct.is_sparse(), direct_trace)
+        (True, True, ([], [(True, True)]))
+        sage: dense_fallback
+        [1 0 1]
+        [0 1 0]
+        sage: (dense_fallback.is_sparse(), dense_trace)
+        (True, ([], []))
+        sage: (early == dense_fallback, early_trace)
+        (True, ([5], []))
+        sage: (boundary, boundary_trace)
+        ([1 1], ([5, 3], []))
+
     Check that independent row scaling keeps the performance-critical bound
     small when rows have distinct denominators.  Counting calls to
     ``previous_prime`` avoids a timing-dependent test::
@@ -553,7 +680,13 @@ def matrix_rational_echelon_form_multimodular(Matrix self, height_guess=None, pr
 
     verbose("Multimodular echelon algorithm on %s x %s matrix" % (self._nrows, self._ncols), caller_name="multimod echelon")
     cdef Matrix E, dE
+    cdef Matrix_integer_sparse B_sparse
     cdef bint default_height_guess = height_guess is None
+    cdef bint dense_flint_candidate = False
+    cdef bint generic_sparse_moduli = False
+    cdef bint sparse_input = self.is_sparse()
+    cdef bint use_dense_flint = False
+    cdef Py_ssize_t i, nonzero_count
     if self._nrows == 0 or self._ncols == 0:
         return self, ()
 
@@ -578,9 +711,70 @@ def matrix_rational_echelon_form_multimodular(Matrix self, height_guess=None, pr
         # candidate is checked below.
         M = floor(max(2, height_guess + 1))
 
-    if self.is_sparse():
+    if sparse_input:
         from sage.matrix.matrix_modn_sparse import MAX_MODULUS
-        p = MAX_MODULUS + 1
+        # The generic sparse fallback below is deliberately retained for
+        # genuinely sparse matrices.  For a matrix whose storage is already
+        # close to dense, however, FLINT is both faster and memory-appropriate
+        # when the Hadamard reconstruction bound can exceed the complete
+        # optimized sparse prime range.
+        B_sparse = B
+        nonzero_count = 0
+        for i in range(self._nrows):
+            nonzero_count += B_sparse._matrix[i].num_nonzero
+        # Only a wide input can have an echelon form whose height is much
+        # larger than its own, which is what exhausts the prime range; a
+        # matrix with at least as many rows as columns either meets the
+        # full-rank shortcut below or has its output bounded by ``ncols``.
+        dense_flint_candidate = (
+            self._nrows < self._ncols
+            and 4 * nonzero_count >= 3 * self.nrows() * self.ncols())
+        sparse_prime_product = _sparse_prime_product(MAX_MODULUS)
+        if M > sparse_prime_product:
+            if dense_flint_candidate:
+                use_dense_flint = True
+            else:
+                from sage.rings.finite_rings.finite_field_constructor import GF
+                generic_sparse_moduli = True
+        elif dense_flint_candidate and (proof or default_height_guess):
+            # Compare the Hadamard bound 2 * r^r * H(B)^(2r) against the prime
+            # product.  Materializing it outright would build an integer of
+            # about 2*r*H(B).nbits() bits, which for a wide input with large
+            # entries dwarfs the matrix itself, so settle it from bit lengths
+            # whenever they are conclusive.  H(B)^(2r) has between
+            # 2r*(nbits(H)-1)+1 and 2r*nbits(H) bits; only when those straddle
+            # the prime product do we evaluate exactly, and there the value is
+            # by construction no larger than that product.
+            rank_bound = Integer(self._nrows)
+            head = 2 * rank_bound**rank_bound
+            threshold_bits = sparse_prime_product.nbits()
+            low_bits = head.nbits() + 2 * rank_bound * (height.nbits() - 1)
+            high_bits = head.nbits() + 2 * rank_bound * height.nbits()
+            if low_bits > threshold_bits:
+                use_dense_flint = True
+            elif high_bits < threshold_bits:
+                use_dense_flint = False
+            else:
+                use_dense_flint = (head * height**(2 * rank_bound)
+                                   >= sparse_prime_product)
+        if use_dense_flint:
+            verbose("Using dense FLINT because the optimized sparse "
+                    "prime range may be insufficient.", level=2,
+                    caller_name="multimod echelon")
+            B_sparse = None
+            B = None
+            E = self.dense_matrix()
+            E.echelonize(algorithm='flint:multimodular')
+            pivots = E.pivots()
+            result = E.sparse_matrix()
+            # ``echelonize`` caches the dense matrix as its own echelon form,
+            # so it would only be reclaimed by the cyclic collector.
+            E.clear_cache()
+            return result, pivots
+        if generic_sparse_moduli:
+            p = 1 << 255
+        else:
+            p = MAX_MODULUS + 1
     else:
         from sage.matrix.matrix_modn_dense_double import MAX_MODULUS
         p = MAX_MODULUS + 1
@@ -591,8 +785,22 @@ def matrix_rational_echelon_form_multimodular(Matrix self, height_guess=None, pr
     problem = 0
     lifts = {}
     while True:
-        p = previous_prime(p)
         while prod < M:
+            if generic_sparse_moduli:
+                p = next_prime(p, proof=True)
+            elif sparse_input and p <= 2:
+                # Matrix_modn_sparse is limited to small C-int moduli.  Once
+                # those primes are exhausted, keep the computation sparse but
+                # use fewer, larger primes to amortize the generic backend.
+                from sage.rings.finite_rings.finite_field_constructor import GF
+                generic_sparse_moduli = True
+                p = next_prime(1 << 255, proof=True)
+            else:
+                try:
+                    p = previous_prime(p)
+                except ValueError:
+                    raise RuntimeError("ran out of primes in multimodular "
+                                       "echelon form")
             problem = problem + 1
             if problem > 50:
                 verbose("echelon multi-modular possibly not converging?", caller_name="multimod echelon")
@@ -601,7 +809,10 @@ def matrix_rational_echelon_form_multimodular(Matrix self, height_guess=None, pr
                         level=2, caller_name="multimod echelon")
 
             # We use denoms=False, since the rows of B are integral.
-            A = B._mod_int(p)
+            if generic_sparse_moduli:
+                A = B.change_ring(GF(p))
+            else:
+                A = B._mod_int(p)
             t = verbose("time to reduce matrix mod p:",t, level=2, caller_name="multimod echelon")
             A.echelonize()
             t = verbose("time to put reduced matrix in echelon form:",t, level=2, caller_name="multimod echelon")
@@ -624,7 +835,6 @@ def matrix_rational_echelon_form_multimodular(Matrix self, height_guess=None, pr
                 # do not save A since it is bad.
                 verbose("Excluding this prime (bad pivots).", caller_name="multimod echelon")
             t = verbose("time for pivot compare", t, level=2, caller_name="multimod echelon")
-            p = previous_prime(p)
         # Find set of best matrices.
         Y = []
         # recompute product, since may drop bad matrices
@@ -632,13 +842,13 @@ def matrix_rational_echelon_form_multimodular(Matrix self, height_guess=None, pr
         t = verbose("now comparing pivots and dropping any bad ones", level=2, t=t, caller_name="multimod echelon")
         for i in range(len(X)):
             if cmp_pivots(best_pivots, X[i].pivots()) <= 0:
-                p = X[i].base_ring().order()
-                if p not in lifts:
+                q = X[i].base_ring().order()
+                if q not in lifts:
                     t0 = verbose("Lifting a good matrix", level=2, caller_name="multimod echelon")
                     lift = X[i].lift()
-                    lifts[p] = (lift, p)
+                    lifts[q] = (lift, q)
                     verbose("Finished lift", level=2, caller_name="multimod echelon", t=t0)
-                Y.append(lifts[p])
+                Y.append(lifts[q])
                 prod = prod * X[i].base_ring().order()
         verbose("finished comparing pivots", level=2, t=t, caller_name="multimod echelon")
         if prod < M:


### PR DESCRIPTION
Fixes #42411.

### Problem

`matrix_rational_echelon_form_multimodular` first clears denominators and runs **all** the modular reduction on the integer matrix `B`. The rational-reconstruction correctness check is

```
H(d*E) * ncols(A) * H(A) < prod(reduction primes)
```

where `H(A)` is the height of the *integer* matrix that was reduced mod the primes — this is exactly what the docstring's step 5 states. The code instead used `H(self)`, the height of the **rational** input.

For an input with denominators, `H(self)` can be far smaller than `H(B)`, so the bound was much too small. The algorithm then stopped with too few primes and verified against the wrong height, accepting an **incorrect** rational reconstruction.

This affected sparse `QQ` matrices by default (they use the Python multimodular algorithm) and dense matrices with `algorithm='multimodular'`. Minimal reproducer from the issue:

```python
sage: F = matrix(QQ, [[1000001000, -1/501000500, 3], [1, -1, 1]], sparse=True)
sage: F.echelon_form() == matrix(QQ, F.list(), nrows=2).echelon_form(algorithm='flint')
False   # before this PR
```

`proof=False` was affected even more broadly: it skipped verification entirely and sized the prime product from `height_guess` alone, unrelated to what rational reconstruction actually needs. It returned matrices whose row space was not even the row space of the input — for random rational matrices this happened in roughly a third of cases, and for plain integer matrices in about one in ten.

### Fix (first commit)

**Use the right height, and make that height small.** The bound must refer to the integer matrix that is actually reduced. Naively that is `self._clear_denom()[0]`, scaled by the *global* lcm of all denominators, whose height is enormous — using it would be correct but would cost a large number of extra primes.

Instead, denominators are now cleared **one row at a time**, and each row's content is divided out (`_clear_denom_rowwise` on `Matrix_rational_dense` / `Matrix_rational_sparse`). Row scaling does not change the echelon form, so the certificate stays valid, while the primitive integer matrix is dramatically smaller: on a 60×70 matrix with random rational entries, `H(B)` is **4121 bits instead of 249203**. The methods return the height, so no separate pass over the matrix is needed. As a bonus, no prime can divide an entire row of a primitive matrix.

In the sparse case only genuinely nonzero entries are stored, so `B` satisfies the sparse invariant that stored entries are nonzero even when the input carries explicitly stored zeros — as `_clear_denom` already did. Otherwise the ghost entries would also make the exact check below compare unequal for purely structural reasons, since sparse equality compares the stored dictionaries.

`height_guess` is now also based on that integer matrix, since `H(d*E)` tracks `H(B)`, not `H(self)`.

**`proof=False` is now correct, not merely unverified.** It first tries the standard height certificate; only if that fails does it fall back to an exact check — the candidate must have reduced-echelon shape for the computed pivots, and satisfy

```
d*B == B[:, P] * (d*E)[:r]
```

Together with `r = rank(B mod p) <= rank(B)` this proves `E` is the echelon form of `B` (and that `P` is the true pivot set), by uniqueness of the reduced echelon form. Early reconstruction is attempted only when the caller supplies an explicit `height_guess`; with the default guess there is no user knowledge to exploit, so it starts from the standard bound. Retry growth is geometric but always exceeds the current prime product, so a retry always buys at least one new prime.

**Drive-by fixes in the same code path.** `Matrix_rational_dense.echelon_form` accepted `height_guess` and `proof` and then silently dropped them (it called `E.echelonize(algorithm)`); they are forwarded now. It also cached every algorithm's result under a single key, so `echelon_form('multimodular')` could return a `'flint'` result; the key is per algorithm now, and an immutable matrix already in echelon form is still returned as itself rather than copied. `**kwds` stays documented as ignored — the multimodular routine accepts only `height_guess` and `proof`, so forwarding unknown keywords would only turn a previously ignored argument into a `TypeError`. `Matrix_rational_sparse` now defaults `proof=None`, so the global `proof.linear_algebra` flag is honoured as it already was for dense matrices.

For integer-entry matrices `B == self`, so the bound and the performance are unchanged; only matrices with genuine denominators are affected.

### Running out of primes (second commit)

`Matrix_modn_sparse` is capped at `MAX_MODULUS = 46341`, so the sparse multimodular path can only use the 4792 primes below that, whose product is 66444 bits. A rational echelon form needing a larger modulus walked off the bottom of the prime list and raised `ValueError: no previous prime`.

This is **pre-existing and independent of this issue** — `develop` fails identically on the same input — but the correct bound needs a larger prime product than the buggy one did, so leaving a crash one matrix-size away from the fix seemed wrong.

- A sparse input that is already at least three quarters dense, and wide enough that its echelon form can be far taller than itself, is delegated to dense FLINT; the result is still returned sparse. Whether the reconstruction bound outruns the prime range is decided from *bit lengths*, since materializing `2*r^r * H(B)^(2r)` would build an integer of about `2*r*H(B).nbits()` bits — far larger than the matrix itself.
- Any other sparse input that exhausts the optimized primes continues with generic sparse matrices over 256-bit primes instead of raising.
- The prime advance moved to the top of the inner loop (a retry no longer skips a prime) and the lift loop no longer clobbers `p`.

| matrix | develop | this PR |
|---|---|---|
| 60×70 sparse QQ, random rationals | `ValueError: no previous prime` (77.7 s) | **22.2 s, correct** |
| 60×70 sparse QQ, 30% dense, 40-bit | `ValueError: no previous prime` | **87.8 s, correct** |
| 40×45 sparse QQ | 22.6 s | **12.9 s** |

### Benchmarks

Wall time is min-of-3 (min-of-10 for the one sub-parity row, discussed below); `primes` counts prime *selections*, which is deterministic. It is not the number of modular images: develop's loop advanced the prime an extra time on every retry, so it selects more primes than it reduces by. `develop` = 10.10.beta5, same machine and script.

| case | develop | this PR | |
|---|---|---|---|
| int dense 40×50, 300-bit | 2.484 s / 935 | 2.481 s / 914 | — |
| int dense, `proof=False` | 2.878 s / 1004 | **2.377 s** / 914 | **1.21× faster** |
| row-denominator dense 80×100 | 0.370 s / 65 | **0.200 s** / 55 | **1.85× faster** |
| row-denominator dense, `proof=False` | 0.358 s / 67 | **0.186 s** / 55 | **1.92× faster** |
| row-denominator sparse 80×100 | 0.980 s / 102 | **0.746 s** / 101 | **1.31× faster** |
| row-denominator sparse, `proof=False` | 0.932 s / 103 | **0.726 s** / 101 | **1.28× faster** |
| random-rational dense 14×16 | 0.295 s / 602 | **0.204 s** / 596 | **1.45× faster** |
| random-rational dense, `proof=False` | 0.311 s / 629 | **0.208 s** / 596 | **1.50× faster** |
| small-denominator sparse 80×90 | 0.472 s / 128 | **0.396 s** / 107 | **1.19× faster** |
| small-denominator sparse, `proof=False` | 0.368 s / 123 | 0.388 s / 107 | 0.95× |
| `ModularSymbols(389,2)` | 0.052 s | 0.054 s | — |
| `ModularSymbols(1000,2)` | 0.543 s | 0.489 s | — |
| `ModularSymbols(97,2).decomposition()` | 0.111 s | 0.109 s | — |

Every case with denominators is **faster than develop** despite the larger (now correct) bound: the primitive row-wise clearing shrinks `B`'s entries enough that each `B._mod_int(p)` more than pays for the handful of extra primes. Integer matrices and modular symbols are unchanged, as expected — for them `B == self`.

The one cell below parity is small-denominator sparse with `proof=False`, and it is worth being precise about what that 5% buys. Counting the algorithm's own modular images on that matrix:

| build | mode | time | modular images | retry rounds |
|---|---|---|---|---|
| develop | `proof=True` | 0.391 s | 107 | 21 |
| develop | `proof=False` | 0.368 s | **101** | 22 |
| this PR | `proof=True` | 0.379 s | 107 | 19 |
| this PR | `proof=False` | 0.388 s | **107** | 19 |

The whole gap is six extra modular images. Develop's `proof=False` is `if not proof: break` — it returns at the first rational reconstruction that happens to succeed, which here is at 101 images, having checked nothing. This PR keeps going until the height certificate actually holds, at 107. That is exactly the mechanism by which develop's `proof=False` returned matrices whose row space was not the input's: it stops when *something* reconstructs, not when the result is provably right.

So the only thing that beats this PR on that matrix is develop's unverified answer. This PR's `proof=False` (0.388 s) is still marginally faster than develop's `proof=True` (0.391 s), and its `proof=True` is faster than develop's — same 107 images, but 19 retry rounds instead of 21, thanks to the retry-growth fix.

The issue's own 2×3 reproducer echelonizes in 0.35 ms.

### Testing

New doctests cover: the issue's matrix through both the dense `algorithm='multimodular'` and the sparse default path, and through `proof=False`; the exact row-space certificate rejecting a premature reconstruction and a bad-pivot-only reconstruction (with a `height_guess` at which the bad pivot set really does reach the check); the shape checker; that the cheap height certificate short-circuits the exact fallback; that row-wise clearing keeps the prime count small, and that it does not turn a stored zero into a stored entry of `B`; that `height_guess`/`proof` are forwarded by `echelon_form` while unknown keywords stay ignored, that its cache is per algorithm and that an immutable matrix in echelon form is its own echelon form, and that the sparse class honours `proof.linear_algebra`; and both ends of the optimized sparse prime range, including the switch to generic moduli and the dense-FLINT delegation.

Beyond the doctests, the branch was checked against `algorithm='flint'` on randomized and adversarial inputs, across dense × sparse × `proof` × `height_guess`: entries built from products of the first reduction primes to force bad pivots, reduction primes as denominators, rank-deficient and leading-zero-column cases, 1×2 matrices (the shape the reporter mentions), and sparse matrices deliberately carrying explicitly stored zeros — **0 mismatches in 6400 cases**, and no sparse matrix whose stored entries include a zero. Full doctest runs of `src/sage/matrix/`, `src/sage/modular/modsym/`, `src/sage/modular/hecke/` and `src/sage/modules/` pass.

### Noticed but out of scope

Three pre-existing bugs surfaced while working on this code. `develop` behaves identically on all three, so they are filed separately rather than widening this diff:

- #42531 — sparse `echelon_form` caches and returns a **mutable** matrix, so a caller can corrupt the cache: `E = A.echelon_form(); E[0,0] = 0` and `A.echelon_form()` then returns the mutated matrix. This is #10543, which was fixed for the dense class only.
- #42532 — `add_to_entry` calls neither `check_mutability()` nor `clear_cache()` in any matrix class, including the generic one in `matrix0.pyx` (unlike `__setitem__`). It therefore writes into immutable matrices and leaves `det()`, `rank()` and `echelon_form()` stale.
- #42533 — `matrix_integer_sparse_rational_reconstruction` leaks its GMP temporaries on the `ValueError` path, which the retry loop takes on every reconstruction that is not yet liftable.

### 📝 Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

