### PR TITLE
Fix docstring for lift() in invariant module

### DIFF
--- a/src/sage/modules/with_basis/invariant.py
+++ b/src/sage/modules/with_basis/invariant.py
@@ -64,7 +64,7 @@ class FiniteDimensionalInvariantModule(SubmoduleWithBasis):
         sage: R = Representation(G, M, action)
         sage: I = R.invariant_module()
 
-    Then we can lift the basis from the invariant to the original module::
+    Then we can lift the basis from the invariant submodule to the ambient G-module R:
 
         sage: [I.lift(b) for b in I.basis()]
         [M[1] + M[2] + M[3]]

--- a/src/sage/modules/with_basis/invariant.py
+++ b/src/sage/modules/with_basis/invariant.py
@@ -64,7 +64,7 @@ class FiniteDimensionalInvariantModule(SubmoduleWithBasis):
         sage: R = Representation(G, M, action)
         sage: I = R.invariant_module()
 
-    Then we can lift the basis from the invariant submodule to the ambient G-module R:
+    Then we can lift the basis from the invariant submodule to the ambient G-module R::
 
         sage: [I.lift(b) for b in I.basis()]
         [M[1] + M[2] + M[3]]


### PR DESCRIPTION
The documentation incorrectly states that `I.lift()` returns elements in the "original module" M, but the actual behavior returns elements in the ambient G-module R. This PR updates the docstring to accurately reflect the code's behavior.

**Before:**
Then we can lift the basis from the invariant to the original module::


**After:**
Then we can lift the basis from the invariant submodule to the ambient G-module R::

### Related Issue
Fixes #41664

### Testing
- Ran `git diff` to verify the change
- No functional code changes, only documentation update

### Checklist
- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### Dependencies
None
