### PR TITLE
Add cache keys for combinations

### DIFF
--- a/src/sage/combinat/combination.py
+++ b/src/sage/combinat/combination.py
@@ -176,6 +176,15 @@ def Combinations(mset, k=None, *, as_tuples=False):
         sage: l = [vector((0,0)), vector((0,1))]                                        # needs sage.modules
         sage: Combinations(l).list()                                                    # needs sage.modules
         [[], [(0, 0)], [(0, 1)], [(0, 0), (0, 1)]]
+
+    Combinations can be used as Cartesian product factors (:issue:`39004`)::
+
+        sage: from sage.categories.cartesian_product import cartesian_product
+        sage: a = Combinations([1,2,3], 2)
+        sage: cartesian_product([a, a]).cardinality()
+        9
+        sage: cartesian_product([Combinations([1,2]), a]).cardinality()
+        12
     """
     # Check to see if everything in mset is unique
     is_unique = False
@@ -214,6 +223,18 @@ class Combinations_mset(Parent):
         self.mset = mset
         self.as_tuples = as_tuples
         Parent.__init__(self, category=FiniteEnumeratedSets())
+
+    def _cache_key(self):
+        """
+        Return a cache key for ``self``.
+
+        TESTS::
+
+            sage: from sage.misc.cachefunc import cache_key
+            sage: cache_key(Combinations([1,2,3]))
+            (..., (1, 2, 3), False)
+        """
+        return (self.__class__, tuple(self.mset), self.as_tuples)
 
     def __contains__(self, x) -> bool:
         """
@@ -367,6 +388,18 @@ class Combinations_msetk(Parent):
         self.k = k
         self.as_tuples = as_tuples
         Parent.__init__(self, category=FiniteEnumeratedSets())
+
+    def _cache_key(self):
+        """
+        Return a cache key for ``self``.
+
+        TESTS::
+
+            sage: from sage.misc.cachefunc import cache_key
+            sage: cache_key(Combinations([1,2,3], 2))
+            (..., (1, 2, 3), 2, False)
+        """
+        return (self.__class__, tuple(self.mset), self.k, self.as_tuples)
 
     def __contains__(self, x) -> bool:
         """


### PR DESCRIPTION
This adds `_cache_key()` to the finite `Combinations` parents so they can be used by cached constructions such as `cartesian_product`

The issue was that `Combinations(...)` parents define equality but are not hashable, and they also did not provide `_cache_key()`. That made `cartesian_product([Combinations([1,2,3], 2), Combinations([1,2,3], 2)])` fail while building the cached Cartesian product parent

The change keeps the parents unhashable and only adds cache keys for the existing cache machinery. The key includes the concrete class, the multiset data, `k` when present, and the `as_tuples` output mode

Fixes #39004
Related to #19986

Checks:

- reproduced the failure on the current dev image before the patch
- `./sage -t --long src/sage/combinat/combination.py`
- `./sage -tox -e relint -- src/sage/combinat/combination.py`
- `./sage -tox -e rst -- src/sage/combinat/combination.py`
- manual checks for set, multiset, fixed-length, and `as_tuples` combinations inside `cartesian_product`

### :memo: Checklist

- [x] The title is concise and informative
- [x] The description explains in detail what this PR is about
- [x] I have linked a relevant issue or discussion
- [x] I have created tests covering the changes
- [x] I have updated the documentation and checked the documentation preview

### :hourglass: Dependencies

None