### PR TITLE
m4rie feature and build system support

### DIFF
--- a/.github/workflows/ci-minimal.yml
+++ b/.github/workflows/ci-minimal.yml
@@ -93,7 +93,7 @@ jobs:
       # those to fail as well.
       - name: Remove optional packages from Conda environment
         shell: bash -l {0}
-        run: conda remove bliss libbraiding libhomfly rw sirocco
+        run: conda remove bliss libbraiding libhomfly m4rie rw sirocco
 
       - name: Print Conda environment
         shell: bash -l {0}
@@ -107,7 +107,7 @@ jobs:
           # Let Meson discover the compiler through the ccache wrappers.
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
 
-          meson setup --buildtype=release --python.install-env=prefix --prefix="${HOME}/.local" --wrap-mode=nodownload -Dbuild-docs=false -Dbliss=disabled -Dcoxeter3=disabled -Dlibbraiding=disabled -Dlibhomfly=disabled -Dmcqd=disabled -Dmeataxe=disabled -Drankwidth=disabled -Dsirocco=disabled -Dtdlib=disabled builddir
+          meson setup --buildtype=release --python.install-env=prefix --prefix="${HOME}/.local" --wrap-mode=nodownload -Dbuild-docs=false -Dbliss=disabled -Dcoxeter3=disabled -Dlibbraiding=disabled -Dlibhomfly=disabled -Dm4rie=disabled -Dmcqd=disabled -Dmeataxe=disabled -Drankwidth=disabled -Dsirocco=disabled -Dtdlib=disabled builddir
           meson install -C builddir
 
       - name: Check that all modules can be imported

--- a/meson.options
+++ b/meson.options
@@ -73,6 +73,13 @@ option(
 )
 
 option(
+  'm4rie',
+  type: 'feature',
+  value: 'auto',
+  description: 'm4rie interface for matrices over GF(2^e)'
+)
+
+option(
   'mcqd',
   type: 'feature',
   value: 'auto',

--- a/src/meson.build
+++ b/src/meson.build
@@ -176,11 +176,11 @@ if not m4ri.found()
     sources: true,
   )
 endif
-m4rie = dependency('m4rie', required: false)
-if not m4rie.found()
-  # For some reason, m4rie is not found via pkg-config on some systems (eg Conda)
-  m4rie = cc.find_library('m4rie', required: not is_windows, disabler: true)
-endif
+
+# m4rie requires m4ri, but the check should fail if m4ri is not present,
+# so let's not over-complicate the logic.
+m4rie = dependency('m4rie', required: get_option('m4rie'), disabler: true)
+
 mtx = dependency('libmtx', required: false)
 if not mtx.found()
   # fallback for older versions without pkg-config

--- a/src/sage/config.py.in
+++ b/src/sage/config.py.in
@@ -45,6 +45,7 @@ coxeter3_enabled = @COXETER3_ENABLED@
 eclib_enabled = @ECLIB_ENABLED@
 libbraiding_enabled = @LIBBRAIDING_ENABLED@
 libhomfly_enabled = @LIBHOMFLY_ENABLED@
+m4rie_enabled = @M4RIE_ENABLED@
 mcqd_enabled = @MCQD_ENABLED@
 meataxe_enabled = @MEATAXE_ENABLED@
 rankwidth_enabled = @RANKWIDTH_ENABLED@

