### PR TITLE
Docs: Add docstring and example to MySFBasis.__init__

### DIFF
--- a/src/doc/en/thematic_tutorials/tutorial-implementing-algebraic-structures.rst
+++ b/src/doc/en/thematic_tutorials/tutorial-implementing-algebraic-structures.rst
@@ -495,20 +495,20 @@ with respect to `h`; namely, we set `X_\lambda = \sum_{\mu\geq \lambda, |\mu|=|\
     ....:
     ....:     def __init__(self, R, *args, **kwargs):
     ....:         """
-                    Initialize the basis.
-
-                    INPUT:
-
-                    - ``R`` -- the base ring.
-                    - ``*args``, ``**kwargs`` -- optional arguments passed to the
-                    :class:`CombinatorialFreeModule` constructor.
-
-                    EXAMPLE::
-
-                        sage: X = MySFBasis(QQ, prefix='x')
-                        sage: X
-                        Jason's basis for symmetric functions over Rational Field
-                    """
+    ....:         Initialize the basis.
+    ....:
+    ....:         INPUT:
+    ....:
+    ....:         - ``R`` -- the base ring.
+    ....:         - ``*args``, ``**kwargs`` -- optional arguments passed to the
+    ....:           :class:`CombinatorialFreeModule` constructor.
+    ....:
+    ....:         EXAMPLE::
+    ....:
+    ....:             sage: X = MySFBasis(QQ, prefix='x')
+    ....:             sage: X
+    ....:             Jason's basis for symmetric functions over Rational Field
+    ....:         """
     ....:         CombinatorialFreeModule.__init__(self, R, Partitions(), category=AlgebrasWithBasis(R), *args, **kwargs)
     ....:         self._h = SymmetricFunctions(R).homogeneous()
     ....:         self._to_h = self.module_morphism( self._to_h_on_basis, triangular='lower', unitriangular=True, codomain=self._h)

--- a/src/doc/en/thematic_tutorials/tutorial-implementing-algebraic-structures.rst
+++ b/src/doc/en/thematic_tutorials/tutorial-implementing-algebraic-structures.rst
@@ -494,7 +494,21 @@ with respect to `h`; namely, we set `X_\lambda = \sum_{\mu\geq \lambda, |\mu|=|\
     ....:     """
     ....:
     ....:     def __init__(self, R, *args, **kwargs):
-    ....:         """ TODO: Informative doc-string and examples """
+    ....:         """
+                    Initialize the basis.
+
+                    INPUT:
+
+                    - ``R`` -- the base ring.
+                    - ``*args``, ``**kwargs`` -- optional arguments passed to the
+                    :class:`CombinatorialFreeModule` constructor.
+
+                    EXAMPLE::
+
+                        sage: X = MySFBasis(QQ, prefix='x')
+                        sage: X
+                        Jason's basis for symmetric functions over Rational Field
+                    """
     ....:         CombinatorialFreeModule.__init__(self, R, Partitions(), category=AlgebrasWithBasis(R), *args, **kwargs)
     ....:         self._h = SymmetricFunctions(R).homogeneous()
     ....:         self._to_h = self.module_morphism( self._to_h_on_basis, triangular='lower', unitriangular=True, codomain=self._h)

--- a/src/doc/en/thematic_tutorials/tutorial-implementing-algebraic-structures.rst
+++ b/src/doc/en/thematic_tutorials/tutorial-implementing-algebraic-structures.rst
@@ -499,15 +499,14 @@ with respect to `h`; namely, we set `X_\lambda = \sum_{\mu\geq \lambda, |\mu|=|\
     ....:
     ....:         INPUT:
     ....:
-    ....:         - ``R`` -- the base ring.
+    ....:         - ``R`` -- the base ring
     ....:         - ``*args``, ``**kwargs`` -- optional arguments passed to the
-    ....:           :class:`CombinatorialFreeModule` constructor.
+    ....:           :class:`CombinatorialFreeModule` constructor
     ....:
     ....:         EXAMPLE::
     ....:
     ....:             sage: X = MySFBasis(QQ, prefix='x')
-    ....:             sage: X
-    ....:             Jason's basis for symmetric functions over Rational Field
+    ....:             sage: TestSuite(X).run()
     ....:         """
     ....:         CombinatorialFreeModule.__init__(self, R, Partitions(), category=AlgebrasWithBasis(R), *args, **kwargs)
     ....:         self._h = SymmetricFunctions(R).homogeneous()


### PR DESCRIPTION
**Description:**
This PR replaces a TODO placeholder in tutorial-implementing-algebraic-structures.rst with an informative docstring for the __init__ method of MySFBasis.

The __init__ method lacked documentation regarding its input parameters and usage. I have added INPUT and EXAMPLE sections consistent with the existing documentation standards to help new users understand the initialization of this basis. I verified the example by running the doctest locally to ensure consistency with the current implementation.

Fixes #42429

:memo: **Checklist**
[x] The title is concise and informative.
[x] The description explains in detail what this PR is about.
[x] I have linked a relevant issue or discussion.
[x] I have created tests covering the changes.
[x] I have updated the documentation and checked the documentation preview.