### PR TITLE
making gfan doctests robust for version changes, and allow flint 3.6+

### DIFF
--- a/build/pkgs/flint/spkg-configure.m4
+++ b/build/pkgs/flint/spkg-configure.m4
@@ -3,12 +3,12 @@ SAGE_SPKG_CONFIGURE([flint], [
         AC_CHECK_HEADERS([flint/flint.h flint/padic.h], [dnl
           dnl gr_get_fexpr appears in Flint 3.0
           AC_SEARCH_LIBS([gr_get_fexpr], [flint], [dnl
-            dnl Assume Flint 3.6 is too new
-            AC_MSG_CHECKING([whether FLINT version is >= 3.6.0])
+            dnl Assume Flint 3.7 is too new
+            AC_MSG_CHECKING([whether FLINT version is >= 3.7.0])
             AC_COMPILE_IFELSE([dnl
               AC_LANG_PROGRAM([[#include <flint/flint.h>
-                                #if __FLINT_RELEASE > 30599
-                                # error "FLINT 3.6 is too new"
+                                #if __FLINT_RELEASE > 30699
+                                # error "FLINT 3.7 is too new"
                                 #endif
                               ]])
             ], [dnl

--- a/build/pkgs/gap/distros/homebrew.txt
+++ b/build/pkgs/gap/distros/homebrew.txt
@@ -1,1 +1,2 @@
-gap-system/gap/gap
+# gap-system/gap/gap
+# commented out 2026-07-03, as it breaks doctesting without --debug, see #42471

--- a/src/doc/de/tutorial/tour_advanced.rst
+++ b/src/doc/de/tutorial/tour_advanced.rst
@@ -60,12 +60,12 @@ dreidimensionalen projektiven Raum berechnen:
     Groebner fan of the ideal:
     Ideal (b^2 - a*c, c^2 - b*d, -b*c + a*d) of Multivariate Polynomial Ring
     in a, b, c, d over Rational Field
-    sage: F.reduced_groebner_bases ()
-    [[-c^2 + b*d, -b*c + a*d, -b^2 + a*c],
+    sage: list(map(sorted, F.reduced_groebner_bases()))
+    [[-b^2 + a*c, -b*c + a*d, -c^2 + b*d],
      [-b*c + a*d, -c^2 + b*d, b^2 - a*c],
      [-c^3 + a*d^2, -c^2 + b*d, b*c - a*d, b^2 - a*c],
-     [-c^2 + b*d, b^2 - a*c, b*c - a*d, c^3 - a*d^2],
-     [-b*c + a*d, -b^2 + a*c, c^2 - b*d],
+     [-c^2 + b*d, b*c - a*d, b^2 - a*c, c^3 - a*d^2],
+     [-b^2 + a*c, -b*c + a*d, c^2 - b*d],
      [-b^3 + a^2*d, -b^2 + a*c, c^2 - b*d, b*c - a*d],
      [-b^2 + a*c, c^2 - b*d, b*c - a*d, b^3 - a^2*d],
      [c^2 - b*d, b*c - a*d, b^2 - a*c]]

--- a/src/doc/en/tutorial/tour_advanced.rst
+++ b/src/doc/en/tutorial/tour_advanced.rst
@@ -59,12 +59,12 @@ space:
     Groebner fan of the ideal:
     Ideal (b^2 - a*c, c^2 - b*d, -b*c + a*d) of Multivariate Polynomial Ring
     in a, b, c, d over Rational Field
-    sage: F.reduced_groebner_bases ()
-    [[-c^2 + b*d, -b*c + a*d, -b^2 + a*c],
+    sage: list(map(sorted, F.reduced_groebner_bases()))
+    [[-b^2 + a*c, -b*c + a*d, -c^2 + b*d],
      [-b*c + a*d, -c^2 + b*d, b^2 - a*c],
      [-c^3 + a*d^2, -c^2 + b*d, b*c - a*d, b^2 - a*c],
-     [-c^2 + b*d, b^2 - a*c, b*c - a*d, c^3 - a*d^2],
-     [-b*c + a*d, -b^2 + a*c, c^2 - b*d],
+     [-c^2 + b*d, b*c - a*d, b^2 - a*c, c^3 - a*d^2],
+     [-b^2 + a*c, -b*c + a*d, c^2 - b*d],
      [-b^3 + a^2*d, -b^2 + a*c, c^2 - b*d, b*c - a*d],
      [-b^2 + a*c, c^2 - b*d, b*c - a*d, b^3 - a^2*d],
      [c^2 - b*d, b*c - a*d, b^2 - a*c]]

--- a/src/doc/fr/tutorial/tour_advanced.rst
+++ b/src/doc/fr/tutorial/tour_advanced.rst
@@ -61,12 +61,12 @@ projectif de dimension 3.
     Groebner fan of the ideal:
     Ideal (b^2 - a*c, c^2 - b*d, -b*c + a*d) of Multivariate Polynomial Ring
     in a, b, c, d over Rational Field
-    sage: F.reduced_groebner_bases ()
-    [[-c^2 + b*d, -b*c + a*d, -b^2 + a*c],
+    sage: list(map(sorted, F.reduced_groebner_bases()))
+    [[-b^2 + a*c, -b*c + a*d, -c^2 + b*d],
      [-b*c + a*d, -c^2 + b*d, b^2 - a*c],
      [-c^3 + a*d^2, -c^2 + b*d, b*c - a*d, b^2 - a*c],
-     [-c^2 + b*d, b^2 - a*c, b*c - a*d, c^3 - a*d^2],
-     [-b*c + a*d, -b^2 + a*c, c^2 - b*d],
+     [-c^2 + b*d, b*c - a*d, b^2 - a*c, c^3 - a*d^2],
+     [-b^2 + a*c, -b*c + a*d, c^2 - b*d],
      [-b^3 + a^2*d, -b^2 + a*c, c^2 - b*d, b*c - a*d],
      [-b^2 + a*c, c^2 - b*d, b*c - a*d, b^3 - a^2*d],
      [c^2 - b*d, b*c - a*d, b^2 - a*c]]

--- a/src/doc/ja/tutorial/tour_advanced.rst
+++ b/src/doc/ja/tutorial/tour_advanced.rst
@@ -59,12 +59,12 @@ Sageでは，3次元射影空間における捻れ3次曲線のトーリック�
     Groebner fan of the ideal:
     Ideal (b^2 - a*c, c^2 - b*d, -b*c + a*d) of Multivariate Polynomial Ring
     in a, b, c, d over Rational Field
-    sage: F.reduced_groebner_bases ()
-    [[-c^2 + b*d, -b*c + a*d, -b^2 + a*c],
+    sage: list(map(sorted, F.reduced_groebner_bases()))
+    [[-b^2 + a*c, -b*c + a*d, -c^2 + b*d],
      [-b*c + a*d, -c^2 + b*d, b^2 - a*c],
      [-c^3 + a*d^2, -c^2 + b*d, b*c - a*d, b^2 - a*c],
-     [-c^2 + b*d, b^2 - a*c, b*c - a*d, c^3 - a*d^2],
-     [-b*c + a*d, -b^2 + a*c, c^2 - b*d],
+     [-c^2 + b*d, b*c - a*d, b^2 - a*c, c^3 - a*d^2],
+     [-b^2 + a*c, -b*c + a*d, c^2 - b*d],
      [-b^3 + a^2*d, -b^2 + a*c, c^2 - b*d, b*c - a*d],
      [-b^2 + a*c, c^2 - b*d, b*c - a*d, b^3 - a^2*d],
      [c^2 - b*d, b*c - a*d, b^2 - a*c]]

--- a/src/doc/pt/tutorial/tour_advanced.rst
+++ b/src/doc/pt/tutorial/tour_advanced.rst
@@ -61,12 +61,12 @@ projetivo:
     Groebner fan of the ideal:
     Ideal (b^2 - a*c, c^2 - b*d, -b*c + a*d) of Multivariate Polynomial Ring
     in a, b, c, d over Rational Field
-    sage: F.reduced_groebner_bases ()
-    [[-c^2 + b*d, -b*c + a*d, -b^2 + a*c],
+    sage: list(map(sorted, F.reduced_groebner_bases()))
+    [[-b^2 + a*c, -b*c + a*d, -c^2 + b*d],
      [-b*c + a*d, -c^2 + b*d, b^2 - a*c],
      [-c^3 + a*d^2, -c^2 + b*d, b*c - a*d, b^2 - a*c],
-     [-c^2 + b*d, b^2 - a*c, b*c - a*d, c^3 - a*d^2],
-     [-b*c + a*d, -b^2 + a*c, c^2 - b*d],
+     [-c^2 + b*d, b*c - a*d, b^2 - a*c, c^3 - a*d^2],
+     [-b^2 + a*c, -b*c + a*d, c^2 - b*d],
      [-b^3 + a^2*d, -b^2 + a*c, c^2 - b*d, b*c - a*d],
      [-b^2 + a*c, c^2 - b*d, b*c - a*d, b^3 - a^2*d],
      [c^2 - b*d, b*c - a*d, b^2 - a*c]]

--- a/src/doc/ru/tutorial/tour_advanced.rst
+++ b/src/doc/ru/tutorial/tour_advanced.rst
@@ -55,12 +55,12 @@ Sage может вычислить тороидальный идеал непл�
     Groebner fan of the ideal:
     Ideal (b^2 - a*c, c^2 - b*d, -b*c + a*d) of Multivariate Polynomial Ring
     in a, b, c, d over Rational Field
-    sage: F.reduced_groebner_bases ()
-    [[-c^2 + b*d, -b*c + a*d, -b^2 + a*c],
+    sage: list(map(sorted, F.reduced_groebner_bases()))
+    [[-b^2 + a*c, -b*c + a*d, -c^2 + b*d],
      [-b*c + a*d, -c^2 + b*d, b^2 - a*c],
      [-c^3 + a*d^2, -c^2 + b*d, b*c - a*d, b^2 - a*c],
-     [-c^2 + b*d, b^2 - a*c, b*c - a*d, c^3 - a*d^2],
-     [-b*c + a*d, -b^2 + a*c, c^2 - b*d],
+     [-c^2 + b*d, b*c - a*d, b^2 - a*c, c^3 - a*d^2],
+     [-b^2 + a*c, -b*c + a*d, c^2 - b*d],
      [-b^3 + a^2*d, -b^2 + a*c, c^2 - b*d, b*c - a*d],
      [-b^2 + a*c, c^2 - b*d, b*c - a*d, b^3 - a^2*d],
      [c^2 - b*d, b*c - a*d, b^2 - a*c]]

--- a/src/doc/zh/tutorial/tour_advanced.rst
+++ b/src/doc/zh/tutorial/tour_advanced.rst
@@ -53,12 +53,12 @@ Sage 可以计算三维射影空间中扭曲三次曲线的环理想：
     Groebner fan of the ideal:
     Ideal (b^2 - a*c, c^2 - b*d, -b*c + a*d) of Multivariate Polynomial Ring
     in a, b, c, d over Rational Field
-    sage: F.reduced_groebner_bases ()
-    [[-c^2 + b*d, -b*c + a*d, -b^2 + a*c],
+    sage: list(map(sorted, F.reduced_groebner_bases()))
+    [[-b^2 + a*c, -b*c + a*d, -c^2 + b*d],
      [-b*c + a*d, -c^2 + b*d, b^2 - a*c],
      [-c^3 + a*d^2, -c^2 + b*d, b*c - a*d, b^2 - a*c],
-     [-c^2 + b*d, b^2 - a*c, b*c - a*d, c^3 - a*d^2],
-     [-b*c + a*d, -b^2 + a*c, c^2 - b*d],
+     [-c^2 + b*d, b*c - a*d, b^2 - a*c, c^3 - a*d^2],
+     [-b^2 + a*c, -b*c + a*d, c^2 - b*d],
      [-b^3 + a^2*d, -b^2 + a*c, c^2 - b*d, b*c - a*d],
      [-b^2 + a*c, c^2 - b*d, b*c - a*d, b^3 - a^2*d],
      [c^2 - b*d, b*c - a*d, b^2 - a*c]]

--- a/src/sage/interfaces/gfan.py
+++ b/src/sage/interfaces/gfan.py
@@ -61,7 +61,7 @@ class Gfan:
 
         EXAMPLES::
 
-            sage: print(gfan('Q[x,y]{x^2-y-1,y^2-xy-2/3}', cmd='bases'))                # needs gfan
+            sage: print(gfan('Q[x,y]{x^2-y-1,y^2-xy-2/3}', cmd='bases'))                # needs gfan # random
             Q[x,y]
             {{
             y^4+4/9-7/3*y^2-y^3,

--- a/src/sage/rings/polynomial/groebner_fan.py
+++ b/src/sage/rings/polynomial/groebner_fan.py
@@ -999,7 +999,7 @@ class GroebnerFan(SageObject):
 
             sage: R.<a,b> = PolynomialRing(QQ,2)
             sage: gf = R.ideal([a^3-b^2,b^2-a-1]).groebner_fan()
-            sage: gf._gfan_reduced_groebner_bases()
+            sage: gf._gfan_reduced_groebner_bases()                    # random
             'Q[a,b]{{b^6-1+2*b^2-3*b^4,a+1-b^2},{a^3-1-a,b^2-1-a}}'
         """
         B = self.gfan(cmd='bases')
@@ -1030,23 +1030,23 @@ class GroebnerFan(SageObject):
             sage: X = G.reduced_groebner_bases()
             sage: len(X)
             33
-            sage: X[0]
-            [z^15 - z, x - z^9, y - z^11]
-            sage: X[0].ideal()
+            sage: sorted(X[0])
+            [z^15 - z, y - z^11, x - z^9]
+            sage: X[0].ideal()                            # random
             Ideal (z^15 - z, x - z^9, y - z^11) of Multivariate Polynomial Ring in x, y, z over Rational Field
-            sage: X[:5]
-            [[z^15 - z, x - z^9, y - z^11],
-            [y^2 - z^8, x - z^9, y*z^4 - z, -y + z^11],
-            [y^3 - z^5, x - y^2*z, y^2*z^3 - y, y*z^4 - z, -y^2 + z^8],
-            [y^4 - z^2, x - y^2*z, y^2*z^3 - y, y*z^4 - z, -y^3 + z^5],
-            [y^9 - z, y^6*z - y, x - y^2*z, -y^4 + z^2]]
+            sage: list(map(sorted, X[:5]))
+            [[z^15 - z, y - z^11, x - z^9],
+             [-y + z^11, y*z^4 - z, y^2 - z^8, x - z^9],
+             [-y^2 + z^8, y*z^4 - z, y^2*z^3 - y, y^3 - z^5, x - y^2*z],
+             [-y^3 + z^5, y*z^4 - z, y^2*z^3 - y, y^4 - z^2, x - y^2*z],
+             [-y^4 + z^2, y^6*z - y, y^9 - z, x - y^2*z]]
             sage: R3.<x,y,z> = PolynomialRing(GF(2477),3)
             sage: gf = R3.ideal([300*x^3-y,y^2-z,z^2-12]).groebner_fan()
-            sage: gf.reduced_groebner_bases()
+            sage: list(map(sorted, gf.reduced_groebner_bases()))
             [[z^2 - 12, y^2 - z, x^3 + 933*y],
-            [y^4 - 12, x^3 + 933*y, -y^2 + z],
-            [x^6 - 1062*z, z^2 - 12, -300*x^3 + y],
-            [x^12 + 200, -300*x^3 + y, -828*x^6 + z]]
+             [-y^2 + z, x^3 + 933*y, y^4 - 12],
+             [-300*x^3 + y, z^2 - 12, x^6 - 1062*z],
+             [-828*x^6 + z, -300*x^3 + y, x^12 + 200]]
         """
         G = self._gfan_reduced_groebner_bases()
         if G.find(']') != -1:
@@ -1101,7 +1101,7 @@ class GroebnerFan(SageObject):
 
             sage: R.<x,y> = PolynomialRing(QQ,2)
             sage: gf = R.ideal([x^3-y,y^3-x-1]).groebner_fan()
-            sage: gf.gfan()
+            sage: gf.gfan()                                           # random
             'Q[x,y]\n{{\ny^9-1-y+3*y^3-3*y^6,\nx+1-y^3}\n,\n{\nx^3-y,\ny^3-1-x}\n,\n{\nx^9-1-x,\ny-x^3}\n}\n'
         """
         if I is None:
@@ -1122,8 +1122,8 @@ class GroebnerFan(SageObject):
             sage: R.<x,y> = PolynomialRing(QQ,2)
             sage: gf = R.ideal([x^3-y,y^3-x-1]).groebner_fan()
             sage: a = gf.__iter__()
-            sage: next(a)
-            [y^9 - 3*y^6 + 3*y^3 - y - 1, -y^3 + x + 1]
+            sage: sorted(next(a))
+            [-y^3 + x + 1, y^9 - 3*y^6 + 3*y^3 - y - 1]
         """
         yield from self.reduced_groebner_bases()
 
@@ -1135,8 +1135,8 @@ class GroebnerFan(SageObject):
 
             sage: R4.<w1,w2,w3,w4> = PolynomialRing(QQ,4)
             sage: gf = R4.ideal([w1^2-w2,w2^3-1,2*w3-w4^2,w4^2-w1]).groebner_fan()
-            sage: gf[0]
-            [w4^12 - 1, -w4^4 + w2, -w4^2 + w1, -1/2*w4^2 + w3]
+            sage: sorted(gf[0])
+            [-w4^4 + w2, -w4^2 + w1, -1/2*w4^2 + w3, w4^12 - 1]
         """
         return self.reduced_groebner_bases()[i]
 
@@ -1149,8 +1149,8 @@ class GroebnerFan(SageObject):
 
             sage: R.<x,y,z> = PolynomialRing(QQ,3)
             sage: G = R.ideal([x - z^3, y^2 - x + x^2 - z^3*x]).groebner_fan()
-            sage: G.buchberger()
-            [-z^3 + y^2, -z^3 + x]
+            sage: sorted(G.buchberger())
+            [-z^3 + x, -z^3 + y^2]
         """
         B = self.gfan(cmd='buchberger')
         if B.find(']') != -1:
@@ -1880,7 +1880,9 @@ class ReducedGroebnerBasis(SageObject, list):
 
             sage: R.<x,y,z> = PolynomialRing(QQ,3)
             sage: G = R.ideal([x - z^3, y^2 - 13*x]).groebner_fan()
-            sage: G[0].ideal()
+            sage: G[0].ideal()                                         # random
             Ideal (-13*z^3 + y^2, -z^3 + x) of Multivariate Polynomial Ring in x, y, z over Rational Field
+            sage: sorted(G[0].ideal().gens())
+            [-13*z^3 + y^2, -z^3 + x]
         """
         return self.__groebner_fan.ring().ideal(self)


### PR DESCRIPTION
gfan 0.8 has changed orders of things such as Grobner bases stored.
Here we make tests version-insensitive.
We had to mark `# random` a few tests, which do verbatim comparisons of long ACSII strings.
These are still tested indirectly, so this does not affect test robustness

Fixes #42472

Also, relaxed version condition on flint to test 3.6 (and it seems to work just fine)

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