--- a/src/sage/features/m4rie.py
+++ b/src/sage/features/m4rie.py
@@ -1,0 +1,50 @@
+r"""
+Feature for the m4rie library (matrices over `GF(2^e)`)
+"""
+
+from sage.config import m4rie_enabled
+from sage.features.build_feature import BuildModule
+
+
+class M4rie(BuildModule):
+    r"""
+    A :class:`sage.features.Feature` describing the presence of
+    :mod:`sage.matrix.matrix_gf2e_dense`, based on m4rie.
+
+    EXAMPLES::
+
+        sage: from sage.features.m4rie import M4rie
+        sage: M4rie().is_present()  # needs m4rie
+        FeatureTestResult('m4rie', True)
+        sage: M4rie().is_present()  # needs !m4rie
+        FeatureTestResult('m4rie', False)
+
+    A runtime check. We only check the "present" case because, if
+    feature checks are _not_ deferred, the ``needs !m4rie`` can be
+    satisfied (disabled at build time) at the same time we are able to
+    import a module that was installed for a previous build of sage::
+
+        sage: from sage.features.m4rie import M4rie
+        sage: M4rie().is_present_at_runtime()  # needs m4rie
+        FeatureTestResult('m4rie', True)
+
+    """
+    _enabled_in_build = m4rie_enabled
+
+    def __init__(self):
+        r"""
+        EXAMPLES::
+
+            sage: from sage.features.m4rie import M4rie
+            sage: M4rie()
+            Feature('m4rie')
+
+        """
+        module_name = "sage.matrix.matrix_gf2e_dense"
+        super().__init__('m4rie',
+                         module_name,
+                         type='standard')
+
+
+def all_features():
+    return [M4rie()]

--- a/src/sage/features/sagemath.py
+++ b/src/sage/features/sagemath.py
@@ -417,10 +417,10 @@ class sage__libs__linbox(JoinFeature):
                              spkg='sagemath_linbox', type='standard')
 
 
-class sage__libs__m4ri(JoinFeature):
+class sage__libs__m4ri(PythonModule):
     r"""
-    A :class:`sage.features.Feature` describing the presence of Cython modules
-    depending on the M4RI and/or M4RIe libraries.
+    A :class:`sage.features.Feature` describing the presence of
+    Cython modules depending on the M4RI library.
 
     In addition to the modularization purposes that this tag serves,
     it also provides attribution to the upstream project.
@@ -428,8 +428,9 @@ class sage__libs__m4ri(JoinFeature):
     TESTS::
 
         sage: from sage.features.sagemath import sage__libs__m4ri
-        sage: sage__libs__m4ri().is_present()                                           # needs sage.libs.m4ri
+        sage: sage__libs__m4ri().is_present()  # needs sage.libs.m4ri
         FeatureTestResult('sage.libs.m4ri', True)
+
     """
     def __init__(self):
         r"""
@@ -439,10 +440,10 @@ class sage__libs__m4ri(JoinFeature):
             sage: isinstance(sage__libs__m4ri(), sage__libs__m4ri)
             True
         """
-        JoinFeature.__init__(self, 'sage.libs.m4ri',
-                             [PythonModule('sage.matrix.matrix_gf2e_dense'),
-                              PythonModule('sage.matrix.matrix_mod2_dense')],
-                             spkg='sagemath_m4ri', type='standard')
+        PythonModule.__init__(self,
+                              "sage.matrix.matrix_mod2_dense",
+                              spkg="m4ri",
+                              type="standard")
 
 
 class sage__libs__ntl(JoinFeature):

--- a/src/sage/matrix/matrix_gf2e_dense.pyx
+++ b/src/sage/matrix/matrix_gf2e_dense.pyx
@@ -2,6 +2,7 @@
 # distutils: library_dirs = M4RI_LIBDIR
 # distutils: include_dirs = M4RI_INCDIR
 # distutils: extra_compile_args = M4RI_CFLAGS
