### PR TITLE
cache generators of kernel subgroup in EllipticCurveHom objects

### DIFF
--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -1821,6 +1821,8 @@ class EllipticCurveIsogeny(EllipticCurveHom):
         self.__kernel_mod_sign = {}
         self.__v = self.__w = 0
 
+        self._kernel_gens = tuple(kernel_gens)  # cache for .kernel_gens()
+
         # Fast path: The kernel is given by a single generating point.
         if len(kernel_gens) == 1 and kernel_gens[0]:
             self.__init_from_kernel_point(kernel_gens[0])

--- a/src/sage/schemes/elliptic_curves/hom.py
+++ b/src/sage/schemes/elliptic_curves/hom.py
@@ -734,10 +734,12 @@ class EllipticCurveHom(Morphism):
 
     def kernel_gens(self, **kwds):
         r"""
-        Return a list of points which generate the kernel
-        subgroup of this isogeny.
+        Return a list of points which generate the kernel subgroup
+        of this isogeny.
 
-        ALGORITHM: Thin convenience wrapper around :meth:`kernel_subgroup`.
+        ALGORITHM: Returns the kernel generators given at construction
+        time if available; otherwise a thin convenience wrapper around
+        :meth:`kernel_subgroup`.
 
         EXAMPLES::
 
@@ -803,7 +805,9 @@ class EllipticCurveHom(Morphism):
             sage: h == phi.kernel_polynomial()
             True
         """
-        return [g.element() for g in self.kernel_subgroup(**kwds).gens()]
+        if not hasattr(self, '_kernel_gens'):
+            self._kernel_gens = tuple(g.element() for g in self.kernel_subgroup(**kwds).gens())
+        return list(self._kernel_gens)
 
     def dual(self):
         r"""

--- a/src/sage/schemes/elliptic_curves/hom_composite.py
+++ b/src/sage/schemes/elliptic_curves/hom_composite.py
@@ -390,6 +390,8 @@ class EllipticCurveHom_composite(EllipticCurveHom):
             if P not in E:
                 raise ValueError(f'given point {P} does not lie on {E}')
 
+        self._kernel_gens = tuple(kernel)  # cache for .kernel_gens()
+
         self._phis = _compute_factored_isogeny(kernel, velu_sqrt_bound=velu_sqrt_bound)
 
         if not self._phis:

--- a/src/sage/schemes/elliptic_curves/hom_velusqrt.py
+++ b/src/sage/schemes/elliptic_curves/hom_velusqrt.py
@@ -740,6 +740,8 @@ class EllipticCurveHom_velusqrt(EllipticCurveHom):
         if self._degree % 2 != 1 or self._degree < 9:
             raise NotImplementedError('only implemented for odd degrees >= 9')
 
+        self._kernel_gens = P,  # cache for .kernel_gens()
+
         try:
             self._raw_domain = E.short_weierstrass_model()
         except ValueError:


### PR DESCRIPTION
Simple patch to avoid recomputing generators of the kernel if they're already known by construction.