### PR TITLE
Fix AttributeError in ClusterSeed.mutation_sequence when show_sequenc…

### DIFF
--- a/src/sage/combinat/cluster_algebra_quiver/cluster_seed.py
+++ b/src/sage/combinat/cluster_algebra_quiver/cluster_seed.py
@@ -2738,6 +2738,14 @@ class ClusterSeed(SageObject):
             sage: S = ClusterSeed(['A',2])
             sage: S.mutation_sequence([0,1,0,1], return_output='var')
             [(x1 + 1)/x0, (x0 + x1 + 1)/(x0*x1), (x0 + 1)/x1, x0]
+
+        Verify that calling mutation_sequence with show_sequence set to True executes without raising an AttributeError
+
+        sage: B = Matrix([[0,1],[-1, 0]])
+        sage: S = ClusterSeed(B)
+        sage: S.mutation_sequence([0,1], show_sequence=True)
+        [A seed for a cluster algebra of rank 2, A seed for a cluster algebra of rank 2]
+
         """
         seed = ClusterSeed(self)
 
@@ -2750,7 +2758,7 @@ class ClusterSeed(SageObject):
             seed_sequence.append(seed)
 
         if show_sequence:
-            self.quiver().mutation_sequence2(sequence=sequence, show_sequence=True, fig_size=fig_size)
+            self.quiver().mutation_sequence(sequence=sequence, show_sequence=True, fig_size=fig_size)
 
         if return_output == 'seed':
             return seed_sequence


### PR DESCRIPTION
AttributeError issue with mutation_sequence function in cluster_seed.py when show_sequence is set to True. There was a simple typo which called 'mutation_sequence2' throwing an attribution error.

Example:

sage: B = Matrix([[0,1],[-1, 0]])
sage: S = ClusterSeed(B)
sage: S.mutation_sequence([0,1], show_sequence=True) 
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[6], line 1
----> 1 S.mutation_sequence([Integer(0),Integer(1)], show_sequence=True)

File /var/tmp/sage-10.9-current/local/lib/python3.14/site-packages/sage/combinat/cluster_algebra_quiver/cluster_seed.py:2753, in ClusterSeed.mutation_sequence(self, sequence, show_sequence, fig_size, return_output)
   2750     seed_sequence.append(seed)
   2752 if show_sequence:
-> 2753     self.quiver().mutation_sequence2(sequence=sequence, show_sequence=True, fig_size=fig_size)
   2755 if return_output == 'seed':
   2756     return seed_sequence

AttributeError: 'ClusterQuiver' object has no attribute 'mutation_sequence2'

After the fix we get expected behavior:

sage: B = Matrix([[0,1],[-1, 0]])
sage: S = ClusterSeed(B)
sage: S.mutation_sequence([0,1], show_sequence=True) Launched png viewer for Graphics object consisting of 24 graphics primitives [A seed for a cluster algebra of rank 2,
 A seed for a cluster algebra of rank 2]

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x ] The title is concise and informative.
- [x ] The description explains in detail what this PR is about.
- [x ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


