### PR TITLE
graphs: support planarity 3 (graph.h) again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -726,3 +726,10 @@ ignore = ["E501", "E741"]
 no-build-isolation-package = ["sagemath"]
 # Build these packages from source instead of installing pre-built wheels.
 no-binary-package = ["cypari2", "pplpy", "primecountpy"]
+# These are built from source against system libraries (PARI, PPL, primecount).
+# uv caches the built wheel keyed by the sdist hash and Python/platform tag, not
+# by the system library soname, so a cached wheel goes stale when a distro bumps
+# a soname (e.g. PARI libpari-gmp-tls.so.8 -> .so.9). reinstall-package implies
+# --refresh-package, evicting the stale cache so they rebuild against the
+# currently installed libraries.
+reinstall-package = ["cypari2", "pplpy", "primecountpy"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -726,10 +726,3 @@ ignore = ["E501", "E741"]
 no-build-isolation-package = ["sagemath"]
 # Build these packages from source instead of installing pre-built wheels.
 no-binary-package = ["cypari2", "pplpy", "primecountpy"]
-# These are built from source against system libraries (PARI, PPL, primecount).
-# uv caches the built wheel keyed by the sdist hash and Python/platform tag, not
-# by the system library soname, so a cached wheel goes stale when a distro bumps
-# a soname (e.g. PARI libpari-gmp-tls.so.8 -> .so.9). reinstall-package implies
-# --refresh-package, evicting the stale cache so they rebuild against the
-# currently installed libraries.
-reinstall-package = ["cypari2", "pplpy", "primecountpy"]

--- a/src/sage/graphs/meson.build
+++ b/src/sage/graphs/meson.build
@@ -21,6 +21,18 @@ if not planarity.found()
     disabler: true,
   )
 endif
+planarity_compile_args = []
+if planarity.found()
+  if cc.has_header('planarity/graphLib.h', dependencies: planarity)
+    planarity_compile_args += '-DSAGE_PLANARITY_HAVE_GRAPHLIB_H'
+  elif cc.has_header('planarity/graph.h', dependencies: planarity)
+    planarity_compile_args += '-DSAGE_PLANARITY_HAVE_GRAPH_H'
+  else
+    error(
+      'planarity library found, but neither planarity/graphLib.h nor planarity/graph.h is available',
+    )
+  endif
+endif
 
 py.install_sources(
   '__init__.py',
@@ -119,16 +131,19 @@ extension_data = {
 
 foreach name, pyx : extension_data
   deps = [py_dep, cysignals, flint, gmp]
+  c_args = []
   if name == 'cliquer'
     deps += cliquer
   elif name == 'planarity'
     deps += planarity
+    c_args += planarity_compile_args
   endif
   py.extension_module(
     name,
     sources: pyx,
     subdir: 'sage/graphs',
     install: true,
+    c_args: c_args,
     include_directories: [
       inc_cpython,
       inc_data_structures,

--- a/src/sage/graphs/planarity-compat.h
+++ b/src/sage/graphs/planarity-compat.h
@@ -1,5 +1,51 @@
-#include <planarity/graphLib.h>
+#ifndef SAGE_GRAPHS_PLANARITY_COMPAT_H
+#define SAGE_GRAPHS_PLANARITY_COMPAT_H
 
-#if GP_PROJECTVERSION_MAJOR < 5
+/*
+ * Compatibility shim across releases of the edge-addition-planarity-suite.
+ *
+ * Header location:
+ *   - planarity 3 installs only <planarity/graph.h>;
+ *   - planarity 4 installs <planarity/graphLib.h> and a <planarity/graph.h> shim;
+ *   - planarity 5 installs only <planarity/graphLib.h>.
+ * graphLib.h is therefore preferred whenever it is present.
+ *
+ * Function name:
+ *   - up to planarity 4 the vertex-capacity routine is gp_InitGraph();
+ *   - planarity 5 renamed it to gp_EnsureVertexCapacity().
+ * planarity.pyx always calls gp_EnsureVertexCapacity(); for older releases it is
+ * aliased back to gp_InitGraph() below.
+ *
+ * meson.build probes for the headers and defines SAGE_PLANARITY_HAVE_GRAPHLIB_H
+ * or SAGE_PLANARITY_HAVE_GRAPH_H; the __has_include path is only a fallback for
+ * compiling this header outside the meson build.
+ */
+#if defined(SAGE_PLANARITY_HAVE_GRAPHLIB_H)
+#include <planarity/graphLib.h>
+#elif defined(SAGE_PLANARITY_HAVE_GRAPH_H)
+#include <planarity/graph.h>
+#define SAGE_PLANARITY_NEEDS_INITGRAPH_ALIAS
+#elif defined(__has_include)
+#if __has_include(<planarity/graphLib.h>)
+#include <planarity/graphLib.h>
+#elif __has_include(<planarity/graph.h>)
+#include <planarity/graph.h>
+#define SAGE_PLANARITY_NEEDS_INITGRAPH_ALIAS
+#else
+#error "neither planarity/graphLib.h nor planarity/graph.h is available"
+#endif
+#else
+#include <planarity/graphLib.h>
+#endif
+
+/*
+ * Alias gp_EnsureVertexCapacity() to gp_InitGraph() for releases predating the
+ * rename: the graph.h path (planarity 3, which does not define
+ * GP_PROJECTVERSION_MAJOR) and planarity 4 (GP_PROJECTVERSION_MAJOR == 4).
+ */
+#if defined(SAGE_PLANARITY_NEEDS_INITGRAPH_ALIAS) || \
+    (defined(GP_PROJECTVERSION_MAJOR) && GP_PROJECTVERSION_MAJOR < 5)
 #define gp_EnsureVertexCapacity gp_InitGraph
+#endif
+
 #endif


### PR DESCRIPTION
### 📚 Description

gh-42405 switched the planarity wrapper to `#include <planarity/graphLib.h>`
unconditionally. planarity 3 installs only `<planarity/graph.h>`, so building
against it now fails — this breaks the Ubuntu 26.04 CI job, which ships
`libplanarity 3.0.2.0`:

```
planarity-compat.h:1:10: fatal error: planarity/graphLib.h: No such file or directory
    1 | #include <planarity/graphLib.h>
```

This PR restores planarity 3 support while keeping planarity 4/5 working:

- `meson.build` probes for `planarity/graphLib.h` (preferred) or
  `planarity/graph.h` and defines `SAGE_PLANARITY_HAVE_GRAPHLIB_H` /
  `SAGE_PLANARITY_HAVE_GRAPH_H` accordingly, passed as compile args to the
  `planarity` extension only.
- `planarity-compat.h` includes the detected header (with an `__has_include`
  fallback for compilation outside meson) and aliases the planarity-5
  `gp_EnsureVertexCapacity()` back to `gp_InitGraph()` for releases that predate
  the rename: planarity 3 (which does not define `GP_PROJECTVERSION_MAJOR`) and
  planarity 4 (`GP_PROJECTVERSION_MAJOR == 4`).

Verified against the upstream `Version_3.0.2.0` headers that `graph.h` exposes
`gp_InitGraph(graphP, int)`, the `vertexRec`/`edgeRec` and `V`/`E`/`N` graph
layout, and the `OK`/`NOTOK`/`NONEMBEDDABLE`/`EMBEDFLAGS_PLANAR` constants the
wrapper relies on, so it both compiles and links. The fix is exercised by the
existing `planarity` doctests on the planarity-3 CI runner.

### ⌛ Dependencies

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
