### PR TITLE
Support libgap conversion for general and relative number fields

### DIFF
--- a/src/sage/groups/matrix_gps/finitely_generated.py
+++ b/src/sage/groups/matrix_gps/finitely_generated.py
@@ -271,6 +271,42 @@ def MatrixGroup(*gens, **kwds):
         Traceback (most recent call last):
         ...
         AttributeError: 'LinearMatrixGroup_generic_with_category' object has no attribute 'gens'...
+
+    Matrices over number fields supported by GAP construct GAP-backed
+    groups::
+
+        sage: # needs sage.libs.gap
+        sage: from sage.groups.matrix_gps.finitely_generated_gap import FinitelyGeneratedMatrixGroup_gap
+        sage: K.<a> = QuadraticField(3)
+        sage: G = MatrixGroup([matrix(K, 2, [1, a, 0, 1])])
+        sage: isinstance(G, FinitelyGeneratedMatrixGroup_gap)
+        True
+
+    Relative number fields supported by GAP also construct GAP-backed
+    groups, including towers whose relative generator is not a primitive
+    element of the absolute field (here ``b`` does not generate ``L`` over
+    ``QQ``, so the entries are reconstructed from the relative basis)::
+
+        sage: # needs sage.libs.gap
+        sage: R.<x> = QQ[]
+        sage: K.<a> = NumberField(x^2 + 1)
+        sage: S.<y> = K[]
+        sage: L.<b> = K.extension(y^2 - 2)
+        sage: M = matrix(L, 2, [1, a*b, 0, 1])
+        sage: G = MatrixGroup([M])
+        sage: isinstance(G, FinitelyGeneratedMatrixGroup_gap)
+        True
+        sage: G.gen(0).matrix() == M
+        True
+
+        sage: # needs sage.libs.gap
+        sage: K.<zeta> = CyclotomicField(3)
+        sage: S.<y> = K[]
+        sage: L.<b> = K.extension(y^2 - 2)
+        sage: M = matrix(L, 2, [1, zeta*b + 1, 0, 1])
+        sage: G = MatrixGroup([M])
+        sage: G.gen(0).matrix() == M
+        True
     """
     if isinstance(gens[-1], dict):   # hack for unpickling
         kwds.update(gens[-1])

--- a/src/sage/groups/matrix_gps/finitely_generated.py
+++ b/src/sage/groups/matrix_gps/finitely_generated.py
@@ -272,22 +272,13 @@ def MatrixGroup(*gens, **kwds):
         ...
         AttributeError: 'LinearMatrixGroup_generic_with_category' object has no attribute 'gens'...
 
-    Matrices over number fields supported by GAP construct GAP-backed
-    groups::
+    Matrices over relative number fields supported by GAP construct
+    GAP-backed groups.  This includes towers whose relative generator is not
+    a primitive element of the absolute field (here ``b`` does not generate
+    ``L`` over ``QQ``, so entries are reconstructed from the relative basis)::
 
         sage: # needs sage.libs.gap
         sage: from sage.groups.matrix_gps.finitely_generated_gap import FinitelyGeneratedMatrixGroup_gap
-        sage: K.<a> = QuadraticField(3)
-        sage: G = MatrixGroup([matrix(K, 2, [1, a, 0, 1])])
-        sage: isinstance(G, FinitelyGeneratedMatrixGroup_gap)
-        True
-
-    Relative number fields supported by GAP also construct GAP-backed
-    groups, including towers whose relative generator is not a primitive
-    element of the absolute field (here ``b`` does not generate ``L`` over
-    ``QQ``, so the entries are reconstructed from the relative basis)::
-
-        sage: # needs sage.libs.gap
         sage: R.<x> = QQ[]
         sage: K.<a> = NumberField(x^2 + 1)
         sage: S.<y> = K[]
@@ -296,15 +287,6 @@ def MatrixGroup(*gens, **kwds):
         sage: G = MatrixGroup([M])
         sage: isinstance(G, FinitelyGeneratedMatrixGroup_gap)
         True
-        sage: G.gen(0).matrix() == M
-        True
-
-        sage: # needs sage.libs.gap
-        sage: K.<zeta> = CyclotomicField(3)
-        sage: S.<y> = K[]
-        sage: L.<b> = K.extension(y^2 - 2)
-        sage: M = matrix(L, 2, [1, zeta*b + 1, 0, 1])
-        sage: G = MatrixGroup([M])
         sage: G.gen(0).matrix() == M
         True
     """

--- a/src/sage/rings/number_field/number_field.py
+++ b/src/sage/rings/number_field/number_field.py
@@ -1643,6 +1643,20 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             !2
             sage: L(gap(tau)^3)     # indirect doctest                                  # needs sage.libs.gap
             2
+            sage: L(libgap(tau)^3)   # indirect doctest                                  # needs sage.libs.gap
+            2
+            sage: L(libgap(tau + 1)) # indirect doctest                                  # needs sage.libs.gap
+            tau + 1
+
+        GAP may print elements of a cyclotomic base field as ``E(n)``; these
+        should be interpreted in the base field, not in the universal
+        cyclotomic field::
+
+            sage: K.<zeta> = CyclotomicField(3)
+            sage: S.<y> = K[]
+            sage: L.<b> = K.extension(y^2 - 2)
+            sage: L(libgap(zeta*b + 1)) == zeta*b + 1                                    # needs sage.libs.gap
+            True
 
         Check that :issue:`22202` and :issue:`27765` are fixed::
 
