### PR TITLE
Fix polynomial quotient element conversion

### DIFF
--- a/src/sage/rings/polynomial/polynomial_quotient_ring.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring.py
@@ -11,7 +11,7 @@ EXAMPLES::
     sage: x in S
     True
     sage: S.gen() in R
-    False
+    True
     sage: 1 in S
     True
 
@@ -92,7 +92,7 @@ class PolynomialQuotientRingFactory(UniqueFactory):
         sage: x in S
         True
         sage: a in R
-        False
+        True
         sage: S.polynomial_ring()
         Univariate Polynomial Ring in x over Integer Ring
         sage: S.modulus()

--- a/src/sage/rings/polynomial/polynomial_ring.py
+++ b/src/sage/rings/polynomial/polynomial_ring.py
@@ -397,6 +397,39 @@ class PolynomialRing_generic(Ring):
 
             sage: QQ['λ']('λ^2')
             λ^2
+
+        Elements of polynomial quotient rings are converted explicitly by
+        lifting them to their polynomial representatives (:issue:`42029`)::
+
+            sage: R.<x> = GF(7)[]
+            sage: S.<u> = R.quotient(x^3)
+            sage: T.<v> = R.quotient(x^2)
+            sage: R(u)
+            x
+            sage: R(v)
+            x
+            sage: R(u + 2)
+            x + 2
+
+        This is an explicit conversion, not a ring homomorphism or coercion::
+
+            sage: R(u^3)
+            0
+            sage: R(u)^3
+            x^3
+            sage: u in R
+            True
+            sage: R.has_coerce_map_from(S)
+            False
+
+        This does not affect conversions from quotient representations of
+        other rings (:issue:`42029`)::
+
+            sage: P.<t> = QQ[]
+            sage: K.<a> = NumberField(t^2 + 1)                                          # needs sage.rings.number_field
+            sage: Q = K.polynomial_quotient_ring()                                      # needs sage.rings.number_field
+            sage: K['x'](Q.gen())                                                       # needs sage.rings.number_field
+            a
         """
         C = self.element_class
         if isinstance(x, (list, tuple)):
@@ -422,6 +455,12 @@ class PolynomialRing_generic(Ring):
             if P == self.base_ring():
                 return C(self, [x], check=True, is_gen=False,
                          construct=construct)
+            from sage.rings.polynomial.polynomial_quotient_ring_element import (
+                PolynomialQuotientRingElement,
+            )
+            if (isinstance(x, PolynomialQuotientRingElement)
+                    and P.polynomial_ring() is self):
+                return x.lift()
         if isinstance(x, sage.interfaces.abc.SingularElement) and self._has_singular:
             self._singular_().set_ring()
             try:


### PR DESCRIPTION
Fixes #42029

`PolynomialRing._element_constructor_` currently lets polynomial quotient elements fall through to coefficient conversion. Over finite fields this can end up in rational reconstruction and produce confusing errors instead of using the quotient element's polynomial representative

This handles explicit conversion from a `PolynomialQuotientRingElement` only when its cover polynomial ring is the target ring. In that case `R(a)` returns `a.lift()`, while `R.has_coerce_map_from(Q)` stays false

The number field quotient representation case is covered too, so conversions like `K['x'](K.polynomial_quotient_ring().gen())` still treat the quotient generator as a scalar

Tests:
- `./sage -tox -e pycodestyle-minimal -- src/sage/rings/polynomial/polynomial_ring.py src/sage/rings/polynomial/polynomial_quotient_ring.py`
- `./sage -tox -e pyright -- src/sage/rings/polynomial/polynomial_ring.py src/sage/rings/polynomial/polynomial_quotient_ring.py`
- direct runtime checks for the issue examples and the number-field quotient regression

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

None
