### PR TITLE
Fix outdated Matplotlib license link

### DIFF
--- a/COPYING.txt
+++ b/COPYING.txt
@@ -959,7 +959,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ================================================================================
 
 matplotlib:
-(from http://matplotlib.sourceforge.net/users/license.html)
+(from https://matplotlib.org/stable/users/project/license.html)
 
 Matplotlib only uses BSD compatible code, and its license is based on
 the PSF license. See the Open Source Initiative licenses page for

--- a/build/pkgs/matplotlib/SPKG.rst
+++ b/build/pkgs/matplotlib/SPKG.rst
@@ -15,7 +15,7 @@ License
 -------
 
 The Matplotlib license - see
-http://matplotlib.sourceforge.net/users/license.html: Matplotlib only
+https://matplotlib.org/stable/users/project/license.html: Matplotlib only
 uses BSD compatible code, and its license is based on the PSF license.
 See the Open Source Initiative licenses page for details on individual
 licenses. Non-BSD compatible licenses (eg LGPL) are acceptable in


### PR DESCRIPTION
This PR updates an outdated Matplotlib license URL in `COPYING.txt` and `build/pkgs/matplotlib/SPKG.rst`.

The old SourceForge URL no longer points to the current Matplotlib license documentation, so it is replaced with the current Matplotlib project license page.

No code changes are included.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

None.

