### PR TITLE
Avoid slow PARI factorization in isogenies_prime_degree over finite fields

### DIFF
--- a/src/sage/schemes/elliptic_curves/isogeny_small_degree.py
+++ b/src/sage/schemes/elliptic_curves/isogeny_small_degree.py
@@ -2608,6 +2608,18 @@ def isogenies_prime_degree_general(E, l, minimal_models=True):
         ....:  for phi in E.isogenies_prime_degree(37)]
         [(0, 0, 0, 840*i + 1081, 0),
          (0, 0, 0, -840*i + 1081, 0)]
+
+    Over a finite field, factoring the full `l`-division polynomial via PARI
+    can hit a slow path; we use a distinct-degree shortcut instead. The
+    following example used to hang for several minutes::
+
+        sage: F.<a> = GF(8)
+        sage: E = EllipticCurve(F, [1, 0, 0, 0, a^2 + a])
+        sage: isos = E.isogenies_prime_degree(19)
+        sage: len(isos)
+        2
+        sage: all(phi.degree() == 19 for phi in isos)
+        True
     """
     if not l.is_prime():
         raise ValueError(f"{l} is not prime")
@@ -2618,7 +2630,46 @@ def isogenies_prime_degree_general(E, l, minimal_models=True):
 
     psi_l = E.division_polynomial(l)
 
-    factors = [h for h,_ in psi_l.factor() if h.degree().divides(l//2)]
+    K = E.base_ring()
+    if K.is_finite():
+        # Over a finite field, factoring ``psi_l`` directly can be very slow
+        # (PARI's generic factor over `GF(q)` has worst-case behaviour for
+        # division polynomials). Only the factors whose
+        # degree divides ``(l-1)/2`` matter, and they can be obtained
+        # cheaply by a single distinct-degree step:
+        # ``gcd(psi_l, x^(q^((l-1)/2)) - x)`` is the product of all
+        # irreducible factors of ``psi_l`` whose degree divides ``(l-1)/2``.
+        # In odd characteristic, factoring this smaller polynomial is fast.
+        R = psi_l.parent()
+        x = R.gen()
+        q = K.cardinality()
+        half = l // 2
+        # Remove repeated factors when possible. If the derivative vanishes
+        # identically (as can happen in characteristic ``l``), the gcd below
+        # with ``x^(q^half) - x`` still removes multiplicities, since that
+        # polynomial is squarefree.
+        dpsi = psi_l.derivative()
+        g = psi_l if dpsi.is_zero() else psi_l // psi_l.gcd(dpsi)
+        # Compute ``x^(q^half) mod g`` by repeated Frobenius.
+        h = x
+        for _ in range(half):
+            h = pow(h, q, g)
+        big = g.gcd(h - x)
+        if K.characteristic() == 2:
+            # Avoid PARI's binary-field factorization, which can hit a slow
+            # path here.  Since ``big`` is squarefree and already contains
+            # only factors of degrees dividing ``half``, repeated extraction
+            # of such irreducible factors gives exactly the required list.
+            factors = []
+            while big.degree() > 0:
+                f = big.any_irreducible_factor(assume_squarefree=True, ext_degree=half)
+                factors.append(f)
+                big //= f
+            factors.sort(key=lambda f: (f.degree(), [str(c) for c in f.list()]))
+        else:
+            factors = [f for f, _ in big.factor() if f.degree().divides(half)]
+    else:
+        factors = [h for h, _ in psi_l.factor() if h.degree().divides(l // 2)]
 
     kernels = []  # will store all kernel polynomials found
 

--- a/src/sage/schemes/elliptic_curves/isogeny_small_degree.py
+++ b/src/sage/schemes/elliptic_curves/isogeny_small_degree.py
@@ -2609,9 +2609,10 @@ def isogenies_prime_degree_general(E, l, minimal_models=True):
         [(0, 0, 0, 840*i + 1081, 0),
          (0, 0, 0, -840*i + 1081, 0)]
 
-    Over a finite field, factoring the full `l`-division polynomial via PARI
-    can hit a slow path; we use a distinct-degree shortcut instead. The
-    following example used to hang for several minutes::
+    Over a finite field of characteristic different from `l`, first using a
+    distinct-degree step to discard irrelevant factors can make the
+    factorization much faster. The following example used to hang for several
+    minutes::
 
         sage: F.<a> = GF(8)
         sage: E = EllipticCurve(F, [1, 0, 0, 0, a^2 + a])
@@ -2631,43 +2632,18 @@ def isogenies_prime_degree_general(E, l, minimal_models=True):
     psi_l = E.division_polynomial(l)
 
     K = E.base_ring()
-    if K.is_finite():
-        # Over a finite field, factoring ``psi_l`` directly can be very slow
-        # (PARI's generic factor over `GF(q)` has worst-case behaviour for
-        # division polynomials). Only the factors whose
-        # degree divides ``(l-1)/2`` matter, and they can be obtained
-        # cheaply by a single distinct-degree step:
-        # ``gcd(psi_l, x^(q^((l-1)/2)) - x)`` is the product of all
+    if K.is_finite() and l != K.characteristic():
+        # Factoring ``psi_l`` directly can be very slow. Only the factors
+        # whose degree divides ``(l-1)/2`` matter, and they can be obtained
+        # first by a single distinct-degree step:
+        # ``gcd(psi_l, x^(q^((l-1)/2)) - x)`` is the product of all distinct
         # irreducible factors of ``psi_l`` whose degree divides ``(l-1)/2``.
-        # In odd characteristic, factoring this smaller polynomial is fast.
-        R = psi_l.parent()
-        x = R.gen()
+        x = psi_l.parent().gen()
         q = K.cardinality()
-        half = l // 2
-        # Remove repeated factors when possible. If the derivative vanishes
-        # identically (as can happen in characteristic ``l``), the gcd below
-        # with ``x^(q^half) - x`` still removes multiplicities, since that
-        # polynomial is squarefree.
-        dpsi = psi_l.derivative()
-        g = psi_l if dpsi.is_zero() else psi_l // psi_l.gcd(dpsi)
-        # Compute ``x^(q^half) mod g`` by repeated Frobenius.
-        h = x
-        for _ in range(half):
-            h = pow(h, q, g)
-        big = g.gcd(h - x)
-        if K.characteristic() == 2:
-            # Avoid PARI's binary-field factorization, which can hit a slow
-            # path here.  Since ``big`` is squarefree and already contains
-            # only factors of degrees dividing ``half``, repeated extraction
-            # of such irreducible factors gives exactly the required list.
-            factors = []
-            while big.degree() > 0:
-                f = big.any_irreducible_factor(assume_squarefree=True, ext_degree=half)
-                factors.append(f)
-                big //= f
-            factors.sort(key=lambda f: (f.degree(), [str(c) for c in f.list()]))
-        else:
-            factors = [f for f, _ in big.factor() if f.degree().divides(half)]
+        half = l // 2  # equals (l-1)/2 since l is odd here
+        # Here ``psi_l`` is squarefree because multiplication by ``l`` is separable.
+        big = psi_l.gcd(pow(x, q**half, psi_l) - x)
+        factors = [f for f, _ in big.factor()]
     else:
         factors = [h for h, _ in psi_l.factor() if h.degree().divides(l // 2)]
 


### PR DESCRIPTION
### Avoid slow PARI factorization of division polynomials over finite fields

In `isogenies_prime_degree_general`, only the factors of the `l`-division
polynomial whose degree divides `(l-1)/2` are relevant. Over a finite field we
now recover them with a single distinct-degree step
(`gcd(psi_l, x^(q^((l-1)/2)) - x)`, computed by repeated Frobenius) instead of a
full `.factor()`, which can be extremely slow. In characteristic 2 we extract the
irreducible factors directly, avoiding PARI's binary-field factorization slow
path.

The following example used to hang for several minutes:

```python
sage: F.<a> = GF(8)
sage: E = EllipticCurve(F, [1, 0, 0, 0, a^2 + a])
sage: E.isogenies_prime_degree(19)
```

This is one of the two algorithmic improvements originally bundled into #42158,
split out per the reviewer's suggestion. It is independent of the `kerpoly`
correctness fix in #42158.
