### PR TITLE
Fix BooleanPolynomial nilpotency test

### DIFF
--- a/src/sage/rings/polynomial/pbori/pbori.pyx
+++ b/src/sage/rings/polynomial/pbori/pbori.pyx
@@ -3531,6 +3531,33 @@ cdef class BooleanPolynomial(MPolynomial):
         """
         return self._pbpoly.isZero()
 
+    def is_nilpotent(BooleanPolynomial self):
+        r"""
+        Return whether ``self`` is nilpotent.
+
+        Boolean rings are reduced, so the only nilpotent boolean
+        polynomial is zero.
+
+        EXAMPLES::
+
+            sage: P.<x,y> = BooleanPolynomialRing(2)
+            sage: P(0).is_nilpotent()
+            True
+
+            sage: x.is_nilpotent()
+            False
+
+            sage: (x + y).is_nilpotent()
+            False
+
+        Check that :issue:`23311` is fixed::
+
+            sage: B.<a,b,c> = BooleanPolynomialRing()
+            sage: (a + b).is_nilpotent()
+            False
+        """
+        return self._pbpoly.isZero()
+
     def __bool__(self) -> bool:
         r"""
         Check if ``self`` is not zero.


### PR DESCRIPTION
Fixes #23311

`BooleanPolynomial` currently inherits the generic multivariate polynomial `is_nilpotent()` implementation, which expects dictionary-style monomial data that pbori boolean polynomials do not expose

This adds the boolean polynomial implementation directly. Boolean rings are reduced, so the nilpotency check is the same as the zero test here

Tests:
- `python -m sage.doctest -p 1 src/sage/rings/polynomial/pbori/pbori.pyx`
- direct runtime check for `(a + b).is_nilpotent()` in `BooleanPolynomialRing()`
- `git diff --check`

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

None
