### PR TITLE
Implement _cache_key for polynomial quotient rings with unhashable modulus

### DIFF
--- a/src/sage/rings/polynomial/polynomial_quotient_ring.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring.py
@@ -647,6 +647,35 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
         """
         return hash((self.polynomial_ring(), self.modulus()))
 
+    def _cache_key(self):
+        """
+        Return a key which identifies this ring for caching.
+
+        This is used as a fallback by cached functions and methods when
+        this ring is not hashable, which happens when the coefficients of
+        the modulus are inexact, e.g., `p`-adic numbers.
+
+        EXAMPLES::
+
+            sage: R.<x> = Zq(4, names='a')[]
+            sage: S = R.quotient(x)
+            sage: S._cache_key()
+            (<class 'sage.rings.polynomial.polynomial_quotient_ring.PolynomialQuotientRing_generic'>,
+             Univariate Polynomial Ring in x over 2-adic Unramified Extension Ring in a defined by x^2 + x + 1,
+             (1 + O(2^20))*x)
+
+        TESTS:
+
+        Check that :issue:`42518` is fixed::
+
+            sage: R.<x> = Zq(7^2, names='T')[]
+            sage: S = R.quotient(x)
+            sage: 5 * S(123)
+            6 + 3*7 + 5*7^2 + 7^3 + O(7^20)
+        """
+        return (PolynomialQuotientRing_generic,
+                self.polynomial_ring(), self.modulus())
+
     def _singular_init_(self, S=None):
         """
         Represent ``self`` in the Singular interface.


### PR DESCRIPTION
Polynomial quotient rings whose modulus has inexact coefficients (e.g. `p`-adic numbers) are unhashable, because their hash is derived from the modulus and inexact elements are unhashable by design. Cached functions in the coercion machinery then fall back to `_cache_key()`, which was not implemented for polynomial quotient rings, so e.g. multiplying an element of such a ring by an integer failed:

```
sage: R.<x> = Zq(7^2, names='T')[]
sage: S = R.quotient(x)
sage: 5 * S(123)
TypeError: <class 'sage.rings.polynomial.polynomial_quotient_ring.PolynomialQuotientRing_generic_with_category'> is not hashable and does not implement _cache_key()
```

This PR implements `_cache_key()` on `PolynomialQuotientRing_generic`, mirroring the ring's `__eq__` semantics (compare the polynomial ring and the modulus), following the same convention as `Polynomial._cache_key()`. The unhashable modulus in the key is resolved recursively by the cache-key machinery in `sage.misc.cachefunc`.

Fixes #42518

### 📝 Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)