### PR TITLE
Fix deprecation warnings with numpy 2.5

### DIFF
--- a/src/doc/en/thematic_tutorials/numerical_sage/cvxopt.rst
+++ b/src/doc/en/thematic_tutorials/numerical_sage/cvxopt.rst
@@ -46,8 +46,7 @@ we could do the following.
 
 ::
 
-    sage: B = numpy.array([1.0]*5)                                                      # needs cvxopt
-    sage: B.shape=(5,1)                                                                 # needs cvxopt
+    sage: B = numpy.array([1.0]*5).reshape((5,1))                                       # needs cvxopt
     sage: print(B)                                                                      # needs cvxopt
     [[1.]
      [1.]

--- a/src/doc/en/thematic_tutorials/numerical_sage/numpy.rst
+++ b/src/doc/en/thematic_tutorials/numerical_sage/numpy.rst
@@ -170,8 +170,7 @@ to manipulate
     array([  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,
             11.,  12.,  13.,  14.,  15.,  16.,  17.,  18.,  19.,  20.,  21.,
             22.,  23.,  24.])
-    sage: n.shape=(5,5)
-    sage: n
+    sage: n.reshape((5,5))
     array([[ 0.,  1.,  2.,  3.,  4.],
            [ 5.,  6.,  7.,  8.,  9.],
            [10., 11., 12., 13., 14.],
@@ -186,8 +185,7 @@ NumPy arrays can be sliced as well
 
 ::
 
-    sage: n = numpy.array(range(25),dtype=float)
-    sage: n.shape = (5,5)
+    sage: n = numpy.array(range(25),dtype=float).reshape((5,5))
     sage: n[2:4,1:3]
     array([[11., 12.],
            [16., 17.]])


### PR DESCRIPTION
Fixes
```
File "/usr/share/doc/sage/html/en/thematic_tutorials/_sources/numerical_sage/numpy.rst.txt", line 173, in numpy.rst
Failed example:
    n.shape=(5,5)
Expected nothing
Got:
    doctest:warning
      File "<doctest numpy.rst[32]>", line 1, in <module>
        n.shape=(Integer(5),Integer(5))
      File "/usr/lib/python3.14/_py_warnings.py", line 230, in _showwarnmsg
        sw(msg.message, msg.category, msg.filename, msg.lineno,
    :
    DeprecationWarning: Setting the shape on a NumPy array has been deprecated in NumPy 2.5.
    As an alternative, you can create a new view using np.reshape (with copy=False if needed).
```