### PR TITLE
Fix `add_vertices` not working when called with read-once iterator

### DIFF
--- a/src/sage/graphs/bipartite_graph.py
+++ b/src/sage/graphs/bipartite_graph.py
@@ -829,12 +829,26 @@ class BipartiteGraph(Graph):
             RuntimeError: cannot add duplicate vertex to other partition
             sage: (bg.left, bg.right)
             ({0, 1, 2}, set())
+            sage: bg.add_vertices([0, 1, 2], left=[False])
+            Traceback (most recent call last):
+            ...
+            ValueError: zip() argument 2 is longer than argument 1
+
+
+        Check that :issue:`42512` is fixed::
+
+            sage: bg = BipartiteGraph()
+            sage: bg.add_vertices(iter(range(5)), left=True)
+            sage: list(bg)
+            [0, 1, 2, 3, 4]
         """
         # sanity check on partition specifiers
         if left and right:  # also triggered if both lists are specified
             raise RuntimeError("only one partition may be specified")
         if not (left or right):
             raise RuntimeError("partition must be specified (e.g. left=True)")
+
+        vertices = list(vertices)
 
         # handle partitions
         if left and (not isinstance(left, Iterable)):
@@ -849,7 +863,7 @@ class BipartiteGraph(Graph):
                 left = [not tf for tf in right]
             new_left = set()
             new_right = set()
-            for tf, vv in zip(left, vertices):
+            for tf, vv in zip(left, vertices, strict=True):
                 if tf:
                     new_left.add(vv)
                 else:


### PR DESCRIPTION
I expect that `BipartiteGraph.add_vertices` works for any iterable sequence, including read-once iterators. The following should add 5 vertices, but it actually did not add any:
```sage
G = BipartiteGraph()
G.add_vertices(iter(range(5)), left=True)
```
This is re-occuring bug, see e.g. e1a36723c5b4ec27c2ce255b04363619af1ef1f9.

I also added the `strict=True` argument to `zip()` to enforce the "same length" requirement mentioned in the docstring.

- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.
