### PR TITLE
Add callable symbolic unicode mapsto doctest

### DIFF
--- a/src/sage/symbolic/callable.py
+++ b/src/sage/symbolic/callable.py
@@ -31,11 +31,13 @@ When you do arithmetic with::
     sage: f + g
     (x, y, t, w) |--> t + w + x + y
 
-Unicode art uses the mapsto arrow (:issue:`30374`)::
+Unicode art uses the mapsto arrow (:issue:`30374`). At the Sage prompt,
+``%display unicode_art`` enables this representation as the default display
+mode::
 
     sage: from sage.typeset.unicode_art import unicode_art
     sage: s(t) = t^3
-    sage: print(format(unicode_art(s)).rstrip())                                       # needs sympy
+    sage: unicode_art(s)                                                                # needs sympy
          3
     t ↦ t
 

--- a/src/sage/symbolic/callable.py
+++ b/src/sage/symbolic/callable.py
@@ -31,6 +31,14 @@ When you do arithmetic with::
     sage: f + g
     (x, y, t, w) |--> t + w + x + y
 
+Unicode art uses the mapsto arrow (:issue:`30374`)::
+
+    sage: from sage.typeset.unicode_art import unicode_art
+    sage: s(t) = t^3
+    sage: print(format(unicode_art(s)).rstrip())                                       # needs sympy
+         3
+    t ↦ t
+
 TESTS:
 
 The arguments in the definition must be symbolic variables (:issue:`10747`)::


### PR DESCRIPTION
Fixes #30374

Callable symbolic expressions already render the unicode mapsto arrow in current `develop`. This adds a direct regression doctest for that output, so the old display issue is covered in `sage.symbolic.callable`

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

None