### PR TITLE
Libbraiding feature and build system support

### DIFF
--- a/.github/workflows/ci-minimal.yml
+++ b/.github/workflows/ci-minimal.yml
@@ -93,7 +93,7 @@ jobs:
       # those to fail as well.
       - name: Remove optional packages from Conda environment
         shell: bash -l {0}
-        run: conda remove bliss libhomfly rw sirocco
+        run: conda remove bliss libbraiding libhomfly rw sirocco
 
       - name: Print Conda environment
         shell: bash -l {0}
@@ -108,7 +108,7 @@ jobs:
           export CC="ccache $CC"
           export CXX="ccache $CXX"
 
-          meson setup --python.install-env=prefix --prefix="${HOME}/.local" --wrap-mode=nodownload -Dbuild-docs=false -Dbliss=disabled -Dcoxeter3=disabled -Dlibhomfly=disabled -Dmcqd=disabled -Dmeataxe=disabled -Drankwidth=disabled -Dsirocco=disabled -Dtdlib=disabled builddir
+          meson setup --python.install-env=prefix --prefix="${HOME}/.local" --wrap-mode=nodownload -Dbuild-docs=false -Dbliss=disabled -Dcoxeter3=disabled -Dlibbraiding=disabled -Dlibhomfly=disabled -Dmcqd=disabled -Dmeataxe=disabled -Drankwidth=disabled -Dsirocco=disabled -Dtdlib=disabled builddir
           meson install -C builddir
 
       - name: Check that all modules can be imported

