### PR TITLE
Add is_even and is_odd methods to Integer

### DIFF
--- a/src/sage/rings/integer.pxd
+++ b/src/sage/rings/integer.pxd
@@ -30,6 +30,9 @@ cdef class Integer(EuclideanDomainElement):
     cdef Integer _divide_knowing_divisible_by(Integer self, Integer right)
     cdef bint _is_power_of(Integer self, Integer n) noexcept
 
+    cpdef bint is_even(self) noexcept
+    cpdef bint is_odd(self) noexcept
+
     cdef bint _pseudoprime_is_prime(self, proof) except -1
 
 cdef int mpz_set_str_python(mpz_ptr z, char* s, int base) except -1

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -5058,6 +5058,46 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             return R.zero()
         return R(self).abs().log()
 
+    cpdef bint is_even(self) noexcept:
+        r"""
+        Return whether or not this Integer is even.
+
+        EXAMPLES::
+
+            sage: 0.is_even()
+            True
+            sage: (-2).is_even()
+            True
+            sage: 12.is_even()
+            True
+            sage: 1.is_even()
+            False
+
+        AUTHORS:
+
+        - Vincent Macri (2026-07-08)
+        """
+        return mpz_even_p(self.value)
+
+    cpdef bint is_odd(self) noexcept:
+        r"""
+        Return whether or not this Integer is odd.
+
+        EXAMPLES::
+
+            sage: 1.is_odd()
+            True
+            sage: (-9).is_odd()
+            True
+            sage: 0.is_odd()
+            False
+
+        AUTHORS:
+
+        - Vincent Macri (2026-07-08)
+        """
+        return mpz_odd_p(self.value)
+
     cdef bint _is_power_of(Integer self, Integer n) noexcept:
         r"""
         Return a nonzero int if there is an integer b with


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Adds two one-line methods to `Integer` to check if a number is even or odd. These are faster than computing the value of the Integer mod 2.
Some timings:

```python
sage: %timeit [a.is_odd() for a in srange(-100, 100)]
71.3 μs ± 12.4 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

sage: %timeit [bool(a % 2) for a in srange(-100, 100)]  # Includes creating Integer(2)
105 μs ± 1.39 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

sage: %timeit [bool(a % 2r) for a in srange(-100, 100)]
72.8 μs ± 5.23 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

sage: %timeit [a % 2r == 1r for a in srange(-100, 100)]
81.3 μs ± 1.35 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

```python
sage: %timeit [a.is_even() for a in srange(-100, 100)]
66.1 μs ± 4.99 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

sage: %timeit [not (a % 2) for a in srange(-100, 100)]  # Includes creating Integer(2)
106 μs ± 3.57 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

sage: %timeit [not (a % 2r) for a in srange(-100, 100)]
75.1 μs ± 5.45 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

```python
sage: a = 123456789012345678901234567890

sage: %timeit a.is_odd()
98.5 ns ± 2.35 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

sage: %timeit bool(a % 2)  # Includes creating Integer(2)
321 ns ± 38.5 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

sage: %timeit bool(a % 2r)
119 ns ± 2.54 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```

So the speedup is small, except when writing Sage code with the preparser on and not using Python ints. I imagine lots of Sage users aren't aware of the subtleties of Sage versus Python ints so this would give a nice speedup for them. The performance gain of using this in library code would be smaller, but it arguably would enhance readability.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


