### PR TITLE
Speed up 2-adic valuation using trailing_zero_bits

### DIFF
--- a/src/sage/rings/integer.pxd
+++ b/src/sage/rings/integer.pxd
@@ -1,4 +1,4 @@
-from sage.libs.gmp.types cimport __mpz_struct, mpz_t, mpz_ptr
+from sage.libs.gmp.types cimport __mpz_struct, mp_bitcnt_t, mpz_t, mpz_ptr
 from sage.libs.gmp.mpz cimport mpz_set
 
 from sage.structure.element cimport EuclideanDomainElement, RingElement
@@ -23,6 +23,7 @@ cdef class Integer(EuclideanDomainElement):
     cdef _or(Integer self, Integer other)
     cdef _xor(Integer self, Integer other)
 
+    cpdef mp_bitcnt_t trailing_zero_bits(self) noexcept
     cpdef size_t _exact_log_log2_iter(self, Integer m) noexcept
     cpdef size_t _exact_log_mpfi_log(self, m) noexcept
     cpdef RingElement _valuation(Integer self, Integer p)

--- a/src/sage/rings/integer.pyi
+++ b/src/sage/rings/integer.pyi
@@ -37,6 +37,9 @@ class Integer(EuclideanDomainElement):
     def _xor(self, other: 'Integer') -> 'Integer':
         ...
 
+    def trailing_zero_bits(self) -> int:
+        ...
+
     def _exact_log_log2_iter(self, m: 'Integer') -> int:
         ...
 

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -1400,7 +1400,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
         """
         return self.bit_length()
 
-    def trailing_zero_bits(self):
+    cpdef mp_bitcnt_t trailing_zero_bits(self) noexcept:
         """
         Return the number of trailing zero bits in ``self``, i.e.
         the exponent of the largest power of 2 dividing ``self``.
@@ -1417,10 +1417,15 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             5
             sage: 0.trailing_zero_bits()
             0
+
+        TESTS::
+
+            sage: type(0.trailing_zero_bits()) is int
+            True
         """
         if mpz_sgn(self.value) == 0:
-            return int(0)
-        return int(mpz_scan1(self.value, 0))
+            return 0
+        return mpz_scan1(self.value, 0)
 
     def digits(self, base=10, digits=None, padto=0):
         r"""
@@ -4336,13 +4341,21 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
 
         - David Roe (3/31/07)
         """
+        cdef int cmp2
+        cdef Integer v
+        cdef mpz_t u
+
         if mpz_sgn(self.value) == 0:
             return sage.rings.infinity.infinity
-        if mpz_cmp_ui(p.value, 2) < 0:
+        cmp2 = mpz_cmp_ui(p.value, 2)
+        if cmp2 < 0:
             raise ValueError("You can only compute the valuation with respect to a integer larger than 1.")
 
-        cdef Integer v = PY_NEW(Integer)
-        cdef mpz_t u
+        v = PY_NEW(Integer)
+        if cmp2 == 0:
+            mpz_set_ui(v.value, mpz_scan1(self.value, 0))
+            return v
+
         mpz_init(u)
         sig_on()
         mpz_set_ui(v.value, mpz_remove(u, self.value, p.value))


### PR DESCRIPTION
Use the existing `trailing_zero_bits()` to compute the 2-adic valuation, as
suggested in #40375.

Two changes to `sage.rings.integer.Integer`:

- `trailing_zero_bits()` becomes a `cpdef` method returning `mp_bitcnt_t`,
  so it can be called from Cython without Python-call/boxing overhead. The
  Python-visible return type is unchanged (a plain `int`); a doctest pins
  this down.
- `_valuation()` gets a `p == 2` fast path that computes the valuation with
  `mpz_scan1` directly instead of the heavier `mpz_remove` (which also needs
  a scratch `mpz_t` and must traverse the whole number for odd inputs).

The error/zero handling and the `p != 2` path are unchanged, so behavior is
identical; only the `p == 2` case is faster.

### Benchmarks

Measured with full rebuilds of `develop` vs. this branch (`timeit`, best of 7,
ns/call):

| case | baseline | patched | speedup |
|---|--:|--:|--:|
| `valuation(2)`, small int | 128 | 89 | 1.45× |
| `valuation(2)`, large int (v₂=10⁵) | 1352 | 367 | 3.69× |
| `valuation(2)`, large odd int (v₂=0) | 392 | 90 | 4.37× |
| `p_primary_part(2)`, large int | 1650 | 660 | 2.50× |
| `a.trailing_zero_bits()` from Cython, small | 51 | 22 | 2.28× |
| `valuation(3)` (regression check) | 270 | 281 | ≈1× (noise) |

The non-2 path shows no measurable regression.

Fixes #40375.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

None.