### PR TITLE
Add freelist to ETuple to reduce allocation overhead

### DIFF
--- a/src/sage/rings/polynomial/polydict.pyx
+++ b/src/sage/rings/polynomial/polydict.pyx
@@ -1343,6 +1343,9 @@ cdef inline bint dual_etuple_iter(ETuple self, ETuple other, size_t *ind1, size_
             ind2[0] += 1
     return 1
 
+# ETuples are short-lived in polynomial arithmetic; this reuses the Python
+# object shell while keeping _data allocation/deallocation unchanged.
+@cython.freelist(1000)
 cdef class ETuple:
     """
     Representation of the exponents of a polydict monomial. If


### PR DESCRIPTION
### 📚 Description

`ETuple` (the sparse exponent vector behind every `polydict` monomial) is
allocated and freed constantly during multivariate polynomial arithmetic over
the generic implementation. This PR decorates the class with
`@cython.freelist(1000)` so Cython recycles the Python object *shell* on
deallocation instead of routing every short-lived instance through
`tp_alloc`/`tp_free`.

The `_data` exponent buffer (`sig_malloc`/`sig_free`) is **untouched** — only
the object header is pooled — so there is no behavioral change and no risk of
the memory leak that stalled the earlier hand-rolled pool in #26291. There is
precedent for this exact mechanism in the tree (`coerce_dict.pyx` uses
`@cython.freelist(256)`).

This is a small, self-contained step toward the pooling goal of #26291.

### ✅ Correctness

`ETuple` has no Python-object C members (`_length`, `_nonzero`, `int *_data`),
so it is not GC-tracked and the freelist is safe. It has no subclasses, and
`__dealloc__` frees `_data` before the shell is cached. Cython `memset`s a
recycled shell to zero before `__cinit__`, preserving the zero-initialization
that `ETuple.__mul__(factor <= 0)` and `_new()` rely on.

Tested on a local build:

- `src/sage/rings/polynomial/polydict.pyx` — 392/392 doctests pass
- `src/sage/rings/polynomial/multi_polynomial_element.py` — 539/539 doctests pass

### 📈 Benchmark

Measured by recompiling each side (with/without the decorator) and running the
script below; median ns/op, `length=20`. The microbenchmark numbers were stable
across repeated runs.

| Benchmark | before | after | speedup | note |
| --- | ---: | ---: | ---: | --- |
| `new_dense` (pure `_new()` alloc) | 25.9 | 23.0 | **1.13x** | direct freelist win, stable |
| `emin_eadd_dense` | 202.8 | 193.6 | 1.05x | stable |
| `eadd_p_insert_sparse` | 62.1 | 59.6 | 1.04x | stable |
| `eadd_dense` | 103.0 | 99.2 | 1.04x | stable |
| `eadd_sparse` | 74.3 | 71.9 | 1.03x | |
| `init_list_dense` | 286.9 | 288.5 | ~1.00x | `_data`-malloc bound (expected flat) |
| `init_dict_sparse` | 396.9 | 400.3 | ~1.00x | `_data`-malloc bound (expected flat) |
| `generic_polydict_power` (8 vars, deg 9) | 85.6 ms | 83.3 ms | 1.03x | within noise |
| `generic_monomial_hilbert_series` | 12.4 ms | 12.7 ms | ~1.00x | within noise |

The gain is concentrated in the object-allocation path (~5-13%). Constructors
dominated by the `_data` allocation are flat, exactly as expected since the
freelist only pools the shell. Large arithmetic workloads improve only within
run-to-run noise at these sizes — so the honest framing is "lower ETuple
allocation overhead," not "faster polynomial arithmetic."

<details>
<summary>Benchmark script used (not included in this PR; run from the repo root)</summary>

```bash
./sage --python benchmark_etuple.py --markdown logs/issue-26291-etuple.md
```

```python
#!/usr/bin/env python3
"""
Benchmark ETuple allocation and ETuple-heavy polynomial workloads.

Run from the Sage source tree with::

    ./sage --python tools/benchmark_etuple.py --markdown logs/issue-26291-etuple.md

The benchmarks are intended for comparing branches while investigating
https://github.com/sagemath/sage/issues/26291.  They are not doctests: timing
thresholds would be too noisy for the normal test suite.
"""

from __future__ import annotations

import argparse
import json
import platform
import statistics
import subprocess
import sys
import timeit
from pathlib import Path
from typing import Any, Callable


MICROBENCH_CODE = r"""
from sage.rings.polynomial.polydict cimport ETuple


def bench_new(ETuple T, int loops):
    cdef int i
    cdef ETuple U
    for i in range(loops):
        U = T._new()


def bench_eadd(ETuple T, int loops):
    cdef int i
    cdef ETuple U
    for i in range(loops):
        U = T.eadd(T)


def bench_emin_eadd(ETuple T, int loops):
    cdef int i
    cdef ETuple U = T
    for i in range(loops):
        U = T.emin(T.eadd(T))


def bench_eadd_p_insert(ETuple T, int loops):
    cdef int i
    cdef ETuple U = T
    for i in range(loops):
        U = T.eadd_p(1, 0)


def bench_init_from_list(object values, int loops):
    cdef int i
    cdef ETuple U
    for i in range(loops):
        U = ETuple(values)


def bench_init_from_dict(object values, int length, int loops):
    cdef int i
    cdef ETuple U
    for i in range(loops):
        U = ETuple(values, length)
"""


def git_revision() -> str:
    try:
        return subprocess.check_output(
            ["git", "rev-parse", "--short", "HEAD"],
            text=True,
            stderr=subprocess.DEVNULL,
        ).strip()
    except Exception:
        return "unknown"


def load_microbench_module():
    from sage.misc.cython import compile_and_load

    return compile_and_load(MICROBENCH_CODE)


def summarize(seconds: list[float], operations: int) -> dict[str, Any]:
    per_op = [value / operations for value in seconds]
    return {
        "best_s": min(seconds),
        "median_s": statistics.median(seconds),
        "best_ns_per_op": min(per_op) * 1e9,
        "median_ns_per_op": statistics.median(per_op) * 1e9,
        "samples_s": seconds,
    }


def time_callable(
    func: Callable[[], Any],
    *,
    operations: int,
    repeat: int,
    number: int,
    warmup: int,
) -> dict[str, Any]:
    for _ in range(warmup):
        func()
    samples = timeit.repeat(func, repeat=repeat, number=number)
    return summarize(samples, operations * number)


def run_microbenchmarks(args: argparse.Namespace) -> list[dict[str, Any]]:
    from sage.rings.polynomial.polydict import ETuple

    module = load_microbench_module()
    dense_values = list(range(args.length))
    sparse_values = [0] * args.length
    for index in range(0, args.length, max(1, args.length // args.nonzero)):
        sparse_values[index] = index + 1
    sparse_values = sparse_values[: args.length]
    sparse_dict = {index: value for index, value in enumerate(sparse_values) if value}

    dense = ETuple(dense_values)
    sparse = ETuple(sparse_values)

    cases = [
        ("new_dense", lambda: module.bench_new(dense, args.inner_loops), dense),
        ("eadd_dense", lambda: module.bench_eadd(dense, args.inner_loops), dense),
        ("emin_eadd_dense", lambda: module.bench_emin_eadd(dense, args.inner_loops), dense),
        ("init_list_dense", lambda: module.bench_init_from_list(dense_values, args.inner_loops), dense),
        ("init_dict_sparse", lambda: module.bench_init_from_dict(sparse_dict, args.length, args.inner_loops), sparse),
        ("eadd_sparse", lambda: module.bench_eadd(sparse, args.inner_loops), sparse),
        ("eadd_p_insert_sparse", lambda: module.bench_eadd_p_insert(sparse, args.inner_loops), sparse),
    ]

    results = []
    for name, func, etuple in cases:
        timing = time_callable(
            func,
            operations=args.inner_loops,
            repeat=args.repeat,
            number=args.number,
            warmup=args.warmup,
        )
        timing.update(
            {
                "group": "micro",
                "name": name,
                "length": len(etuple),
                "nonzero": len(etuple.nonzero_positions()),
                "inner_loops": args.inner_loops,
            }
        )
        results.append(timing)
    return results


def run_dict_key_benchmarks(args: argparse.Namespace) -> list[dict[str, Any]]:
    from sage.rings.polynomial.polydict import ETuple

    left = [ETuple({i % args.length: i + 1}, args.length) for i in range(args.dict_terms)]
    right = [ETuple({(2 * i + 1) % args.length: i + 2}, args.length) for i in range(args.dict_terms)]

    def build_eadd_dict():
        data = {}
        for e0 in left:
            for e1 in right:
                e = e0.eadd(e1)
                data[e] = data.get(e, 0) + 1
        return data

    return [
        {
            "group": "micro",
            "name": "fresh_eadd_dict_keys",
            "length": args.length,
            "left_terms": len(left),
            "right_terms": len(right),
            **time_callable(
                build_eadd_dict,
                operations=len(left) * len(right),
                repeat=args.repeat,
                number=args.number,
                warmup=args.warmup,
            ),
        }
    ]


def run_polynomial_workloads(args: argparse.Namespace) -> list[dict[str, Any]]:
    from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
    from sage.rings.rational_field import QQ

    results = []

    def generic_power():
        ring = PolynomialRing(QQ, args.poly_vars, "x", implementation="generic")
        elt = sum(ring.gens())
        elt ** args.poly_degree

    results.append(
        {
            "group": "workload",
            "name": "generic_polydict_power",
            "vars": args.poly_vars,
            "degree": args.poly_degree,
            **time_callable(
                generic_power,
                operations=1,
                repeat=args.repeat,
                number=args.workload_number,
                warmup=args.warmup,
            ),
        }
    )

    def generic_product():
        ring = PolynomialRing(QQ, args.poly_vars, "x", implementation="generic")
        gens = ring.gens()
        left = sum((i + 1) * gens[i] for i in range(args.poly_vars // 2))
        right = sum((i + 1) * gens[i] for i in range(args.poly_vars // 2, args.poly_vars))
        left * right

    results.append(
        {
            "group": "workload",
            "name": "generic_polydict_product",
            "vars": args.poly_vars,
            **time_callable(
                generic_product,
                operations=1,
                repeat=args.repeat,
                number=args.workload_number,
                warmup=args.warmup,
            ),
        }
    )

    def hilbert_series():
        ring = PolynomialRing(QQ, 6, "x", implementation="generic")
        x = ring.gens()
        ideal = ring.ideal(
            [
                x[0] ** 3 * x[1] ** 2,
                x[1] ** 3 * x[2],
                x[2] ** 2 * x[3] ** 2,
                x[3] * x[4] ** 3,
                x[4] ** 2 * x[5] ** 2,
                x[0] * x[5] ** 4,
            ]
        )
        ideal.hilbert_series(algorithm="sage")

    results.append(
        {
            "group": "workload",
            "name": "generic_monomial_hilbert_series",
            **time_callable(
                hilbert_series,
                operations=1,
                repeat=args.repeat,
                number=args.workload_number,
                warmup=args.warmup,
            ),
        }
    )

    return results


def format_markdown(payload: dict[str, Any]) -> str:
    lines = [
        "# ETuple Benchmark Results",
        "",
        f"- Git revision: `{payload['metadata']['git_revision']}`",
        f"- Python: `{payload['metadata']['python']}`",
        f"- Platform: `{payload['metadata']['platform']}`",
        f"- Command: `{payload['metadata']['command']}`",
        "",
        "| Group | Name | Best ns/op | Median ns/op | Parameters |",
        "| --- | --- | ---: | ---: | --- |",
    ]
    for result in payload["results"]:
        params = {
            key: result[key]
            for key in (
                "length",
                "nonzero",
                "inner_loops",
                "left_terms",
                "right_terms",
                "vars",
                "degree",
            )
            if key in result
        }
        lines.append(
            "| {group} | {name} | {best:.1f} | {median:.1f} | `{params}` |".format(
                group=result["group"],
                name=result["name"],
                best=result["best_ns_per_op"],
                median=result["median_ns_per_op"],
                params=json.dumps(params, sort_keys=True),
            )
        )
    lines.append("")
    lines.append("Raw JSON follows.")
    lines.append("")
    lines.append("```json")
    lines.append(json.dumps(payload, indent=2, sort_keys=True))
    lines.append("```")
    lines.append("")
    return "\n".join(lines)


def parse_args(argv: list[str]) -> argparse.Namespace:
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument("--repeat", type=int, default=7)
    parser.add_argument("--number", type=int, default=200)
    parser.add_argument("--workload-number", type=int, default=3)
    parser.add_argument("--inner-loops", type=int, default=10_000)
    parser.add_argument("--warmup", type=int, default=1)
    parser.add_argument("--length", type=int, default=20)
    parser.add_argument("--nonzero", type=int, default=5)
    parser.add_argument("--dict-terms", type=int, default=20)
    parser.add_argument("--poly-vars", type=int, default=8)
    parser.add_argument("--poly-degree", type=int, default=9)
    parser.add_argument("--json", type=Path, help="write JSON results to this path")
    parser.add_argument("--markdown", type=Path, help="write Markdown results to this path")
    parser.add_argument(
        "--skip-workloads",
        action="store_true",
        help="run only ETuple microbenchmarks",
    )
    return parser.parse_args(argv)


def main(argv: list[str] | None = None) -> int:
    args = parse_args(sys.argv[1:] if argv is None else argv)
    results = run_microbenchmarks(args)
    results.extend(run_dict_key_benchmarks(args))
    if not args.skip_workloads:
        results.extend(run_polynomial_workloads(args))

    payload = {
        "metadata": {
            "git_revision": git_revision(),
            "python": sys.version.replace("\n", " "),
            "platform": platform.platform(),
            "command": " ".join(sys.argv),
        },
        "results": results,
    }

    if args.json:
        args.json.parent.mkdir(parents=True, exist_ok=True)
        args.json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
    if args.markdown:
        args.markdown.parent.mkdir(parents=True, exist_ok=True)
        args.markdown.write_text(format_markdown(payload))

    print(format_markdown(payload))
    return 0


if __name__ == "__main__":
    raise SystemExit(main())

```

</details>

### 📝 Checklist

- [x] The title is concise, informative, and self-explanatory.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes (existing doctests exercise the path).
- [ ] I have updated the documentation accordingly.

### ⌛ Dependencies

None.

Part of #26291.
