### PR TITLE
Compare Frobenius isogenies without building rational maps

### DIFF
--- a/src/sage/schemes/elliptic_curves/hom_frobenius.py
+++ b/src/sage/schemes/elliptic_curves/hom_frobenius.py
@@ -153,6 +153,7 @@ from sage.structure.sequence import Sequence
 
 from sage.rings.integer_ring import ZZ
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+from sage.structure.richcmp import op_EQ
 
 from sage.rings.finite_rings.finite_field_base import FiniteField
 
@@ -308,6 +309,32 @@ class EllipticCurveHom_frobenius(EllipticCurveHom):
                 f'\n  To:   {self._codomain}'
 
     # EllipticCurveHom methods
+
+    @staticmethod
+    def _comparison_impl(left, right, op):
+        r"""
+        Compare two Frobenius isogenies without constructing rational maps.
+
+        TESTS:
+
+        Comparing high-degree Frobenius maps should not build their
+        bivariate rational maps, whose exponents can exceed Singular's
+        internal limit::
+
+            sage: from sage.schemes.elliptic_curves.hom_frobenius import EllipticCurveHom_frobenius
+            sage: p = 2^31 - 1
+            sage: E = EllipticCurve(GF(p), [1, 0])
+            sage: pi = EllipticCurveHom_frobenius(E, 2)
+            sage: pi == EllipticCurveHom_frobenius(E, 2)
+            True
+        """
+        if op != op_EQ:
+            return NotImplemented
+        if not isinstance(left, EllipticCurveHom_frobenius):
+            return NotImplemented
+        if not isinstance(right, EllipticCurveHom_frobenius):
+            return NotImplemented
+        return left.domain() == right.domain() and left._n == right._n
 
     def rational_maps(self):
         """


### PR DESCRIPTION
## Summary

Split out of #42169, which bundled this together with unrelated changes.

Comparing two `EllipticCurveHom_frobenius` objects falls back to the generic `EllipticCurveHom` comparison, which compares rational maps. Constructing the bivariate rational maps of a Frobenius isogeny raises the coordinates to the `p^n`-th power, and for large `p` the resulting exponents can exceed Singular's internal limit.

Two Frobenius isogenies are equal if and only if they have the same domain and raise the coordinates to the same power of `p`, so this adds an `EllipticCurveHom_frobenius._comparison_impl` testing exactly that.

## Details

- Adds `EllipticCurveHom_frobenius._comparison_impl`.
- Adds a doctest comparing Frobenius maps over `\GF{2^{31}-1}`, which previously went through the rational maps.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

None. This is independent of #42169 and #42516.