@@ -1714,11 +1728,10 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
                 raise TypeError("%s has unsupported PARI type %s" % (x, x.type()))
             x = self.absolute_polynomial().parent()(x)
             return self._element_class(self, x)
+        if isinstance(x, LibGapElement):
+            return self._convert_from_gap_string(str(x))
         if isinstance(x, GapElement):
-            s = x._sage_repr()
-            if self.variable_name() in s:
-                return self._convert_from_str(s)
-            return self._convert_from_str(s.replace('!', ''))
+            return self._convert_from_gap_string(x._sage_repr())
         if isinstance(x, str):
             return self._convert_from_str(x)
         if isinstance(x, (tuple, list,
@@ -1897,6 +1910,63 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             -1/3*theta25 - 1
         """
         w = sage_eval(x, locals=self.gens_dict())
+        if not (isinstance(w, Element) and w.parent() is self):
+            return self(w)
+        return w
+
+    def _convert_from_gap_string(self, x):
+        """
+        Coerce a GAP string representation into this number field.
+
+        GAP marks algebraic-field constants with exclamation marks and uses
+        ``E(n)`` for cyclotomic elements.  The latter must be interpreted in
+        the number field tower, otherwise it is evaluated in the universal
+        cyclotomic field and may not coerce into relative extensions.
+
+        TESTS::
+
+            sage: x = polygen(QQ, 'x')
+            sage: K.<a> = NumberField(x^2 - 2)
+            sage: K._convert_from_gap_string('!3')
+            3
+            sage: K._convert_from_gap_string('a+2')
+            a + 2
+
+        Over a cyclotomic base field, ``E(n)`` is interpreted in the tower
+        rather than in the universal cyclotomic field::
+
+            sage: K.<zeta> = CyclotomicField(3)
+            sage: S.<y> = K[]
+            sage: L.<b> = K.extension(y^2 - 2)
+            sage: L._convert_from_gap_string('E(3)*b+1')
+            zeta*b + 1
+        """
+        x = x.replace('!', '')
+        if 'E(' not in x:
+            return self._convert_from_str(x)
+
+        import re
+        from sage.rings.universal_cyclotomic_field import E as universal_cyclotomic_E
+
+        def gap_E(n):
+            zeta = universal_cyclotomic_E(n)
+            K = self
+            seen = set()
+            while id(K) not in seen:
+                seen.add(id(K))
+                try:
+                    return K(zeta)
+                except (TypeError, ValueError, NotImplementedError):
+                    pass
+                try:
+                    K = K.base_field()
+                except (AttributeError, NotImplementedError):
+                    break
+            return zeta
+
+        local_vars = self.gens_dict()
+        local_vars['__gap_E'] = gap_E
+        w = sage_eval(re.sub(r'\bE\(', '__gap_E(', x), locals=local_vars)
         if not (isinstance(w, Element) and w.parent() is self):
             return self(w)
         return w
@@ -4503,6 +4573,7 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             f'return {E}; end,[])'
         )
 
+    @cached_method
     def _libgap_(self):
         """
         Override :meth:`sage.structure.sage_object.SageObject._libgap_`,
@@ -4543,12 +4614,31 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             x^2-3
             sage: gapK.PrimitiveElement()
             a
-        """
-        if not self.is_absolute():
-            raise NotImplementedError("Currently, only simple algebraic extensions are implemented in libgap")
 
+        Relative number fields are converted as towers of GAP algebraic
+        extensions::
+
+            sage: S.<y> = K[]
+            sage: L.<b> = K.extension(y^2 - a)
+            sage: gapL = libgap(L); gapL
+            <algebraic extension over the Rationals of degree 4>
+            sage: gapL.GeneratorsOfField()
+            [ b ]
+        """
         from sage.libs.gap.libgap import libgap
-        return libgap.AlgebraicExtension(self.base_ring(), self.polynomial(), str(self.gen()))
+        if self.is_absolute():
+            return libgap.AlgebraicExtension(self.base_ring(), self.polynomial(), str(self.gen()))
+
+        gap_base = libgap(self.base_field())
+        polynomial = self.relative_polynomial()
+        x = gap_base.Indeterminate(polynomial.variable_name())
+        gap_polynomial = gap_base.Zero()
+        power = gap_base.One()
+        for coeff in polynomial.list():
+            gap_coeff = libgap(coeff) * gap_base.One()
+            gap_polynomial += gap_coeff * power
+            power *= x
+        return libgap.AlgebraicExtension(gap_base, gap_polynomial, str(self.gen()))
 
     def characteristic(self):
         """

--- a/src/sage/rings/number_field/number_field.py
+++ b/src/sage/rings/number_field/number_field.py
@@ -76,11 +76,8 @@ AUTHORS:
 # ****************************************************************************
 from __future__ import annotations
 
-import keyword
-import re
 from collections import Counter
 from itertools import count
-from unicodedata import normalize
 
 from cypari2.gen import Gen as pari_gen
 
@@ -1731,10 +1728,8 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
                 raise TypeError("%s has unsupported PARI type %s" % (x, x.type()))
             x = self.absolute_polynomial().parent()(x)
             return self._element_class(self, x)
-        if isinstance(x, LibGapElement):
-            return self._convert_from_gap_string(str(x))
-        if isinstance(x, GapElement):
-            return self._convert_from_gap_string(x._sage_repr())
+        if isinstance(x, (LibGapElement, GapElement)):
+            return self._convert_from_gap_element(x)
         if isinstance(x, str):
             return self._convert_from_str(x)
         if isinstance(x, (tuple, list,
@@ -1917,64 +1912,58 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             return self(w)
         return w
 
-    def _convert_from_gap_string(self, x):
+    def _convert_from_gap_element(self, x):
         """
-        Coerce a GAP string representation into this number field.
+        Convert a GAP element into this number field.
 
-        GAP marks algebraic-field constants with exclamation marks and uses
-        ``E(n)`` for cyclotomic elements.  The latter must be interpreted in
-        the number field tower, otherwise it is evaluated in the universal
-        cyclotomic field and may not coerce into relative extensions.
+        The conversion uses coordinates in GAP's power basis, recursively
+        converting the coefficients into the base field.
 
         TESTS::
 
             sage: x = polygen(QQ, 'x')
             sage: K.<a> = NumberField(x^2 - 2)
-            sage: K._convert_from_gap_string('!3')
-            3
-            sage: K._convert_from_gap_string('a+2')
+            sage: K._convert_from_gap_element(gap(a)^2)                                  # needs sage.libs.gap
+            2
+            sage: K._convert_from_gap_element(libgap(a + 2))                             # needs sage.libs.gap
             a + 2
+            sage: K._convert_from_gap_element(libgap(3/2))                               # needs sage.libs.gap
+            3/2
 
-        Over a cyclotomic base field, ``E(n)`` is interpreted in the tower
-        rather than in the universal cyclotomic field::
+        Elements from the base of a relative field also convert through the
+        classic GAP interface::
+
+            sage: S.<y> = K[]
+            sage: L.<b> = K.extension(y^2 - 3)
+            sage: L._convert_from_gap_element(gap(a + 1))                                # needs sage.libs.gap
+            a + 1
+
+        GAP collapses relative extensions of degree one to their base field::
+
+            sage: E.<c> = K.extension(y - a)
+            sage: E._convert_from_gap_element(libgap(c)) == c                            # needs sage.libs.gap
+            True
+
+        This also works recursively over a cyclotomic base field::
 
             sage: K.<zeta> = CyclotomicField(3)
             sage: S.<y> = K[]
             sage: L.<b> = K.extension(y^2 - 2)
-            sage: L._convert_from_gap_string('E(3)*b+1')
+            sage: L._convert_from_gap_element(libgap(zeta*b + 1))                        # needs sage.libs.gap
             zeta*b + 1
         """
-        x = x.replace('!', '')
-        local_vars = dict(zip(self._gap_generator_names(), self.gens()))
-
-        if 'E(' in x:
-            from sage.rings.universal_cyclotomic_field import (
-                E as universal_cyclotomic_E,
-            )
-
-            def gap_E(n):
-                zeta = universal_cyclotomic_E(n)
-                K = self
-                seen = set()
-                while id(K) not in seen:
-                    seen.add(id(K))
-                    try:
-                        return K(zeta)
-                    except (TypeError, ValueError, NotImplementedError):
-                        pass
-                    try:
-                        K = K.base_field()
-                    except (AttributeError, NotImplementedError):
-                        break
-                return zeta
-
-            local_vars['__gap_E'] = gap_E
-            x = re.sub(r'\bE\(', '__gap_E(', x)
-
-        w = sage_eval(x, locals=local_vars)
-        if not (isinstance(w, Element) and w.parent() is self):
-            return self(w)
-        return w
+        if x.IsRat():
+            return self(QQ(x))
+        if not self.is_absolute() and (isinstance(x, GapElement) or self.relative_degree() == 1):
+            return self(self.base_field()(x))
+        if isinstance(x, LibGapElement):
+            from sage.libs.gap.libgap import libgap
+            gap_field = libgap(self)
+        else:
+            gap_field = self._gap_()
+        basis = gap_field.Basis()
+        coefficients = basis.Coefficients(x * gap_field.One())
+        return self([self.base_field()(c) for c in coefficients])
 
     def _Hom_(self, codomain, category=None):
         """
@@ -4533,55 +4522,6 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
         Kbnf = self.pari_bnf(proof=proof)
         return Kbnf.rnfisnorminit(L.pari_relative_polynomial())
 
-    @cached_method
-    def _gap_generator_names(self):
-        """
-        Return parser-safe, collision-free GAP generator names for this tower.
-
-        GAP prints algebraic extension elements in terms of the names supplied
-        to ``AlgebraicExtension``.  Sage permits a relative extension to reuse
-        the name of a generator below its immediate base field, so those names
-        must be made unique in GAP to keep conversions unambiguous.  They must
-        also be valid Python identifiers because :func:`sage_eval` parses GAP
-        output when converting elements back to Sage.
-
-        TESTS::
-
-            sage: R.<x> = QQ[]
-            sage: K.<a> = NumberField(x^2 - 2)
-            sage: S.<y> = K[]
-            sage: L.<b> = K.extension(y^2 - 3)
-            sage: T.<z> = L[]
-            sage: M.<a> = L.extension(z^2 - 5)
-            sage: M.variable_names()
-            ('a', 'b', 'a')
-            sage: M._gap_generator_names()
-            ('a_', 'b', 'a')
-
-        Python keywords, preparser helper names, and names changed by
-        identifier normalization are made safe as well::
-
-            sage: NumberField(x^2 - 2, 'True')._gap_generator_names()
-            ('True_',)
-            sage: [NumberField(x^2 - 2, name)._gap_generator_names()[0]
-            ....:  for name in ('Integer', 'RealNumber', 'ComplexNumber')]
-            ['Integer_', 'RealNumber_', 'ComplexNumber_']
-            sage: NumberField(x^2 - 2, 'a²')._gap_generator_names()
-            ('a2',)
-        """
-        name = normalize('NFKC', self.variable_name())
-        if not name.isidentifier():
-            name = '_sage_gen'
-        elif keyword.iskeyword(name) or name in ('ComplexNumber', 'Integer', 'RealNumber'):
-            name += '_'
-        if self.is_absolute():
-            return (name,)
-
-        base_names = self.base_field()._gap_generator_names()
-        while name in base_names:
-            name += '_'
-        return (name,) + base_names
-
     def _gap_init_(self) -> str:
         """
         Implements :meth:`sage.structure.sage_object.SageObject._gap_init_`
@@ -4628,11 +4568,9 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
         x = q.variable_name()
         E = 'E' if x != 'E' else 'F'
         R = G(self.base_ring())
-        name = self._gap_generator_names()[0]
-
         return (
             f'CallFuncList(function() local {x},{E}; {x}:=Indeterminate({R.name()},"{x}"); '
-            f'{E}:=AlgebraicExtension({R.name()},{self.polynomial()!r},"{name}"); '
+            f'{E}:=AlgebraicExtension({R.name()},{self.polynomial()!r},"{self.gen()}"); '
             f'return {E}; end,[])'
         )
 
@@ -4689,9 +4627,8 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             [ b ]
         """
         from sage.libs.gap.libgap import libgap
-        name = self._gap_generator_names()[0]
         if self.is_absolute():
-            return libgap.AlgebraicExtension(self.base_ring(), self.polynomial(), name)
+            return libgap.AlgebraicExtension(self.base_ring(), self.polynomial(), str(self.gen()))
 
         gap_base = libgap(self.base_field())
         polynomial = self.relative_polynomial()
@@ -4699,10 +4636,9 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
         gap_polynomial = gap_base.Zero()
         power = gap_base.One()
         for coeff in polynomial.list():
-            gap_coeff = libgap(coeff) * gap_base.One()
-            gap_polynomial += gap_coeff * power
+            gap_polynomial += libgap(coeff) * power
             power *= x
-        return libgap.AlgebraicExtension(gap_base, gap_polynomial, name)
+        return libgap.AlgebraicExtension(gap_base, gap_polynomial, str(self.gen()))
 
     def characteristic(self):
         """

--- a/src/sage/rings/number_field/number_field.py
+++ b/src/sage/rings/number_field/number_field.py
@@ -1643,6 +1643,20 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             !2
             sage: L(gap(tau)^3)     # indirect doctest                                  # needs sage.libs.gap
             2
+            sage: L(libgap(tau)^3)   # indirect doctest                                  # needs sage.libs.gap
+            2
+            sage: L(libgap(tau + 1)) # indirect doctest                                  # needs sage.libs.gap
+            tau + 1
+
+        GAP may print elements of a cyclotomic base field as ``E(n)``; these
+        should be interpreted in the base field, not in the universal
+        cyclotomic field::
+
+            sage: K.<zeta> = CyclotomicField(3)
+            sage: S.<y> = K[]
+            sage: L.<b> = K.extension(y^2 - 2)
+            sage: L(libgap(zeta*b + 1)) == zeta*b + 1                                    # needs sage.libs.gap
+            True
 
         Check that :issue:`22202` and :issue:`27765` are fixed::
 
@@ -1714,11 +1728,10 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
                 raise TypeError("%s has unsupported PARI type %s" % (x, x.type()))
             x = self.absolute_polynomial().parent()(x)
             return self._element_class(self, x)
+        if isinstance(x, LibGapElement):
+            return self._convert_from_gap_string(str(x))
         if isinstance(x, GapElement):
-            s = x._sage_repr()
-            if self.variable_name() in s:
-                return self._convert_from_str(s)
-            return self._convert_from_str(s.replace('!', ''))
+            return self._convert_from_gap_string(x._sage_repr())
         if isinstance(x, str):
             return self._convert_from_str(x)
         if isinstance(x, (tuple, list,
@@ -1897,6 +1910,63 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             -1/3*theta25 - 1
         """
         w = sage_eval(x, locals=self.gens_dict())
+        if not (isinstance(w, Element) and w.parent() is self):
+            return self(w)
+        return w
+
+    def _convert_from_gap_string(self, x):
+        """
+        Coerce a GAP string representation into this number field.
+
+        GAP marks algebraic-field constants with exclamation marks and uses
+        ``E(n)`` for cyclotomic elements.  The latter must be interpreted in
+        the number field tower, otherwise it is evaluated in the universal
+        cyclotomic field and may not coerce into relative extensions.
+
+        TESTS::
+
+            sage: x = polygen(QQ, 'x')
+            sage: K.<a> = NumberField(x^2 - 2)
+            sage: K._convert_from_gap_string('!3')
+            3
+            sage: K._convert_from_gap_string('a+2')
+            a + 2
+
+        Over a cyclotomic base field, ``E(n)`` is interpreted in the tower
+        rather than in the universal cyclotomic field::
+
+            sage: K.<zeta> = CyclotomicField(3)
+            sage: S.<y> = K[]
+            sage: L.<b> = K.extension(y^2 - 2)
+            sage: L._convert_from_gap_string('E(3)*b+1')
+            zeta*b + 1
+        """
+        x = x.replace('!', '')
+        if 'E(' not in x:
+            return self._convert_from_str(x)
+
+        import re
+        from sage.rings.universal_cyclotomic_field import E as universal_cyclotomic_E
+
+        def gap_E(n):
+            zeta = universal_cyclotomic_E(n)
+            K = self
+            seen = set()
+            while id(K) not in seen:
+                seen.add(id(K))
+                try:
+                    return K(zeta)
+                except (TypeError, ValueError, NotImplementedError):
+                    pass
+                try:
+                    K = K.base_field()
+                except (AttributeError, NotImplementedError):
+                    break
+            return zeta
+
+        local_vars = self.gens_dict()
+        local_vars['__gap_E'] = gap_E
+        w = sage_eval(re.sub(r'\bE\(', '__gap_E(', x), locals=local_vars)
         if not (isinstance(w, Element) and w.parent() is self):
             return self(w)
         return w
@@ -4505,6 +4575,7 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             f'return {E}; end,[])'
         )
 
+    @cached_method
     def _libgap_(self):
         """
         Override :meth:`sage.structure.sage_object.SageObject._libgap_`,
@@ -4545,12 +4616,31 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             x^2-3
             sage: gapK.PrimitiveElement()
             a
-        """
-        if not self.is_absolute():
-            raise NotImplementedError("Currently, only simple algebraic extensions are implemented in libgap")
 
+        Relative number fields are converted as towers of GAP algebraic
+        extensions::
+
+            sage: S.<y> = K[]
+            sage: L.<b> = K.extension(y^2 - a)
+            sage: gapL = libgap(L); gapL
+            <algebraic extension over the Rationals of degree 4>
+            sage: gapL.GeneratorsOfField()
+            [ b ]
+        """
         from sage.libs.gap.libgap import libgap
-        return libgap.AlgebraicExtension(self.base_ring(), self.polynomial(), str(self.gen()))
+        if self.is_absolute():
+            return libgap.AlgebraicExtension(self.base_ring(), self.polynomial(), str(self.gen()))
+
+        gap_base = libgap(self.base_field())
+        polynomial = self.relative_polynomial()
+        x = gap_base.Indeterminate(polynomial.variable_name())
+        gap_polynomial = gap_base.Zero()
+        power = gap_base.One()
+        for coeff in polynomial.list():
+            gap_coeff = libgap(coeff) * gap_base.One()
+            gap_polynomial += gap_coeff * power
+            power *= x
+        return libgap.AlgebraicExtension(gap_base, gap_polynomial, str(self.gen()))
 
     def characteristic(self):
         """

--- a/src/sage/rings/number_field/number_field.py
+++ b/src/sage/rings/number_field/number_field.py
@@ -76,8 +76,11 @@ AUTHORS:
 # ****************************************************************************
 from __future__ import annotations
 
+import keyword
+import re
 from collections import Counter
 from itertools import count
+from unicodedata import normalize
 
 from cypari2.gen import Gen as pari_gen
 
@@ -1942,31 +1945,33 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             zeta*b + 1
         """
         x = x.replace('!', '')
-        if 'E(' not in x:
-            return self._convert_from_str(x)
+        local_vars = dict(zip(self._gap_generator_names(), self.gens()))
 
-        import re
-        from sage.rings.universal_cyclotomic_field import E as universal_cyclotomic_E
+        if 'E(' in x:
+            from sage.rings.universal_cyclotomic_field import (
+                E as universal_cyclotomic_E,
+            )
 
-        def gap_E(n):
-            zeta = universal_cyclotomic_E(n)
-            K = self
-            seen = set()
-            while id(K) not in seen:
-                seen.add(id(K))
-                try:
-                    return K(zeta)
-                except (TypeError, ValueError, NotImplementedError):
-                    pass
-                try:
-                    K = K.base_field()
-                except (AttributeError, NotImplementedError):
-                    break
-            return zeta
+            def gap_E(n):
+                zeta = universal_cyclotomic_E(n)
+                K = self
+                seen = set()
+                while id(K) not in seen:
+                    seen.add(id(K))
+                    try:
+                        return K(zeta)
+                    except (TypeError, ValueError, NotImplementedError):
+                        pass
+                    try:
+                        K = K.base_field()
+                    except (AttributeError, NotImplementedError):
+                        break
+                return zeta
 
-        local_vars = self.gens_dict()
-        local_vars['__gap_E'] = gap_E
-        w = sage_eval(re.sub(r'\bE\(', '__gap_E(', x), locals=local_vars)
+            local_vars['__gap_E'] = gap_E
+            x = re.sub(r'\bE\(', '__gap_E(', x)
+
+        w = sage_eval(x, locals=local_vars)
         if not (isinstance(w, Element) and w.parent() is self):
             return self(w)
         return w
@@ -4528,6 +4533,55 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
         Kbnf = self.pari_bnf(proof=proof)
         return Kbnf.rnfisnorminit(L.pari_relative_polynomial())
 
+    @cached_method
+    def _gap_generator_names(self):
+        """
+        Return parser-safe, collision-free GAP generator names for this tower.
+
+        GAP prints algebraic extension elements in terms of the names supplied
+        to ``AlgebraicExtension``.  Sage permits a relative extension to reuse
+        the name of a generator below its immediate base field, so those names
+        must be made unique in GAP to keep conversions unambiguous.  They must
+        also be valid Python identifiers because :func:`sage_eval` parses GAP
+        output when converting elements back to Sage.
+
+        TESTS::
+
+            sage: R.<x> = QQ[]
+            sage: K.<a> = NumberField(x^2 - 2)
+            sage: S.<y> = K[]
+            sage: L.<b> = K.extension(y^2 - 3)
+            sage: T.<z> = L[]
+            sage: M.<a> = L.extension(z^2 - 5)
+            sage: M.variable_names()
+            ('a', 'b', 'a')
+            sage: M._gap_generator_names()
+            ('a_', 'b', 'a')
+
+        Python keywords, preparser helper names, and names changed by
+        identifier normalization are made safe as well::
+
+            sage: NumberField(x^2 - 2, 'True')._gap_generator_names()
+            ('True_',)
+            sage: [NumberField(x^2 - 2, name)._gap_generator_names()[0]
+            ....:  for name in ('Integer', 'RealNumber', 'ComplexNumber')]
+            ['Integer_', 'RealNumber_', 'ComplexNumber_']
+            sage: NumberField(x^2 - 2, 'a²')._gap_generator_names()
+            ('a2',)
+        """
+        name = normalize('NFKC', self.variable_name())
+        if not name.isidentifier():
+            name = '_sage_gen'
+        elif keyword.iskeyword(name) or name in ('ComplexNumber', 'Integer', 'RealNumber'):
+            name += '_'
+        if self.is_absolute():
+            return (name,)
+
+        base_names = self.base_field()._gap_generator_names()
+        while name in base_names:
+            name += '_'
+        return (name,) + base_names
+
     def _gap_init_(self) -> str:
         """
         Implements :meth:`sage.structure.sage_object.SageObject._gap_init_`
@@ -4559,6 +4613,12 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             [ tau ]
             sage: gap(tau)^3
             !2
+
+        Generator names that are Python keywords remain convertible from GAP::
+
+            sage: T = NumberField(z^2 - 3, 'True')
+            sage: T(gap(T.gen())) == T.gen()
+            True
         """
         if not self.is_absolute():
             raise NotImplementedError("Currently, only simple algebraic extensions are implemented in gap")
@@ -4568,10 +4628,11 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
         x = q.variable_name()
         E = 'E' if x != 'E' else 'F'
         R = G(self.base_ring())
+        name = self._gap_generator_names()[0]
 
         return (
             f'CallFuncList(function() local {x},{E}; {x}:=Indeterminate({R.name()},"{x}"); '
-            f'{E}:=AlgebraicExtension({R.name()},{self.polynomial()!r},"{self.gen()}"); '
+            f'{E}:=AlgebraicExtension({R.name()},{self.polynomial()!r},"{name}"); '
             f'return {E}; end,[])'
         )
 
@@ -4628,8 +4689,9 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             [ b ]
         """
         from sage.libs.gap.libgap import libgap
+        name = self._gap_generator_names()[0]
         if self.is_absolute():
-            return libgap.AlgebraicExtension(self.base_ring(), self.polynomial(), str(self.gen()))
+            return libgap.AlgebraicExtension(self.base_ring(), self.polynomial(), name)
 
         gap_base = libgap(self.base_field())
         polynomial = self.relative_polynomial()
@@ -4640,7 +4702,7 @@ class NumberField_generic(WithEqualityById, number_field_base.NumberField):
             gap_coeff = libgap(coeff) * gap_base.One()
             gap_polynomial += gap_coeff * power
             power *= x
-        return libgap.AlgebraicExtension(gap_base, gap_polynomial, str(self.gen()))
+        return libgap.AlgebraicExtension(gap_base, gap_polynomial, name)
 
     def characteristic(self):
         """

--- a/src/sage/rings/number_field/number_field_element.pyx
+++ b/src/sage/rings/number_field/number_field_element.pyx
@@ -524,6 +524,36 @@ cdef class NumberFieldElement(NumberFieldElement_base):
             sage: type(_)
             <class 'sage.libs.gap.element.GapElement_Cyclotomic'>
 
+            sage: K.<a> = QuadraticField(3)
+            sage: libgap(a)                                                              # needs sage.libs.gap
+            a
+            sage: libgap(a + 2)                                                          # needs sage.libs.gap
+            a+2
+            sage: libgap(a)^2                                                            # needs sage.libs.gap
+            !3
+
+            sage: R.<x> = QQ[]
+            sage: K.<a> = NumberField(x^2 - 2)
+            sage: S.<y> = K[]
+            sage: L.<b> = K.extension(y^2 - a)
+            sage: libgap(b)                                                              # needs sage.libs.gap
+            b
+            sage: libgap(a*b + 2)                                                        # needs sage.libs.gap
+            a*b+!2
+
+        The relative generator need not be a primitive element of the
+        absolute field (here ``b`` does not generate ``L`` over ``QQ``)::
+
+            sage: K.<a> = NumberField(x^2 + 1)
+            sage: S.<y> = K[]
+            sage: L.<b> = K.extension(y^2 - 2)
+            sage: libgap(a*b)                                                            # needs sage.libs.gap
+            a*b
+            sage: L(libgap(a*b)) == a*b                                                  # needs sage.libs.gap
+            True
+            sage: L(libgap(a + b)) == a + b                                              # needs sage.libs.gap
+            True
+
         Check that :issue:`15276` is fixed::
 
             sage: for n in range(2,20):                                                 # needs sage.libs.gap
@@ -536,10 +566,25 @@ cdef class NumberFieldElement(NumberFieldElement_base):
         """
         from sage.rings.number_field.number_field import NumberField_cyclotomic
         P = self.parent()
-        if not isinstance(P, NumberField_cyclotomic):
-            raise NotImplementedError("libgap conversion is only implemented for cyclotomic fields")
-
         from sage.libs.gap.libgap import libgap
+        if not isinstance(P, NumberField_cyclotomic):
+            gap_field = libgap(P)
+            E = gap_field.GeneratorsOfField()[0]
+            if not P.is_absolute():
+                # ``self.list()`` gives the coordinates over the base field in
+                # the relative power basis ``[1, E, E^2, ...]`` of the relative
+                # generator ``E``.  This is the representation that matches GAP's
+                # tower; ``self.polynomial()`` would instead use the absolute
+                # primitive element, which only coincides with ``E`` when the
+                # relative generator happens to generate ``L`` over ``QQ``.
+                total = gap_field.Zero()
+                power = gap_field.One()
+                for coeff in self.list():
+                    total += libgap(coeff) * gap_field.One() * power
+                    power *= E
+                return total
+            return self.polynomial()(E) * gap_field.One()
+
         E = libgap(P).GeneratorsOfField()[0]
         n = P._n()
         if n % 4 == 2:

--- a/src/sage/rings/number_field/number_field_element.pyx
+++ b/src/sage/rings/number_field/number_field_element.pyx
@@ -523,6 +523,36 @@ cdef class NumberFieldElement(NumberFieldElement_base):
             sage: type(_)
             <class 'sage.libs.gap.element.GapElement_Cyclotomic'>
 
+            sage: K.<a> = QuadraticField(3)
+            sage: libgap(a)                                                              # needs sage.libs.gap
+            a
+            sage: libgap(a + 2)                                                          # needs sage.libs.gap
+            a+2
+            sage: libgap(a)^2                                                            # needs sage.libs.gap
+            !3
+
+            sage: R.<x> = QQ[]
+            sage: K.<a> = NumberField(x^2 - 2)
+            sage: S.<y> = K[]
+            sage: L.<b> = K.extension(y^2 - a)
+            sage: libgap(b)                                                              # needs sage.libs.gap
+            b
+            sage: libgap(a*b + 2)                                                        # needs sage.libs.gap
+            a*b+!2
+
+        The relative generator need not be a primitive element of the
+        absolute field (here ``b`` does not generate ``L`` over ``QQ``)::
+
+            sage: K.<a> = NumberField(x^2 + 1)
+            sage: S.<y> = K[]
+            sage: L.<b> = K.extension(y^2 - 2)
+            sage: libgap(a*b)                                                            # needs sage.libs.gap
+            a*b
+            sage: L(libgap(a*b)) == a*b                                                  # needs sage.libs.gap
+            True
+            sage: L(libgap(a + b)) == a + b                                              # needs sage.libs.gap
+            True
+
         Check that :issue:`15276` is fixed::
 
             sage: for n in range(2,20):                                                 # needs sage.libs.gap
@@ -535,10 +565,25 @@ cdef class NumberFieldElement(NumberFieldElement_base):
         """
         from sage.rings.number_field.number_field import NumberField_cyclotomic
         P = self.parent()
-        if not isinstance(P, NumberField_cyclotomic):
-            raise NotImplementedError("libgap conversion is only implemented for cyclotomic fields")
-
         from sage.libs.gap.libgap import libgap
+        if not isinstance(P, NumberField_cyclotomic):
+            gap_field = libgap(P)
+            E = gap_field.GeneratorsOfField()[0]
+            if not P.is_absolute():
+                # ``self.list()`` gives the coordinates over the base field in
+                # the relative power basis ``[1, E, E^2, ...]`` of the relative
+                # generator ``E``.  This is the representation that matches GAP's
+                # tower; ``self.polynomial()`` would instead use the absolute
+                # primitive element, which only coincides with ``E`` when the
+                # relative generator happens to generate ``L`` over ``QQ``.
+                total = gap_field.Zero()
+                power = gap_field.One()
+                for coeff in self.list():
+                    total += libgap(coeff) * gap_field.One() * power
+                    power *= E
+                return total
+            return self.polynomial()(E) * gap_field.One()
+
         E = libgap(P).GeneratorsOfField()[0]
         n = P._n()
         if n % 4 == 2:

--- a/src/sage/rings/number_field/number_field_element.pyx
+++ b/src/sage/rings/number_field/number_field_element.pyx
@@ -553,6 +553,36 @@ cdef class NumberFieldElement(NumberFieldElement_base):
             sage: L(libgap(a + b)) == a + b                                              # needs sage.libs.gap
             True
 
+        Generator names reused below the immediate base field remain distinct
+        in a deeper relative tower::
+
+            sage: K.<a> = NumberField(x^2 - 2)
+            sage: S.<y> = K[]
+            sage: L.<b> = K.extension(y^2 - 3)
+            sage: T.<z> = L[]
+            sage: M.<a> = L.extension(z^2 - 5)
+            sage: top = M.gen()
+            sage: bottom = M(K.gen())
+            sage: all(M(libgap(v)) == v for v in (top, bottom, top + bottom))             # needs sage.libs.gap
+            True
+
+        Names requiring Python identifier normalization also remain distinct::
+
+            sage: N = L.extension(z^2 - 5, '𝔞')
+            sage: all(N(libgap(v)) == v for v in N.gens())                               # needs sage.libs.gap
+            True
+
+        Python keywords, preparser helper names, and non-identifiers are made
+        safe::
+
+            sage: for name in ('True', 'Integer', 'a½'):                                 # needs sage.libs.gap
+            ....:     N = NumberField(x^2 - 7, name)
+            ....:     assert N(libgap(N.gen() + 1)) == N.gen() + 1
+
+            sage: N = NumberField(x^2 - 7, 'RealNumber')
+            sage: N(libgap.eval('1.5')) == 3/2                                            # needs sage.libs.gap
+            True
+
         Check that :issue:`15276` is fixed::
 
             sage: for n in range(2,20):                                                 # needs sage.libs.gap

--- a/src/sage/rings/number_field/number_field_element.pyx
+++ b/src/sage/rings/number_field/number_field_element.pyx
@@ -553,8 +553,8 @@ cdef class NumberFieldElement(NumberFieldElement_base):
             sage: L(libgap(a + b)) == a + b                                              # needs sage.libs.gap
             True
 
-        Generator names reused below the immediate base field remain distinct
-        in a deeper relative tower::
+        Reusing a printed generator name below the immediate base field is
+        unambiguous because conversion uses power-basis coordinates::
 
             sage: K.<a> = NumberField(x^2 - 2)
             sage: S.<y> = K[]
@@ -566,21 +566,10 @@ cdef class NumberFieldElement(NumberFieldElement_base):
             sage: all(M(libgap(v)) == v for v in (top, bottom, top + bottom))             # needs sage.libs.gap
             True
 
-        Names requiring Python identifier normalization also remain distinct::
+        Unicode generator names do not need special parsing::
 
-            sage: N = L.extension(z^2 - 5, '𝔞')
+            sage: N = L.extension(z^2 - 5, 'λ')
             sage: all(N(libgap(v)) == v for v in N.gens())                               # needs sage.libs.gap
-            True
-
-        Python keywords, preparser helper names, and non-identifiers are made
-        safe::
-
-            sage: for name in ('True', 'Integer', 'a½'):                                 # needs sage.libs.gap
-            ....:     N = NumberField(x^2 - 7, name)
-            ....:     assert N(libgap(N.gen() + 1)) == N.gen() + 1
-
-            sage: N = NumberField(x^2 - 7, 'RealNumber')
-            sage: N(libgap.eval('1.5')) == 3/2                                            # needs sage.libs.gap
             True
 
         Check that :issue:`15276` is fixed::
@@ -599,20 +588,16 @@ cdef class NumberFieldElement(NumberFieldElement_base):
         if not isinstance(P, NumberField_cyclotomic):
             gap_field = libgap(P)
             E = gap_field.GeneratorsOfField()[0]
-            if not P.is_absolute():
-                # ``self.list()`` gives the coordinates over the base field in
-                # the relative power basis ``[1, E, E^2, ...]`` of the relative
-                # generator ``E``.  This is the representation that matches GAP's
-                # tower; ``self.polynomial()`` would instead use the absolute
-                # primitive element, which only coincides with ``E`` when the
-                # relative generator happens to generate ``L`` over ``QQ``.
-                total = gap_field.Zero()
-                power = gap_field.One()
-                for coeff in self.list():
-                    total += libgap(coeff) * gap_field.One() * power
-                    power *= E
-                return total
-            return self.polynomial()(E) * gap_field.One()
+            # For a relative field, ``self.list()`` gives the coordinates in
+            # the relative power basis; ``self.polynomial()`` instead uses the
+            # absolute primitive element.
+            coefficients = self.polynomial().list() if P.is_absolute() else self.list()
+            total = gap_field.Zero()
+            power = gap_field.One()
+            for coeff in coefficients:
+                total += libgap(coeff) * power
+                power *= E
+            return total
 
         E = libgap(P).GeneratorsOfField()[0]
         n = P._n()


### PR DESCRIPTION
### 📚 Description

Extend `libgap(...)` conversion beyond cyclotomic fields so that matrix
groups (and Coxeter groups) over number fields can use the GAP backend.

- `NumberFieldElement._libgap_` converts both absolute and relative fields
  via the GAP algebraic-extension tower. Relative elements use the relative
  power-basis coordinates (`self.list()`), which match GAP's generator even
  when it is not an absolute primitive element of the field.
- `NumberField_generic._libgap_` builds relative fields as towers of GAP
  algebraic extensions, and is now cached.
- The reverse conversion is centralized in `_convert_from_gap_string`, which
  strips GAP's `!` constant markers and interprets cyclotomic `E(n)` in the
  field tower rather than in the universal cyclotomic field.

This is split out from #42383 (CoxeterGroup default base ring), which depends
on this conversion support but is reviewed separately.

### 📝 Checklist

- [x] The title is concise and informative.
- [x] I have linked a relevant issue or PR.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.
