### PR TITLE
Fix issues with scipy 1.18

### DIFF
--- a/src/sage/matrix/args.pyx
+++ b/src/sage/matrix/args.pyx
@@ -1344,9 +1344,6 @@ cdef class MatrixArgs:
         self.set_ncols(incols)
         str_dtype = str(e.dtype)
 
-        if not (e.flags.c_contiguous is True or e.flags.f_contiguous is True):
-            raise TypeError('numpy matrix must be either c_contiguous or f_contiguous')
-
         from sage.matrix.constructor import matrix
         from sage.rings.real_double import RDF
         from sage.rings.complex_double import CDF

--- a/src/sage/matrix/matrix_numpy_dense.pyx
+++ b/src/sage/matrix/matrix_numpy_dense.pyx
@@ -457,9 +457,9 @@ cdef class Matrix_numpy_dense(Matrix_dense):
             sage: n = m.numpy()
             sage: import numpy
             sage: tuple(numpy.linalg.eig(n))
-            (array([-0.37228132,  5.37228132]),
-             array([[-0.82456484, -0.41597356],
-                   [ 0.56576746, -0.90937671]]))
+            (array([-0.37228132...,  5.37228132...]),
+             array([[-0.82456484..., -0.41597356...],
+                   [ 0.56576746..., -0.90937671...]]))
             sage: m = matrix(RDF, 2, range(6)); m
             [0.0 1.0 2.0]
             [3.0 4.0 5.0]

--- a/src/sage/plot/plot3d/list_plot3d.py
+++ b/src/sage/plot/plot3d/list_plot3d.py
@@ -622,7 +622,7 @@ def list_plot3d_tuples(v, interpolation_type, **kwds):
             kx = kwds['degree']
             ky = kwds['degree']
         s = kwds.get('smoothing', len(x) - numpy.sqrt(2 * len(x)))
-        s = interpolate.bisplrep(x, y, z, [1] * len(x), xmin, xmax,
+        s = interpolate.bisplrep(x, y, z, [1.0] * len(x), xmin, xmax,
                                  ymin, ymax, kx=kx, ky=ky, s=s)
 
         def f(x, y):


### PR DESCRIPTION
Most notably, stop requiring numpy arrays to be contiguous. This is not under sage's control, and is not true for the arrays returned by some functions (such as `eig`) in scipy 1.18 [1]

[1] https://github.com/scipy/scipy/issues/25477
