### PR TITLE
Cache the coset action in fixed_points for functorial composition of species

### DIFF
--- a/src/sage/rings/lazy_species.py
+++ b/src/sage/rings/lazy_species.py
@@ -64,6 +64,7 @@ bi-point-determining graphs we use Corollary (4.6) in
 from sage.arith.misc import divisors, multinomial
 from sage.functions.other import binomial, factorial
 from sage.libs.gap.libgap import libgap
+from sage.misc.cachefunc import cached_function
 from sage.misc.lazy_list import lazy_list
 from sage.misc.misc_c import prod
 from sage.rings.integer_ring import ZZ
@@ -2900,6 +2901,30 @@ def weighted_partitions_by_capacity(weights, capacities):
         next_bin = chosen_bin + 1
 
 
+@cached_function
+def _factor_coset_action(k, A):
+    r"""
+    Return the action of the symmetric group on `k` letters on the
+    cosets of the subgroup ``A``.
+
+    This is cached, because :func:`fixed_points` is called many times
+    with the same ``(k, A)`` but varying ``B`` (the indecomposable
+    factors of the molecules of the left species recur), and
+    constructing the coset action dominates that branch.
+
+    EXAMPLES::
+
+        sage: from sage.rings.lazy_species import _factor_coset_action
+        sage: A = PermutationGroup([(1,2)])
+        sage: act = _factor_coset_action(3, A)
+        sage: act.Image().NrMovedPoints().sage()    # S_3 on the 3 cosets of A
+        3
+        sage: _factor_coset_action(3, A) is act      # the result is cached
+        True
+    """
+    return libgap.FactorCosetAction(libgap.SymmetricGroup(k), A)
+
+
 def fixed_points(k, A, B):
     r"""
     Compute the number of fixed points of the action of `B` on
@@ -2927,11 +2952,11 @@ def fixed_points(k, A, B):
     if index == 1:
         return ZZ.one()
 
-    S = libgap.SymmetricGroup(k)
     if index < 1000:
-        act = libgap.FactorCosetAction(S, A)
+        act = _factor_coset_action(k, A)
         return index - libgap.Length(libgap.MovedPoints(libgap.Image(act, B))).sage()
 
+    S = libgap.SymmetricGroup(k)
     N_B = None
     count = ZZ.zero()
     for hom in libgap.IsomorphicSubgroups(A, B):


### PR DESCRIPTION
### Summary

The subgroup-based algorithm for functorial composition of species
(`functorial_composition(..., algorithm="subgroups")`) spends most of its
time in the helper `fixed_points(k, A, B)`. For a non-trivial proper subgroup
`A` of small index, this builds the action of `S_k` on the cosets of `A` and
reads off how many cosets are fixed by `B`.

`fixed_points` is called once for every (indecomposable factor of a left
molecule, subgroup class) pair — tens of thousands of times for a single
coefficient — and the indecomposable factors recur, so the very same coset
action `FactorCosetAction(S_k, A)` is reconstructed over and over.

This PR caches that coset action in a small helper `_factor_coset_action(k, A)`.
The results are unchanged; this is purely an implementation speedup.

### Effect: neutral for set-like species, faster for others

The cache only matters in the small-index branch of `fixed_points`. For species
whose molecules are products of symmetric groups (e.g. the species of graphs),
the relevant index is `1` and the coset action is never built — so the cache is
neutral. For species with other molecules (e.g. oriented sets, cyclic species),
the small-index branch is exercised constantly and the cache helps.

```python
sage: L.<X> = LazyCombinatorialSpecies(QQ)
sage: E = L.Sets()
sage: pairs = E * E.restrict(2, 2)

# graphs: molecules are products of symmetric groups -> neutral
sage: graphs = (E^2).functorial_composition(pairs)
sage: %time _ = graphs[7]

# oriented sets: non-symmetric molecules -> small-index branch is hit
sage: Eo = L.OrientedSets()
sage: oriented = (Eo^2).functorial_composition(pairs)
sage: %time _ = oriented[6]
```

Measured before/after (same machine):

| coefficient | before | after | |
|---|---|---|---|
| `(E^2) □ pairs` `[7]` (graphs) | 11.66 s | 11.53 s | neutral |
| `(Eo^2) □ pairs` `[6]` (oriented) | 3.72 s | 0.90 s | ~4× |

### Notes

- The cached objects are small: the `index < 1000` guard bounds each coset
  action to a permutation representation on fewer than 1000 points.