--- a/meson.options
+++ b/meson.options
@@ -59,6 +59,13 @@ option(
 )
 
 option(
+  'libbraiding',
+  type: 'feature',
+  value: 'auto',
+  description: 'libbraiding interface to braid groups'
+)
+
+option(
   'libhomfly',
   type: 'feature',
   value: 'auto',

--- a/src/doc/en/reference/spkg/index.rst
+++ b/src/doc/en/reference/spkg/index.rst
@@ -51,6 +51,7 @@ Features
    sage/features/kenzo
    sage/features/latex
    sage/features/latte
+   sage/features/libbraiding
    sage/features/libhomfly
    sage/features/lrs
    sage/features/mcqd

--- a/src/sage/config.py.in
+++ b/src/sage/config.py.in
@@ -61,6 +61,7 @@ bliss_enabled = @BLISS_ENABLED@
 brial_enabled = @BRIAL_ENABLED@
 coxeter3_enabled = @COXETER3_ENABLED@
 eclib_enabled = @ECLIB_ENABLED@
+libbraiding_enabled = @LIBBRAIDING_ENABLED@
 libhomfly_enabled = @LIBHOMFLY_ENABLED@
 mcqd_enabled = @MCQD_ENABLED@
 meataxe_enabled = @MEATAXE_ENABLED@

--- a/src/sage/features/bliss.py
+++ b/src/sage/features/bliss.py
@@ -14,10 +14,9 @@ Features for testing the presence of ``bliss``
 # *****************************************************************************
 
 from sage.config import bliss_enabled
-from sage.features import PythonModule
-from sage.features.build_feature import BuildFeature
+from sage.features.build_feature import BuildModule
 
-class Bliss(BuildFeature):
+class Bliss(BuildModule):
     r"""
     A :class:`~sage.features.Feature` which describes whether the
     :mod:`sage.graphs.bliss` module is available in this installation
@@ -26,38 +25,36 @@ class Bliss(BuildFeature):
     EXAMPLES::
 
         sage: from sage.features.bliss import Bliss
-        sage: Bliss().require()  # needs bliss
+        sage: Bliss().is_present()  # needs bliss
+        FeatureTestResult('bliss', True)
+        sage: Bliss().is_present()  # needs !bliss
+        FeatureTestResult('bliss', False)
+
+    A runtime check. We only check the "present" case because, if
+    feature checks are _not_ deferred, the ``needs !bliss`` can be
+    satisfied (disabled at build time) at the same time we are able to
+    import a module that was installed for a previous build of sage::
+
+        sage: from sage.features.bliss import Bliss
+        sage: Bliss().is_present_at_runtime()  # needs bliss
+        FeatureTestResult('bliss', True)
+
     """
     _enabled_in_build = bliss_enabled
 
     def __init__(self):
         r"""
-        TESTS::
+        EXAMPLES::
 
             sage: from sage.features.bliss import Bliss
             sage: Bliss()
             Feature('bliss')
 
         """
+        module_name = "sage.graphs.bliss"
         super().__init__("bliss",
+                         module_name,
                          url='http://www.tcs.hut.fi/Software/bliss/')
-
-    def is_present_at_runtime(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features import FeatureTestResult
-            sage: from sage.features.bliss import Bliss
-            sage: result = Bliss().is_present_at_runtime()
-            sage: isinstance(result, FeatureTestResult)
-            True
-            sage: result  # needs bliss
-            FeatureTestResult('bliss', True)
-
-        """
-        result = PythonModule("sage.graphs.bliss")._is_present()
-        result.feature = self
-        return result
 
 def all_features():
     return [Bliss()]

--- a/src/sage/features/brial.py
+++ b/src/sage/features/brial.py
@@ -3,11 +3,10 @@ Feature for testing the presence of (lib)brial
 """
 
 from sage.config import brial_enabled
-from sage.features import PythonModule
-from sage.features.build_feature import BuildFeature
+from sage.features.build_feature import BuildModule
 
 
-class Brial(BuildFeature):
+class Brial(BuildModule):
     r"""
     A :class:`sage.features.Feature` describing the presence of
     :mod:`sage.rings.polynomial.pbori`.
@@ -16,7 +15,7 @@ class Brial(BuildFeature):
     the presence and usability of libbrial -- a slightly more
     modern fork of PolyBoRi, which hopefully explains the name.
 
-    TESTS::
+    EXAMPLES::
 
         sage: from sage.features.brial import Brial
         sage: Brial().is_present()  # needs brial
@@ -24,42 +23,32 @@ class Brial(BuildFeature):
         sage: Brial().is_present()  # needs !brial
         FeatureTestResult('brial', False)
 
+    A runtime check. We only check the "present" case because, if
+    feature checks are _not_ deferred, the ``needs !brial`` can be
+    satisfied (disabled at build time) at the same time we are able to
+    import a module that was installed for a previous build of sage::
+
+        sage: from sage.features.brial import Brial
+        sage: Brial().is_present_at_runtime()  # needs brial
+        FeatureTestResult('brial', True)
+
     """
     _enabled_in_build = brial_enabled
 
     def __init__(self):
         r"""
-        TESTS::
+        EXAMPLES::
 
             sage: from sage.features.brial import Brial
-            sage: isinstance(Brial(), Brial)
-            True
-        """
-        super().__init__("brial", spkg="brial", type="standard")
-
-
-    def is_present_at_runtime(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features import FeatureTestResult
-            sage: from sage.features.brial import Brial
-            sage: brial = Brial()
-            sage: result = brial.is_present_at_runtime()
-            sage: isinstance(result, FeatureTestResult)
-            True
-            sage: result  # needs brial
-            FeatureTestResult('brial', True)
+            sage: Brial()
+            Feature('brial')
 
         """
-        # The build system installs the sage/rings/pbori source code
-        # even when brial support is disabled, so a naive import of
-        # that module will actually succeed. We check for a
-        # conditionally-compiled cython module instead.
-        cython_modname = "sage.rings.polynomial.pbori.pbori"
-        result = PythonModule(cython_modname)._is_present()
-        result.feature = self
-        return result
+        module_name = "sage.rings.polynomial.pbori.pbori"
+        super().__init__("brial",
+                         module_name,
+                         type="standard")
+
 
 def all_features():
     return [Brial()]

--- a/src/sage/features/build_feature.py
+++ b/src/sage/features/build_feature.py
@@ -133,3 +133,78 @@ class BuildFeature(Feature):
         # "False" to the config file.
         result = bool(self._enabled_in_build)
         return FeatureTestResult(self, result)
+
+
+class BuildModule(BuildFeature):
+    r"""
+    A :class:`~sage.features.Feature` indicating the presence of
+    a python (or cython) module, with explicit support from the build
+    system.
+
+    This subclass encapsulates the runtime import check that is
+    standard for most python and cython modules. Its constructor takes
+    a ``module_name`` parameter that (optionally) differs from the
+    name of the feature. It is this ``module_name`` that we actually
+    try to import when feature checks are deferred to runtime.
+    """
+    def __init__(self, name, module_name=None, **kwargs):
+        r"""
+        EXAMPLES::
+
+            sage: from sage.features.build_feature import BuildModule
+            sage: f = BuildModule("libgap", "sage.libs.gap.libgap")
+            sage: f._enabled_in_build = True
+            sage: f.is_present()
+            FeatureTestResult('libgap', True)
+
+        """
+        if module_name is None:
+            self._module_name = name
+        else:
+            self._module_name = module_name
+
+        super().__init__(name, **kwargs)
+
+    def is_present_at_runtime(self):
+        r"""
+        Check for the module at runtime.
+
+        This uses :func:`importlib.util.find_spec` rather than (say)
+        :func:`importlib.import_module` because we are only checking
+        for the _presence_ of the feature; if there's an error, then
+        so be it, but that doesn't mean that the feature is
+        nonexistent! Perhaps more importantly, this allows us to check
+        for the presence of a feature cheaply, without triggering a
+        module import. If the feature check performed the import,
+        doing a lazy import inside of ``if foo.is_present(): ...``
+        would be pointless.
+
+        TESTS::
+
+            sage: from sage.features.build_feature import BuildModule
+            sage: f = BuildModule("libgap", "sage.libs.gap.libgap")
+            sage: f.is_present_at_runtime()
+            FeatureTestResult('libgap', True)
+
+        ::
+
+            sage: from sage.features.build_feature import BuildModule
+            sage: f = BuildModule("sage.libs.nonexistent")
+            sage: f.is_present_at_runtime()
+            FeatureTestResult('sage.libs.nonexistent', False)
+
+        """
+        from importlib import import_module
+        result = True
+        msg = f"Successfully imported module `{self._module_name}`"
+
+        try:
+            import_module(self._module_name)
+        except ModuleNotFoundError:
+            result = False
+            msg = f"Module `{self._module_name}` not found"
+        except ImportError:
+            result = False
+            msg = f"Unable to import module `{self._module_name}`"
+
+        return FeatureTestResult(self, result, reason=msg)

--- a/src/sage/features/build_feature.py
+++ b/src/sage/features/build_feature.py
@@ -128,7 +128,6 @@ class BuildFeature(Feature):
         """
         if self.is_runtime_detectable():
             return self.is_present_at_runtime()
-        import sage.config
         # Wrap with bool() so that we can be lazy and use meson's
         # set10() rather than painstakingly writing "True" and
         # "False" to the config file.

--- a/src/sage/features/coxeter3.py
+++ b/src/sage/features/coxeter3.py
@@ -14,10 +14,9 @@ Features for testing the presence of ``coxeter3``
 # *****************************************************************************
 
 from sage.config import coxeter3_enabled
-from sage.features import PythonModule
-from sage.features.build_feature import BuildFeature
+from sage.features.build_feature import BuildModule
 
-class Coxeter3(BuildFeature):
+class Coxeter3(BuildModule):
     r"""
     A :class:`~sage.features.Feature` which describes whether the
     :mod:`sage.libs.coxeter3` module is available in this installation
@@ -26,43 +25,35 @@ class Coxeter3(BuildFeature):
     EXAMPLES::
 
         sage: from sage.features.coxeter3 import Coxeter3
-        sage: Coxeter3().require()  # needs coxeter3
+        sage: Coxeter3().is_present()  # needs coxeter3
+        FeatureTestResult('coxeter3', True)
+        sage: Coxeter3().is_present()  # needs !coxeter3
+        FeatureTestResult('coxeter3', False)
+
+    A runtime check. We only check the "present" case because, if
+    feature checks are _not_ deferred, the ``needs !coxeter3`` can be
+    satisfied (disabled at build time) at the same time we are able to
+    import a module that was installed for a previous build of sage::
+
+        sage: from sage.features.coxeter3 import Coxeter3
+        sage: Coxeter3().is_present_at_runtime()  # needs coxeter3
+        FeatureTestResult('coxeter3', True)
 
     """
     _enabled_in_build = coxeter3_enabled
 
     def __init__(self):
         r"""
-        TESTS::
+        EXAMPLES::
 
             sage: from sage.features.coxeter3 import Coxeter3
             sage: Coxeter3()
             Feature('coxeter3')
 
         """
-        super().__init__("coxeter3", spkg="coxeter3")
+        module_name = "sage.libs.coxeter3.coxeter"
+        super().__init__("coxeter3", module_name)
 
-    def is_present_at_runtime(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features import FeatureTestResult
-            sage: from sage.features.coxeter3 import Coxeter3
-            sage: result = Coxeter3().is_present_at_runtime()
-            sage: isinstance(result, FeatureTestResult)
-            True
-            sage: result  # needs coxeter3
-            FeatureTestResult('coxeter3', True)
-
-        """
-        # The build system installs the sage/libs/coxeter3 source code
-        # even when coxeter3 support is disabled, so a naive import of
-        # that module will actually succeed. We check for a
-        # conditionally-compiled cython module instead.
-        cython_modname = "sage.libs.coxeter3.coxeter"
-        result = PythonModule(cython_modname)._is_present()
-        result.feature = self
-        return result
 
 def all_features():
     return [Coxeter3()]

--- a/src/sage/features/libbraiding.py
+++ b/src/sage/features/libbraiding.py
@@ -2,37 +2,48 @@ r"""
 Feature for testing the presence of libbraiding
 """
 
-from sage.features.join_feature import JoinFeature
-from sage.features import PythonModule
+from sage.config import libbraiding_enabled
+from sage.features.build_feature import BuildModule
 
 
-class Libbraiding(JoinFeature):
+class Libbraiding(BuildModule):
     r"""
     A :class:`sage.features.Feature` describing the presence of
-    :mod:`sage.libs.braiding`, the interface to braid groups via
-    libbraiding.
+    :mod:`sage.libs.braiding`, the interface to libbraiding.
 
-    TESTS::
+    EXAMPLES::
 
         sage: from sage.features.libbraiding import Libbraiding
         sage: Libbraiding().is_present()  # needs libbraiding
         FeatureTestResult('libbraiding', True)
         sage: Libbraiding().is_present()  # needs !libbraiding
-        FeatureTestResult('sage.libs.braiding', False)
+        FeatureTestResult('libbraiding', False)
+
+    A runtime check. We only check the "present" case because, if
+    feature checks are _not_ deferred, the ``needs !libbraiding`` can be
+    satisfied (disabled at build time) at the same time we are able to
+    import a module that was installed for a previous build of sage::
+
+        sage: from sage.features.libbraiding import Libbraiding
+        sage: Libbraiding().is_present_at_runtime()  # needs libbraiding
+        FeatureTestResult('libbraiding', True)
 
     """
+    _enabled_in_build = libbraiding_enabled
+
     def __init__(self):
         r"""
-        TESTS::
+        EXAMPLES::
 
             sage: from sage.features.libbraiding import Libbraiding
-            sage: isinstance(Libbraiding(), Libbraiding)
-            True
+            sage: Libbraiding()
+            Feature('libbraiding')
 
         """
-        JoinFeature.__init__(self, 'libbraiding',
-                             [PythonModule('sage.libs.braiding')],
-                             spkg='libbraiding', type='standard')
+        module_name = "sage.libs.braiding"
+        super().__init__('libbraiding',
+                         module_name,
+                         type='standard')
 
 
 def all_features():

--- a/src/sage/features/libbraiding.py
+++ b/src/sage/features/libbraiding.py
@@ -1,0 +1,39 @@
+r"""
+Feature for testing the presence of libbraiding
+"""
+
+from sage.features.join_feature import JoinFeature
+from sage.features import PythonModule
+
+
+class Libbraiding(JoinFeature):
+    r"""
+    A :class:`sage.features.Feature` describing the presence of
+    :mod:`sage.libs.braiding`, the interface to braid groups via
+    libbraiding.
+
+    TESTS::
+
+        sage: from sage.features.libbraiding import Libbraiding
+        sage: Libbraiding().is_present()  # needs libbraiding
+        FeatureTestResult('libbraiding', True)
+        sage: Libbraiding().is_present()  # needs !libbraiding
+        FeatureTestResult('sage.libs.braiding', False)
+
+    """
+    def __init__(self):
+        r"""
+        TESTS::
+
+            sage: from sage.features.libbraiding import Libbraiding
+            sage: isinstance(Libbraiding(), Libbraiding)
+            True
+
+        """
+        JoinFeature.__init__(self, 'libbraiding',
+                             [PythonModule('sage.libs.braiding')],
+                             spkg='libbraiding', type='standard')
+
+
+def all_features():
+    return [Libbraiding()]

--- a/src/sage/features/libhomfly.py
+++ b/src/sage/features/libhomfly.py
@@ -3,16 +3,15 @@ Feature for testing the presence of libhomfly
 """
 
 from sage.config import libhomfly_enabled
-from sage.features import PythonModule
-from sage.features.build_feature import BuildFeature
+from sage.features.build_feature import BuildModule
 
 
-class Libhomfly(BuildFeature):
+class Libhomfly(BuildModule):
     r"""
     A :class:`sage.features.Feature` describing the presence of
     :mod:`sage.libs.homfly`, the interface to libhomfly.
 
-    TESTS::
+    EXAMPLES::
 
         sage: from sage.features.libhomfly import Libhomfly
         sage: Libhomfly().is_present()  # needs libhomfly
@@ -20,37 +19,31 @@ class Libhomfly(BuildFeature):
         sage: Libhomfly().is_present()  # needs !libhomfly
         FeatureTestResult('libhomfly', False)
 
+    A runtime check. We only check the "present" case because, if
+    feature checks are _not_ deferred, the ``needs !libhomfly`` can be
+    satisfied (disabled at build time) at the same time we are able to
+    import a module that was installed for a previous build of sage::
+
+        sage: from sage.features.libhomfly import Libhomfly
+        sage: Libhomfly().is_present_at_runtime()  # needs libhomfly
+        FeatureTestResult('libhomfly', True)
+
     """
     _enabled_in_build = libhomfly_enabled
 
     def __init__(self):
         r"""
-        TESTS::
+        EXAMPLES::
 
             sage: from sage.features.libhomfly import Libhomfly
-            sage: isinstance(Libhomfly(), Libhomfly)
-            True
+            sage: Libhomfly()
+            Feature('libhomfly')
 
         """
-        super().__init__('libhomfly', spkg='libhomfly', type='standard')
-
-    def is_present_at_runtime(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features import FeatureTestResult
-            sage: from sage.features.libhomfly import Libhomfly
-            sage: lhf = Libhomfly()
-            sage: result = lhf.is_present_at_runtime()
-            sage: isinstance(result, FeatureTestResult)
-            True
-            sage: result  # needs libhomfly
-            FeatureTestResult('libhomfly', True)
-
-        """
-        result = PythonModule("sage.libs.homfly")._is_present()
-        result.feature = self
-        return result
+        module_name = "sage.libs.homfly"
+        super().__init__('libhomfly',
+                         module_name,
+                         type='standard')
 
 
 def all_features():

--- a/src/sage/features/mcqd.py
+++ b/src/sage/features/mcqd.py
@@ -12,10 +12,9 @@ Features for testing the presence of ``mcqd``
 # *****************************************************************************
 
 from sage.config import mcqd_enabled
-from sage.features import PythonModule
-from sage.features.build_feature import BuildFeature
+from sage.features.build_feature import BuildModule
 
-class Mcqd(BuildFeature):
+class Mcqd(BuildModule):
     r"""
     A :class:`~sage.features.Feature` describing the presence of
     the :mod:`~sage.graphs.mcqd` module, which is the SageMath
@@ -26,37 +25,33 @@ class Mcqd(BuildFeature):
         sage: from sage.features.mcqd import Mcqd
         sage: Mcqd().is_present()  # needs mcqd
         FeatureTestResult('mcqd', True)
+        sage: Mcqd().is_present()  # needs !mcqd
+        FeatureTestResult('mcqd', False)
+
+    A runtime check. We only check the "present" case because, if
+    feature checks are _not_ deferred, the ``needs !mcqd`` can be
+    satisfied (disabled at build time) at the same time we are able to
+    import a module that was installed for a previous build of sage::
+
+        sage: from sage.features.mcqd import Mcqd
+        sage: Mcqd().is_present_at_runtime()  # needs mcqd
+        FeatureTestResult('mcqd', True)
 
     """
     _enabled_in_build = mcqd_enabled
 
     def __init__(self):
         """
-        TESTS::
+        EXAMPLES::
 
             sage: from sage.features.mcqd import Mcqd
-            sage: isinstance(Mcqd(), Mcqd)
-            True
+            sage: Mcqd()
+            Feature('mcqd')
 
         """
-        super().__init__("mcqd", spkg="mcqd")
+        module_name = "sage.graphs.mcqd"
+        super().__init__("mcqd", module_name)
 
-    def is_present_at_runtime(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features import FeatureTestResult
-            sage: from sage.features.mcqd import Mcqd
-            sage: result = Mcqd().is_present_at_runtime()
-            sage: isinstance(result, FeatureTestResult)
-            True
-            sage: result  # needs mcqd
-            FeatureTestResult('mcqd', True)
-
-        """
-        result = PythonModule("sage.graphs.mcqd")._is_present()
-        result.feature = self
-        return result
 
 def all_features():
     return [Mcqd()]

--- a/src/sage/features/meataxe.py
+++ b/src/sage/features/meataxe.py
@@ -13,10 +13,9 @@ Feature for testing the presence of ``meataxe``
 # *****************************************************************************
 
 from sage.config import meataxe_enabled
-from sage.features import PythonModule
-from sage.features.build_feature import BuildFeature
+from sage.features.build_feature import BuildModule
 
-class Meataxe(BuildFeature):
+class Meataxe(BuildModule):
     r"""
     A :class:`~sage.features.Feature` describing the presence of
     the Sage modules that depend on the :ref:`meataxe <spkg_meataxe>`
@@ -27,38 +26,33 @@ class Meataxe(BuildFeature):
         sage: from sage.features.meataxe import Meataxe
         sage: Meataxe().is_present()  # needs meataxe
         FeatureTestResult('meataxe', True)
+        sage: Meataxe().is_present()  # needs !meataxe
+        FeatureTestResult('meataxe', False)
+
+    A runtime check. We only check the "present" case because, if
+    feature checks are _not_ deferred, the ``needs !meataxe`` can be
+    satisfied (disabled at build time) at the same time we are able to
+    import a module that was installed for a previous build of sage::
+
+        sage: from sage.features.meataxe import Meataxe
+        sage: Meataxe().is_present_at_runtime()  # needs meataxe
+        FeatureTestResult('meataxe', True)
 
     """
     _enabled_in_build = meataxe_enabled
 
     def __init__(self):
         r"""
-        TESTS::
+        EXAMPLES::
 
             sage: from sage.features.meataxe import Meataxe
-            sage: isinstance(Meataxe(), Meataxe)
-            True
+            sage: Meataxe()
+            Feature('meataxe')
 
         """
-        super().__init__("meataxe", spkg="meataxe")
+        module_name = "sage.matrix.matrix_gfpn_dense"
+        super().__init__("meataxe", module_name)
 
-    def is_present_at_runtime(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features import FeatureTestResult
-            sage: from sage.features.meataxe import Meataxe
-            sage: result = Meataxe().is_present_at_runtime()
-            sage: isinstance(result, FeatureTestResult)
-            True
-            sage: result  # needs meataxe
-            FeatureTestResult('meataxe', True)
-
-        """
-        modname = "sage.matrix.matrix_gfpn_dense"
-        result = PythonModule(modname)._is_present()
-        result.feature = self
-        return result
 
 def all_features():
     return [Meataxe()]

--- a/src/sage/features/rankwidth.py
+++ b/src/sage/features/rankwidth.py
@@ -13,11 +13,9 @@ Feature for the rank-width graph decomposition
 # ****************************************************************************
 
 from sage.config import rankwidth_enabled
-from sage.features import PythonModule
-from sage.features.build_feature import BuildFeature
+from sage.features.build_feature import BuildModule
 
-
-class RankWidth(BuildFeature):
+class RankWidth(BuildModule):
     r"""
     A :class:`~sage.features.Feature` indicating whether or not the
     rank-width graph decomposition is available.
@@ -35,6 +33,15 @@ class RankWidth(BuildFeature):
         sage: RankWidth().is_present()  # needs !rankwidth
         FeatureTestResult('rankwidth', False)
 
+    A runtime check. We only check the "present" case because, if
+    feature checks are _not_ deferred, the ``needs !rankwidth`` can be
+    satisfied (disabled at build time) at the same time we are able to
+    import a module that was installed for a previous build of sage::
+
+        sage: from sage.features.rankwidth import RankWidth
+        sage: RankWidth().is_present_at_runtime()  # needs rankwidth
+        FeatureTestResult('rankwidth', True)
+
     """
     _enabled_in_build = rankwidth_enabled
 
@@ -47,26 +54,12 @@ class RankWidth(BuildFeature):
             Feature('rankwidth')
 
         """
-        super().__init__("rankwidth", spkg="rw", type="standard")
+        module_name = "sage.graphs.graph_decompositions.rankwidth"
+        super().__init__("rankwidth",
+                         module_name,
+                         spkg="rw",
+                         type="standard")
 
-    def is_present_at_runtime(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features import FeatureTestResult
-            sage: from sage.features.rankwidth import RankWidth
-            sage: rw = RankWidth()
-            sage: result = rw.is_present_at_runtime()
-            sage: isinstance(result, FeatureTestResult)
-            True
-            sage: result  # needs rankwidth
-            FeatureTestResult('rankwidth', True)
-
-        """
-        cython_modname = "sage.graphs.graph_decompositions.rankwidth"
-        result = PythonModule(cython_modname)._is_present()
-        result.feature = self
-        return result
 
 def all_features():
     return [RankWidth()]

--- a/src/sage/features/sagemath.py
+++ b/src/sage/features/sagemath.py
@@ -311,28 +311,6 @@ class sage__groups(JoinFeature):
                              spkg='sagemath_groups', type='standard')
 
 
-class sage__libs__braiding(PythonModule):
-    r"""
-    A :class:`~sage.features.Feature` describing the presence of :mod:`sage.libs.braiding`.
-
-    EXAMPLES::
-
-        sage: from sage.features.sagemath import sage__libs__braiding
-        sage: sage__libs__braiding().is_present()                                            # needs sage.libs.braiding
-        FeatureTestResult('sage.libs.braiding', True)
-    """
-
-    def __init__(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features.sagemath import sage__libs__braiding
-            sage: isinstance(sage__libs__braiding(), sage__libs__braiding)
-            True
-        """
-        PythonModule.__init__(self, 'sage.libs.braiding',
-                              spkg='sagemath_libbraiding', type='standard')
-
 
 
 class sage__libs__flint(JoinFeature):
@@ -1028,7 +1006,6 @@ def all_features():
         sage__geometry__polyhedron(),
         sage__graphs(),
         sage__groups(),
-        sage__libs__braiding(),
         sage__libs__flint(),
         sage__libs__gap(),
         sage__libs__giac(),

--- a/src/sage/features/sirocco.py
+++ b/src/sage/features/sirocco.py
@@ -14,10 +14,9 @@ Features for testing the presence of ``sirocco``
 # *****************************************************************************
 
 from sage.config import sirocco_enabled
-from sage.features import PythonModule
-from sage.features.build_feature import BuildFeature
+from sage.features.build_feature import BuildModule
 
-class Sirocco(BuildFeature):
+class Sirocco(BuildModule):
     r"""
     A :class:`~sage.features.Feature` which describes whether the
     :mod:`sage.libs.sirocco` module is available in this installation
@@ -26,38 +25,35 @@ class Sirocco(BuildFeature):
     EXAMPLES::
 
         sage: from sage.features.sirocco import Sirocco
-        sage: Sirocco().require()  # needs sirocco
+        sage: Sirocco().is_present()  # needs sirocco
+        FeatureTestResult('sirocco', True)
+        sage: Sirocco().is_present()  # needs !sirocco
+        FeatureTestResult('sirocco', False)
+
+    A runtime check. We only check the "present" case because, if
+    feature checks are _not_ deferred, the ``needs !sirocco`` can be
+    satisfied (disabled at build time) at the same time we are able to
+    import a module that was installed for a previous build of sage::
+
+        sage: from sage.features.sirocco import Sirocco
+        sage: Sirocco().is_present_at_runtime()  # needs sirocco
+        FeatureTestResult('sirocco', True)
 
     """
     _enabled_in_build = sirocco_enabled
 
     def __init__(self):
         r"""
-        TESTS::
+        EXAMPLES::
 
             sage: from sage.features.sirocco import Sirocco
             sage: Sirocco()
             Feature('sirocco')
 
         """
-        super().__init__("sirocco", spkg="sirocco")
+        module_name = "sage.libs.sirocco"
+        super().__init__("sirocco", module_name, spkg="sirocco")
 
-    def is_present_at_runtime(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features import FeatureTestResult
-            sage: from sage.features.sirocco import Sirocco
-            sage: result = Sirocco().is_present_at_runtime()
-            sage: isinstance(result, FeatureTestResult)
-            True
-            sage: result  # needs sirocco
-            FeatureTestResult('sirocco', True)
-
-        """
-        result = PythonModule("sage.libs.sirocco")._is_present()
-        result.feature = self
-        return result
 
 def all_features():
     return [Sirocco()]

--- a/src/sage/features/tdlib.py
+++ b/src/sage/features/tdlib.py
@@ -13,44 +13,45 @@ Features for testing the presence of ``tdlib``
 # *****************************************************************************
 
 from sage.config import tdlib_enabled
-from sage.features import PythonModule
-from sage.features.build_feature import BuildFeature
+from sage.features.build_feature import BuildModule
 
-class Tdlib(BuildFeature):
+class Tdlib(BuildModule):
     r"""
     A :class:`~sage.features.Feature` describing the presence of
-    the SageMath interface to the :ref:`tdlib <spkg_tdlib>` library.
+    the SageMath interface to the treedec (formerly tdlib) library.
+
+    EXAMPLES::
+
+        sage: from sage.features.tdlib import Tdlib
+        sage: Tdlib().is_present()  # needs tdlib
+        FeatureTestResult('tdlib', True)
+        sage: Tdlib().is_present()  # needs !tdlib
+        FeatureTestResult('tdlib', False)
+
+    A runtime check. We only check the "present" case because, if
+    feature checks are _not_ deferred, the ``needs !tdlib`` can be
+    satisfied (disabled at build time) at the same time we are able to
+    import a module that was installed for a previous build of sage::
+
+        sage: from sage.features.tdlib import Tdlib
+        sage: Tdlib().is_present_at_runtime()  # needs tdlib
+        FeatureTestResult('tdlib', True)
+
     """
     _enabled_in_build = tdlib_enabled
 
     def __init__(self):
         r"""
-        TESTS::
+        EXAMPLES::
 
             sage: from sage.features.tdlib import Tdlib
-            sage: isinstance(Tdlib(), Tdlib)
-            True
+            sage: Tdlib()
+            Feature('tdlib')
 
         """
-        super().__init__("tdlib", spkg="tdlib")
+        module_name = "sage.graphs.graph_decompositions.tdlib"
+        super().__init__("tdlib", module_name, spkg="tdlib")
 
-    def is_present_at_runtime(self):
-        r"""
-        TESTS::
-
-            sage: from sage.features import FeatureTestResult
-            sage: from sage.features.tdlib import Tdlib
-            sage: result = Tdlib().is_present_at_runtime()
-            sage: isinstance(result, FeatureTestResult)
-            True
-            sage: result  # needs tdlib
-            FeatureTestResult('tdlib', True)
-
-        """
-        modname = "sage.graphs.graph_decompositions.tdlib"
-        result = PythonModule(modname)._is_present()
-        result.feature = self
-        return result
 
 def all_features():
     return [Tdlib()]

--- a/src/sage/groups/artin.py
+++ b/src/sage/groups/artin.py
@@ -400,8 +400,13 @@ class FiniteTypeArtinGroupElement(ArtinGroupElement):
 
             sage: B = BraidGroup(4)
             sage: b = B([1, 2, 3, -1, 2, -3])
-            sage: b.left_normal_form()
-            (s0^-1*s1^-1*s0^-1*s2^-1*s1^-1*s0^-1, s0*s1*s2*s1*s0, s0*s2*s1)
+            sage: actual = b.left_normal_form()
+            sage: s0, s1, s2 = B.gens()
+            sage: expected = (s0^-1*s1^-1*s0^-1*s2^-1*s1^-1*s0^-1,
+            ....:             s0*s1*s2*s1*s0,
+            ....:             s0*s2*s1)
+            sage: actual == expected
+            True
             sage: c = B([1])
             sage: c.left_normal_form()
             (1, s0)

--- a/src/sage/groups/braid.py
+++ b/src/sage/groups/braid.py
@@ -74,7 +74,7 @@ from sage.categories.action import Action
 from sage.categories.groups import Groups
 from sage.combinat.permutation import Permutation, Permutations
 from sage.combinat.subset import Subsets
-from sage.features.sagemath import sage__libs__braiding
+from sage.features.libbraiding import Libbraiding
 from sage.functions.generalized import sign
 from sage.groups.artin import FiniteTypeArtinGroup, FiniteTypeArtinGroupElement
 from sage.groups.finitely_presented import (
@@ -103,7 +103,7 @@ lazy_import('sage.libs.braiding',
              'leastcommonmultiple', 'conjugatingbraid', 'ultrasummitset',
              'thurston_type', 'rigidity', 'sliding_circuits', 'send_to_sss',
              'send_to_uss', 'send_to_sc', 'trajectory', 'cyclic_slidings'],
-            feature=sage__libs__braiding())
+            feature=Libbraiding())
 lazy_import('sage.knots.knot', 'Knot')
 
 

--- a/src/sage/groups/braid.py
+++ b/src/sage/groups/braid.py
@@ -1506,14 +1506,15 @@ class Braid(FiniteTypeArtinGroupElement):
         return self.annular_khovanov_complex(qagrad, ring).homology()
 
     @cached_method
-    def left_normal_form(self, algorithm='libbraiding'):
+    def left_normal_form(self, algorithm=None):
         r"""
         Return the left normal form of the braid.
 
         INPUT:
 
-        - ``algorithm`` -- string (default: ``'artin'``); must be one of the following:
+        - ``algorithm`` -- string (default: None); must be one of the following:
 
+          * ``None`` -- use 'libbraiding' if available, and 'artin' otherwise
           * ``'artin'`` -- the general method for Artin groups is used
           * ``'libbraiding'`` -- the algorithm from the ``libbraiding`` package
 
@@ -1546,6 +1547,11 @@ class Braid(FiniteTypeArtinGroupElement):
             sage: B([1,2,1]).left_normal_form()
             (s0*s1*s0,)
         """
+        if algorithm is None:
+            algorithm = 'artin'
+            if Libbraiding().is_present():
+                algorithm = 'libbraiding'
+
         if algorithm == 'libbraiding':
             lnf = leftnormalform(self)
             B = self.parent()

--- a/src/sage/groups/braid.py
+++ b/src/sage/groups/braid.py
@@ -1530,9 +1530,14 @@ class Braid(FiniteTypeArtinGroupElement):
             sage: B.one().left_normal_form()
             (1,)
             sage: b = B([-2, 2, -4, -4, 4, -5, -1, 4, -1, 1])
-            sage: L1 = b.left_normal_form(); L1
+            sage: L1 = b.left_normal_form()
+            sage: L1  # needs libbraiding
             (s0^-1*s1^-1*s0^-1*s2^-1*s1^-1*s0^-1*s3^-1*s2^-1*s1^-1*s0^-1*s4^-1*s3^-1*s2^-1*s1^-1*s0^-1,
              s0*s2*s1*s0*s3*s2*s1*s0*s4*s3*s2*s1,
+             s3)
+            sage: L1  # needs !libbraiding (artin fallback)
+            (s0^-1*s1^-1*s0^-1*s2^-1*s1^-1*s0^-1*s3^-1*s2^-1*s1^-1*s0^-1*s4^-1*s3^-1*s2^-1*s1^-1*s0^-1,
+             s2*s3*s4*s0*s1*s2*s3*s0*s1*s2*s0*s1,
              s3)
             sage: L1 == b.left_normal_form()
             True

--- a/src/sage/groups/braid.py
+++ b/src/sage/groups/braid.py
@@ -541,6 +541,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: B = BraidGroup(3)
             sage: a = B([2, 2, -1, -1])
             sage: b = B([2, 1, 2, 1])
@@ -1646,6 +1647,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: B = BraidGroup(4)
             sage: b = B([1, 2, 1, -2, 3, 1])
             sage: b.right_normal_form()
@@ -1661,6 +1663,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: B = BraidGroup(4)
             sage: b = B([2, 1, 3, 2])
             sage: b.centralizer()
@@ -1670,6 +1673,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         Check that the :issue:`35529` is fixed::
 
+            sage: # needs libbraiding
             sage: BG = BraidGroup(5)
             sage: b = BG([3, 3, 4, 3, 3, 2, 1, 4, 3, 2]) # b is s2^2*s3*s2^2*s1*s0*s3*s2*s1
             sage: b.centralizer()
@@ -1686,6 +1690,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: B = BraidGroup(3)
             sage: b = B([1, 2, -1, -2, -2, 1])
             sage: b.super_summit_set()
@@ -1708,6 +1713,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: B = BraidGroup(3)
             sage: b = B([1, 2, -1, -2, -2, 1])
             sage: c = B([1, 2, 1])
@@ -1730,6 +1736,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: B = BraidGroup(3)
             sage: b = B([1, 2, -1, -2, -2, 1])
             sage: c = B([1, 2, 1])
@@ -1755,6 +1762,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: B = BraidGroup(3)
             sage: B.one().conjugating_braid(B.one())
             1
@@ -1812,6 +1820,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: B = BraidGroup(3)
             sage: a = B([2, 2, -1, -1])
             sage: b = B([2, 1, 2, 1])
@@ -1841,6 +1850,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: B = BraidGroup(4)
             sage: B.one().pure_conjugating_braid(B.one())
             1
@@ -1923,6 +1933,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: B = BraidGroup(3)
             sage: a = B([2, 2, -1, -1, 2, 2])
             sage: b = B([2, 1, 2, 1])
@@ -1954,6 +1965,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: B = BraidGroup(3)
             sage: b = B([1, 2, -1])
             sage: b.thurston_type()
@@ -1973,6 +1985,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: B = BraidGroup(3)
             sage: b = B([1, 2, -1])
             sage: b.is_reducible()
@@ -1989,6 +2002,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: B = BraidGroup(3)
             sage: a = B([2, 2, -1, -1, 2, 2])
             sage: b = B([2, 1, 2, 1])
@@ -2005,6 +2019,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: B = BraidGroup(3)
             sage: a = B([2, 2, -1, -1, 2, 2])
             sage: b = B([2, 1, 2, 1])
@@ -2021,6 +2036,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: B = BraidGroup(3)
             sage: b = B([2, 1, 2, 1])
             sage: a = B([2, 2, -1, -1, 2, 2])
@@ -2040,6 +2056,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: B = BraidGroup(3)
             sage: a = B([2, 2, -1, -1, 2, 2])
             sage: a.sliding_circuits()
@@ -2076,6 +2093,8 @@ class Braid(FiniteTypeArtinGroupElement):
             sage: b  = B5((-1, 2, -3, -1, -3, 4, 2, -3, 2, 4, 2, -3)) # closure K12a_427
             sage: bm = b.mirror_image(); bm
             s0*s1^-1*s2*s0*s2*s3^-1*s1^-1*s2*s1^-1*s3^-1*s1^-1*s2
+
+            sage: # needs libbraiding
             sage: bm.is_conjugated(b)
             True
             sage: bm.is_conjugated(~b)
@@ -2092,6 +2111,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: b  = BraidGroup(3)((1, 1, -2, 1, -2, 1, -2, -2))  # closure K8_17
             sage: br = b.reverse(); br
             s1^-1*(s1^-1*s0)^3*s0
@@ -2302,6 +2322,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: B = BraidGroup(4)
             sage: b = B([1, 2, 1, 2, 3, -1, 2, 1, 3])
             sage: b.super_summit_set_element()
@@ -2318,6 +2339,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: B = BraidGroup(4)
             sage: b = B([1, 2, 1, 2, 3, -1, 2, -1, 3])
             sage: b.ultra_summit_set_element()
@@ -2334,6 +2356,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: B = BraidGroup(4)
             sage: b = B([1, 2, 1, 2, 3, -1, 2, -1, 3])
             sage: b.sliding_circuits_element()
@@ -2349,6 +2372,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: B = BraidGroup(4)
             sage: b = B([1, 2, 1, 2, 3, -1, 2, -1, 3])
             sage: b.trajectory()
@@ -2369,6 +2393,7 @@ class Braid(FiniteTypeArtinGroupElement):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: B = BraidGroup(4)
             sage: b = B([1, 2, 1, 2, 3, -1, 2, 1])
             sage: b.cyclic_slidings()
@@ -3488,6 +3513,8 @@ class BraidGroup_class(FiniteTypeArtinGroup):
             sage: b = B((1,-2,-1,3,2,1))
             sage: bm = mirr(b); bm
             s0^-1*s1*s0*s2^-1*s1^-1*s0^-1
+
+            sage: # needs libbraiding
             sage: bm == ~b
             False
             sage: bm.is_conjugated(b)

--- a/src/sage/knots/free_knotinfo_monoid.py
+++ b/src/sage/knots/free_knotinfo_monoid.py
@@ -221,7 +221,7 @@ class FreeKnotInfoMonoid(IndexedFreeAbelianMonoid):
 
         EXAMPLES::
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: from sage.knots.free_knotinfo_monoid import FreeKnotInfoMonoid
             sage: FKIM =  FreeKnotInfoMonoid()
             sage: K = KnotInfo.K5_1.link().mirror_image()
@@ -262,6 +262,7 @@ class FreeKnotInfoMonoid(IndexedFreeAbelianMonoid):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: from sage.knots.free_knotinfo_monoid import FreeKnotInfoMonoid
             sage: FKIM =  FreeKnotInfoMonoid()
             sage: FKIM.inject_variables(select=3)
@@ -302,7 +303,7 @@ class FreeKnotInfoMonoid(IndexedFreeAbelianMonoid):
 
         EXAMPLES::
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: from sage.knots.free_knotinfo_monoid import FreeKnotInfoMonoid
             sage: FKIM =  FreeKnotInfoMonoid()
             sage: FKIM.inject_variables(select=3)
@@ -370,7 +371,7 @@ class FreeKnotInfoMonoid(IndexedFreeAbelianMonoid):
 
         EXAMPLES::
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: from sage.knots.free_knotinfo_monoid import FreeKnotInfoMonoid
             sage: FKIM =  FreeKnotInfoMonoid()
             sage: K = KnotInfo.K5_1.link().mirror_image()
@@ -399,7 +400,7 @@ class FreeKnotInfoMonoid(IndexedFreeAbelianMonoid):
 
         EXAMPLES::
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: from sage.knots.free_knotinfo_monoid import FreeKnotInfoMonoid
             sage: FKIM =  FreeKnotInfoMonoid()
             sage: K = KnotInfo.K5_1.link().mirror_image()

--- a/src/sage/knots/knot.py
+++ b/src/sage/knots/knot.py
@@ -442,7 +442,7 @@ class Knot(Link, Element, metaclass=InheritComparisonClasscallMetaclass):
             [(4, 1), (2, 5), (6, 3), (10, 7), (8, 11), (12, 9)]
             sage: K2.dowker_notation()
             [(4, 1), (2, 5), (6, 3), (7, 10), (11, 8), (9, 12)]
-            sage: K.homfly_polynomial() == K2.homfly_polynomial()  # needs libhomfly
+            sage: K.homfly_polynomial() == K2.homfly_polynomial()  # needs libbraiding libhomfly
             False
 
         TESTS::

--- a/src/sage/knots/knotinfo.py
+++ b/src/sage/knots/knotinfo.py
@@ -128,7 +128,7 @@ types::
 
 Obtaining the HOMFLY-PT polynomial::
 
-    sage: # needs libhomfly
+    sage: # needs libbraiding libhomfly
     sage: L.homfly_polynomial()
     -v^-1*z - v^-3*z - v^-3*z^-1 + v^-5*z^-1
     sage: _ == l.homfly_polynomial(normalization='vz')
@@ -201,7 +201,7 @@ will be reduced to proper links with 7 crossings.
 Finally there is a method :meth:`Link.get_knotinfo` of class :class:`Link` to find an instance
 in the KnotInfo database::
 
-    sage: # needs libhomfly
+    sage: # needs libbraiding libhomfly
     sage: L = Link([[3,1,2,4], [8,9,1,7], [5,6,7,3], [4,18,6,5],
     ....:           [17,19,8,18], [9,10,11,14], [10,12,13,11],
     ....:           [12,19,15,13], [20,16,14,15], [16,20,17,2]])
@@ -616,7 +616,7 @@ class KnotInfoBase(Enum):
 
         EXAMPLES::
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: L = KnotInfo.L4a1_1
             sage: L._homfly_pol_ring('u', 'v')
             Multivariate Laurent Polynomial Ring in u, v over Integer Ring
@@ -1388,7 +1388,7 @@ class KnotInfoBase(Enum):
 
         EXAMPLES::
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: K3_1 = KnotInfo.K3_1
             sage: PK3_1 = K3_1.homfly_polynomial(); PK3_1
             -v^4 + v^2*z^2 + 2*v^2
@@ -1399,7 +1399,7 @@ class KnotInfoBase(Enum):
 
         for proper links::
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: L4a1_1 = KnotInfo.L4a1_1
             sage: PL4a1_1 = L4a1_1.homfly_polynomial(var1='x', var2='y'); PL4a1_1
             -x^5*y + x^3*y^3 - x^5*y^-1 + 3*x^3*y + x^3*y^-1
@@ -1409,7 +1409,7 @@ class KnotInfoBase(Enum):
         check the skein-relation from the KnotInfo description page (applied to one
         of the positive crossings of the right-handed trefoil)::
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: R = PK3_1.parent()
             sage: PO = R.one()
             sage: L2a1_1 = KnotInfo.L2a1_1
@@ -1420,7 +1420,7 @@ class KnotInfoBase(Enum):
 
         TESTS::
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: H = KnotInfo.L11n459_1_1_1.homfly_polynomial()   # optional - database_knotinfo
             sage: all(L.homfly_polynomial() == L.link().homfly_polynomial(normalization='vz')\
             ....:     for L in KnotInfo if L.crossing_number() < 7)
@@ -2253,7 +2253,7 @@ class KnotInfoBase(Enum):
 
         EXAMPLES::
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: KnotInfo.L4a1_0.is_unique()
             True
             sage: KnotInfo.L5a1_0.is_unique()
@@ -2307,7 +2307,7 @@ class KnotInfoBase(Enum):
 
         EXAMPLES::
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: KnotInfo.L4a1_0.inject()
             Defining L4a1_0
             sage: L4a1_0.is_recoverable()
@@ -2821,7 +2821,7 @@ class KnotInfoSeries(UniqueRepresentation, SageObject):
 
         EXAMPLES::
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: KnotInfo.L4a1_0.series().inject()
             Defining L4a
             sage: L4a.is_recoverable()
@@ -2850,6 +2850,7 @@ class KnotInfoSeries(UniqueRepresentation, SageObject):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: TestSuite(KnotInfo.L5a1_0.series()).run(verbose=True)  # indirect doctest
             running ._test_category() . . . pass
             running ._test_new() . . . pass

--- a/src/sage/knots/link.py
+++ b/src/sage/knots/link.py
@@ -645,6 +645,7 @@ class Link(SageObject):
 
         EXAMPLES::
 
+            sage: # needs libbraiding
             sage: B = BraidGroup(8)
             sage: L1 = Link(B([-1, -1, -1, -2, 1, -2, 3, -2, 5, 4]))
             sage: H = hash(L1)
@@ -2784,6 +2785,7 @@ class Link(SageObject):
             s0^2*s1^-1*(s1^-1*s0)^2*s1^-1
             sage: br = K8_17r.braid(); br
             s0^-1*s1*s0^-2*s1^2*s0^-1*s1
+            sage: # needs libbraiding
             sage: b.is_conjugated(br)
             False
             sage: b == br.reverse()
@@ -3183,47 +3185,52 @@ class Link(SageObject):
 
         We give some examples::
 
+            sage: # needs libbraiding libhomfly
             sage: g = BraidGroup(2).gen(0)
             sage: K = Knot(g^5)
-            sage: K.homfly_polynomial()                                                 # needs libhomfly
+            sage: K.homfly_polynomial()
             L^-4*M^4 - 4*L^-4*M^2 + 3*L^-4 - L^-6*M^2 + 2*L^-6
 
         The Hopf link::
 
+            sage: # needs libbraiding libhomfly
             sage: L = Link([[1,4,2,3],[4,1,3,2]])
-            sage: L.homfly_polynomial('x', 'y')                                         # needs libhomfly
+            sage: L.homfly_polynomial('x', 'y')
             -x^-1*y + x^-1*y^-1 + x^-3*y^-1
 
         Another version of the Hopf link where the orientation
         has been changed. Therefore we substitute `x \mapsto L^{-1}`
         and `y \mapsto M`::
 
+            sage: # needs libbraiding libhomfly
             sage: L = Link([[1,3,2,4], [4,2,3,1]])
-            sage: L.homfly_polynomial()                                                 # needs libhomfly
+            sage: L.homfly_polynomial()
             L^3*M^-1 - L*M + L*M^-1
             sage: L = Link([[1,3,2,4], [4,2,3,1]])
-            sage: L.homfly_polynomial(normalization='az')                               # needs libhomfly
+            sage: L.homfly_polynomial(normalization='az')
             a^3*z^-1 - a*z - a*z^-1
 
         The figure-eight knot::
 
+            sage: # needs libbraiding libhomfly
             sage: L = Link([[2,5,4,1], [5,3,7,6], [6,9,1,4], [9,7,3,2]])
-            sage: L.homfly_polynomial()                                                 # needs libhomfly
+            sage: L.homfly_polynomial()
             -L^2 + M^2 - 1 - L^-2
-            sage: L.homfly_polynomial('a', 'z', 'az')                                   # needs libhomfly
+            sage: L.homfly_polynomial('a', 'z', 'az')
             a^2 - z^2 - 1 + a^-2
 
         The "monster" unknot::
 
+            sage: # needs libbraiding libhomfly
             sage: L = Link([[3,1,2,4], [8,9,1,7], [5,6,7,3], [4,18,6,5],
             ....:           [17,19,8,18], [9,10,11,14], [10,12,13,11],
             ....:           [12,19,15,13], [20,16,14,15], [16,20,17,2]])
-            sage: L.homfly_polynomial()                                                 # needs libhomfly
+            sage: L.homfly_polynomial()
             1
 
         Comparison with KnotInfo::
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: KI =  K.get_knotinfo(mirror_version=False); KI
              <KnotInfo.K5_1: '5_1'>
             sage: K.homfly_polynomial(normalization='vz') == KI.homfly_polynomial()
@@ -3231,7 +3238,7 @@ class Link(SageObject):
 
         The knot `9_6`::
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: B = BraidGroup(3)
             sage: K = Knot(B([-1,-1,-1,-1,-1,-1,-2,1,-2,-2]))
             sage: K.homfly_polynomial()
@@ -3265,7 +3272,7 @@ class Link(SageObject):
 
         This works with isolated components::
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: L = Link([[[1, -1], [2, -2]], [1, 1]])
             sage: L2 = Link([[1, 4, 2, 3], [2, 4, 1, 3]])
             sage: L2.homfly_polynomial()  # not tested (:issue:`39544`)
@@ -3284,7 +3291,7 @@ class Link(SageObject):
         Check that :issue:`30346` is fixed::
 
             sage: L = Link([])
-            sage: L.homfly_polynomial()                                                 # needs libhomfly
+            sage: L.homfly_polynomial()  # needs libbraiding libhomfly
             1
 
         REFERENCES:
@@ -4165,13 +4172,13 @@ class Link(SageObject):
             sage: L = Link([[2, 5, 4, 1], [5, 7, 6, 4], [7, 9, 8, 6], [9, 11, 10, 8],
             ....:           [11, 13, 12, 10], [13, 15, 14, 12], [15, 17, 16, 14],
             ....:           [3, 19, 18, 17], [16, 18, 21, 1], [19, 3, 2, 21]])
-            sage: L._markov_move_cmp(b)  # both are isotopic to ``9_3``
+            sage: L._markov_move_cmp(b)  # needs libbraiding, both are isotopic to ``9_3``
             True
             sage: bL = L.braid(); bL
             s0^7*s1*s0^-1*s1
             sage: Lb = Link(b); Lb
             Link with 1 component represented by 13 crossings
-            sage: Lb._markov_move_cmp(bL)
+            sage: Lb._markov_move_cmp(bL)  # needs libbraiding
             True
             sage: L == Lb
             False
@@ -4223,11 +4230,12 @@ class Link(SageObject):
 
         EXAMPLES::
 
+            sage: # needs libbraiding libhomfly
             sage: KnotInfo.L5a1_0.inject()
             Defining L5a1_0
-            sage: ML = L5a1_0.link()._knotinfo_matching_list(); ML                      # needs libhomfly
+            sage: ML = L5a1_0.link()._knotinfo_matching_list(); ML
             ([<KnotInfo.L5a1_0: 'L5a1{0}'>, <KnotInfo.L5a1_1: 'L5a1{1}'>], True)
-            sage: ML == Link(L5a1_0.braid())._knotinfo_matching_list()                  # needs libhomfly
+            sage: ML == Link(L5a1_0.braid())._knotinfo_matching_list()
             True
 
         Care is needed for links having non irreducible HOMFLY-PT polynomials::
@@ -4319,7 +4327,7 @@ class Link(SageObject):
 
         EXAMPLES::
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: KnotInfo.L4a1_0.inject()
             Defining L4a1_0
             sage: L4a1_0.link()._knotinfo_matching_dict()
@@ -4430,7 +4438,7 @@ class Link(SageObject):
             sage: b, = BraidGroup(2).gens()
             sage: Link(b**13).get_knotinfo()    # optional - database_knotinfo
             KnotInfo['K13a_4878']
-            sage: Link(b**14).get_knotinfo()    # needs libhomfly
+            sage: Link(b**14).get_knotinfo()    # needs libbraiding libhomfly
             Traceback (most recent call last):
             ...
             NotImplementedError: this link having more than 11 crossings cannot be determined
@@ -4438,14 +4446,14 @@ class Link(SageObject):
             sage: Link([[1, 4, 2, 5], [3, 8, 4, 1], [5, 2, 6, 3],
             ....:       [6, 10, 7, 9], [10, 8, 9, 7]])
             Link with 2 components represented by 5 crossings
-            sage: _.get_knotinfo()                                                      # needs libhomfly
+            sage: _.get_knotinfo()  # needs libbraiding libhomfly
             Traceback (most recent call last):
             ...
             NotImplementedError: this (possibly non prime) link cannot be determined
 
         Lets identify the monster unknot::
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: L = Link([[3,1,2,4], [8,9,1,7], [5,6,7,3], [4,18,6,5],
             ....:           [17,19,8,18], [9,10,11,14], [10,12,13,11],
             ....:           [12,19,15,13], [20,16,14,15], [16,20,17,2]])
@@ -4454,7 +4462,7 @@ class Link(SageObject):
 
         Usage of option ``mirror_version``::
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: L.get_knotinfo(mirror_version=False) == KnotInfo.K0_1
             True
 
@@ -4497,7 +4505,7 @@ class Link(SageObject):
         the same unoriented name (according to the note above) the option can be
         used to achieve more detailed information::
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: L2a1 = Link(b**2)
             sage: L2a1.get_knotinfo()
             (Series of links L2a1, <SymmetryMutant.mixed: 'x'>)
@@ -4505,7 +4513,7 @@ class Link(SageObject):
             [(<KnotInfo.L2a1_0: 'L2a1{0}'>, <SymmetryMutant.mirror_image: 'm'>),
              (<KnotInfo.L2a1_1: 'L2a1{1}'>, <SymmetryMutant.itself: 's'>)]
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: KnotInfo.L5a1_0.inject()
             Defining L5a1_0
             sage: l5 = Link(L5a1_0.braid())
@@ -4571,7 +4579,7 @@ class Link(SageObject):
 
         Non prime knots can be detected, as well::
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: b = BraidGroup(4)((1, 2, 2, 2, -1, 2, 2, 2, -3, -3, -3))
             sage: Kb = Knot(b)
             sage: Kb.get_knotinfo()
@@ -4605,7 +4613,7 @@ class Link(SageObject):
              (<KnotInfo.L10a151_1_0: 'L10a151{1,0}'>, <SymmetryMutant.unknown: '?'>),
              (<KnotInfo.L10a151_1_1: 'L10a151{1,1}'>, <SymmetryMutant.unknown: '?'>)]
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: L = KnotInfo.L6a2_0
             sage: L1 = L.link()
             sage: L2 = L.link(L.items.braid_notation)
@@ -4781,7 +4789,7 @@ class Link(SageObject):
 
         EXAMPLES::
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: l1 = Link([[2, 9, 3, 10], [4, 13, 5, 14], [6, 11, 7, 12],
             ....:            [8, 1, 9, 2], [10, 7, 11, 8], [12, 5, 13, 6],
             ....:            [14, 3, 1, 4]])
@@ -4791,7 +4799,7 @@ class Link(SageObject):
             sage: l1.is_isotopic(l2)
             True
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: l3 = l2.mirror_image()
             sage: l1.is_isotopic(l3)
             False
@@ -4814,7 +4822,7 @@ class Link(SageObject):
 
         Using verbosity::
 
-            sage: # needs libhomfly
+            sage: # needs libbraiding libhomfly
             sage: set_verbose(1)
             sage: l1.is_isotopic(l2)
             verbose 1 (... link.py, is_isotopic) identified by KnotInfo (KnotInfo.K7_2, SymmetryMutant.mirror_image)
@@ -4832,7 +4840,7 @@ class Link(SageObject):
             sage: L1 = L.link()
             sage: L2 = L.link(L.items.braid_notation)
             sage: set_verbose(1)
-            sage: L1.is_isotopic(L2)  # needs libhomfly
+            sage: L1.is_isotopic(L2)  # needs libbraiding libhomfly
             verbose 1 (... link.py, is_isotopic) identified by KnotInfo uniquely (KnotInfo.L6a2_0, SymmetryMutant.itself)
             True
             sage: KnotInfo.K0_1.link().is_isotopic(KnotInfo.L2a1_0.link())

--- a/src/sage/libs/braiding.pyx
+++ b/src/sage/libs/braiding.pyx
@@ -65,6 +65,7 @@ def conjugatingbraid(braid1, braid2):
 
     EXAMPLES::
 
+        sage: # needs libbraiding
         sage: from sage.libs.braiding import conjugatingbraid
         sage: B = BraidGroup(3)
         sage: b = B([1, 2, 1, -2])
@@ -97,6 +98,7 @@ def leftnormalform(braid):
 
     EXAMPLES::
 
+        sage: # needs libbraiding
         sage: from sage.libs.braiding import leftnormalform
         sage: B = BraidGroup(3)
         sage: b = B([1, 2, 1, -2])
@@ -127,6 +129,7 @@ def rightnormalform(braid):
 
     EXAMPLES::
 
+        sage: # needs libbraiding
         sage: from sage.libs.braiding import rightnormalform
         sage: B = BraidGroup(3)
         sage: b = B([1, 2, 1, -2])
@@ -154,6 +157,7 @@ def greatestcommondivisor(braid1, braid2):
 
     EXAMPLES::
 
+        sage: # needs libbraiding
         sage: from sage.libs.braiding import greatestcommondivisor
         sage: B = BraidGroup(3)
         sage: b1 = B([1, 2, -1])
@@ -183,6 +187,7 @@ def leastcommonmultiple(braid1, braid2):
 
     EXAMPLES::
 
+        sage: # needs libbraiding
         sage: from sage.libs.braiding import leastcommonmultiple
         sage: B = BraidGroup(3)
         sage: b1 = B([1, 2, -1])
@@ -214,6 +219,7 @@ def centralizer(braid):
 
     EXAMPLES::
 
+        sage: # needs libbraiding
         sage: from sage.libs.braiding import centralizer
         sage: B = BraidGroup(3)
         sage: b = B([1, 2, -1])
@@ -248,6 +254,7 @@ def supersummitset(braid):
 
     EXAMPLES::
 
+        sage: # needs libbraiding
         sage: from sage.libs.braiding import supersummitset
         sage: B = BraidGroup(3)
         sage: b = B([1, 2, -1])
@@ -277,6 +284,7 @@ def ultrasummitset(braid):
 
     EXAMPLES::
 
+        sage: # needs libbraiding
         sage: from sage.libs.braiding import ultrasummitset
         sage: B = BraidGroup(3)
         sage: b = B([1, 2, -1])
@@ -305,6 +313,7 @@ def thurston_type(braid):
 
     EXAMPLES::
 
+        sage: # needs libbraiding
         sage: from sage.libs.braiding import thurston_type
         sage: B = BraidGroup(3)
         sage: b = B([1, 2, -1])
@@ -342,6 +351,7 @@ def rigidity(braid):
 
     EXAMPLES::
 
+        sage: # needs libbraiding
         sage: from sage.libs.braiding import rigidity
         sage: B = BraidGroup(3)
         sage: c = B([1, 1, 1, 2, 2])
@@ -371,6 +381,7 @@ def sliding_circuits(braid):
 
     EXAMPLES::
 
+        sage: # needs libbraiding
         sage: from sage.libs.braiding import sliding_circuits
         sage: B = BraidGroup(3)
         sage: c = B([1, 1, 1, 2, 2])
@@ -405,6 +416,7 @@ def send_to_sss(braid):
 
     EXAMPLES::
 
+        sage: # needs libbraiding
         sage: from sage.libs.braiding import send_to_sss
         sage: B = BraidGroup(4)
         sage: d = B([1, 2, 1, 2, 3, -1, 2,- 3])
@@ -435,6 +447,7 @@ def send_to_uss(braid):
 
     EXAMPLES::
 
+        sage: # needs libbraiding
         sage: from sage.libs.braiding import send_to_uss
         sage: B = BraidGroup(4)
         sage: d = B([1, 2, 1, 2, 3, -1, 2,- 1])
@@ -465,6 +478,7 @@ def send_to_sc(braid):
 
     EXAMPLES::
 
+        sage: # needs libbraiding
         sage: from sage.libs.braiding import send_to_sc
         sage: B = BraidGroup(4)
         sage: d = B([1, 2, 1, 2, 3, -1, 2, 2])
@@ -495,6 +509,7 @@ def trajectory(braid):
 
     EXAMPLES::
 
+        sage: # needs libbraiding
         sage: from sage.libs.braiding import trajectory
         sage: B = BraidGroup(4)
         sage: d = B([1, 2, 1, 2, 3, -1, 2, 2])
@@ -528,6 +543,7 @@ def cyclic_slidings(braid):
 
     EXAMPLES::
 
+        sage: # needs libbraiding
         sage: from sage.libs.braiding import cyclic_slidings
         sage: B = BraidGroup(4)
         sage: d = B([1, 2, 1, 2, 3, -1, 2, 2])

--- a/src/sage/libs/meson.build
+++ b/src/sage/libs/meson.build
@@ -209,6 +209,7 @@ endforeach
 
 # Record in the config file whether or not optional packages were
 # found, so that we don't have to look for them at runtime.
+conf_data.set10('LIBBRAIDING_ENABLED', braiding.found())
 conf_data.set10('LIBHOMFLY_ENABLED', homfly.found())
 conf_data.set10('MEATAXE_ENABLED', mtx.found())
 conf_data.set10('SIROCCO_ENABLED', sirocco.found())

--- a/src/sage/libs/meson.build
+++ b/src/sage/libs/meson.build
@@ -76,7 +76,7 @@ endif
 braiding = dependency(
   'libbraiding',
   version: '>=1.3.1',
-  required: false,
+  required: get_option('libbraiding'),
   disabler: true,
 )
 

--- a/src/sage/schemes/curves/zariski_vankampen.py
+++ b/src/sage/schemes/curves/zariski_vankampen.py
@@ -68,8 +68,6 @@ from sage.rings.rational_field import QQ
 from sage.rings.real_mpfr import RealField
 from sage.schemes.curves.constructor import Curve
 
-lazy_import('sage.libs.braiding', ['leftnormalform', 'rightnormalform'])
-
 roots_interval_cache: dict[tuple, Any] = {}
 
 
@@ -1435,6 +1433,10 @@ def conjugate_positive_form(braid) -> list[list]:
         sage: conjugate_positive_form(s1)
         [[s1^3, []]]
     """
+    from sage.features.libbraiding import Libbraiding
+    Libbraiding().require()
+    from sage.libs.braiding import rightnormalform
+
     B = braid.parent()
     d = B.strands()
     rnf = rightnormalform(braid)
@@ -1507,6 +1509,10 @@ def braid2rels(L) -> list:
         sage: braid2rels(L)
         [(4, 1, -2, -1), (2, -4, -2, 1)]
     """
+    from sage.features.libbraiding import Libbraiding
+    Libbraiding().require()
+    from sage.libs.braiding import leftnormalform
+
     br = L[0]
     L1 = L[1]
     B = br.parent()
@@ -1653,6 +1659,11 @@ def fundamental_group_from_braid_mon(bm, degree=None,
         a1 = tuple([-j for j in reversed(a)])
         cnjdelta.append(a + (d - j,) + a1)
     homcnjdelta = F.hom(codomain=F, im_gens=cnjdelta)
+
+    from sage.features.libbraiding import Libbraiding
+    Libbraiding().require()
+    from sage.libs.braiding import rightnormalform
+
     for j, k in enumerate(vertical0):
         l1 = d + j + 1
         br = bm[k]

--- a/src/sage/schemes/curves/zariski_vankampen.py
+++ b/src/sage/schemes/curves/zariski_vankampen.py
@@ -1416,6 +1416,7 @@ def conjugate_positive_form(braid) -> list[list]:
 
     EXAMPLES::
 
+        sage: # needs libbraiding
         sage: from sage.schemes.curves.zariski_vankampen import conjugate_positive_form
         sage: B = BraidGroup(4)
         sage: t = B((1, 3, 2, -3, 1, 1))
@@ -1503,6 +1504,7 @@ def braid2rels(L) -> list:
 
     EXAMPLES::
 
+        sage: # needs libbraiding
         sage: from sage.schemes.curves.zariski_vankampen import braid2rels
         sage: B.<s0, s1, s2> = BraidGroup(4)
         sage: L = ((s1*s0)^2, [s2])


### PR DESCRIPTION
Rename the existing "sage.libs.braiding" feature, and convert it to one that has support from our build system. Then add the `# needs libbraiding` tags, and test it all on the minimal CI job.

**Dependencies:**
* https://github.com/sagemath/sage/pull/42389