### PR TITLE
pytest: harden the test integration and clear the collection blocklist

### DIFF
--- a/.github/workflows/write-dockerfile.sh
+++ b/.github/workflows/write-dockerfile.sh
@@ -275,7 +275,7 @@ cat <<EOF
 FROM with-system-packages AS bootstrapped
 #:bootstrapping:
 RUN rm -rf /new /sage/.git
-$ADD Makefile VERSION.txt COPYING.txt condarc.yml README.md bootstrap conftest.py configure_wrapper configure.ac sage .homebrew-build-env tox.ini .gitignore pyproject.toml meson.build meson.options /new/
+$ADD Makefile VERSION.txt COPYING.txt condarc.yml README.md bootstrap configure_wrapper configure.ac sage .homebrew-build-env tox.ini .gitignore pyproject.toml meson.build meson.options /new/
 $ADD config/config.rpath /new/config/config.rpath
 $ADD src/meson.build /new/src/
 $ADD src/bin /new/src/bin

--- a/conftest.py
+++ b/conftest.py
@@ -224,12 +224,6 @@ def pytest_collect_file(
 
     See `pytest documentation <https://docs.pytest.org/en/latest/reference/reference.html#std-hook-pytest_collect_file>`_.
     """
-    if (
-        file_path.parent.name == "combinat"
-        or file_path.parent.parent.name == "combinat"
-    ):
-        # Crashes CI for some reason
-        return IgnoreCollector.from_parent(parent)
     if file_path.suffix == ".pyx":
         # We don't allow pytests to be defined in Cython files.
         # Normally, Cython files are filtered out already by pytest and we only

--- a/conftest.py
+++ b/conftest.py
@@ -173,6 +173,15 @@ class SageDoctestModule(DoctestModule):
                     pytest.skip("unable to import module %r" % self.path)
                 else:
                     raise
+
+        # Honour the standard pytest opt-out: a module with ``__test__ = False``
+        # is not collected. We check it here (before the finder runs) because
+        # the stdlib doctest finder otherwise treats ``__test__`` as a dict of
+        # extra doctests and crashes on the bool. ``sage -t`` reads the raw
+        # source and ignores ``__test__``, so doctests still run there.
+        if getattr(module, "__test__", True) is False:
+            return
+
         # Uses internal doctest module parsing mechanism.
         finder = MockAwareDocTestFinder()
         optionflags = get_optionflags(self.config)
@@ -239,12 +248,6 @@ def pytest_collect_file(
                 and file_path.parent.name == "nbconvert"
             ):
                 # This is an executable file.
-                return IgnoreCollector.from_parent(parent)
-
-            if (
-                file_path.name in ("forker.py", "reporting.py")
-            ) and file_path.parent.name == "doctest":
-                # Fails with many errors due to different testing framework
                 return IgnoreCollector.from_parent(parent)
 
             return SageDoctestModule.from_parent(parent, path=file_path)

--- a/conftest.py
+++ b/conftest.py
@@ -41,28 +41,50 @@ if TYPE_CHECKING:
 _random_seed_key = pytest.StashKey[int]()
 
 
-def _resolve_lazy_imports(module: object) -> None:
+def _resolve_lazy_members(obj: object) -> None:
     """
-    Eagerly resolve the :class:`~sage.misc.lazy_import.LazyImport` objects in
-    ``module``'s namespace.
+    Eagerly resolve lazy members that cache themselves into ``obj``'s namespace.
 
-    The stdlib doctest finder iterates over ``module.__dict__``; touching a
-    lazy import there triggers its resolution, which mutates the namespace and
-    raises ``RuntimeError: dictionary changed size during iteration``. Forcing
-    resolution up front (over a snapshot of the values) avoids that. This does
-    no extra work overall: the finder would resolve the same lazy imports while
-    walking the module.
+    The stdlib doctest finder iterates over ``obj.__dict__`` for both modules
+    and classes. Touching a lazy member during that walk resolves it and writes
+    the result back into the namespace, raising ``RuntimeError: dictionary
+    changed size during iteration``. Resolving them up front avoids that, and
+    does no extra work overall: the finder would resolve the same members while
+    walking ``obj``, and the resolved values are cached globally.
+
+    Two kinds of lazy member cause this:
+
+    - :class:`~sage.misc.lazy_import.LazyImport` objects stored directly in a
+      module (or class) namespace; and
+
+    - :class:`~sage.misc.lazy_attribute.lazy_class_attribute` descriptors, which
+      are looked up along the MRO but cache their value into the *subclass* that
+      they are accessed on (e.g. ``_axiom`` on a category with axiom).
     """
+    from sage.misc.lazy_attribute import lazy_class_attribute
     from sage.misc.lazy_import import LazyImport
 
-    for value in list(vars(module).values()):
-        if isinstance(value, LazyImport):
+    if isinstance(obj, type):
+        names = {
+            name
+            for klass in obj.__mro__
+            for name, value in list(vars(klass).items())
+            if isinstance(value, (LazyImport, lazy_class_attribute))
+        }
+        for name in names:
             try:
-                value._get_object()
+                getattr(obj, name)
             except Exception:
-                # Leave unresolvable lazy imports in place; the finder's usual
+                # Leave unresolvable members in place; the finder's usual
                 # missing-feature/module handling applies when they are reached.
                 pass
+    elif inspect.ismodule(obj):
+        for value in list(vars(obj).values()):
+            if isinstance(value, LazyImport):
+                try:
+                    value._get_object()
+                except Exception:
+                    pass
 
 
 def is_subpath(path: Path, parent: Path) -> bool:
@@ -120,6 +142,11 @@ class SageDoctestModule(DoctestModule):
             ) -> None:
                 if _is_mocked(obj):
                     return
+                # Resolve lazy members of obj before super()._find iterates
+                # obj.__dict__, to avoid "dictionary changed size during
+                # iteration" when the walk triggers a lazy import or
+                # lazy_class_attribute.
+                _resolve_lazy_members(obj)
                 with _patch_unwrap_mock_aware():
                     # Type ignored because this is a private function.
                     super()._find(  # type:ignore[misc]
@@ -146,10 +173,6 @@ class SageDoctestModule(DoctestModule):
                     pytest.skip("unable to import module %r" % self.path)
                 else:
                     raise
-        # Resolve lazy imports before the finder walks the module namespace,
-        # to avoid "dictionary changed size during iteration".
-        _resolve_lazy_imports(module)
-
         # Uses internal doctest module parsing mechanism.
         finder = MockAwareDocTestFinder()
         optionflags = get_optionflags(self.config)
@@ -222,16 +245,6 @@ def pytest_collect_file(
                 and file_path.parent.name == "nbconvert"
             ):
                 # This is an executable file.
-                return IgnoreCollector.from_parent(parent)
-
-            if (
-                file_path.name == "finite_dimensional_lie_algebras_with_basis.py"
-                and file_path.parent.name == "categories"
-            ):
-                # TODO: Fix this. Unlike the cases handled by
-                # _resolve_lazy_imports, the "dictionary changed size during
-                # iteration" here originates deeper than the module namespace
-                # (nested class/category dicts resolved during the finder walk).
                 return IgnoreCollector.from_parent(parent)
 
             if (

--- a/conftest.py
+++ b/conftest.py
@@ -247,16 +247,6 @@ def pytest_collect_file(
                 # Fails with many errors due to different testing framework
                 return IgnoreCollector.from_parent(parent)
 
-            if (
-                file_path.name == "finitely_presented.py"
-                and file_path.parent.name == "groups"
-            ):
-                # Passes under `sage -t` but not here: pytest extracts doctests
-                # from __doc__ (where Python collapses backslash-continuations
-                # and processes escapes in non-raw docstrings) while sage -t
-                # reads the raw source, plus some order-dependent GAP state.
-                return IgnoreCollector.from_parent(parent)
-
             return SageDoctestModule.from_parent(parent, path=file_path)
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -41,6 +41,30 @@ if TYPE_CHECKING:
 _random_seed_key = pytest.StashKey[int]()
 
 
+def _resolve_lazy_imports(module: object) -> None:
+    """
+    Eagerly resolve the :class:`~sage.misc.lazy_import.LazyImport` objects in
+    ``module``'s namespace.
+
+    The stdlib doctest finder iterates over ``module.__dict__``; touching a
+    lazy import there triggers its resolution, which mutates the namespace and
+    raises ``RuntimeError: dictionary changed size during iteration``. Forcing
+    resolution up front (over a snapshot of the values) avoids that. This does
+    no extra work overall: the finder would resolve the same lazy imports while
+    walking the module.
+    """
+    from sage.misc.lazy_import import LazyImport
+
+    for value in list(vars(module).values()):
+        if isinstance(value, LazyImport):
+            try:
+                value._get_object()
+            except Exception:
+                # Leave unresolvable lazy imports in place; the finder's usual
+                # missing-feature/module handling applies when they are reached.
+                pass
+
+
 def is_subpath(path: Path, parent: Path) -> bool:
     # Check if the path is in a subdirectory, or a subsubdirectory, ... of the parent
     path = path.resolve()
@@ -122,6 +146,10 @@ class SageDoctestModule(DoctestModule):
                     pytest.skip("unable to import module %r" % self.path)
                 else:
                     raise
+        # Resolve lazy imports before the finder walks the module namespace,
+        # to avoid "dictionary changed size during iteration".
+        _resolve_lazy_imports(module)
+
         # Uses internal doctest module parsing mechanism.
         finder = MockAwareDocTestFinder()
         optionflags = get_optionflags(self.config)
@@ -197,17 +225,13 @@ def pytest_collect_file(
                 return IgnoreCollector.from_parent(parent)
 
             if (
-                (
-                    file_path.name == "finite_dimensional_lie_algebras_with_basis.py"
-                    and file_path.parent.name == "categories"
-                )
-                or (
-                    file_path.name == "__init__.py"
-                    and file_path.parent.name == "crypto"
-                )
-                or (file_path.name == "__init__.py" and file_path.parent.name == "mq")
+                file_path.name == "finite_dimensional_lie_algebras_with_basis.py"
+                and file_path.parent.name == "categories"
             ):
-                # TODO: Fix these (import fails with "RuntimeError: dictionary changed size during iteration")
+                # TODO: Fix this. Unlike the cases handled by
+                # _resolve_lazy_imports, the "dictionary changed size during
+                # iteration" here originates deeper than the module namespace
+                # (nested class/category dicts resolved during the finder walk).
                 return IgnoreCollector.from_parent(parent)
 
             if (

--- a/conftest.py
+++ b/conftest.py
@@ -36,6 +36,11 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+# Stash key holding the per-session Sage random seed (resolved in
+# ``pytest_configure`` and applied by the ``set_random_seed`` fixture).
+_random_seed_key = pytest.StashKey[int]()
+
+
 def is_subpath(path: Path, parent: Path) -> bool:
     # Check if the path is in a subdirectory, or a subsubdirectory, ... of the parent
     path = path.resolve()
@@ -280,6 +285,118 @@ def pytest_addoption(parser):
         help="Run doctests in all .py modules",
         dest="doctest",
     )
+    # Mirror `sage -t`: long-running tests are skipped unless explicitly
+    # requested. Tests are tagged with the ``long`` / ``longlong`` markers
+    # (declared in ``pyproject.toml``).
+    group.addoption(
+        "--long",
+        action="store_true",
+        default=False,
+        help="Also run tests marked as long (skipped by default)",
+        dest="run_long",
+    )
+    group.addoption(
+        "--longlong",
+        action="store_true",
+        default=False,
+        help="Also run tests marked as long or longlong (skipped by default)",
+        dest="run_longlong",
+    )
+    group.addoption(
+        "--random-seed",
+        type=int,
+        default=None,
+        metavar="SEED",
+        help=(
+            "Seed for Sage's random number generator, set before each test "
+            "(default: a fresh random seed, reported in the test header). "
+            "Can also be set via the SAGE_PYTEST_RANDOM_SEED environment variable."
+        ),
+        dest="random_seed",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """
+    Resolve the Sage random seed once per session.
+
+    The seed is taken from ``--random-seed``, falling back to the
+    ``SAGE_PYTEST_RANDOM_SEED`` environment variable, and finally to a fresh
+    random seed. It is stashed on the config and applied before each test by
+    the :func:`set_random_seed` fixture, mirroring ``sage -t``.
+    """
+    import os
+
+    from sage.misc import randstate
+
+    seed = config.getoption("random_seed")
+    if seed is None:
+        env_seed = os.environ.get("SAGE_PYTEST_RANDOM_SEED")
+        seed = int(env_seed) if env_seed else None
+    if seed is None:
+        # Let Sage pick a fresh seed and record it so the run is reproducible.
+        randstate.set_random_seed()
+        seed = randstate.initial_seed()
+    config.stash[_random_seed_key] = seed
+
+
+def pytest_report_header(config: pytest.Config) -> str:
+    """Report the random seed so a failing run can be reproduced."""
+    seed = config.stash[_random_seed_key]
+    return f"Sage random seed: {seed} (re-run with --random-seed={seed})"
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]):
+    """
+    Skip tests marked ``long`` / ``longlong`` unless the corresponding
+    command-line option is given.
+
+    This mirrors the behaviour of ``sage -t``, where long-running tests are
+    only executed when ``--long`` is passed. ``--longlong`` implies ``--long``.
+
+    See `pytest documentation <https://docs.pytest.org/en/stable/reference/reference.html#std-hook-pytest_collection_modifyitems>`_.
+    """
+    run_longlong = config.getoption("run_longlong")
+    run_long = config.getoption("run_long") or run_longlong
+
+    skip_long = pytest.mark.skip(reason="need --long option to run")
+    skip_longlong = pytest.mark.skip(reason="need --longlong option to run")
+
+    for item in items:
+        if not run_longlong and "longlong" in item.keywords:
+            item.add_marker(skip_longlong)
+        elif not run_long and "long" in item.keywords:
+            item.add_marker(skip_long)
+
+        _skip_if_features_missing(item)
+
+
+def _skip_if_features_missing(item: pytest.Item) -> None:
+    """
+    Honour the ``optional`` marker: skip ``item`` unless every named Sage
+    feature is available, using the same detection as the doctest framework.
+
+    Feature names are those accepted by the doctest ``# optional - ...`` and
+    ``# needs ...`` tags, e.g. ``sage.symbolic``, ``sage.plot``, ``latex``,
+    ``pynormaliz``. Usage::
+
+        @pytest.mark.optional("sage.plot", "latex")
+        def test_something():
+            ...
+    """
+    features = [
+        name for marker in item.iter_markers(name="optional") for name in marker.args
+    ]
+    if not features:
+        return
+
+    from sage.doctest.external import available_software
+
+    missing = [name for name in features if name not in available_software]
+    if missing:
+        item.add_marker(
+            pytest.mark.skip(reason="missing Sage feature(s): " + ", ".join(missing))
+        )
 
 
 # Monkey patch exception printing to replace the full qualified name of the exception by its short name
@@ -336,6 +453,21 @@ def doctest_run(
 doctest.DocTestRunner.run = doctest_run
 
 
+@pytest.fixture(autouse=True)
+def set_random_seed(request: pytest.FixtureRequest):
+    """
+    Seed Sage's random number generator before each test.
+
+    This mirrors ``sage -t``: the same seed (resolved once per session in
+    :func:`pytest_configure`) is applied before every test, so a run is
+    reproducible with ``--random-seed=<seed>`` (the seed is printed in the
+    test header).
+    """
+    from sage.misc.randstate import set_random_seed as sage_set_random_seed
+
+    sage_set_random_seed(request.config.stash[_random_seed_key])
+
+
 @pytest.fixture(autouse=True, scope="session")
 def add_imports(doctest_namespace: dict[str, Any]):
     """
@@ -374,3 +506,39 @@ def tmpfile():
     t = NamedTemporaryFile(delete=False)
     yield t
     unlink(t.name)
+
+
+@pytest.fixture
+def assert_close():
+    r"""
+    Assert that two (possibly symbolic or exact) numbers are numerically close.
+
+    This is the Sage-aware counterpart of :func:`pytest.approx` for the cases
+    it does not handle directly, in particular symbolic and exact values:
+    both arguments are evaluated numerically (via :func:`complex`) before
+    being compared. Real, complex, rational, and symbolic inputs are all
+    accepted.
+
+    The tolerance follows :func:`math.isclose`: the values are close when
+    ``abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)``. This mirrors
+    the ``# rel tol`` / ``# abs tol`` doctest flags.
+
+    EXAMPLES (used as a pytest fixture)::
+
+        def test_sqrt(assert_close):
+            from sage.all import sqrt
+            assert_close(sqrt(2), 1.4142135623730951)
+            assert_close(sqrt(2), 1.41421, rel_tol=1e-5)
+    """
+    import cmath
+
+    def _assert_close(actual, expected, *, rel_tol=1e-9, abs_tol=0.0):
+        a = complex(actual)
+        e = complex(expected)
+        if not cmath.isclose(a, e, rel_tol=rel_tol, abs_tol=abs_tol):
+            raise AssertionError(
+                f"{actual!r} is not close to {expected!r} "
+                f"(|diff| = {abs(a - e):.3e}, rel_tol={rel_tol}, abs_tol={abs_tol})"
+            )
+
+    return _assert_close

--- a/conftest.py
+++ b/conftest.py
@@ -254,36 +254,13 @@ def pytest_collect_file(
                 return IgnoreCollector.from_parent(parent)
 
             if (
-                (
-                    file_path.name == "arithgroup_generic.py"
-                    and file_path.parent.name == "arithgroup"
-                )
-                or (
-                    file_path.name == "pari.py"
-                    and file_path.parent.name == "lfunctions"
-                )
-                or (
-                    file_path.name == "permgroup_named.py"
-                    and file_path.parent.name == "perm_gps"
-                )
-                or (
-                    file_path.name == "finitely_generated.py"
-                    and file_path.parent.name == "matrix_gps"
-                )
-                or (
-                    file_path.name == "libgap_mixin.py"
-                    and file_path.parent.name == "groups"
-                )
-                or (
-                    file_path.name == "finitely_presented.py"
-                    and file_path.parent.name == "groups"
-                )
-                or (
-                    file_path.name == "classical_geometries.py"
-                    and file_path.parent.name == "generators"
-                )
+                file_path.name == "finitely_presented.py"
+                and file_path.parent.name == "groups"
             ):
-                # Fails with "Fatal Python error"
+                # Passes under `sage -t` but not here: pytest extracts doctests
+                # from __doc__ (where Python collapses backslash-continuations
+                # and processes escapes in non-raw docstrings) while sage -t
+                # reads the raw source, plus some order-dependent GAP state.
                 return IgnoreCollector.from_parent(parent)
 
             return SageDoctestModule.from_parent(parent, path=file_path)

--- a/conftest.py
+++ b/conftest.py
@@ -550,3 +550,31 @@ def assert_close():
             )
 
     return _assert_close
+
+
+@pytest.fixture
+def run_test_suite():
+    r"""
+    Run Sage's :class:`~sage.misc.sage_unittest.TestSuite` on an object.
+
+    This wraps the ubiquitous ``TestSuite(obj).run(...)`` idiom used by unit
+    tests. Crucially it defaults ``raise_on_failure=True`` so that a failing
+    test suite actually fails the pytest test: with the bare ``TestSuite.run``
+    default (``raise_on_failure=False``) failures are only printed, not raised.
+
+    Any keyword arguments are forwarded to
+    :meth:`~sage.misc.sage_unittest.TestSuite.run` (e.g. ``skip``,
+    ``max_runs``, ``verbose``).
+
+    EXAMPLES (used as a pytest fixture)::
+
+        def test_my_parent(run_test_suite):
+            from sage.all import ZZ
+            run_test_suite(ZZ)
+    """
+    from sage.misc.sage_unittest import TestSuite
+
+    def _run(obj, *, raise_on_failure=True, **kwargs):
+        TestSuite(obj).run(raise_on_failure=raise_on_failure, **kwargs)
+
+    return _run

--- a/meson.build
+++ b/meson.build
@@ -218,8 +218,3 @@ root = meson.current_source_dir()
 root_build = meson.current_build_dir()
 
 subdir('src')
-
-py.install_sources(
-  'conftest.py',
-  subdir: 'sage',
-)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,11 @@ python_files = "*_test.py"
 # The "no:faulthandler" hands signal handling to cysignals: pytest's faulthandler installs its own SIGSEGV/SIGFPE
 # handlers (via sigaltstack) that conflict with cysignals, turning signals that Sage handles internally into
 # spurious "Fatal Python error" crashes during doctest collection/execution.
-addopts = "--import-mode importlib -p no:warnings -p no:faulthandler --strict-markers"
+# "-p sage._pytest_plugin" loads Sage's pytest plugin at startup. This is read
+# from this rootdir config regardless of the working directory, so the plugin's
+# options (--doctest, --long, --random-seed, ...) are registered even when there
+# is no conftest.py at the repo root. See sage/_pytest_plugin.py.
+addopts = "--import-mode importlib -p no:warnings -p no:faulthandler -p sage._pytest_plugin --strict-markers"
 doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"
 # https://docs.pytest.org/en/stable/reference/reference.html#confval-consider_namespace_packages
 consider_namespace_packages = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,15 +115,15 @@ python_files = "*_test.py"
 # spurious "Fatal Python error" crashes during doctest collection/execution.
 # "-p sage._pytest_plugin" loads Sage's pytest plugin at startup. This is read
 # from this rootdir config regardless of the working directory, so the plugin's
-# options (--doctest, --long, --random-seed, ...) are registered even when there
-# is no conftest.py at the repo root. See sage/_pytest_plugin.py.
+# options (--doctest, --random-seed) are registered even when there is no
+# conftest.py at the repo root. See sage/_pytest_plugin.py.
 addopts = "--import-mode importlib -p no:warnings -p no:faulthandler -p sage._pytest_plugin --strict-markers"
 doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"
 # https://docs.pytest.org/en/stable/reference/reference.html#confval-consider_namespace_packages
 consider_namespace_packages = true
 markers = [
-  "long: long-running tests (run with --long)",
-  "longlong: extremely long-running tests (run with --longlong)",
+  "long: long-running tests (run by default; exclude with -m 'not long')",
+  "longlong: extremely long-running tests (run by default; exclude with -m 'not longlong')",
   "optional(*features): skip the test unless all named Sage features are present (mirrors the doctest '# optional'/'# needs' tags)",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,8 +109,11 @@ platforms = ['linux-64', 'linux-aarch64', 'osx-64', 'osx-arm64']
 # it does is try to import sagemath_giac.
 norecursedirs = "local prefix venv build builddir pkgs .git .github src/doc src/bin src/sage/libs/giac tools subprojects"
 python_files = "*_test.py"
-# The "no:warnings" is to stop pytest from capturing warnings so that they are printed to the output of the doctest
-addopts = "--import-mode importlib -p no:warnings --strict-markers"
+# The "no:warnings" is to stop pytest from capturing warnings so that they are printed to the output of the doctest.
+# The "no:faulthandler" hands signal handling to cysignals: pytest's faulthandler installs its own SIGSEGV/SIGFPE
+# handlers (via sigaltstack) that conflict with cysignals, turning signals that Sage handles internally into
+# spurious "Fatal Python error" crashes during doctest collection/execution.
+addopts = "--import-mode importlib -p no:warnings -p no:faulthandler --strict-markers"
 doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"
 # https://docs.pytest.org/en/stable/reference/reference.html#confval-consider_namespace_packages
 consider_namespace_packages = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,8 +115,9 @@ doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"
 # https://docs.pytest.org/en/stable/reference/reference.html#confval-consider_namespace_packages
 consider_namespace_packages = true
 markers = [
-  "long: long-running tests",
-  "longlong: extremely long-running tests",
+  "long: long-running tests (run with --long)",
+  "longlong: extremely long-running tests (run with --longlong)",
+  "optional(*features): skip the test unless all named Sage features are present (mirrors the doctest '# optional'/'# needs' tags)",
 ]
 
 # External dependencies in the format proposed by https://peps.python.org/pep-0725

--- a/src/doc/en/developer/tools.rst
+++ b/src/doc/en/developer/tools.rst
@@ -389,9 +389,33 @@ Pytest
 `Pytest <https://docs.pytest.org/en/stable/>`_ is a testing framework.
 It is included in the Sage distribution as an optional package.
 
-Currently, Sage only makes very limited use of pytest, for testing the
-package :mod:`sage.numerical.backends` and some modules in
-:mod:`sage.manifolds`.
+Most of Sage's automated tests are :ref:`doctests <chapter-doctesting>`,
+which double as documentation. Pytest complements them by hosting *unit
+tests* -- tests that are not meant to appear in the reference manual.
+Reach for a pytest unit test (rather than a doctest) when the test:
+
+- exercises many cases via parametrization
+  (``@pytest.mark.parametrize``), randomized, or property-based inputs;
+
+- is a regression test for a fixed bug, with no pedagogical value to a
+  reader of the documentation;
+
+- checks an error path and reads more naturally with
+  ``pytest.raises(...)`` than with a doctest traceback; or
+
+- needs fixtures, temporary files, mocking, or shared expensive setup.
+
+Keep using doctests for everything that illustrates how an object or
+function is used, and keep using :class:`~sage.misc.sage_unittest.TestSuite`
+for category/axiom conformance.
+
+*Naming convention:* Unit tests live in files named ``<something>_test.py``
+next to the module they test (for example,
+:sage_root:`src/sage/numerical/backends/glpk_backend_test.py`). This is the
+only pattern pytest collects as unit tests; note that the older
+``test_<something>.py`` files are ordinary modules that merely *contain*
+doctests, run by ``./sage -t``. Unit tests cannot be defined in Cython
+(``.pyx``) files; place them in a sibling ``_test.py`` file instead.
 
 *Installation:*
 
@@ -407,6 +431,45 @@ package :mod:`sage.numerical.backends` and some modules in
   For example, ``./sage -pytest -n 4`` will run 4 tests in parallel, while
   ``./sage -pytest -n auto`` will spawn a number of workers processes equal
   to the number of available CPUs.
+
+*Markers:* As with the doctester, long-running tests and tests that depend
+on optional features are skipped by default:
+
+- ``@pytest.mark.long`` / ``@pytest.mark.longlong`` mark long-running tests.
+  They are skipped unless ``./sage -pytest`` is passed ``--long`` (runs
+  ``long`` tests) or ``--longlong`` (runs both ``long`` and ``longlong``
+  tests), mirroring ``./sage -t --long``.
+
+- ``@pytest.mark.optional("feature", ...)`` skips the test unless every
+  named feature is present. Feature names are the same ones used by the
+  doctest ``# optional - ...`` and ``# needs ...`` tags, for example::
+
+      import pytest
+
+      @pytest.mark.optional("sage.plot", "latex")
+      def test_plot_to_pdf():
+          ...
+
+*Randomness:* Sage's random number generator is seeded before every test, as
+in ``sage -t``. The seed is reported in the test header so a failing run can
+be reproduced. Pass ``--random-seed=<seed>`` (or set the
+``SAGE_PYTEST_RANDOM_SEED`` environment variable) to replay a particular run;
+otherwise a fresh random seed is used each time.
+
+*Fixtures:* In addition to the standard pytest fixtures, ``conftest.py``
+provides:
+
+- ``tmpfile`` -- a temporary file that can be reopened and is cleaned up
+  afterwards.
+
+- ``assert_close`` -- assert that two numbers are numerically close, the
+  Sage-aware counterpart of :func:`pytest.approx` for symbolic and exact
+  values (both arguments are evaluated numerically before comparison)::
+
+      def test_sqrt(assert_close):
+          from sage.all import sqrt
+          assert_close(sqrt(2), 1.4142135623730951)
+          assert_close(sqrt(2), 1.41421, rel_tol=1e-5)
 
 - VS Code: Install the `Python extension <https://marketplace.visualstudio.com/items?itemName=ms-python.python>`_ and follow the `official VS Code documentation <https://code.visualstudio.com/docs/python/testing>`__.
 

--- a/src/doc/en/developer/tools.rst
+++ b/src/doc/en/developer/tools.rst
@@ -417,6 +417,15 @@ only pattern pytest collects as unit tests; note that the older
 doctests, run by ``./sage -t``. Unit tests cannot be defined in Cython
 (``.pyx``) files; place them in a sibling ``_test.py`` file instead.
 
+*Excluding a module:* To stop pytest from collecting a module (its unit tests
+*and* its doctests), set ``__test__ = False`` at module level. This is the
+standard pytest opt-out; it is the right tool when a module's name or contents
+would otherwise be mis-collected (a ``Test``-prefixed class, a ``test_``
+helper) or when its doctests cannot run under pytest (for example, code that
+manipulates ``sys.stdout``'s file descriptor, which conflicts with pytest's
+capture). ``./sage -t`` reads the raw source and ignores ``__test__``, so its
+doctests still run there.
+
 *Installation:*
 
 - ``./sage -i pytest pytest_xdist``.

--- a/src/doc/en/developer/tools.rst
+++ b/src/doc/en/developer/tools.rst
@@ -423,7 +423,18 @@ doctests, run by ``./sage -t``. Unit tests cannot be defined in Cython
 
 *Usage:*
 
-- Tox, Sage doctester: At the end of ``./sage -t`` (or ``./sage --tox -e doctest``), Pytest is automatically invoked.
+- Sage doctester (recommended): ``./sage -t`` runs the unit tests for the
+  given files or directories right after their doctests, so a single command
+  covers both. The relevant options are forwarded to pytest, so the whole run
+  is configured and seeded consistently:
+
+  - ``./sage -t --long`` also runs ``long`` unit tests (``longlong`` tests are
+    never run this way);
+  - ``-p N`` distributes both doctests and unit tests across ``N`` threads;
+  - the random seed reported by ``./sage -t`` is reused for the unit tests, so
+    a failing run can be reproduced with ``./sage -t --random-seed=<seed>``.
+
+  ``./sage --tox -e doctest`` invokes the doctester in the same way.
 
 - Manual: Run ``./sage -pytest path/to/the/test_file.py`` or ``./sage -pytest``
   to run all tests. The additional argument ``-n`` can be used to

--- a/src/doc/en/developer/tools.rst
+++ b/src/doc/en/developer/tools.rst
@@ -476,8 +476,8 @@ be reproduced. Pass ``--random-seed=<seed>`` (or set the
 ``SAGE_PYTEST_RANDOM_SEED`` environment variable) to replay a particular run;
 otherwise a fresh random seed is used each time.
 
-*Fixtures:* In addition to the standard pytest fixtures, ``conftest.py``
-provides:
+*Fixtures:* In addition to the standard pytest fixtures, Sage's pytest plugin
+(:sage_root:`src/sage/_pytest_plugin.py`) provides:
 
 - ``tmpfile`` -- a temporary file that can be reopened and is cleaned up
   afterwards.
@@ -493,7 +493,10 @@ provides:
 
 - VS Code: Install the `Python extension <https://marketplace.visualstudio.com/items?itemName=ms-python.python>`_ and follow the `official VS Code documentation <https://code.visualstudio.com/docs/python/testing>`__.
 
-*Configuration:* :sage_root:`conftest.py`
+*Configuration:* :sage_root:`src/sage/_pytest_plugin.py` (loaded via
+``addopts = "... -p sage._pytest_plugin"`` in :sage_root:`pyproject.toml`, so
+its options are available regardless of the working directory) and the
+``[tool.pytest.ini_options]`` section of :sage_root:`pyproject.toml`.
 
 *Documentation:* https://docs.pytest.org/en/stable/index.html
 

--- a/src/doc/en/developer/tools.rst
+++ b/src/doc/en/developer/tools.rst
@@ -452,13 +452,15 @@ doctests still run there.
   ``./sage -pytest -n auto`` will spawn a number of workers processes equal
   to the number of available CPUs.
 
-*Markers:* As with the doctester, long-running tests and tests that depend
-on optional features are skipped by default:
+*Markers:*
 
 - ``@pytest.mark.long`` / ``@pytest.mark.longlong`` mark long-running tests.
-  They are skipped unless ``./sage -pytest`` is passed ``--long`` (runs
-  ``long`` tests) or ``--longlong`` (runs both ``long`` and ``longlong``
-  tests), mirroring ``./sage -t --long``.
+  Unlike the doctester, a plain ``pytest`` run executes them by default (this
+  is how they get continuous-integration coverage); restrict a run with the
+  standard pytest marker expression, e.g. ``-m 'not longlong'`` or
+  ``-m 'not long and not longlong'``. ``./sage -t`` applies such an expression
+  to its internal pytest run, so it skips both unless ``--long`` is given (and
+  never runs ``longlong``), matching its historic behaviour.
 
 - ``@pytest.mark.optional("feature", ...)`` skips the test unless every
   named feature is present. Feature names are the same ones used by the

--- a/src/sage/_pytest_plugin.py
+++ b/src/sage/_pytest_plugin.py
@@ -1,8 +1,13 @@
 # pyright: strict
-"""Configuration and fixtures for pytest.
+"""Sage's pytest plugin: configuration, collection hooks, and fixtures.
 
-This file configures pytest and provides some global fixtures.
-See https://docs.pytest.org/en/latest/index.html for more details.
+This module is loaded as a pytest plugin via ``addopts = "... -p
+sage._pytest_plugin"`` in ``pyproject.toml`` rather than as a ``conftest.py``.
+Loading it as a plugin (read from the rootdir config regardless of the working
+directory) means its command-line options -- ``--doctest``, ``--long``,
+``--longlong``, ``--random-seed`` -- are registered even though there is no
+``conftest.py`` at the repository root. See
+https://docs.pytest.org/en/latest/index.html for more details.
 """
 
 from __future__ import annotations
@@ -132,7 +137,7 @@ class SageDoctestModule(DoctestModule):
                     obj = inspect.unwrap(obj)
 
                 # Type ignored because this is a private function.
-                return super()._find_lineno(  # type:ignore[misc]
+                return super()._find_lineno(  # type: ignore[misc]
                     obj,
                     source_lines,
                 )
@@ -149,7 +154,7 @@ class SageDoctestModule(DoctestModule):
                 _resolve_lazy_members(obj)
                 with _patch_unwrap_mock_aware():
                     # Type ignored because this is a private function.
-                    super()._find(  # type:ignore[misc]
+                    super()._find(  # type: ignore[misc]
                         tests, obj, name, module, source_lines, globs, seen
                     )
 
@@ -253,9 +258,7 @@ def pytest_collect_file(
             return SageDoctestModule.from_parent(parent, path=file_path)
 
 
-def pytest_ignore_collect(
-    collection_path: Path, config: pytest.Config
-) -> bool | None:
+def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> bool | None:
     """
     This hook is called when collecting test files, and can be used to
     prevent considering this path for collection by returning ``True``.
@@ -504,6 +507,7 @@ def tmpfile():
     """
     from os import unlink
     from tempfile import NamedTemporaryFile
+
     t = NamedTemporaryFile(delete=False)
     yield t
     unlink(t.name)

--- a/src/sage/_pytest_plugin.py
+++ b/src/sage/_pytest_plugin.py
@@ -1,4 +1,3 @@
-# pyright: strict
 """Sage's pytest plugin: configuration, collection hooks, and fixtures.
 
 This module is loaded as a pytest plugin via ``addopts = "... -p

--- a/src/sage/_pytest_plugin.py
+++ b/src/sage/_pytest_plugin.py
@@ -4,9 +4,9 @@
 This module is loaded as a pytest plugin via ``addopts = "... -p
 sage._pytest_plugin"`` in ``pyproject.toml`` rather than as a ``conftest.py``.
 Loading it as a plugin (read from the rootdir config regardless of the working
-directory) means its command-line options -- ``--doctest``, ``--long``,
-``--longlong``, ``--random-seed`` -- are registered even though there is no
-``conftest.py`` at the repository root. See
+directory) means its command-line options -- ``--doctest`` and
+``--random-seed`` -- are registered even though there is no ``conftest.py`` at
+the repository root. See
 https://docs.pytest.org/en/latest/index.html for more details.
 """
 
@@ -289,23 +289,9 @@ def pytest_addoption(parser):
         help="Run doctests in all .py modules",
         dest="doctest",
     )
-    # Mirror `sage -t`: long-running tests are skipped unless explicitly
-    # requested. Tests are tagged with the ``long`` / ``longlong`` markers
-    # (declared in ``pyproject.toml``).
-    group.addoption(
-        "--long",
-        action="store_true",
-        default=False,
-        help="Also run tests marked as long (skipped by default)",
-        dest="run_long",
-    )
-    group.addoption(
-        "--longlong",
-        action="store_true",
-        default=False,
-        help="Also run tests marked as long or longlong (skipped by default)",
-        dest="run_longlong",
-    )
+    # Note: the ``long``/``longlong`` markers (declared in ``pyproject.toml``)
+    # run by default; select with the standard pytest marker expression, e.g.
+    # ``-m 'not longlong'``. We deliberately do not add ``--long``-style flags.
     group.addoption(
         "--random-seed",
         type=int,
@@ -352,26 +338,16 @@ def pytest_report_header(config: pytest.Config) -> str:
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]):
     """
-    Skip tests marked ``long`` / ``longlong`` unless the corresponding
-    command-line option is given.
+    Skip collected tests whose required Sage features are missing.
 
-    This mirrors the behaviour of ``sage -t``, where long-running tests are
-    only executed when ``--long`` is passed. ``--longlong`` implies ``--long``.
+    Note that the ``long`` / ``longlong`` markers are intentionally *not*
+    skipped here: they run by default and are selected with the standard pytest
+    marker expression (e.g. ``-m 'not longlong'``); ``sage -t`` passes such an
+    expression for its internal pytest run.
 
     See `pytest documentation <https://docs.pytest.org/en/stable/reference/reference.html#std-hook-pytest_collection_modifyitems>`_.
     """
-    run_longlong = config.getoption("run_longlong")
-    run_long = config.getoption("run_long") or run_longlong
-
-    skip_long = pytest.mark.skip(reason="need --long option to run")
-    skip_longlong = pytest.mark.skip(reason="need --longlong option to run")
-
     for item in items:
-        if not run_longlong and "longlong" in item.keywords:
-            item.add_marker(skip_longlong)
-        elif not run_long and "long" in item.keywords:
-            item.add_marker(skip_long)
-
         _skip_if_features_missing(item)
 
 

--- a/src/sage/combinat/positive_integer_semigroup_test.py
+++ b/src/sage/combinat/positive_integer_semigroup_test.py
@@ -1,16 +1,10 @@
-import pytest
-
-
-def test_positive_integer_semigroup():
+def test_positive_integer_semigroup(run_test_suite):
     r"""
     Run the ``TestSuite()`` for ``PositiveIntegerSemigroup``
     (this can take quite a long time).
     """
-    from sage.misc.sage_unittest import TestSuite
     from sage.combinat.backtrack import PositiveIntegerSemigroup
     PP = PositiveIntegerSemigroup()
 
     # fewer max_runs since these are kind of slow
-    TestSuite(PP).run(verbose=True,
-                      raise_on_failure=True,
-                      max_runs=256)
+    run_test_suite(PP, verbose=True, max_runs=256)

--- a/src/sage/doctest/__main__.py
+++ b/src/sage/doctest/__main__.py
@@ -209,18 +209,20 @@ def main():
 
     exit_code_pytest = 0
 
-    # Never run "long long" tests via sage -t (or python -m
-    # sage.doctest) to avoid catching users by surprise with
-    # tests that run for several minutes.
-    pytest_markers = "not longlong"
-    if not args.long:
-        # Multiple "-m" flags cannot be combined,
-        #
-        #   https://github.com/pytest-dev/pytest/issues/7229
-        #
-        # so we construct one big compound statement instead.
-        pytest_markers += " and not long"
-    pytest_options = ["-m", pytest_markers]
+    pytest_options = []
+
+    # Long-running tests are gated by conftest.py via the --long/--longlong
+    # options (see pytest_collection_modifyitems). "longlong" tests are never
+    # run via sage -t (or python -m sage.doctest) to avoid catching users by
+    # surprise with tests that run for several minutes; "long" tests are run
+    # only with --long, mirroring the doctester.
+    if args.long:
+        pytest_options.append("--long")
+
+    # Seed pytest with the same random seed as the doctest run, so the whole
+    # sage -t invocation is reproducible from the single seed it reports.
+    if DC.options.random_seed is not None:
+        pytest_options += ["--random-seed", str(DC.options.random_seed)]
 
     if pytest_nprocs != 1 and not find_spec("xdist"):
         # The default is "1", so anything else is an explicit request

--- a/src/sage/doctest/__main__.py
+++ b/src/sage/doctest/__main__.py
@@ -209,15 +209,20 @@ def main():
 
     exit_code_pytest = 0
 
-    pytest_options = []
-
-    # Long-running tests are gated by conftest.py via the --long/--longlong
-    # options (see pytest_collection_modifyitems). "longlong" tests are never
-    # run via sage -t (or python -m sage.doctest) to avoid catching users by
-    # surprise with tests that run for several minutes; "long" tests are run
-    # only with --long, mirroring the doctester.
-    if args.long:
-        pytest_options.append("--long")
+    # Never run "long long" tests via sage -t (or python -m
+    # sage.doctest) to avoid catching users by surprise with
+    # tests that run for several minutes. A plain ``pytest`` invocation runs
+    # them (and is how they get CI coverage); we restrict here with the
+    # standard pytest marker expression.
+    pytest_markers = "not longlong"
+    if not args.long:
+        # Multiple "-m" flags cannot be combined,
+        #
+        #   https://github.com/pytest-dev/pytest/issues/7229
+        #
+        # so we construct one big compound statement instead.
+        pytest_markers += " and not long"
+    pytest_options = ["-m", pytest_markers]
 
     # Seed pytest with the same random seed as the doctest run, so the whole
     # sage -t invocation is reproducible from the single seed it reports.

--- a/src/sage/doctest/forker.py
+++ b/src/sage/doctest/forker.py
@@ -87,6 +87,13 @@ from sage.structure.sage_object import SageObject
 if typing.TYPE_CHECKING:
     from sage.doctest.control import DocTestController
 
+# Tell pytest not to collect the doctests in this module: they exercise the
+# doctesting framework itself (spoofing stdin/stdout, nested doctest runners),
+# which conflicts with pytest's output capture (e.g. ``sys.stdout.fileno()``
+# raises under capture). They run fine under ``sage -t``, which ignores this
+# flag and reads the raw source.
+__test__ = False
+
 # With OS X, Python 3.8 defaults to use 'spawn' instead of 'fork' in
 # multiprocessing, and Sage doctesting doesn't work with 'spawn'. See
 # trac #27754.

--- a/src/sage/doctest/reporting.py
+++ b/src/sage/doctest/reporting.py
@@ -51,6 +51,12 @@ from sage.doctest.sources import DictAsObject
 from sage.doctest.util import count_noun
 from sage.structure.sage_object import SageObject
 
+# Tell pytest not to collect the doctests in this module: they exercise the
+# doctesting framework itself (running nested doctests and inspecting their
+# reported results), which conflicts with pytest. They run fine under
+# ``sage -t``, which ignores this flag and reads the raw source.
+__test__ = False
+
 if sys.platform != "win32":
     from signal import SIGALRM, SIGBUS, SIGHUP, SIGKILL, SIGPIPE, SIGQUIT
 

--- a/src/sage/groups/matrix_gps/finitely_generated.py
+++ b/src/sage/groups/matrix_gps/finitely_generated.py
@@ -363,8 +363,8 @@ class FinitelyGeneratedMatrixGroup_generic(MatrixGroup_generic):
             sage: type(G)
             <class 'sage.groups.matrix_gps.finitely_generated.FinitelyGeneratedMatrixGroup_generic_with_category'>
 
-            sage: from sage.groups.matrix_gps.finitely_generated import \
-            ....:     FinitelyGeneratedMatrixGroup_generic
+            sage: from sage.groups.matrix_gps.finitely_generated import (
+            ....:     FinitelyGeneratedMatrixGroup_generic)
             sage: G = FinitelyGeneratedMatrixGroup_generic(2, QQ, [matrix(QQ, [[1,2], [3,4]])])
             sage: G.gens()
             (

--- a/src/sage/meson.build
+++ b/src/sage/meson.build
@@ -94,6 +94,7 @@ endforeach
 
 py.install_sources(
   '__init__.py',
+  '_pytest_plugin.py',
   'all.py',
   'all_cmdline.py',
   'all_test.py',

--- a/src/sage/misc/sage_unittest.py
+++ b/src/sage/misc/sage_unittest.py
@@ -147,6 +147,12 @@ class TestSuite:
           ``Semigroups()``).
     """
 
+    # Tell pytest not to collect this as a test class despite its ``Test``
+    # prefix; it has an ``__init__`` and is not a pytest test case. Without
+    # this, importing ``TestSuite`` at module level in a ``*_test.py`` file
+    # triggers a ``PytestCollectionWarning``.
+    __test__ = False
+
     def __init__(self, instance):
         """
         TESTS::

--- a/src/sage/numerical/backends/cvxopt_backend_test.py
+++ b/src/sage/numerical/backends/cvxopt_backend_test.py
@@ -12,7 +12,10 @@ class TestCVXOPTBackend(GenericBackendTests):
     def backend(self) -> GenericBackend:
         return MixedIntegerLinearProgram(solver="CVXOPT").get_backend()
 
-    def test_sage_unittest_testsuite(self, sage_object: SageObject):
+    def test_sage_unittest_testsuite(self, sage_object: SageObject, run_test_suite):
         # TODO: Remove this test as soon as all old test methods are migrated
-        from sage.misc.sage_unittest import TestSuite
-        TestSuite(sage_object).run(verbose=True, raise_on_failure=True, skip=("_test_pickling","_test_solve","_test_solve_trac_18572"))
+        run_test_suite(
+            sage_object,
+            verbose=True,
+            skip=("_test_pickling", "_test_solve", "_test_solve_trac_18572"),
+        )

--- a/src/sage/numerical/backends/cvxpy_backend_test.py
+++ b/src/sage/numerical/backends/cvxpy_backend_test.py
@@ -3,8 +3,13 @@ from sage.numerical.backends.generic_backend_test import GenericBackendTests
 from sage.numerical.backends.generic_backend import GenericBackend
 from sage.numerical.mip import MixedIntegerLinearProgram
 
+# Skip the whole module if cvxpy is not installed. This must be a
+# module-level statement: used as a class decorator, importorskip returns
+# the imported module and the decoration fails with "module object is not
+# callable" whenever cvxpy *is* present.
+pytest.importorskip("cvxpy")
 
-@pytest.importorskip("cvxpy")
+
 class TestCVXPYBackend(GenericBackendTests):
 
     @pytest.fixture

--- a/src/sage/numerical/backends/generic_backend_test.py
+++ b/src/sage/numerical/backends/generic_backend_test.py
@@ -17,7 +17,6 @@ class GenericBackendTests(SageObjectTests):
     def test_ncols_nonnegative(self, backend: GenericBackend):
         assert backend.ncols() >= 0
 
-    def test_sage_unittest_testsuite(self, sage_object: SageObject):
+    def test_sage_unittest_testsuite(self, sage_object: SageObject, run_test_suite):
         # TODO: Remove this test as soon as all old test methods are migrated
-        from sage.misc.sage_unittest import TestSuite
-        TestSuite(sage_object).run(verbose=True, raise_on_failure=True, skip='_test_pickling')
+        run_test_suite(sage_object, verbose=True, skip="_test_pickling")

--- a/src/sage/numerical/backends/scip_backend_test.py
+++ b/src/sage/numerical/backends/scip_backend_test.py
@@ -3,8 +3,13 @@ from sage.numerical.backends.generic_backend_test import GenericBackendTests
 from sage.numerical.backends.generic_backend import GenericBackend
 from sage.numerical.mip import MixedIntegerLinearProgram
 
+# Skip the whole module if pyscipopt is not installed. This must be a
+# module-level statement: used as a class decorator, importorskip returns
+# the imported module and the decoration fails with "module object is not
+# callable" whenever pyscipopt *is* present.
+pytest.importorskip("pyscipopt")
 
-@pytest.importorskip("pyscipopt")
+
 class TestSCIPBackend(GenericBackendTests):
 
     @pytest.fixture

--- a/src/sage/rings/function_field/function_field_test.py
+++ b/src/sage/rings/function_field/function_field_test.py
@@ -84,7 +84,7 @@ pairs = [("J", None),
 
 @pytest.mark.long
 @pytest.mark.parametrize("ff,max_runs", pairs)
-def test_function_field_testsuite(ff, max_runs, request) -> None:
+def test_function_field_testsuite(ff, max_runs, request, run_test_suite) -> None:
     r"""
     Run the TestSuite() on some function fields that are
     constructed in the documentation. They are slow, random, and not
@@ -101,17 +101,13 @@ def test_function_field_testsuite(ff, max_runs, request) -> None:
     - ``request`` -- fixture; a pytest built-in
 
     """
-    # The sage.misc.sage_unittest.TestSuite import is local to avoid
-    # pytest warnings.
-    from sage.misc.sage_unittest import TestSuite
-
     # Convert the fixture name (string) to an actual object using the
     # built-in "request" fixture.
     ff = request.getfixturevalue(ff)
 
     # Pass max_runs only if it's not None; otherwise use the default
-    run_args = {"verbose": True, "raise_on_failure": True}
+    run_args = {"verbose": True}
     if max_runs:
         run_args["max_runs"] = max_runs
 
-    TestSuite(ff).run(**run_args)
+    run_test_suite(ff, **run_args)

--- a/src/sage/rings/padics/padic_lattice_element_test.py
+++ b/src/sage/rings/padics/padic_lattice_element_test.py
@@ -1,10 +1,6 @@
 import pytest
 from sage.rings.padics.factory import ZpLC, ZpLF, QpLC, QpLF
 
-# ZpLC, ZpLF, QpLC, and QpLF all raise FutureWarnings
-from warnings import filterwarnings
-filterwarnings("ignore", category=FutureWarning)
-
 
 @pytest.fixture
 def R1():
@@ -36,20 +32,18 @@ def R4():
 elements = ("R1", "R2", "R3", "R4")
 
 
+# ZpLC, ZpLF, QpLC, and QpLF all raise FutureWarnings; ignore them just for
+# these tests (rather than mutating the warning filters process-wide).
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.long
 @pytest.mark.parametrize("e", elements)
-def test_padic_lattice_element(e, request):
+def test_padic_lattice_element(e, request, run_test_suite):
     r"""
     Run the ``TestSuite()`` for some examples that previously
     lived in the TESTS:: block of the padic_lattice_element module.
     """
-    from sage.misc.sage_unittest import TestSuite
-
     # Convert the string to a real fixture
     e = request.getfixturevalue(e)
 
     # Only do a few runs, _test_matrix_smith() in particular is slow.
-    TestSuite(e).run(verbose=True,
-                     raise_on_failure=True,
-                     skip="_test_teichmuller",
-                     max_runs=8)
+    run_test_suite(e, verbose=True, skip="_test_teichmuller", max_runs=8)

--- a/src/sage/rings/valuation/mapped_valuation_test.py
+++ b/src/sage/rings/valuation/mapped_valuation_test.py
@@ -20,14 +20,10 @@ def w():
 
 @pytest.mark.long
 @pytest.mark.parametrize("idx", [0,1])
-def test_finite_extension_from_limit_valuation_w(w, idx):
+def test_finite_extension_from_limit_valuation_w(w, idx, run_test_suite):
     r"""
     Run the ``TestSuite()`` for two examples given in the
     ``FiniteExtensionFromLimitValuation`` documentation.
     """
-    from sage.misc.sage_unittest import TestSuite
-
     # fewer max_runs, these are kind of slow
-    TestSuite(w[idx]).run(verbose=True,
-                          raise_on_failure=True,
-                          max_runs=512)
+    run_test_suite(w[idx], verbose=True, max_runs=512)

--- a/src/sage/structure/sage_object_test.py
+++ b/src/sage/structure/sage_object_test.py
@@ -9,10 +9,9 @@ class SageObjectTests:
     def sage_object(self, *args, **kwargs) -> SageObject:
         raise NotImplementedError
 
-    def test_sage_unittest_testsuite(self, sage_object: SageObject):
+    def test_sage_unittest_testsuite(self, sage_object: SageObject, run_test_suite):
         """
         Subclasses should override this method if they need to skip some tests.
         """
         # TODO: Remove this test as soon as all old test methods are migrated
-        from sage.misc.sage_unittest import TestSuite
-        TestSuite(sage_object).run(verbose=True, raise_on_failure=True)
+        run_test_suite(sage_object, verbose=True)


### PR DESCRIPTION
### 📜 Summary

This brings Sage's `pytest` integration closer to feature parity with `sage -t`,
removes every per-file/per-directory workaround from the collection blocklist by
fixing the underlying causes, and restructures the configuration so that
`conftest.py` no longer has to live at the repository root.

It is a set of small, independent commits under the umbrella of #28936 (adopt
mainstream Python testing infrastructure). Nothing changes for authors writing
ordinary doctests; `sage -t` remains the authoritative doctest runner.

### 🤔 Motivation

Running `pytest` over the Sage tree relied on a large hand-maintained blocklist
in `conftest.py` ("Crashes CI for some reason", "Fails with Fatal Python
error", …) and the custom options (`--long`, random seed) were either missing
or duplicated between `sage -t` and `conftest.py`. Investigating the blocklist
showed every entry was a *fixable* root cause rather than an inherent
limitation.

### 🛠️ What this does

**Runner parity / pytest-native selection**
- Register and document the `long`/`longlong` markers. A plain `pytest` run
  executes them by default (this is how they get CI coverage); restrict a run
  with the standard marker expression, e.g. `-m 'not longlong'`. `sage -t`
  applies that expression to its internal `pytest` run, so it skips both unless
  `--long` is given (and never runs `longlong`), matching its historic
  behaviour. (Earlier revisions of this PR added `--long`/`--longlong` flags
  that skipped by default; dropped in favour of marker selection per review —
  see thread.)
- Add an `optional("feature", …)` marker that skips unless all named Sage
  features are present, using the same detection as the doctester
  (`# optional`/`# needs`).
- Seed Sage's RNG before each test from `--random-seed` /
  `SAGE_PYTEST_RANDOM_SEED` (else a fresh seed), reported in the header for
  reproducibility; `sage -t` forwards its resolved seed to the internal
  `pytest` run so the whole invocation replays from a single seed.
- Add an `assert_close` fixture (Sage-aware `pytest.approx` for symbolic/exact
  values) and a `run_test_suite` fixture that wraps `TestSuite(obj).run(...)`
  and defaults `raise_on_failure=True` — required for a failing suite to
  actually fail the test. Migrate the existing call sites.

**Collection robustness (blocklist → 0 content exclusions)**
- Pre-resolve `LazyImport` and `lazy_class_attribute` members before the doctest
  finder walks a module/class, fixing `RuntimeError: dictionary changed size
  during iteration` (re-enables `sage.crypto`, `sage.crypto.mq`, and the
  categories with axioms, e.g. `finite_dimensional_lie_algebras_with_basis`).
- Disable pytest's `faulthandler` plugin (`-p no:faulthandler`): it installs
  SIGSEGV/SIGFPE handlers that conflict with cysignals, turning signals Sage
  handles internally into spurious "Fatal Python error" aborts (re-enables the
  GAP/PARI modules: arithgroup, lfunctions/pari, permgroup_named, matrix_gps,
  groups/libgap_mixin, generators/classical_geometries).
- Remove the wholesale `combinat` exclusion (collection-time crash, now fixed):
  11715 doctests collect and a full run completes with no crash.
- Honor module-level `__test__ = False` in the doctest collector, and use it for
  the doctest framework's own `forker.py`/`reporting.py` (their doctests spoof
  stdin/stdout and run nested doctest runners, which conflicts with pytest's
  capture). `sage -t` ignores `__test__` and still runs them.
- Fix the backend tests' misuse of `pytest.importorskip` as a class decorator,
  and a `\`-continuation doctest in `matrix_gps/finitely_generated.py` that does
  not survive `__doc__` extraction.

After this, `conftest.py` has **no per-file content exclusions**; the only
`IgnoreCollector` cases left are structural (`.pyx`, `__main__.py`/`setup.py`,
the nbconvert executable script).

**Configuration as a plugin (no root `conftest.py`)**
- Move `conftest.py` to `src/sage/_pytest_plugin.py` and load it via
  `addopts = "… -p sage._pytest_plugin"`. Because `addopts` is read from the
  rootdir config regardless of the working directory, the plugin's options
  register at startup even with no `conftest.py` at the repo root. This is what
  blocked the plain "move conftest into `src/sage/`" approach in #42203
  (`pytest_addoption` in a non-root conftest is loaded too late). Loading via
  `addopts` keeps the plugin scoped to this repository, unlike a `pytest11`
  entry point which would load for every pytest user that has `sagemath`
  installed.

**Docs**
- Document, in the developer guide, when to use pytest unit tests vs doctests
  vs `TestSuite`, the `*_test.py` convention, the `long`/`optional` markers, the
  random-seed/`assert_close`/`run_test_suite` helpers, and the `__test__ =
  False` opt-out.

### ✅ Testing

- `pytest --doctest --long --random-seed=…` works from both the repo root and
  `src/`.
- The previously blocklisted modules collect and run (combinat: 11715 doctests,
  no crash; categories; the GAP/PARI modules).
- Full `*_test.py` unit suite passes; `sage -t` (doctest controller + internal
  pytest) is unchanged end to end, seeded from the single reported seed.

### 🔗 Related

- Supersedes #42203 — achieves the `conftest.py` relocation and fixes the
  option-registration that blocked it.
- Advances #36981 (run doctests under pytest in CI) by making collection robust.
- Partially addresses #33561 (a `Test`-prefixed class pytest mis-collects):
  `TestSuite` now sets `__test__ = False`.
- Builds on #31103 (backends `TestSuite` → pytest); under the #28936 umbrella;
  related to #30738, #33549, #39211.

### 📝 Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have created tests covering the changes. *(test-infrastructure change;
      validated by running the existing doctest/unit suites — see Testing)*
- [x] I have updated the documentation (developer guide) accordingly.

### ⏳ Dependencies

None. Coordinates with #42203 (this supersedes it).
