### PR TITLE
Add ETuple option to polynomial degrees

### DIFF
--- a/src/sage/rings/polynomial/multi_polynomial_element.py
+++ b/src/sage/rings/polynomial/multi_polynomial_element.py
@@ -535,11 +535,16 @@ class MPolynomial_polydict(Polynomial_singular_repr, MPolynomial_element):
         macaulay2.use(m2_parent)
         return macaulay2('substitute(%s,%s)' % (repr(self), m2_parent._name))
 
-    def degrees(self):
+    def degrees(self, as_ETuples=True):
         r"""
         Return a tuple (precisely - an ``ETuple``) with the
         degree of each variable in this polynomial. The list of degrees is,
         of course, ordered by the order of the generators.
+
+        INPUT:
+
+        - ``as_ETuples`` -- boolean (default: ``True``); if ``True``
+          return the result as an ``ETuple``, otherwise return a tuple
 
         EXAMPLES::
 
@@ -556,12 +561,24 @@ class MPolynomial_polydict(Polynomial_singular_repr, MPolynomial_element):
             sage: f = (1-x) * (1+y+z+x^3)^5
             sage: f.degrees()
             (16, 5, 5, 0)
+            sage: f.degrees(as_ETuples=False)
+            (16, 5, 5, 0)
+            sage: type(f.degrees())
+            <class 'sage.rings.polynomial.polydict.ETuple'>
+            sage: type(f.degrees(as_ETuples=False))
+            <... 'tuple'>
             sage: R(0).degrees()
             (0, 0, 0, 0)
+            sage: type(R(0).degrees(as_ETuples=False))
+            <... 'tuple'>
         """
         if not self:
-            return polydict.ETuple({}, self.parent().ngens())
-        return self._MPolynomial_element__element.max_exp()
+            degrees = polydict.ETuple({}, self.parent().ngens())
+        else:
+            degrees = self._MPolynomial_element__element.max_exp()
+        if as_ETuples:
+            return degrees
+        return tuple(degrees)
 
     def degree(self, x=None, std_grading=False):
         """

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -2912,11 +2912,16 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             return Integer(result)
         return Integer(singular_polynomial_deg(p, NULL, r))
 
-    def degrees(self):
+    def degrees(self, as_ETuples=False):
         """
         Return a tuple with the maximal degree of each variable in
         this polynomial.  The list of degrees is ordered by the order
         of the generators.
+
+        INPUT:
+
+        - ``as_ETuples`` -- boolean (default: ``False``); if ``True``
+          return the result as an ``ETuple``, otherwise return a tuple
 
         EXAMPLES::
 
@@ -2927,6 +2932,18 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             (1, 2, 1)
             sage: (q + y0^5).degrees()
             (5, 2, 1)
+            sage: q.degrees(as_ETuples=False)
+            (1, 2, 1)
+            sage: type(q.degrees(as_ETuples=False))
+            <class 'tuple'>
+            sage: type(q.degrees())
+            <class 'tuple'>
+            sage: q.degrees(as_ETuples=True)
+            (1, 2, 1)
+            sage: type(q.degrees(as_ETuples=True))
+            <class 'sage.rings.polynomial.polydict.ETuple'>
+            sage: R(0).degrees(as_ETuples=True)
+            (0, 0, 0)
 
         TESTS:
 
@@ -2947,7 +2964,10 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             for i from 0 <= i < r.N:
                 d[i] = max(d[i],p_GetExp(p, i+1, r))
             p = pNext(p)
-        return tuple(map(Integer, d))
+        d = list(map(Integer, d))
+        if as_ETuples:
+            return ETuple(d)
+        return tuple(d)
 
     def coefficient(self, degrees):
         """


### PR DESCRIPTION
This adds an `as_ETuples` keyword to `degrees()` for the two finite multivariate polynomial backends that currently expose different return types

The defaults are intentionally unchanged:

- `MPolynomial_polydict.degrees()` still returns an `ETuple`
- `MPolynomial_libsingular.degrees()` still returns a tuple

That keeps existing callers compatible while giving callers an explicit way to request either representation, similar to `exponents(as_ETuples=...)`

Part of #38632

Checks:

- `./sage -b`
- `./sage -t --long src/sage/rings/polynomial/multi_polynomial_element.py src/sage/rings/polynomial/multi_polynomial_libsingular.pyx`
- `./sage -tox -e relint -- src/sage/rings/polynomial/multi_polynomial_element.py src/sage/rings/polynomial/multi_polynomial_libsingular.pyx`
- `./sage -tox -e rst -- src/sage/rings/polynomial/multi_polynomial_element.py src/sage/rings/polynomial/multi_polynomial_libsingular.pyx`
- manual type checks for the defaults, `as_ETuples=True`, `as_ETuples=False`, and zero polynomials

### :memo: Checklist

- [x] The title is concise and informative
- [x] The description explains in detail what this PR is about
- [x] I have linked a relevant issue or discussion
- [x] I have created tests covering the changes
- [x] I have updated the documentation and checked the documentation preview

### :hourglass: Dependencies

None