### PR TITLE
graphs: fix planarity build on systems without <planarity/graphLib.h>

### DIFF
--- a/src/sage/graphs/meson.build
+++ b/src/sage/graphs/meson.build
@@ -12,6 +12,9 @@ if not cliquer.found()
   cliquer = cc.find_library('cliquer', required: false, disabler: true)
 endif
 
+# The planarity public header is found in different locations depending on the
+# version and packaging; planarity.pyx includes it through planarity-compat.h,
+# which selects the available layout with __has_include.
 planarity = dependency('libplanarity', required: false, disabler: true)
 if not planarity.found()
   # fallback for older versions without pkg-config

--- a/src/sage/graphs/planarity-compat.h
+++ b/src/sage/graphs/planarity-compat.h
@@ -1,4 +1,26 @@
-#include <planarity/graphLib.h>
+/*
+ * Include the planarity public header in a way that works across the header
+ * layouts shipped by different planarity versions and distributions:
+ *
+ * - planarity 5 (and the SageMath spkg) install the umbrella header as
+ *   <planarity/graphLib.h>;
+ * - some packages put their include path inside the planarity directory, so
+ *   the umbrella header is reached as <graphLib.h>;
+ * - older planarity (e.g. the libplanarity-dev currently shipped by Debian and
+ *   Ubuntu) provides <planarity/graph.h> but no graphLib.h.
+ *
+ * Sage used <planarity/graph.h> until gh-42405; switching unconditionally to
+ * <planarity/graphLib.h> there broke the build on the last layout above.
+ */
+#if !defined(__has_include)
+#  include <planarity/graphLib.h>
+#elif __has_include(<planarity/graphLib.h>)
+#  include <planarity/graphLib.h>
+#elif __has_include(<graphLib.h>)
+#  include <graphLib.h>
+#else
+#  include <planarity/graph.h>
+#endif
 
 #if GP_PROJECTVERSION_MAJOR < 5
 #define gp_EnsureVertexCapacity gp_InitGraph


### PR DESCRIPTION
### 📜 Summary

Fixes a build regression: on systems whose planarity package does not provide
the `graphLib.h` umbrella header (notably the `libplanarity-dev` currently
shipped by Debian and Ubuntu, which provides `<planarity/graph.h>` only), the
build fails with

```
src/sage/graphs/planarity-compat.h:1:10: fatal error: planarity/graphLib.h: No such file or directory
```

### 🔎 Root cause

#42405 ("Support planarity 5") changed the include in `planarity.pyx` from
`<planarity/graph.h>` to `<planarity/graphLib.h>` (via the new
`planarity-compat.h`). `graphLib.h` is not present in every planarity layout,
so the build regressed on distributions that only ship `graph.h`.

The regression went unnoticed because the distribution build workflow
(`ci.yml`) is path-filtered to `**.build` / `uv.lock` / `subprojects/**` /
`distros/*.txt`; #42405 touched only `.pyx`/`.h`, so that workflow never ran on
it.

### 🛠️ Fix

Use `__has_include` in `planarity-compat.h` to select whichever layout is
present:

1. `<planarity/graphLib.h>` (planarity 5 and the SageMath spkg) — preferred,
   preserves current behaviour;
2. `<graphLib.h>` (packages whose include path is inside the planarity dir);
3. `<planarity/graph.h>` (older planarity, e.g. Debian/Ubuntu) — the header
   Sage used before #42405.

Compilers without `__has_include` keep the previous behaviour. The
`gp_EnsureVertexCapacity`/`gp_InitGraph` shim is unchanged.

### ✅ Testing

Builds cleanly where `<planarity/graphLib.h>` exists (the preferred branch, so
no change to that case). The fallback branches need a build against a planarity
that lacks `graphLib.h` (e.g. Debian/Ubuntu `libplanarity-dev`).

> [!NOTE]
> Because this PR changes only a `.h` file, the path-filtered `ci.yml`
> (distribution builds) will not run automatically — the same reason the
> regression slipped in. It should be triggered manually (workflow_dispatch)
> to validate the fallback on Debian/Ubuntu/Fedora.

### 🔗 Related

Regression from #42405.

### 📝 Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.