### PR TITLE
Add link to FLINT nmod matrices in docs

### DIFF
--- a/src/doc/en/reference/matrices/index.rst
+++ b/src/doc/en/reference/matrices/index.rst
@@ -77,6 +77,7 @@ objects like operation tables (e.g. the multiplication table of a group).
    sage/matrix/matrix_gf2e_dense
    sage/matrix/matrix_modn_dense_double
    sage/matrix/matrix_modn_dense_float
+   sage/matrix/matrix_modn_dense_flint
    sage/matrix/matrix_modn_sparse
    sage/matrix/matrix_symbolic_dense
    sage/matrix/matrix_symbolic_sparse

--- a/src/sage/matrix/matrix_modn_dense_flint.pyx
+++ b/src/sage/matrix/matrix_modn_dense_flint.pyx
@@ -1,10 +1,10 @@
 # distutils: extra_compile_args = -D_XPG6
 # flags chosen from libs/flint/fmpz_poly.pyx
 r"""
-FLINT nmod_mat class wrapper
+Dense matrices over `\Zmod{n}` for `n < 2^{64}` using FLINT
 
-This file implements matrices over `\ZZ/N\ZZ` for `N < 2^{64}` (or `N < 2^{32}` on 32-bit systems).
-It also adds some capabilities for composite `N` that are not present in FLINT.
+This file implements matrices over `\Zmod{n}` for `n < 2^{64}` (or `n < 2^{32}` on 32-bit systems).
+It also adds some capabilities for composite `n` that are not present in FLINT.
 
 AUTHORS:
 
@@ -72,7 +72,7 @@ MAX_MODULUS = (sys.maxsize + 1) << 1
 
 cdef class Matrix_modn_dense_flint(Matrix_dense):
     r"""
-    Matrices modulo `N` for `N < 2^{63}`
+    Matrices modulo `n` for `n < 2^{64}` (or `n < 2^{32}` on 32-bit systems).
 
     EXAMPLES::
 


### PR DESCRIPTION
One line change that I forgot in #42306. Also adjust the wording in the documentation for consistency with the similar files that wrap LinBox.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