+# sage.doctest: needs m4rie
 r"""
 Dense matrices over `\GF{2^e}` for `2 \leq e \leq 16` using the M4RIE library
 

--- a/src/sage/matrix/matrix_space.py
+++ b/src/sage/matrix/matrix_space.py
@@ -102,14 +102,16 @@ def get_matrix_class(R, nrows, ncols, sparse, implementation):
         sage: get_matrix_class(ZZ, 3, 3, False, 'generic')
         <class 'sage.matrix.matrix_generic_dense.Matrix_generic_dense'>
 
-        sage: get_matrix_class(GF(2^15), 3, 3, False, None)                             # needs sage.rings.finite_rings
+        sage: get_matrix_class(GF(2^15), 3, 3, False, None)  # needs m4rie
         <class 'sage.matrix.matrix_gf2e_dense.Matrix_gf2e_dense'>
-        sage: get_matrix_class(GF(2^17), 3, 3, False, None)                             # needs sage.rings.finite_rings
+        sage: get_matrix_class(GF(2^15), 3, 3, False, None)  # needs !m4rie
+        <class 'sage.matrix.matrix_generic_dense.Matrix_generic_dense'>
+        sage: get_matrix_class(GF(2^17), 3, 3, False, None)
         <class 'sage.matrix.matrix_generic_dense.Matrix_generic_dense'>
 
         sage: get_matrix_class(GF(2), 2, 2, False, 'm4ri')                              # needs sage.libs.m4ri
         <class 'sage.matrix.matrix_mod2_dense.Matrix_mod2_dense'>
-        sage: get_matrix_class(GF(4), 2, 2, False, 'm4ri')                              # needs sage.libs.m4ri sage.rings.finite_rings
+        sage: get_matrix_class(GF(4), 2, 2, False, 'm4ri')                              # needs m4rie
         <class 'sage.matrix.matrix_gf2e_dense.Matrix_gf2e_dense'>
         sage: get_matrix_class(GF(7), 2, 2, False, 'linbox-float')                      # needs sage.libs.linbox
         <class 'sage.matrix.matrix_modn_dense_float.Matrix_modn_dense_float'>
@@ -155,7 +157,7 @@ def get_matrix_class(R, nrows, ncols, sparse, implementation):
         <class 'sage.matrix.matrix_modn_dense_flint.Matrix_modn_dense_flint'>
         sage: type(matrix(GF(2), 2, range(4)))                                          # needs sage.libs.m4ri
         <class 'sage.matrix.matrix_mod2_dense.Matrix_mod2_dense'>
-        sage: type(matrix(GF(64, 'z'), 2, range(4)))                                    # needs sage.libs.m4ri sage.rings.finite_rings
+        sage: type(matrix(GF(64, 'z'), 2, range(4)))                                    # needs m4rie
         <class 'sage.matrix.matrix_gf2e_dense.Matrix_gf2e_dense'>
         sage: type(matrix(GF(125, 'z'), 2, range(4)))                       # optional - meataxe, needs sage.rings.finite_rings
         <class 'sage.matrix.matrix_gfpn_dense.Matrix_gfpn_dense'>
@@ -206,6 +208,8 @@ def get_matrix_class(R, nrows, ncols, sparse, implementation):
         return implementation
 
     if not sparse:
+        from sage.features.m4rie import M4rie
+
         if implementation is None:
             # Choose default implementation:
             if R is sage.rings.integer_ring.ZZ:
@@ -251,11 +255,8 @@ def get_matrix_class(R, nrows, ncols, sparse, implementation):
                         return matrix_mod2_dense.Matrix_mod2_dense
 
                 if R.characteristic() == 2 and R.order() <= 65536:  # 65536 == 2^16
-                    try:
+                    if M4rie().is_present():
                         from . import matrix_gf2e_dense
-                    except ImportError:
-                        pass
-                    else:
                         return matrix_gf2e_dense.Matrix_gf2e_dense
 
                 if (not R.is_prime_field()) and R.order() < 256:
@@ -390,6 +391,8 @@ def get_matrix_class(R, nrows, ncols, sparse, implementation):
                 if R.order() == 2:
                     from . import matrix_mod2_dense
                     return matrix_mod2_dense.Matrix_mod2_dense
+
+                M4rie().require()
                 from . import matrix_gf2e_dense
                 return matrix_gf2e_dense.Matrix_gf2e_dense
             raise ValueError("'m4ri' matrices are only available for fields of characteristic 2 and order <= 65536")
@@ -2876,6 +2879,14 @@ register_unpickle_override('sage.matrix.matrix_integer_2x2',
     'MatrixSpace_ZZ_2x2_class', MatrixSpace)
 register_unpickle_override('sage.matrix.matrix_integer_2x2',
     'MatrixSpace_ZZ_2x2', _MatrixSpace_ZZ_2x2)
-lazy_import('sage.matrix.matrix_gf2e_dense', 'unpickle_matrix_gf2e_dense_v0')
-register_unpickle_override('sage.matrix.matrix_mod2e_dense',
-    'unpickle_matrix_mod2e_dense_v0', unpickle_matrix_gf2e_dense_v0)
+
+def _unpickle_gf2e(a, base_ring, nrows, ncols):
+    from sage.features.m4rie import M4rie
+    M4rie().require()
+    from sage.matrix.matrix_gf2e_dense import unpickle_matrix_gf2e_dense_v0
+    return unpickle_matrix_gf2e_dense_v0(a, base_ring, nrows, ncols)
+
+register_unpickle_override(
+    'sage.matrix.matrix_mod2e_dense',
+    'unpickle_matrix_mod2e_dense_v0',
+    _unpickle_gf2e)

--- a/src/sage/matrix/matrix_space.py
+++ b/src/sage/matrix/matrix_space.py
@@ -139,8 +139,6 @@ def get_matrix_class(R, nrows, ncols, sparse, implementation):
         <class 'sage.matrix.matrix_complex_ball_dense.Matrix_complex_ball_dense'>
         sage: type(matrix(GF(2), 2, range(4)))
         <class 'sage.matrix.matrix_mod2_dense.Matrix_mod2_dense'>
-        sage: type(matrix(GF(64,'z'), 2, range(4)))
-        <class 'sage.matrix.matrix_gf2e_dense.Matrix_gf2e_dense'>
         sage: type(matrix(GF(125,'z'), 2, range(4)))     # optional: meataxe
         <class 'sage.matrix.matrix_gfpn_dense.Matrix_gfpn_dense'>
         sage: type(matrix(SR, 2, 2, 0))                                                 # needs sage.symbolic

--- a/src/sage/matrix/special.py
+++ b/src/sage/matrix/special.py
@@ -405,10 +405,10 @@ def random_matrix(ring, nrows, ncols=None, algorithm='randomize', implementation
 
     One can prescribe a specific matrix implementation::
 
-        sage: K.<a> = FiniteField(2^8)                                                  # needs sage.rings.finite_rings
-        sage: type(random_matrix(K, 2, 5))                                              # needs sage.libs.m4ri sage.rings.finite_rings
+        sage: K.<a> = FiniteField(2^8)
+        sage: type(random_matrix(K, 2, 5))  # needs m4rie
         <class 'sage.matrix.matrix_gf2e_dense.Matrix_gf2e_dense'>
-        sage: type(random_matrix(K, 2, 5, implementation='generic'))                    # needs sage.rings.finite_rings
+        sage: type(random_matrix(K, 2, 5, implementation='generic'))
         <class 'sage.matrix.matrix_generic_dense.Matrix_generic_dense'>
 
     Random rational matrices.  Now ``num_bound`` and ``den_bound`` control the

--- a/src/sage/meson.build
+++ b/src/sage/meson.build
@@ -170,6 +170,7 @@ configure_file(
 # runtime.
 conf_data.set10('DEFER_FEATURE_CHECKS', get_option('defer_feature_checks'))
 conf_data.set10('ECLIB_ENABLED', ec.found())
+conf_data.set10('M4RIE_ENABLED', m4rie.found())
 
 # Write config file
 # Should be last so that subdir calls can modify the config data


### PR DESCRIPTION
Add a feature in `sage.features.m4rie` that has support from our build system. Minor changes to `MatrixSpace()` are needed, then  we add a few `# needs m4rie` tags, and test it all on the minimal CI job.

This one's easy.