### PR TITLE
Use precomputed table of marks for functorial composition of species

### DIFF
--- a/src/sage/rings/lazy_species.py
+++ b/src/sage/rings/lazy_species.py
@@ -64,6 +64,7 @@ bi-point-determining graphs we use Corollary (4.6) in
 from sage.arith.misc import divisors, multinomial
 from sage.functions.other import binomial, factorial
 from sage.libs.gap.libgap import libgap
+from sage.libs.gap.util import GAPError
 from sage.misc.cachefunc import cached_function
 from sage.misc.lazy_list import lazy_list
 from sage.misc.misc_c import prod
@@ -2789,8 +2790,9 @@ def _table_of_marks_symmetric_group(n):
     the symmetric groups in a range of small degrees.  Looking up the
     precomputed table is dramatically faster than computing it from the
     group, and it is feasible for degrees where computing from the
-    group is not.  When the table is not in the library, we fall back
-    to computing it from the group.
+    group is not.  When the table is not in the library -- either
+    because the degree is out of range or because ``tomlib`` is not
+    installed -- we fall back to computing it from the group.
 
     EXAMPLES::
 
@@ -2806,7 +2808,11 @@ def _table_of_marks_symmetric_group(n):
         sage: _table_of_marks_symmetric_group(3) == libgap.TableOfMarks(_SymmetricGroup(3))
         True
     """
-    tom = libgap.TableOfMarks("S%s" % n)
+    try:
+        tom = libgap.TableOfMarks("S%s" % n)
+    except GAPError:
+        # ``tomlib`` is not installed at all
+        tom = libgap.fail
     if tom != libgap.fail:
         return tom
     return libgap.TableOfMarks(_SymmetricGroup(n))

--- a/src/sage/rings/lazy_species.py
+++ b/src/sage/rings/lazy_species.py
@@ -64,6 +64,7 @@ bi-point-determining graphs we use Corollary (4.6) in
 from sage.arith.misc import divisors, multinomial
 from sage.functions.other import binomial, factorial
 from sage.libs.gap.libgap import libgap
+from sage.misc.cachefunc import cached_function
 from sage.misc.lazy_list import lazy_list
 from sage.misc.misc_c import prod
 from sage.rings.integer_ring import ZZ
@@ -1585,7 +1586,7 @@ class FunctorialCompositionSpeciesElement(LazyCombinatorialSpeciesElement):
             f_N = left.generating_series()[N] * factorial(N)
             return f_N * R(S_n)
 
-        M = libgap.TableOfMarks(S_n)
+        M = _table_of_marks_symmetric_group(n)
         m = libgap.MarksTom(M).Length().sage()
         C_n = [libgap.RepresentativeTom(M, i+1) for i in range(m)]
         l_G = [H.gap()
@@ -2777,6 +2778,38 @@ class RestrictedSpeciesElement(LazyCombinatorialSpeciesElement):
 ######################################################################
 # helpers for functorial composition
 ######################################################################
+
+
+@cached_function
+def _table_of_marks_symmetric_group(n):
+    r"""
+    Return the table of marks of the symmetric group on `n` letters.
+
+    GAP's ``tomlib`` package provides precomputed tables of marks for
+    the symmetric groups in a range of small degrees.  Looking up the
+    precomputed table is dramatically faster than computing it from the
+    group, and it is feasible for degrees where computing from the
+    group is not.  When the table is not in the library, we fall back
+    to computing it from the group.
+
+    EXAMPLES::
+
+        sage: from sage.rings.lazy_species import _table_of_marks_symmetric_group
+        sage: M = _table_of_marks_symmetric_group(4)
+        sage: M.MarksTom().Length().sage()
+        11
+
+    The fallback (for degrees not stored in ``tomlib``) gives the same
+    table::
+
+        sage: from sage.rings.species import _SymmetricGroup
+        sage: _table_of_marks_symmetric_group(3) == libgap.TableOfMarks(_SymmetricGroup(3))
+        True
+    """
+    tom = libgap.TableOfMarks("S%s" % n)
+    if tom != libgap.fail:
+        return tom
+    return libgap.TableOfMarks(_SymmetricGroup(n))
 
 
 def weighted_partitions_by_capacity(weights, capacities):


### PR DESCRIPTION
### Summary

The subgroup-based algorithm for functorial composition of species
(`LazyCombinatorialSpeciesElement.functorial_composition(..., algorithm="subgroups")`)
computes the table of marks of the symmetric group $S_n$ for every coefficient.
Currently this is computed from the group via `libgap.TableOfMarks(S_n)`, which is
expensive and quickly becomes the limiting factor — it is effectively infeasible
past degree ~10.

GAP's `tomlib` package ships *precomputed* tables of marks for the symmetric groups,
which are essentially free to look up and available for a much larger range of degrees.

Measured cost of obtaining the table of marks of $S_n$:

| $n$ | from group | `tomlib` lookup |
|----|-----------|-----------------|
| 6  | 1.6 s     | ~0 s            |
| 8  | 5.1 s     | ~0 s            |
| 10 | infeasible | ~0 s (1593 classes) |
| 13 | infeasible | 2.0 s (20832 classes) |

This PR adds a cached helper `_table_of_marks_symmetric_group(n)` that looks up the
library table when available and falls back to computing it from the group otherwise,
and uses it in `_coefficient_subgroups`. The library tables are representation-compatible
with the existing code (their underlying group is the natural symmetric group on
$\{1, \dots, n\}$, and `RepresentativeTom` returns subgroups of it), so the change is
transparent.

### Effect

- Removes the table-of-marks bottleneck in the cases where it dominates, and raises the
  feasible degree for the `"subgroups"` algorithm from ~10 to ~13.
- No change to results: all (long) doctests of `sage/rings/lazy_species.py` pass, and the
  coefficients are identical to those computed from the group.

### Notes

- `tomlib` covers a range of small degrees (roughly $S_4$–$S_{13}$); outside that range
  `TableOfMarks` returns `fail` and we fall back to computing from the group, so there is
  no behavioural regression for any degree.