### PR TITLE
Validate increment vectors for alt nu-Tamari lattices

### DIFF
--- a/src/sage/combinat/nu_tamari_lattice.py
+++ b/src/sage/combinat/nu_tamari_lattice.py
@@ -69,6 +69,7 @@ AUTHORS:
 from sage.categories.finite_lattice_posets import FiniteLatticePosets
 from sage.combinat.nu_dyck_word import NuDyckWords, NuDyckWord
 from sage.combinat.posets.lattices import LatticePoset
+from sage.rings.integer_ring import ZZ
 
 
 def NuTamariLattice(nu):
@@ -243,6 +244,14 @@ def AltNuTamariLattice(nu, delta=None):
         Traceback (most recent call last):
         ...
         ValueError: delta is not a valid increment vector
+        sage: AltNuTamariLattice('010', [-1])
+        Traceback (most recent call last):
+        ...
+        ValueError: delta is not a valid increment vector
+        sage: AltNuTamariLattice('010', [1/2])
+        Traceback (most recent call last):
+        ...
+        ValueError: delta is not a valid increment vector
 
     REFERENCES:
 
@@ -260,7 +269,9 @@ def AltNuTamariLattice(nu, delta=None):
     deltamax = [len(a) for a in nu.split(sep='1')[1:]]
     if delta is None:
         delta = deltamax
-    elif len(delta) != len(deltamax) or any(delta[i] > deltamax[i] for i in range(len(delta))):
+    elif (len(delta) != len(deltamax)
+          or any(d not in ZZ or d < 0 or d > m
+                 for d, m in zip(delta, deltamax))):
         raise ValueError("delta is not a valid increment vector")
 
     def covers(p):


### PR DESCRIPTION
`AltNuTamariLattice` documents `delta` as a list of nonnegative integers, but validation previously checked only its length and coordinate-wise upper bounds. Negative or nonintegral entries could therefore construct an invalid object or fail later with an unrelated semilattice error.

This change validates that every entry belongs to `ZZ`, is nonnegative, and does not exceed its corresponding maximum increment. It also adds regression doctests for negative and fractional entries.

Fixes #42495

Tests:
- `git diff --check`
- `python3 -m py_compile src/sage/combinat/nu_tamari_lattice.py`
- Semantic validation in SageMath 10.8 covering valid, negative, fractional, string, `None`, and over-bound entries

The local checkout is source-only, so the focused Sage doctest and project lint suite will be exercised by CI.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

None.