### PR TITLE
Accept algorithm keyword in finite ring square roots

### DIFF
--- a/src/sage/rings/finite_rings/element_base.pyx
+++ b/src/sage/rings/finite_rings/element_base.pyx
@@ -836,13 +836,13 @@ cdef class FinitePolyExtElement(FiniteRingElement):
         a = self**(n // 2)
         return a == 1 or a == 0
 
-    def square_root(self, extend=False, all=False):
+    def square_root(self, extend=False, all=False, algorithm=None):
         """
         The square root function.
 
         INPUT:
 
-        - ``extend`` -- boolean (default: ``True``); if ``True``, return a
+        - ``extend`` -- boolean (default: ``False``); if ``True``, return a
           square root in an extension ring, if necessary. Otherwise, raise a
           :exc:`ValueError` if the root is not in the base ring.
 
@@ -852,6 +852,9 @@ cdef class FinitePolyExtElement(FiniteRingElement):
 
         - ``all`` -- boolean (default: ``False``); if ``True``, return all
           square roots of ``self``, instead of just one
+
+        - ``algorithm`` -- ignored; accepted for compatibility with finite
+          ring and finite field square-root interfaces
 
         .. WARNING::
 
@@ -868,6 +871,8 @@ cdef class FinitePolyExtElement(FiniteRingElement):
             3
             sage: F(4).square_root()
             2
+            sage: F(4).square_root(algorithm='tonelli')^2 == F(4)
+            True
             sage: K = FiniteField(7^3, 'alpha', implementation='pari_ffelt')
             sage: K(3).square_root()
             Traceback (most recent call last):
@@ -879,7 +884,7 @@ cdef class FinitePolyExtElement(FiniteRingElement):
         except ValueError:
             raise ValueError("must be a perfect square.")
 
-    def sqrt(self, extend=False, all=False):
+    def sqrt(self, extend=False, all=False, algorithm=None):
         """
         See :meth:`square_root`.
 
@@ -889,7 +894,7 @@ cdef class FinitePolyExtElement(FiniteRingElement):
             sage: (a^3 - a - 1).sqrt()
             a^16 + 2*a^15 + a^13 + 2*a^12 + a^10 + 2*a^9 + 2*a^8 + a^7 + a^6 + 2*a^5 + a^4 + 2*a^2 + 2*a + 2
         """
-        return self.square_root(extend=extend, all=all)
+        return self.square_root(extend=extend, all=all, algorithm=algorithm)
 
     def nth_root(self, n, extend=False, all=False, algorithm=None, cunningham=False):
         r"""

--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -1038,14 +1038,14 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
         else:
             return self.element % 2 == 0
 
-    def sqrt(FiniteField_givaroElement self, extend=False, all=False):
+    def sqrt(FiniteField_givaroElement self, extend=False, all=False, algorithm=None):
         """
         Return a square root of this finite field element in its
         parent, if there is one.  Otherwise, raise a :exc:`ValueError`.
 
         INPUT:
 
-        - ``extend`` -- boolean (default: ``True``); if ``True``, return a
+        - ``extend`` -- boolean (default: ``False``); if ``True``, return a
           square root in an extension ring, if necessary. Otherwise,
           raise a :exc:`ValueError` if the root is not in the base ring.
 
@@ -1055,6 +1055,9 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
 
         - ``all`` -- boolean (default: ``False``); if ``True``, return all
           square roots of ``self``, instead of just one
+
+        - ``algorithm`` -- ignored; accepted for compatibility with finite
+          ring and finite field square-root interfaces
 
         .. WARNING::
 
@@ -1096,6 +1099,8 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
             sage: K.<a> = FiniteField(9)
             sage: a.sqrt(extend = False, all = True)
             []
+            sage: K(4).sqrt(algorithm='tonelli')^2 == K(4)
+            True
         """
         if all:
             if self.is_square():

--- a/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
+++ b/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
@@ -640,9 +640,20 @@ cdef class FiniteField_ntl_gf2eElement(FinitePolyExtElement):
         """
         return True
 
-    def sqrt(FiniteField_ntl_gf2eElement self, all=False, extend=False):
+    def sqrt(FiniteField_ntl_gf2eElement self, all=False, extend=False, algorithm=None):
         """
         Return a square root of this finite field element in its parent.
+
+        INPUT:
+
+        - ``all`` -- boolean (default: ``False``); if ``True``, return all
+          square roots of ``self``, instead of just one
+
+        - ``extend`` -- ignored; accepted for compatibility with other finite
+          field implementations
+
+        - ``algorithm`` -- ignored; accepted for compatibility with finite
+          ring and finite field square-root interfaces
 
         EXAMPLES::
 
@@ -652,6 +663,8 @@ cdef class FiniteField_ntl_gf2eElement(FinitePolyExtElement):
             sage: a.sqrt()
             a^19 + a^15 + a^14 + a^12 + a^9 + a^7 + a^4 + a^3 + a + 1
             sage: a.sqrt()^2 == a
+            True
+            sage: a.sqrt(algorithm='tonelli')^2 == a
             True
 
         This failed before :issue:`4899`::

--- a/src/sage/rings/finite_rings/element_pari_ffelt.pyx
+++ b/src/sage/rings/finite_rings/element_pari_ffelt.pyx
@@ -1026,7 +1026,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
         sig_off()
         return bool(i)
 
-    def sqrt(self, extend=False, all=False):
+    def sqrt(self, extend=False, all=False, algorithm=None):
         """
         Return a square root of ``self``, if it exists.
 
@@ -1039,6 +1039,9 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
                This option is not implemented.
 
         - ``all`` -- boolean (default: ``False``)
+
+        - ``algorithm`` -- ignored; accepted for compatibility with finite
+          ring and finite field square-root interfaces
 
         OUTPUT:
 
@@ -1078,6 +1081,8 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
             sage: K.<a> = GF(3^17, implementation='pari_ffelt')
             sage: (a^3 - a - 1).sqrt()
             a^16 + 2*a^15 + a^13 + 2*a^12 + a^10 + 2*a^9 + 2*a^8 + a^7 + a^6 + 2*a^5 + a^4 + 2*a^2 + 2*a + 2
+            sage: K(4).sqrt(algorithm='tonelli')^2 == K(4)
+            True
         """
         if extend:
             raise NotImplementedError

--- a/src/sage/rings/finite_rings/integer_mod.pyx
+++ b/src/sage/rings/finite_rings/integer_mod.pyx
@@ -1106,7 +1106,7 @@ cdef class IntegerMod_abstract(FiniteRingElement):
         # letting PARI do it, so that we can cache the factorisation.
         return lift.__pari__().Zn_issquare(self._parent.factored_order())
 
-    def sqrt(self, extend=True, all=False):
+    def sqrt(self, extend=True, all=False, algorithm=None):
         r"""
         Return square root or square roots of ``self`` modulo `n`.
 
@@ -1118,6 +1118,9 @@ cdef class IntegerMod_abstract(FiniteRingElement):
 
         - ``all`` -- boolean (default: ``False``); if ``True``, return {all}
           square roots of self, instead of just one
+
+        - ``algorithm`` -- ignored; accepted for compatibility with finite
+          ring and finite field square-root interfaces
 
         ALGORITHM: Calculates the square roots mod `p` for each of
         the primes `p` dividing the order of the ring, then lifts
@@ -1147,6 +1150,8 @@ cdef class IntegerMod_abstract(FiniteRingElement):
             9
             sage: Mod(1/25, next_prime(2^90)).sqrt()^(-2)
             25
+            sage: GF(next_prime(2^40))(4).sqrt(algorithm='tonelli')^2
+            4
 
         Error message as requested in :issue:`38802`::
 
@@ -2906,7 +2911,7 @@ cdef class IntegerMod_int(IntegerMod_abstract):
         # letting PARI do it, so that we can cache the factorisation.
         return lift.__pari__().Zn_issquare(self._parent.factored_order())
 
-    def sqrt(self, extend=True, all=False):
+    def sqrt(self, extend=True, all=False, algorithm=None):
         r"""
         Return square root or square roots of ``self`` modulo `n`.
 
@@ -2920,6 +2925,9 @@ cdef class IntegerMod_int(IntegerMod_abstract):
         - ``all`` -- boolean (default: ``False``); if
           ``True``, return {all} square roots of self, instead of
           just one.
+
+        - ``algorithm`` -- ignored; accepted for compatibility with finite
+          ring and finite field square-root interfaces
 
         ALGORITHM: Calculates the square roots mod `p` for each of
         the primes `p` dividing the order of the ring, then lifts
@@ -2949,6 +2957,8 @@ cdef class IntegerMod_int(IntegerMod_abstract):
             9
             sage: Mod(1/25, next_prime(2^90)).sqrt()^(-2)
             25
+            sage: GF(107)(4).sqrt(algorithm='tonelli')^2
+            4
 
         ::
 
@@ -3050,7 +3060,7 @@ cdef class IntegerMod_int(IntegerMod_abstract):
                         return []
                     raise ValueError("self must be a square")
         # Either it failed but extend was True, or the generic algorithm is better
-        return IntegerMod_abstract.sqrt(self, extend=extend, all=all)
+        return IntegerMod_abstract.sqrt(self, extend=extend, all=all, algorithm=algorithm)
 
     def _balanced_abs(self):
         r"""


### PR DESCRIPTION
Part of #40796

Concrete finite ring and finite field square-root implementations currently reject `algorithm=...`, even though the finite-field category method accepts that keyword. This makes the keyword accepted by the concrete `sqrt` and `square_root` methods touched here, while keeping their current backend behavior unchanged

I also fixed two nearby doc default mismatches for `extend=False`

Tests:
- `git diff --check`
- `./sage -b`
- `./sage -tox -e rst -- src/sage/rings/finite_rings/element_base.pyx src/sage/rings/finite_rings/element_givaro.pyx src/sage/rings/finite_rings/element_ntl_gf2e.pyx src/sage/rings/finite_rings/element_pari_ffelt.pyx src/sage/rings/finite_rings/integer_mod.pyx`
- `./sage -tox -e relint -- src/sage/rings/finite_rings/element_base.pyx src/sage/rings/finite_rings/element_givaro.pyx src/sage/rings/finite_rings/element_ntl_gf2e.pyx src/sage/rings/finite_rings/element_pari_ffelt.pyx src/sage/rings/finite_rings/integer_mod.pyx`
- `./sage -t --long src/sage/rings/finite_rings/element_givaro.pyx src/sage/rings/finite_rings/element_ntl_gf2e.pyx src/sage/rings/finite_rings/element_pari_ffelt.pyx src/sage/rings/finite_rings/element_base.pyx src/sage/rings/finite_rings/integer_mod.pyx`

### :memo: Checklist

- [x] The title is concise and informative
- [x] The description explains in detail what this PR is about
- [x] I have linked a relevant issue or discussion
- [x] I have created tests covering the changes
- [ ] I have updated the documentation and checked the documentation preview

### :hourglass: Dependencies

None
