### PR TITLE
Add an optional FLINT/Calcium (ca_t) backend for QQbar/AA arithmetic

### DIFF
--- a/src/doc/en/reference/number_fields/index.rst
+++ b/src/doc/en/reference/number_fields/index.rst
@@ -59,6 +59,7 @@ Algebraic Numbers
    :maxdepth: 1
 
    sage/rings/qqbar
+   sage/rings/qqbar_calcium
    sage/rings/universal_cyclotomic_field
 
 Enumeration of Totally Real Fields

--- a/src/sage/rings/meson.build
+++ b/src/sage/rings/meson.build
@@ -97,6 +97,7 @@ py.install_sources(
   'puiseux_series_ring_element.pxd',
   'puiseux_series_ring_element.pyx',
   'qqbar.py',
+  'qqbar_calcium.pyx',
   'qqbar_decorators.py',
   'quotient_ring.py',
   'quotient_ring_element.py',
@@ -164,6 +165,7 @@ extension_data = {
   'power_series_poly': files('power_series_poly.pyx'),
   'power_series_ring_element': files('power_series_ring_element.pyx'),
   'puiseux_series_ring_element': files('puiseux_series_ring_element.pyx'),
+  'qqbar_calcium': files('qqbar_calcium.pyx'),
   'real_arb': files('real_arb.pyx'),
   'real_double': files('real_double.pyx'),
   'real_double_element_gsl': files('real_double_element_gsl.pyx'),
@@ -206,6 +208,8 @@ foreach name, pyx : extension_data
     deps += [gmpy2]
   elif name == 'power_series_pari'
     deps += [cypari2]
+  elif name == 'qqbar_calcium'
+    deps += [flint, mpfi]
   elif name == 'real_arb'
     deps += [flint, mpfi]
   elif name == 'real_double'

--- a/src/sage/rings/qqbar.py
+++ b/src/sage/rings/qqbar.py
@@ -8767,6 +8767,158 @@ for t1 in (ANRational, ANRoot, ANExtensionElement, ANUnaryExpr, ANBinaryExpr):
     for t2 in (ANUnaryExpr, ANBinaryExpr, ANRoot):
         _binop_algo[t1, t2] = _binop_algo[t2, t1] = an_binop_expr
 
+_algebraic_backend = 'native'
+_ANCalcium = None
+_ca_from_descr = None
+
+
+def algebraic_backend():
+    """
+    Return the name of the active algebraic-number engine, ``'native'``
+    or ``'calcium'``.
+
+    EXAMPLES::
+
+        sage: from sage.rings.qqbar import algebraic_backend
+        sage: algebraic_backend()
+        'native'
+    """
+    return _algebraic_backend
+
+
+def set_algebraic_backend(name):
+    r"""
+    Select the engine used for arithmetic on ``QQbar`` and ``AA``.
+
+    INPUT:
+
+    - ``name`` -- ``'native'`` (the default classical implementation) or
+      ``'calcium'`` (FLINT/Calcium ``ca_t``; experimental)
+
+    With the Calcium backend, sums/differences/products/quotients of
+    algebraic numbers are tracked by FLINT's exact ``ca_t`` type instead of
+    lazy expression trees, and equality, comparison and sign tests are
+    decided by Calcium, falling back to the classical algorithm only when
+    Calcium reports "Unknown". Values already created keep working after
+    switching in either direction.
+
+    EXAMPLES::
+
+        sage: from sage.rings.qqbar import set_algebraic_backend, algebraic_backend
+        sage: set_algebraic_backend('calcium')
+        sage: a = QQbar(2).sqrt() + QQbar(3).sqrt()
+        sage: type(a._descr).__name__
+        'ANCalcium'
+        sage: a^2 == 5 + 2*QQbar(6).sqrt()
+        True
+        sage: set_algebraic_backend('native')
+        sage: b = QQbar(2).sqrt() + QQbar(3).sqrt()
+        sage: type(b._descr).__name__
+        'ANBinaryExpr'
+
+    Elements created under the Calcium backend continue to work after
+    switching back (and can mix with native ones)::
+
+        sage: a + b == 2*a
+        True
+        sage: a.minpoly()
+        x^4 - 10*x^2 + 1
+
+    TESTS::
+
+        sage: set_algebraic_backend('pari')
+        Traceback (most recent call last):
+        ...
+        ValueError: unknown algebraic backend 'pari'
+        sage: algebraic_backend()
+        'native'
+    """
+    global _algebraic_backend, _ANCalcium, _ca_from_descr
+    if name == _algebraic_backend:
+        return
+    if name == 'calcium':
+        from sage.rings.qqbar_calcium import ANCalcium, an_binop_calcium, ca_from_descr
+        _ANCalcium = ANCalcium
+        _ca_from_descr = ca_from_descr
+        # pairs involving ANCalcium stay registered forever (live elements
+        # must keep working after a switch back to 'native')
+        for t in (ANRational, ANRoot, ANExtensionElement, ANUnaryExpr,
+                  ANBinaryExpr, ANCalcium):
+            _binop_algo[t, ANCalcium] = _binop_algo[ANCalcium, t] = an_binop_calcium
+        # replace the lazy-expression path (exactly the entries populated
+        # with an_binop_expr above)
+        for t1 in (ANRational, ANRoot, ANExtensionElement, ANUnaryExpr, ANBinaryExpr):
+            for t2 in (ANUnaryExpr, ANBinaryExpr, ANRoot):
+                _binop_algo[t1, t2] = _binop_algo[t2, t1] = an_binop_calcium
+        _algebraic_backend = 'calcium'
+    elif name == 'native':
+        for t1 in (ANRational, ANRoot, ANExtensionElement, ANUnaryExpr, ANBinaryExpr):
+            for t2 in (ANUnaryExpr, ANBinaryExpr, ANRoot):
+                _binop_algo[t1, t2] = _binop_algo[t2, t1] = an_binop_expr
+        _algebraic_backend = 'native'
+    else:
+        raise ValueError("unknown algebraic backend '%s'" % (name,))
+
+
+class algebraic_backend_context:
+    """
+    Context manager that temporarily selects an algebraic-number engine.
+
+    EXAMPLES::
+
+        sage: from sage.rings.qqbar import algebraic_backend_context, algebraic_backend
+        sage: with algebraic_backend_context('calcium'):
+        ....:     t = type((QQbar(2).sqrt() + 1)._descr).__name__
+        sage: t
+        'ANCalcium'
+        sage: algebraic_backend()
+        'native'
+    """
+    def __init__(self, name):
+        self._name = name
+
+    def __enter__(self):
+        self._old = algebraic_backend()
+        set_algebraic_backend(self._name)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        set_algebraic_backend(self._old)
+        return False
+
+
+def _calcium_ca_of(d):
+    """
+    Return the ``Ca`` value of a descriptor for the comparison fast paths:
+    the wrapped value for :class:`~sage.rings.qqbar_calcium.ANCalcium`
+    descriptors, a cheap conversion for :class:`ANRational`, and ``None``
+    for everything else.
+
+    TESTS::
+
+        sage: from sage.rings.qqbar import _calcium_ca_of, set_algebraic_backend
+        sage: import sage.rings.qqbar as qqbar_module
+        sage: ANCalcium = qqbar_module._ANCalcium
+        sage: qqbar_module._ANCalcium = None
+        sage: _calcium_ca_of(QQbar(2)._descr) is None   # backend never enabled -> None
+        True
+        sage: qqbar_module._ANCalcium = ANCalcium
+        sage: set_algebraic_backend('calcium')
+        sage: a = QQbar(2).sqrt() + 1
+        sage: _calcium_ca_of(a._descr)
+        Ca(2.414213562373095?)
+        sage: _calcium_ca_of(QQbar(1/2)._descr)
+        Ca(0.50000000000000000?)
+        sage: set_algebraic_backend('native')
+    """
+    if _ANCalcium is None:
+        return None
+    if type(d) is _ANCalcium:
+        return d._ca
+    if isinstance(d, ANRational):
+        return _ca_from_descr(d)
+    return None
+
+
 qq_generator = AlgebraicGenerator(QQ, ANRoot(AAPoly([1, -1]), RIF.one()))
 
 
@@ -8801,6 +8953,10 @@ def _init_qqbar():
     QQbar_hash_offset = AlgebraicNumber(ANExtensionElement(QQbar_I_generator, ~ZZ(123456789) + QQbar_I_nf.gen() / ZZ(987654321)))
 
     ZZX_x = ZZ['x'].gen()
+
+    import os
+    if os.environ.get('SAGE_ALGEBRAIC_BACKEND') == 'calcium':
+        set_algebraic_backend('calcium')
 
 
 # This is used in the _algebraic_ method of the golden_ratio constant,

--- a/src/sage/rings/qqbar.py
+++ b/src/sage/rings/qqbar.py
@@ -8888,7 +8888,17 @@ def set_algebraic_backend(name):
         True
         sage: AA(2).sqrt() + AA(3).sqrt() > AA(10).sqrt() * (AA(1)/2)
         True
+
+    Independently exactified elements use Calcium when the native fields
+    have not already been combined::
+
+        sage: e2 = AA(2).sqrt(); e3 = AA(3).sqrt()
+        sage: e2.exactify(); e3.exactify()
+        sage: type((e2 + e3)._descr).__name__
+        'ANCalcium'
         sage: set_algebraic_backend('native')
+        sage: type((e2 + e3)._descr).__name__
+        'ANBinaryExpr'
 
     TESTS::
 
@@ -8903,7 +8913,9 @@ def set_algebraic_backend(name):
     if name == _algebraic_backend:
         return
     if name == 'calcium':
-        from sage.rings.qqbar_calcium import ANCalcium, an_binop_calcium, ca_from_descr
+        from sage.rings.qqbar_calcium import (ANCalcium, an_binop_calcium,
+                                              an_binop_element_calcium,
+                                              ca_from_descr)
         _ANCalcium = ANCalcium
         _ca_from_descr = ca_from_descr
         # pairs involving ANCalcium stay registered forever (live elements
@@ -8915,11 +8927,13 @@ def set_algebraic_backend(name):
         for t1 in _an_descr_types:
             for t2 in _an_inexact_types:
                 _binop_algo[t1, t2] = _binop_algo[t2, t1] = an_binop_calcium
+        _binop_algo[ANExtensionElement, ANExtensionElement] = an_binop_element_calcium
         _algebraic_backend = 'calcium'
     elif name == 'native':
         for t1 in _an_descr_types:
             for t2 in _an_inexact_types:
                 _binop_algo[t1, t2] = _binop_algo[t2, t1] = an_binop_expr
+        _binop_algo[ANExtensionElement, ANExtensionElement] = an_binop_element
         _algebraic_backend = 'native'
     else:
         raise ValueError("unknown algebraic backend '%s'" % (name,))

--- a/src/sage/rings/qqbar.py
+++ b/src/sage/rings/qqbar.py
@@ -8806,8 +8806,13 @@ _binop_algo[ANRational, ANExtensionElement] = \
     _binop_algo[ANExtensionElement, ANRational] = \
         _binop_algo[ANExtensionElement, ANExtensionElement] = an_binop_element
 
-for t1 in (ANRational, ANRoot, ANExtensionElement, ANUnaryExpr, ANBinaryExpr):
-    for t2 in (ANUnaryExpr, ANBinaryExpr, ANRoot):
+# the pairs (re)assigned when switching backends: at least one operand
+# has no exact representation of its own
+_an_descr_types = (ANRational, ANRoot, ANExtensionElement, ANUnaryExpr, ANBinaryExpr)
+_an_inexact_types = (ANUnaryExpr, ANBinaryExpr, ANRoot)
+
+for t1 in _an_descr_types:
+    for t2 in _an_inexact_types:
         _binop_algo[t1, t2] = _binop_algo[t2, t1] = an_binop_expr
 
 _algebraic_backend = 'native'
@@ -8903,18 +8908,17 @@ def set_algebraic_backend(name):
         _ca_from_descr = ca_from_descr
         # pairs involving ANCalcium stay registered forever (live elements
         # must keep working after a switch back to 'native')
-        for t in (ANRational, ANRoot, ANExtensionElement, ANUnaryExpr,
-                  ANBinaryExpr, ANCalcium):
+        for t in _an_descr_types + (ANCalcium,):
             _binop_algo[t, ANCalcium] = _binop_algo[ANCalcium, t] = an_binop_calcium
         # replace the lazy-expression path (exactly the entries populated
         # with an_binop_expr above)
-        for t1 in (ANRational, ANRoot, ANExtensionElement, ANUnaryExpr, ANBinaryExpr):
-            for t2 in (ANUnaryExpr, ANBinaryExpr, ANRoot):
+        for t1 in _an_descr_types:
+            for t2 in _an_inexact_types:
                 _binop_algo[t1, t2] = _binop_algo[t2, t1] = an_binop_calcium
         _algebraic_backend = 'calcium'
     elif name == 'native':
-        for t1 in (ANRational, ANRoot, ANExtensionElement, ANUnaryExpr, ANBinaryExpr):
-            for t2 in (ANUnaryExpr, ANBinaryExpr, ANRoot):
+        for t1 in _an_descr_types:
+            for t2 in _an_inexact_types:
                 _binop_algo[t1, t2] = _binop_algo[t2, t1] = an_binop_expr
         _algebraic_backend = 'native'
     else:

--- a/src/sage/rings/qqbar.py
+++ b/src/sage/rings/qqbar.py
@@ -4122,6 +4122,13 @@ class AlgebraicNumber_base(sage.structure.element.FieldElement):
 
         # case 1: cheap tests
         sd = self._descr
+        if type(sd) is _ANCalcium:
+            z = sd._ca.is_zero()
+            if z is not None:
+                if z:
+                    self._set_descr(ANRational(QQ.zero()))
+                    return False
+                return True
         if isinstance(sd, ANExtensionElement):
             # The ANExtensionElement returns an ANRational
             # instead, if the number is zero.
@@ -5061,6 +5068,21 @@ class AlgebraicNumber(AlgebraicNumber_base):
             # https://github.com/sagemath/sage/issues/29220
             return ri1._richcmp_(ri2, op)
 
+        # Calcium backend: decide exactly when both sides are available
+        if _ANCalcium is not None:
+            ca_s = _calcium_ca_of(sd)
+            ca_o = _calcium_ca_of(od)
+            if (ca_s is not None and ca_o is not None
+                    and (type(sd) is _ANCalcium or type(od) is _ANCalcium)):
+                if op == op_EQ or op == op_NE:
+                    eq = ca_s.equal(ca_o)
+                    if eq is not None:
+                        return eq == (op == op_EQ)
+                else:
+                    c = ca_s.cmp_lex(ca_o)
+                    if c is not None:
+                        return rich_to_bool(op, c)
+
         if op == op_EQ or op == op_NE:
             # some cheap and quite common tests where we can decide
             # equality or difference
@@ -5599,6 +5621,21 @@ class AlgebraicReal(AlgebraicNumber_base):
             # https://github.com/sagemath/sage/issues/29220
             return self._value._richcmp_(other._value, op)
 
+        # Calcium backend: decide exactly when both sides are available
+        if _ANCalcium is not None:
+            ca_s = _calcium_ca_of(sd)
+            ca_o = _calcium_ca_of(od)
+            if (ca_s is not None and ca_o is not None
+                    and (type(sd) is _ANCalcium or type(od) is _ANCalcium)):
+                if op == op_EQ or op == op_NE:
+                    eq = ca_s.equal(ca_o)
+                    if eq is not None:
+                        return eq == (op == op_EQ)
+                else:
+                    c = ca_s.cmp_lex(ca_o)
+                    if c is not None:
+                        return rich_to_bool(op, c)
+
         if op == op_EQ or op == op_NE:
             # some cheap and quite common tests where we can decide equality or difference
             if type(sd) is ANRational and not sd._value:
@@ -5943,6 +5980,12 @@ class AlgebraicReal(AlgebraicNumber_base):
             return self._value.unique_sign()
 
         sd = self._descr
+        if type(sd) is _ANCalcium:
+            s = sd._ca.sign_real()
+            if s is not None:
+                if s == 0:
+                    self._set_descr(ANRational(QQ.zero()))
+                return s
         if isinstance(self._descr, ANRational):
             return sd._value.sign()
         if isinstance(self._descr, ANExtensionElement):
@@ -8823,6 +8866,24 @@ def set_algebraic_backend(name):
         True
         sage: a.minpoly()
         x^4 - 10*x^2 + 1
+
+    Comparisons, sign and zero tests are decided by Calcium (and QQbar's
+    lexicographic order on complex values is preserved)::
+
+        sage: set_algebraic_backend('calcium')
+        sage: rt = [QQbar(p).sqrt() for p in [2, 3, 5, 7, 11, 13]]
+        sage: bool(sum(rt) - sum(reversed(rt)))
+        False
+        sage: (sum(rt) - sum(reversed(rt))).real().sign()
+        0
+        sage: one = QQbar(2).sqrt() * QQbar(1/2).sqrt()
+        sage: QQbar(I) * one < one
+        True
+        sage: (QQbar.zeta(3) + QQbar.zeta(4) - QQbar.zeta(3)) == QQbar.zeta(4)
+        True
+        sage: AA(2).sqrt() + AA(3).sqrt() > AA(10).sqrt() * (AA(1)/2)
+        True
+        sage: set_algebraic_backend('native')
 
     TESTS::
 

--- a/src/sage/rings/qqbar_calcium.pyx
+++ b/src/sage/rings/qqbar_calcium.pyx
@@ -29,12 +29,14 @@ AUTHORS:
 
 import operator
 
+cimport cython
+
 from cysignals.signals cimport sig_on, sig_off
 
 from sage.libs.flint.types cimport (
     ca_t, ca_ctx_t, qqbar_t, qqbar_ptr, acb_t, truth_t,
     fmpz_t, fmpq_t, fmpz_poly_struct, slong,
-    T_TRUE, T_FALSE, T_UNKNOWN)
+    T_TRUE, T_FALSE, T_UNKNOWN, CA_OPT_QQBAR_DEG_LIMIT)
 from sage.libs.flint.ca cimport (
     ca_ctx_init, ca_ctx_clear, ca_init, ca_clear,
     ca_set_fmpq, ca_set_qqbar, ca_get_fmpq, ca_get_qqbar, ca_get_acb,
@@ -63,6 +65,10 @@ from sage.rings.rational_field import QQ
 
 cdef extern from "flint/qqbar.h":
     const fmpz_poly_struct* QQBAR_POLY(const qqbar_t x)
+
+cdef extern from "flint/ca.h":
+    void ca_ctx_set_option(ca_ctx_t ctx, slong i, slong value)
+    slong ca_ctx_get_option(ca_ctx_t ctx, slong i)
 
 cdef extern from "flint/fmpz_poly.h":
     slong _minpoly_degree "fmpz_poly_degree"(const fmpz_poly_struct* poly)
@@ -103,6 +109,11 @@ cdef Ca _new_ca():
     return Ca.__new__(Ca)
 
 
+# ``__dealloc__`` needs ``_ctxref``, so the cyclic GC must not clear it
+# first.  This is safe: a ``Ca`` never lies on a reference cycle (its only
+# Python reference is the context, which holds no Python references), so
+# skipping the clearing pass cannot keep a cycle alive.
+@cython.no_gc_clear
 cdef class Ca:
     """
     A wrapper around one Calcium ``ca_t`` value.
@@ -114,6 +125,16 @@ cdef class Ca:
         sage: from sage.rings.qqbar_calcium import ca_from_rational
         sage: a = ca_from_rational(2); a
         Ca(2)
+
+    A value reachable only through a reference cycle must survive the
+    cyclic garbage collector's clearing pass (this used to segfault)::
+
+        sage: import gc
+        sage: from sage.rings.qqbar import algebraic_backend_context
+        sage: with algebraic_backend_context('calcium'):
+        ....:     b = QQbar(2).sqrt() + QQbar(3).sqrt()
+        sage: d = b._descr; d.loop = d
+        sage: del b, d; _ = gc.collect()
     """
     cdef ca_t x
     cdef CalciumContext _ctxref
@@ -174,6 +195,18 @@ cdef class Ca:
             [-2, 0, 1]
             sage: e.real() in RIF(1.414, 1.415)
             True
+
+        Values whose a-priori degree bound (the product of the extension
+        degrees, here `2^7 = 128`) exceeds Calcium's default limit are
+        retried with a raised limit instead of failing::
+
+            sage: from sage.rings.qqbar import algebraic_backend_context
+            sage: with algebraic_backend_context('calcium'):
+            ....:     u = QQbar(2).sqrt()
+            ....:     for p in [3, 5, 7, 11, 13, 17]:
+            ....:         u = u + QQbar(p).sqrt()
+            sage: u.exactify(); u.minpoly().degree()
+            128
         """
         cdef qqbar_t q
         cdef acb_t z
@@ -182,11 +215,27 @@ cdef class Ca:
         cdef Integer zc
         cdef const fmpz_poly_struct* p
         cdef slong i, d
+        cdef slong deg_limit
         qqbar_init(q)
         try:
             sig_on()
             ok = ca_get_qqbar(q, self.x, _ctx.ctx)
             sig_off()
+            if not ok:
+                # Calcium refuses when the product of the extension degrees
+                # exceeds CA_OPT_QQBAR_DEG_LIMIT (default 120), a bound that
+                # grossly overestimates the actual degree.  Retry once with a
+                # larger limit before giving up.
+                deg_limit = ca_ctx_get_option(_ctx.ctx, CA_OPT_QQBAR_DEG_LIMIT)
+                ca_ctx_set_option(_ctx.ctx, CA_OPT_QQBAR_DEG_LIMIT,
+                                  max(4096, deg_limit))
+                try:
+                    sig_on()
+                    ok = ca_get_qqbar(q, self.x, _ctx.ctx)
+                    sig_off()
+                finally:
+                    ca_ctx_set_option(_ctx.ctx, CA_OPT_QQBAR_DEG_LIMIT,
+                                      deg_limit)
             if not ok:
                 raise ValueError('unable to express this value as an algebraic number')
             p = QQBAR_POLY(q)

--- a/src/sage/rings/qqbar_calcium.pyx
+++ b/src/sage/rings/qqbar_calcium.pyx
@@ -59,7 +59,7 @@ from cysignals.signals cimport sig_on, sig_off
 from sage.libs.flint.types cimport (
     ca_t, ca_ctx_t, qqbar_t, qqbar_ptr, acb_t, truth_t,
     fmpz_t, fmpq_t, fmpz_poly_struct, slong,
-    T_TRUE, T_FALSE, T_UNKNOWN, CA_OPT_QQBAR_DEG_LIMIT)
+    T_TRUE, T_FALSE, CA_OPT_QQBAR_DEG_LIMIT)
 from sage.libs.flint.ca cimport (
     ca_ctx_init, ca_ctx_clear, ca_init, ca_clear,
     ca_set_fmpq, ca_set_qqbar, ca_get_fmpq, ca_get_qqbar, ca_get_acb,
@@ -71,7 +71,7 @@ from sage.libs.flint.fmpq cimport (
 from sage.libs.flint.fmpz cimport fmpz_init, fmpz_clear, fmpz_get_mpz
 from sage.libs.flint.qqbar cimport (
     qqbar_init, qqbar_clear, _qqbar_vec_init, _qqbar_vec_clear,
-    qqbar_get_acb, qqbar_roots_fmpz_poly, qqbar_equal)
+    qqbar_get_acb, qqbar_roots_fmpz_poly)
 from sage.libs.flint.acb cimport acb_init, acb_clear
 from sage.libs.gmp.mpz cimport mpz_fits_slong_p, mpz_get_si
 from sage.rings.complex_arb cimport acb_to_ComplexIntervalFieldElement
@@ -82,7 +82,9 @@ from sage.rings.rational cimport Rational
 
 from sage.rings.complex_interval_field import ComplexIntervalField
 from sage.rings.integer_ring import ZZ
-from sage.rings.qqbar import ANDescr
+from sage.rings.qqbar import (QQbar, ANDescr, ANRational, ANRoot,
+                              ANExtensionElement, ANUnaryExpr, ANBinaryExpr,
+                              an_binop_expr, QQy)
 from sage.rings.rational_field import QQ
 
 
@@ -194,12 +196,14 @@ cdef class Ca:
         cdef acb_t z
         cdef ComplexIntervalFieldElement res
         acb_init(z)
-        sig_on()
-        ca_get_acb(z, self.x, prec, _ctx.ctx)
-        sig_off()
-        res = ComplexIntervalField(prec)(0)
-        acb_to_ComplexIntervalFieldElement(res, z)
-        acb_clear(z)
+        try:
+            sig_on()
+            ca_get_acb(z, self.x, prec, _ctx.ctx)
+            sig_off()
+            res = ComplexIntervalField(prec)(0)
+            acb_to_ComplexIntervalFieldElement(res, z)
+        finally:
+            acb_clear(z)
         return res
 
     def to_qqbar_data(self, long prec=64):
@@ -495,11 +499,13 @@ cdef class Ca:
             sig_off()
             return z
         fmpq_init(t)
-        fmpq_set_mpq(t, q.value)
-        sig_on()
-        ca_pow_fmpq(z.x, self.x, t, _ctx.ctx)
-        sig_off()
-        fmpq_clear(t)
+        try:
+            fmpq_set_mpq(t, q.value)
+            sig_on()
+            ca_pow_fmpq(z.x, self.x, t, _ctx.ctx)
+            sig_off()
+        finally:
+            fmpq_clear(t)
         return z
 
     def _binop(self, Ca o, op):
@@ -649,15 +655,16 @@ cdef class Ca:
         cdef fmpq_t t
         cdef Rational res
         fmpq_init(t)
-        sig_on()
-        ok = ca_get_fmpq(t, self.x, _ctx.ctx)
-        sig_off()
-        if not ok:
+        try:
+            sig_on()
+            ok = ca_get_fmpq(t, self.x, _ctx.ctx)
+            sig_off()
+            if not ok:
+                return None
+            res = Rational.__new__(Rational)
+            fmpq_get_mpq(res.value, t)
+        finally:
             fmpq_clear(t)
-            return None
-        res = Rational.__new__(Rational)
-        fmpq_get_mpq(res.value, t)
-        fmpq_clear(t)
         return res
 
 
@@ -728,7 +735,7 @@ def ca_from_minpoly_root(coeffs, enclosure):
     cdef slong i
     cdef long prec = 64
     cdef Ca res
-    from sage.rings.complex_interval_field import ComplexIntervalField as _CIF
+    _CIF = ComplexIntervalField
     vec = _qqbar_vec_init(d)
     try:
         sig_on()
@@ -808,8 +815,6 @@ def ca_from_descr(descr):
         sage: ca_from_descr(r._descr) is None
         True
     """
-    from sage.rings.qqbar import (ANRational, ANRoot, ANExtensionElement,
-                                  ANUnaryExpr, ANBinaryExpr)
     if isinstance(descr, ANCalciumBase):
         return descr._ca
     if isinstance(descr, ANRational):
@@ -953,7 +958,6 @@ class ANCalcium(ANCalciumBase, ANDescr):
             sage: QQbar(e).minpoly()
             x^4 - 10*x^2 + 1
         """
-        from sage.rings.qqbar import ANRational, ANRoot, QQy
         if self._exact is not None:
             return self._exact
         r = self._ca.get_rational()
@@ -1099,7 +1103,6 @@ def an_binop_calcium(a, b, op):
         sage: q^2 - 5 - 2*QQbar(6).sqrt() == 0
         True
     """
-    from sage.rings.qqbar import QQbar as _QQbar, an_binop_expr
     left = ca_from_descr(a._descr)
     if left is None:
         return an_binop_expr(a, b, op)
@@ -1110,4 +1113,4 @@ def an_binop_calcium(a, b, op):
         c = left._binop(right, op)
     except (ZeroDivisionError, ValueError):
         return an_binop_expr(a, b, op)
-    return ANCalcium(c, a.parent() is _QQbar)
+    return ANCalcium(c, a.parent() is QQbar)

--- a/src/sage/rings/qqbar_calcium.pyx
+++ b/src/sage/rings/qqbar_calcium.pyx
@@ -37,22 +37,35 @@ from sage.libs.flint.types cimport (
     T_TRUE, T_FALSE, T_UNKNOWN)
 from sage.libs.flint.ca cimport (
     ca_ctx_init, ca_ctx_clear, ca_init, ca_clear,
-    ca_set_fmpq, ca_get_fmpq, ca_get_acb,
+    ca_set_fmpq, ca_set_qqbar, ca_get_fmpq, ca_get_qqbar, ca_get_acb,
     ca_add, ca_sub, ca_mul, ca_div, ca_neg, ca_inv, ca_sqrt, ca_abs, ca_re,
     ca_im, ca_conj, ca_pow_fmpq, ca_pow_si, ca_check_is_zero, ca_check_equal,
     ca_check_is_real, ca_check_lt)
 from sage.libs.flint.fmpq cimport (
     fmpq_init, fmpq_clear, fmpq_set_mpq, fmpq_get_mpq)
+from sage.libs.flint.fmpz cimport fmpz_init, fmpz_clear, fmpz_get_mpz
+from sage.libs.flint.qqbar cimport (
+    qqbar_init, qqbar_clear, _qqbar_vec_init, _qqbar_vec_clear,
+    qqbar_get_acb, qqbar_roots_fmpz_poly, qqbar_equal)
 from sage.libs.flint.acb cimport acb_init, acb_clear
 from sage.libs.gmp.mpz cimport mpz_fits_slong_p, mpz_get_si
 from sage.rings.complex_arb cimport acb_to_ComplexIntervalFieldElement
 from sage.rings.complex_interval cimport ComplexIntervalFieldElement
 from sage.rings.integer cimport Integer
+from sage.rings.polynomial.polynomial_integer_dense_flint cimport Polynomial_integer_dense_flint
 from sage.rings.rational cimport Rational
 
 from sage.rings.complex_interval_field import ComplexIntervalField
 from sage.rings.integer_ring import ZZ
 from sage.rings.rational_field import QQ
+
+
+cdef extern from "flint/qqbar.h":
+    const fmpz_poly_struct* QQBAR_POLY(const qqbar_t x)
+
+cdef extern from "flint/fmpz_poly.h":
+    slong _minpoly_degree "fmpz_poly_degree"(const fmpz_poly_struct* poly)
+    void _minpoly_coeff "fmpz_poly_get_coeff_fmpz"(fmpz_t x, const fmpz_poly_struct* poly, slong n)
 
 
 cdef class CalciumContext:
@@ -143,6 +156,62 @@ cdef class Ca:
         acb_to_ComplexIntervalFieldElement(res, z)
         acb_clear(z)
         return res
+
+    def to_qqbar_data(self, long prec=64):
+        """
+        Return ``(coeffs, enclosure)`` where ``coeffs`` are the integer
+        coefficients (constant first) of the minimal polynomial of this
+        (necessarily algebraic) value and ``enclosure`` is a complex
+        interval isolating it among the roots.
+
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: s = ca_from_rational(2).sqrt()
+            sage: coeffs, e = s.to_qqbar_data()
+            sage: coeffs
+            [-2, 0, 1]
+            sage: e.real() in RIF(1.414, 1.415)
+            True
+        """
+        cdef qqbar_t q
+        cdef acb_t z
+        cdef fmpz_t c
+        cdef ComplexIntervalFieldElement enc
+        cdef Integer zc
+        cdef const fmpz_poly_struct* p
+        cdef slong i, d
+        qqbar_init(q)
+        try:
+            sig_on()
+            ok = ca_get_qqbar(q, self.x, _ctx.ctx)
+            sig_off()
+            if not ok:
+                raise ValueError('unable to express this value as an algebraic number')
+            p = QQBAR_POLY(q)
+            d = _minpoly_degree(p)
+            coeffs = []
+            fmpz_init(c)
+            try:
+                for i in range(d + 1):
+                    _minpoly_coeff(c, p, i)
+                    zc = Integer.__new__(Integer)
+                    fmpz_get_mpz(zc.value, c)
+                    coeffs.append(zc)
+            finally:
+                fmpz_clear(c)
+            acb_init(z)
+            try:
+                sig_on()
+                qqbar_get_acb(z, q, prec)
+                sig_off()
+                enc = ComplexIntervalField(prec)(0)
+                acb_to_ComplexIntervalFieldElement(enc, z)
+            finally:
+                acb_clear(z)
+            return coeffs, enc
+        finally:
+            qqbar_clear(q)
 
     cdef inline int _guard_zero(self, str what) except -1:
         # raise if self is (possibly) zero; used before division-like ops
@@ -543,3 +612,77 @@ def ca_from_rational(x):
     ca_set_fmpq(z.x, t, _ctx.ctx)
     fmpq_clear(t)
     return z
+
+
+def ca_from_minpoly_root(coeffs, enclosure):
+    """
+    Return the :class:`Ca` root of the integer polynomial with coefficient
+    list ``coeffs`` (constant first; a ZZ or QQ polynomial is also accepted)
+    isolated by the complex interval ``enclosure``.
+
+    EXAMPLES::
+
+        sage: from sage.rings.qqbar_calcium import ca_from_minpoly_root, ca_from_rational
+        sage: r = ca_from_minpoly_root([-2, 0, 1], CIF(1.4142135623730951))
+        sage: r.equal(ca_from_rational(2).sqrt())
+        True
+
+    A non-isolating enclosure is rejected::
+
+        sage: ca_from_minpoly_root([-2, 0, 1], CIF(RIF(-2, 2)))
+        Traceback (most recent call last):
+        ...
+        ValueError: enclosure does not isolate a single root
+    """
+    from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+    from sage.rings.polynomial.polynomial_element import Polynomial
+    R = PolynomialRing(ZZ, 'y')
+    if isinstance(coeffs, Polynomial):
+        p = coeffs
+        p = p * p.denominator() if p.base_ring() is QQ else p
+        zp_sage = R(p)
+    else:
+        zp_sage = R([ZZ(c) for c in coeffs])
+    if zp_sage.degree() <= 0:
+        raise ValueError('polynomial must be nonconstant')
+    # squarefree part, so every root appears exactly once below
+    zp_sage = zp_sage // zp_sage.gcd(zp_sage.derivative())
+    cdef Polynomial_integer_dense_flint zp = <Polynomial_integer_dense_flint> zp_sage
+    cdef slong d = zp_sage.degree()
+    cdef qqbar_ptr vec
+    cdef acb_t z
+    cdef ComplexIntervalFieldElement re
+    cdef slong i
+    cdef long prec = 64
+    cdef Ca res
+    from sage.rings.complex_interval_field import ComplexIntervalField as _CIF
+    vec = _qqbar_vec_init(d)
+    try:
+        sig_on()
+        qqbar_roots_fmpz_poly(vec, zp._poly, 0)
+        sig_off()
+        target = _CIF(53)(enclosure)
+        while prec <= (1 << 20):
+            hits = []
+            for i in range(d):
+                acb_init(z)
+                try:
+                    qqbar_get_acb(z, &vec[i], prec)
+                    re = _CIF(prec)(0)
+                    acb_to_ComplexIntervalFieldElement(re, z)
+                finally:
+                    acb_clear(z)
+                if re.overlaps(_CIF(prec)(target)):
+                    hits.append(i)
+            if len(hits) == 1:
+                res = _new_ca()
+                sig_on()
+                ca_set_qqbar(res.x, &vec[hits[0]], _ctx.ctx)
+                sig_off()
+                return res
+            if not hits:
+                raise ValueError('enclosure does not isolate a single root')
+            prec *= 2
+        raise ValueError('enclosure does not isolate a single root')
+    finally:
+        _qqbar_vec_clear(vec, d)

--- a/src/sage/rings/qqbar_calcium.pyx
+++ b/src/sage/rings/qqbar_calcium.pyx
@@ -1,0 +1,166 @@
+r"""
+FLINT/Calcium backend for algebraic numbers
+
+This module provides an optional engine for :mod:`sage.rings.qqbar` built on
+FLINT's Calcium ``ca_t`` type. It is activated with
+:func:`sage.rings.qqbar.set_algebraic_backend`; see there for details.
+Nothing in this module is a stable public interface.
+
+EXAMPLES::
+
+    sage: from sage.rings.qqbar_calcium import ca_from_rational
+    sage: ca_from_rational(QQ(1/3))
+    Ca(0.3333333333333334?)
+
+AUTHORS:
+
+- Chenxin Zhong (2026-07-10): initial version (:issue:`42261`)
+"""
+
+# ****************************************************************************
+#       Copyright (C) 2026 Chenxin Zhong <chenxin.zhong@outlook.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
+
+import operator
+
+from cysignals.signals cimport sig_on, sig_off
+
+from sage.libs.flint.types cimport (
+    ca_t, ca_ctx_t, qqbar_t, qqbar_ptr, acb_t, truth_t,
+    fmpz_t, fmpq_t, fmpz_poly_struct, slong,
+    T_TRUE, T_FALSE, T_UNKNOWN)
+from sage.libs.flint.ca cimport (
+    ca_ctx_init, ca_ctx_clear, ca_init, ca_clear,
+    ca_set_fmpq, ca_get_fmpq, ca_get_acb)
+from sage.libs.flint.fmpq cimport fmpq_init, fmpq_clear, fmpq_set_mpq
+from sage.libs.flint.acb cimport acb_init, acb_clear
+from sage.rings.complex_arb cimport acb_to_ComplexIntervalFieldElement
+from sage.rings.complex_interval cimport ComplexIntervalFieldElement
+from sage.rings.integer cimport Integer
+from sage.rings.rational cimport Rational
+
+from sage.rings.complex_interval_field import ComplexIntervalField
+from sage.rings.integer_ring import ZZ
+from sage.rings.rational_field import QQ
+
+
+cdef class CalciumContext:
+    """
+    Owner of the (unique, module-global) Calcium context object.
+
+    TESTS::
+
+        sage: from sage.rings.qqbar_calcium import CalciumContext
+        sage: CalciumContext()
+        <sage.rings.qqbar_calcium.CalciumContext object at ...>
+    """
+    cdef ca_ctx_t ctx
+
+    def __cinit__(self):
+        ca_ctx_init(self.ctx)
+
+    def __dealloc__(self):
+        ca_ctx_clear(self.ctx)
+
+
+cdef CalciumContext _ctx = CalciumContext()
+
+
+cdef inline object _truth(truth_t t):
+    if t == T_TRUE:
+        return True
+    if t == T_FALSE:
+        return False
+    return None
+
+
+cdef Ca _new_ca():
+    return Ca.__new__(Ca)
+
+
+cdef class Ca:
+    """
+    A wrapper around one Calcium ``ca_t`` value.
+
+    Do not instantiate directly; use the ``ca_from_*`` module functions.
+
+    TESTS::
+
+        sage: from sage.rings.qqbar_calcium import ca_from_rational
+        sage: a = ca_from_rational(2); a
+        Ca(2)
+    """
+    cdef ca_t x
+    cdef CalciumContext _ctxref
+
+    def __cinit__(self):
+        self._ctxref = _ctx
+        ca_init(self.x, _ctx.ctx)
+
+    def __dealloc__(self):
+        ca_clear(self.x, self._ctxref.ctx)
+
+    def __repr__(self):
+        """
+        TESTS::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: repr(ca_from_rational(QQ(-7/2)))
+            'Ca(-3.5000000000000000?)'
+        """
+        return 'Ca({})'.format(self.enclosure(53))
+
+    def enclosure(self, long prec=64):
+        """
+        Return a complex interval containing this value.
+
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: ca_from_rational(QQ(1/3)).enclosure(53)
+            0.3333333333333334?
+            sage: ca_from_rational(QQ(1/3)).enclosure(200).diameter() < 2^-190
+            True
+        """
+        cdef acb_t z
+        cdef ComplexIntervalFieldElement res
+        acb_init(z)
+        sig_on()
+        ca_get_acb(z, self.x, prec, _ctx.ctx)
+        sig_off()
+        res = ComplexIntervalField(prec)(0)
+        acb_to_ComplexIntervalFieldElement(res, z)
+        acb_clear(z)
+        return res
+
+
+def ca_from_rational(x):
+    """
+    Return a :class:`Ca` representing the rational number ``x``.
+
+    INPUT:
+
+    - ``x`` -- Integer, Rational, or Python int
+
+    EXAMPLES::
+
+        sage: from sage.rings.qqbar_calcium import ca_from_rational
+        sage: ca_from_rational(QQ(2/3))
+        Ca(0.6666666666666667?)
+        sage: ca_from_rational(5)
+        Ca(5)
+    """
+    cdef Rational q = <Rational> QQ(x)
+    cdef Ca z = _new_ca()
+    cdef fmpq_t t
+    fmpq_init(t)
+    fmpq_set_mpq(t, q.value)
+    ca_set_fmpq(z.x, t, _ctx.ctx)
+    fmpq_clear(t)
+    return z

--- a/src/sage/rings/qqbar_calcium.pyx
+++ b/src/sage/rings/qqbar_calcium.pyx
@@ -12,6 +12,29 @@ EXAMPLES::
     sage: ca_from_rational(QQ(1/3))
     Ca(0.3333333333333334?)
 
+TESTS:
+
+Elements backed by Calcium descriptors pass the test suite.
+(``_test_category`` is skipped: it fails for *all* composite ``QQbar``/``AA``
+elements, native ones included, because ``qqbar`` constructs plain
+``AlgebraicNumber``/``AlgebraicReal`` instances rather than the category
+``element_class`` -- a pre-existing property unrelated to this backend.)
+
+::
+
+    sage: from sage.rings.qqbar import algebraic_backend_context
+    sage: with algebraic_backend_context('calcium'):
+    ....:     a = QQbar(2).sqrt() + QQbar(3).sqrt()
+    ....:     b = AA(2).sqrt() + AA(3).sqrt()
+    sage: type(a._descr).__name__, type(b._descr).__name__
+    ('ANCalcium', 'ANCalcium')
+    sage: TestSuite(a).run(skip=['_test_category'])
+    sage: TestSuite(b).run(skip=['_test_category'])
+    sage: a.minpoly() == b.minpoly()
+    True
+    sage: hash(a) == hash(QQbar(b))
+    True
+
 AUTHORS:
 
 - Chenxin Zhong (2026-07-10): initial version (:issue:`42261`)

--- a/src/sage/rings/qqbar_calcium.pyx
+++ b/src/sage/rings/qqbar_calcium.pyx
@@ -84,7 +84,7 @@ from sage.rings.complex_interval_field import ComplexIntervalField
 from sage.rings.integer_ring import ZZ
 from sage.rings.qqbar import (QQbar, ANDescr, ANRational, ANRoot,
                               ANExtensionElement, ANUnaryExpr, ANBinaryExpr,
-                              an_binop_expr, QQy)
+                              an_binop_expr, an_binop_element, QQy)
 from sage.rings.rational_field import QQ
 
 
@@ -292,7 +292,11 @@ cdef class Ca:
 
     cdef inline int _guard_zero(self, str what) except -1:
         # raise if self is (possibly) zero; used before division-like ops
-        z = _truth(ca_check_is_zero(self.x, _ctx.ctx))
+        cdef truth_t t
+        sig_on()
+        t = ca_check_is_zero(self.x, _ctx.ctx)
+        sig_off()
+        z = _truth(t)
         if z is True:
             raise ZeroDivisionError(what)
         if z is None:
@@ -542,7 +546,11 @@ cdef class Ca:
             sage: s.mul(s).sub(ca_from_rational(2)).is_zero()
             True
         """
-        return _truth(ca_check_is_zero(self.x, _ctx.ctx))
+        cdef truth_t t
+        sig_on()
+        t = ca_check_is_zero(self.x, _ctx.ctx)
+        sig_off()
+        return _truth(t)
 
     def equal(self, Ca o):
         """
@@ -556,7 +564,11 @@ cdef class Ca:
             sage: a.equal(ca_from_rational(2))
             False
         """
-        return _truth(ca_check_equal(self.x, o.x, _ctx.ctx))
+        cdef truth_t t
+        sig_on()
+        t = ca_check_equal(self.x, o.x, _ctx.ctx)
+        sig_off()
+        return _truth(t)
 
     def is_real(self):
         """
@@ -568,7 +580,11 @@ cdef class Ca:
             sage: ca_from_rational(-2).sqrt().is_real()
             False
         """
-        return _truth(ca_check_is_real(self.x, _ctx.ctx))
+        cdef truth_t t
+        sig_on()
+        t = ca_check_is_real(self.x, _ctx.ctx)
+        sig_off()
+        return _truth(t)
 
     def sign_real(self):
         """
@@ -602,13 +618,20 @@ cdef class Ca:
 
     def _sign_of_real_value(self):
         # sign of self, which the caller promises is real-valued
-        z = _truth(ca_check_is_zero(self.x, _ctx.ctx))
+        cdef truth_t t
+        sig_on()
+        t = ca_check_is_zero(self.x, _ctx.ctx)
+        sig_off()
+        z = _truth(t)
         if z is True:
             return 0
         if z is None:
             return None
         cdef Ca zero = ca_from_rational(0)
-        lt = _truth(ca_check_lt(self.x, zero.x, _ctx.ctx))
+        sig_on()
+        t = ca_check_lt(self.x, zero.x, _ctx.ctx)
+        sig_off()
+        lt = _truth(t)
         if lt is True:
             return -1
         if lt is False:
@@ -713,6 +736,16 @@ def ca_from_minpoly_root(coeffs, enclosure):
         Traceback (most recent call last):
         ...
         ValueError: enclosure does not isolate a single root
+
+    The precision of the isolating enclosure is preserved, which matters
+    when distinct roots are closer than double precision::
+
+        sage: y = polygen(QQ, 'y')
+        sage: eps = QQ(1) / 2^100
+        sage: F = RealIntervalField(200)
+        sage: r = ca_from_minpoly_root((y - 1) * (y - (1 + eps)), F(1 + eps))
+        sage: r.equal(ca_from_rational(1 + eps))
+        True
     """
     from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
     from sage.rings.polynomial.polynomial_element import Polynomial
@@ -733,16 +766,19 @@ def ca_from_minpoly_root(coeffs, enclosure):
     cdef acb_t z
     cdef ComplexIntervalFieldElement re
     cdef slong i
-    cdef long prec = 64
+    cdef long prec, target_prec, max_prec
     cdef Ca res
     _CIF = ComplexIntervalField
+    target_prec = enclosure.prec()
+    prec = 64
+    max_prec = max(1 << 20, target_prec)
     vec = _qqbar_vec_init(d)
     try:
         sig_on()
         qqbar_roots_fmpz_poly(vec, zp._poly, 0)
         sig_off()
-        target = _CIF(53)(enclosure)
-        while prec <= (1 << 20):
+        target = _CIF(target_prec)(enclosure)
+        while prec <= max_prec:
             hits = []
             for i in range(d):
                 acb_init(z)
@@ -1114,3 +1150,29 @@ def an_binop_calcium(a, b, op):
     except (ZeroDivisionError, ValueError):
         return an_binop_expr(a, b, op)
     return ANCalcium(c, a.parent() is QQbar)
+
+
+def an_binop_element_calcium(a, b, op):
+    """
+    Apply the native same-field fast paths to two exact descriptors, then
+    use Calcium instead of a lazy expression when their fields have not
+    already been combined.
+
+    EXAMPLES::
+
+        sage: from sage.rings.qqbar_calcium import an_binop_element_calcium
+        sage: a = AA(2).sqrt(); b = AA(3).sqrt()
+        sage: a.exactify(); b.exactify()
+        sage: type(an_binop_element_calcium(a, b, operator.add)).__name__
+        'ANCalcium'
+
+    Elements already represented in the same field retain the native exact
+    arithmetic path::
+
+        sage: type(an_binop_element_calcium(a, a, operator.add)).__name__
+        'ANExtensionElement'
+    """
+    res = an_binop_element(a, b, op)
+    if type(res) is ANBinaryExpr:
+        return an_binop_calcium(a, b, op)
+    return res

--- a/src/sage/rings/qqbar_calcium.pyx
+++ b/src/sage/rings/qqbar_calcium.pyx
@@ -686,3 +686,123 @@ def ca_from_minpoly_root(coeffs, enclosure):
         raise ValueError('enclosure does not isolate a single root')
     finally:
         _qqbar_vec_clear(vec, d)
+
+
+class ANCalciumBase:
+    """
+    Placeholder base marker for :class:`ANCalcium` (defined after the
+    descriptor machinery); only used for ``isinstance`` in
+    :func:`ca_from_descr`.
+
+    TESTS::
+
+        sage: from sage.rings.qqbar_calcium import ANCalciumBase
+        sage: ANCalciumBase
+        <class 'sage.rings.qqbar_calcium.ANCalciumBase'>
+    """
+    pass
+
+
+def ca_from_descr(descr):
+    """
+    Convert a ``qqbar.py`` descriptor to a :class:`Ca`, or return ``None``
+    when the descriptor is of a kind this backend cannot handle (the caller
+    then falls back to the classical path).
+
+    EXAMPLES::
+
+        sage: from sage.rings.qqbar_calcium import ca_from_descr, ca_from_rational
+        sage: ca_from_descr(QQbar(7/3)._descr).get_rational()
+        7/3
+        sage: rt2 = QQbar(2).sqrt()
+        sage: ca_from_descr(rt2._descr).mul(ca_from_descr(rt2._descr)).get_rational()
+        2
+        sage: s = QQbar(2).sqrt() + QQbar(3).sqrt()
+        sage: ca_from_descr(s._descr).equal(
+        ....:     ca_from_rational(2).sqrt().add(ca_from_rational(3).sqrt()))
+        True
+        sage: rt2.exactify()
+        sage: type(rt2._descr).__name__
+        'ANExtensionElement'
+        sage: ca_from_descr(rt2._descr).mul(ca_from_descr(rt2._descr)).get_rational()
+        2
+
+    Roots of polynomials with non-rational algebraic coefficients are
+    unsupported (the caller falls back to the classical path)::
+
+        sage: x = polygen(QQbar)
+        sage: r = (x^2 - QQbar(2).sqrt()).roots(QQbar, multiplicities=False)[0]
+        sage: ca_from_descr(r._descr) is None
+        True
+    """
+    from sage.rings.qqbar import (ANRational, ANRoot, ANExtensionElement,
+                                  ANUnaryExpr, ANBinaryExpr)
+    if isinstance(descr, ANCalciumBase):
+        return descr._ca
+    if isinstance(descr, ANRational):
+        return ca_from_rational(descr._value)
+    if isinstance(descr, ANRoot):
+        cached = getattr(descr, '_calcium_cache', None)
+        if cached is not None:
+            return cached
+        p = descr._poly._poly
+        if p.base_ring() is not QQ:
+            # Rational powering constructs its polynomial over QQbar even
+            # when all coefficients are rational.
+            try:
+                p = p.change_ring(QQ)
+            except (TypeError, ValueError):
+                return None
+        try:
+            res = ca_from_minpoly_root(p, descr._interval)
+        except ValueError:
+            return None
+        descr._calcium_cache = res
+        return res
+    if isinstance(descr, ANExtensionElement):
+        gen = descr._generator
+        ca_gen = getattr(gen, '_calcium_cache', None)
+        if ca_gen is None:
+            ca_gen = ca_from_descr(gen._root)
+            if ca_gen is None:
+                return None
+            gen._calcium_cache = ca_gen
+        res = ca_from_rational(0)
+        for c in reversed(descr._value.polynomial().list()):
+            res = res.mul(ca_gen).add(ca_from_rational(c))
+        return res
+    if isinstance(descr, ANUnaryExpr):
+        arg = ca_from_descr(descr._arg._descr)
+        if arg is None:
+            return None
+        op = descr._op
+        try:
+            if op == '-':
+                return arg.neg()
+            if op == '~':
+                return arg.invert()
+            if op == 'conjugate':
+                return arg.conjugate()
+            if op == 'abs':
+                return arg.abs()
+            if op == 'real':
+                return arg.real()
+            if op == 'imag':
+                return arg.imag()
+            if op == 'norm':
+                return arg.mul(arg.conjugate())
+        except (ZeroDivisionError, ValueError):
+            return None
+        return None
+    if isinstance(descr, ANBinaryExpr):
+        left = ca_from_descr(descr._left._descr)
+        if left is None:
+            return None
+        right = ca_from_descr(descr._right._descr)
+        if right is None:
+            return None
+        try:
+            return left._binop(right, descr._op)
+        except (ZeroDivisionError, ValueError):
+            return None
+    return None

--- a/src/sage/rings/qqbar_calcium.pyx
+++ b/src/sage/rings/qqbar_calcium.pyx
@@ -57,6 +57,7 @@ from sage.rings.rational cimport Rational
 
 from sage.rings.complex_interval_field import ComplexIntervalField
 from sage.rings.integer_ring import ZZ
+from sage.rings.qqbar import ANDescr
 from sage.rings.rational_field import QQ
 
 
@@ -806,3 +807,235 @@ def ca_from_descr(descr):
         except (ZeroDivisionError, ValueError):
             return None
     return None
+
+
+class ANCalcium(ANCalciumBase, ANDescr):
+    """
+    Algebraic-number descriptor whose value is tracked by FLINT/Calcium.
+
+    Slots into the machinery of :mod:`sage.rings.qqbar` exactly like the
+    other ``ANDescr`` subclasses; created by arithmetic when the Calcium
+    backend is enabled.
+
+    EXAMPLES::
+
+        sage: from sage.rings.qqbar_calcium import ANCalcium, ca_from_descr
+        sage: d = ANCalcium(ca_from_descr((QQbar(2).sqrt() + 1)._descr), True)
+        sage: a = QQbar(d)   # wrap in an element
+        sage: a
+        2.414213562373095?
+        sage: a.minpoly()
+        x^2 - 2*x - 1
+    """
+    def __init__(self, ca, complex):
+        """
+        TESTS::
+
+            sage: from sage.rings.qqbar_calcium import ANCalcium, ca_from_rational
+            sage: d = ANCalcium(ca_from_rational(1/2), False)
+            sage: d._complex
+            False
+        """
+        self._ca = ca
+        self._complex = complex
+        self._exact = None
+
+    def is_complex(self):
+        """
+        TESTS::
+
+            sage: from sage.rings.qqbar_calcium import ANCalcium, ca_from_rational
+            sage: ANCalcium(ca_from_rational(1), True).is_complex()
+            True
+        """
+        return self._complex
+
+    def _interval_fast(self, prec):
+        """
+        TESTS::
+
+            sage: from sage.rings.qqbar_calcium import ANCalcium, ca_from_rational
+            sage: ANCalcium(ca_from_rational(1/3), False)._interval_fast(64).parent()
+            Real Interval Field with 64 bits of precision
+            sage: ANCalcium(ca_from_rational(1/3), True)._interval_fast(64).parent()
+            Complex Interval Field with 64 bits of precision
+        """
+        e = self._ca.enclosure(prec)
+        if self._complex:
+            return e
+        return e.real()
+
+    def exactify(self):
+        """
+        Return an exact descriptor (``ANRational`` or ``ANExtensionElement``)
+        for this value, computing the minimal polynomial via Calcium.
+
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ANCalcium, ca_from_descr
+            sage: s = QQbar(2).sqrt() + QQbar(3).sqrt()
+            sage: d = ANCalcium(ca_from_descr(s._descr), True)
+            sage: e = d.exactify()
+            sage: type(e).__name__
+            'ANExtensionElement'
+            sage: QQbar(e).minpoly()
+            x^4 - 10*x^2 + 1
+        """
+        from sage.rings.qqbar import ANRational, ANRoot, QQy
+        if self._exact is not None:
+            return self._exact
+        r = self._ca.get_rational()
+        if r is not None:
+            self._exact = ANRational(r)
+            return self._exact
+        prec = 64
+        while True:
+            coeffs, enc = self._ca.to_qqbar_data(prec)
+            interval = enc if self._complex else enc.real()
+            try:
+                root = ANRoot(QQy(coeffs), interval)
+                break
+            except (ValueError, ArithmeticError):
+                if prec > (1 << 20):
+                    raise
+                prec *= 2
+        self._exact = root.exactify()
+        return self._exact
+
+    def __reduce__(self):
+        """
+        Pickle via the exactified form.
+
+        TESTS::
+
+            sage: from sage.rings.qqbar_calcium import ANCalcium, ca_from_descr
+            sage: s = QQbar(2).sqrt() + QQbar(3).sqrt()
+            sage: a = QQbar(ANCalcium(ca_from_descr(s._descr), True))
+            sage: loads(dumps(a)) == a
+            True
+        """
+        return self.exactify().__reduce__()
+
+    def handle_sage_input(self, sib, coerce, is_qqbar):
+        """
+        TESTS::
+
+            sage: from sage.rings.qqbar_calcium import ANCalcium, ca_from_descr
+            sage: s = QQbar(2).sqrt() + 1
+            sage: a = QQbar(ANCalcium(ca_from_descr(s._descr), True))
+            sage: sage_input(a, verify=True)
+            # Verified
+            ...
+        """
+        return self.exactify().handle_sage_input(sib, coerce, is_qqbar)
+
+    def neg(self, n):
+        """
+        TESTS::
+
+            sage: from sage.rings.qqbar_calcium import ANCalcium, ca_from_rational
+            sage: d = ANCalcium(ca_from_rational(2), False)
+            sage: type(d.neg(None)).__name__
+            'ANCalcium'
+        """
+        return ANCalcium(self._ca.neg(), self._complex)
+
+    def invert(self, n):
+        """
+        TESTS::
+
+            sage: from sage.rings.qqbar_calcium import ANCalcium, ca_from_rational
+            sage: d = ANCalcium(ca_from_rational(2), False)
+            sage: QQbar(d.invert(None))
+            0.50000000000000000?
+        """
+        try:
+            return ANCalcium(self._ca.invert(), self._complex)
+        except ValueError:
+            return ANDescr.invert(self, n)
+
+    def conjugate(self, n):
+        """
+        TESTS::
+
+            sage: from sage.rings.qqbar_calcium import ANCalcium, ca_from_descr
+            sage: d = ANCalcium(ca_from_descr(QQbar.zeta(3)._descr), True)
+            sage: QQbar(d.conjugate(None)) == QQbar.zeta(3).conjugate()
+            True
+        """
+        return ANCalcium(self._ca.conjugate(), self._complex)
+
+    def abs(self, n):
+        """
+        TESTS::
+
+            sage: from sage.rings.qqbar_calcium import ANCalcium, ca_from_rational
+            sage: AA(ANCalcium(ca_from_rational(-2), False).abs(None))
+            2
+        """
+        return ANCalcium(self._ca.abs(), False)
+
+    def norm(self, n):
+        """
+        TESTS::
+
+            sage: from sage.rings.qqbar_calcium import ANCalcium, ca_from_descr
+            sage: d = ANCalcium(ca_from_descr(QQbar.zeta(3)._descr), True)
+            sage: AA(d.norm(None))
+            1
+        """
+        return ANCalcium(self._ca.mul(self._ca.conjugate()), False)
+
+    def real(self, n):
+        """
+        TESTS::
+
+            sage: from sage.rings.qqbar_calcium import ANCalcium, ca_from_descr
+            sage: d = ANCalcium(ca_from_descr(QQbar.zeta(3)._descr), True)
+            sage: AA(d.real(None))
+            -0.500000000000000?
+        """
+        return ANCalcium(self._ca.real(), False)
+
+    def imag(self, n):
+        """
+        TESTS::
+
+            sage: from sage.rings.qqbar_calcium import ANCalcium, ca_from_descr
+            sage: d = ANCalcium(ca_from_descr(QQbar(I)._descr), True)
+            sage: AA(d.imag(None))
+            1
+        """
+        return ANCalcium(self._ca.imag(), False)
+
+
+def an_binop_calcium(a, b, op):
+    """
+    Add, subtract, multiply or divide two algebraic numbers through Calcium.
+
+    Falls back to :func:`sage.rings.qqbar.an_binop_expr` whenever any operand
+    cannot be represented in Calcium or the operation is undecidable.
+
+    EXAMPLES::
+
+        sage: from sage.rings.qqbar_calcium import an_binop_calcium
+        sage: import operator
+        sage: d = an_binop_calcium(QQbar(2).sqrt(), QQbar(3).sqrt(), operator.add)
+        sage: type(d).__name__
+        'ANCalcium'
+        sage: q = QQbar(d); q.exactify()
+        sage: q^2 - 5 - 2*QQbar(6).sqrt() == 0
+        True
+    """
+    from sage.rings.qqbar import QQbar as _QQbar, an_binop_expr
+    left = ca_from_descr(a._descr)
+    if left is None:
+        return an_binop_expr(a, b, op)
+    right = ca_from_descr(b._descr)
+    if right is None:
+        return an_binop_expr(a, b, op)
+    try:
+        c = left._binop(right, op)
+    except (ZeroDivisionError, ValueError):
+        return an_binop_expr(a, b, op)
+    return ANCalcium(c, a.parent() is _QQbar)

--- a/src/sage/rings/qqbar_calcium.pyx
+++ b/src/sage/rings/qqbar_calcium.pyx
@@ -37,9 +37,14 @@ from sage.libs.flint.types cimport (
     T_TRUE, T_FALSE, T_UNKNOWN)
 from sage.libs.flint.ca cimport (
     ca_ctx_init, ca_ctx_clear, ca_init, ca_clear,
-    ca_set_fmpq, ca_get_fmpq, ca_get_acb)
-from sage.libs.flint.fmpq cimport fmpq_init, fmpq_clear, fmpq_set_mpq
+    ca_set_fmpq, ca_get_fmpq, ca_get_acb,
+    ca_add, ca_sub, ca_mul, ca_div, ca_neg, ca_inv, ca_sqrt, ca_abs, ca_re,
+    ca_im, ca_conj, ca_pow_fmpq, ca_pow_si, ca_check_is_zero, ca_check_equal,
+    ca_check_is_real, ca_check_lt)
+from sage.libs.flint.fmpq cimport (
+    fmpq_init, fmpq_clear, fmpq_set_mpq, fmpq_get_mpq)
 from sage.libs.flint.acb cimport acb_init, acb_clear
+from sage.libs.gmp.mpz cimport mpz_fits_slong_p, mpz_get_si
 from sage.rings.complex_arb cimport acb_to_ComplexIntervalFieldElement
 from sage.rings.complex_interval cimport ComplexIntervalFieldElement
 from sage.rings.integer cimport Integer
@@ -137,6 +142,380 @@ cdef class Ca:
         res = ComplexIntervalField(prec)(0)
         acb_to_ComplexIntervalFieldElement(res, z)
         acb_clear(z)
+        return res
+
+    cdef inline int _guard_zero(self, str what) except -1:
+        # raise if self is (possibly) zero; used before division-like ops
+        z = _truth(ca_check_is_zero(self.x, _ctx.ctx))
+        if z is True:
+            raise ZeroDivisionError(what)
+        if z is None:
+            raise ValueError('Calcium cannot decide whether the operand is zero')
+        return 0
+
+    def add(self, Ca o):
+        """
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: ca_from_rational(2).add(ca_from_rational(1/2))
+            Ca(2.5000000000000000?)
+        """
+        cdef Ca z = _new_ca()
+        sig_on()
+        ca_add(z.x, self.x, o.x, _ctx.ctx)
+        sig_off()
+        return z
+
+    def sub(self, Ca o):
+        """
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: ca_from_rational(2).sub(ca_from_rational(3))
+            Ca(-1)
+        """
+        cdef Ca z = _new_ca()
+        sig_on()
+        ca_sub(z.x, self.x, o.x, _ctx.ctx)
+        sig_off()
+        return z
+
+    def mul(self, Ca o):
+        """
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: ca_from_rational(3).mul(ca_from_rational(1/3))
+            Ca(1)
+        """
+        cdef Ca z = _new_ca()
+        sig_on()
+        ca_mul(z.x, self.x, o.x, _ctx.ctx)
+        sig_off()
+        return z
+
+    def div(self, Ca o):
+        """
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: ca_from_rational(1).div(ca_from_rational(3))
+            Ca(0.3333333333333334?)
+
+        Division by zero raises rather than producing a Calcium
+        special value::
+
+            sage: ca_from_rational(1).div(ca_from_rational(0))
+            Traceback (most recent call last):
+            ...
+            ZeroDivisionError: division by zero
+        """
+        o._guard_zero('division by zero')
+        cdef Ca z = _new_ca()
+        sig_on()
+        ca_div(z.x, self.x, o.x, _ctx.ctx)
+        sig_off()
+        return z
+
+    def neg(self):
+        """
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: ca_from_rational(2).neg()
+            Ca(-2)
+        """
+        cdef Ca z = _new_ca()
+        ca_neg(z.x, self.x, _ctx.ctx)
+        return z
+
+    def invert(self):
+        """
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: ca_from_rational(4).invert()
+            Ca(0.25000000000000000?)
+            sage: ca_from_rational(0).invert()
+            Traceback (most recent call last):
+            ...
+            ZeroDivisionError: inversion of zero
+        """
+        self._guard_zero('inversion of zero')
+        cdef Ca z = _new_ca()
+        sig_on()
+        ca_inv(z.x, self.x, _ctx.ctx)
+        sig_off()
+        return z
+
+    def sqrt(self):
+        """
+        Principal square root.
+
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: s = ca_from_rational(2).sqrt(); s
+            Ca(1.414213562373095?)
+            sage: s.mul(s).equal(ca_from_rational(2))
+            True
+        """
+        cdef Ca z = _new_ca()
+        sig_on()
+        ca_sqrt(z.x, self.x, _ctx.ctx)
+        sig_off()
+        return z
+
+    def conjugate(self):
+        """
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: i = ca_from_rational(-1).sqrt()
+            sage: i.conjugate().add(i).is_zero()
+            True
+        """
+        cdef Ca z = _new_ca()
+        sig_on()
+        ca_conj(z.x, self.x, _ctx.ctx)
+        sig_off()
+        return z
+
+    def abs(self):
+        """
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: ca_from_rational(-3).abs()
+            Ca(3)
+        """
+        cdef Ca z = _new_ca()
+        sig_on()
+        ca_abs(z.x, self.x, _ctx.ctx)
+        sig_off()
+        return z
+
+    def real(self):
+        """
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: i = ca_from_rational(-1).sqrt()
+            sage: i.real().is_zero()
+            True
+        """
+        cdef Ca z = _new_ca()
+        sig_on()
+        ca_re(z.x, self.x, _ctx.ctx)
+        sig_off()
+        return z
+
+    def imag(self):
+        """
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: i = ca_from_rational(-1).sqrt()
+            sage: i.imag().equal(ca_from_rational(1))
+            True
+        """
+        cdef Ca z = _new_ca()
+        sig_on()
+        ca_im(z.x, self.x, _ctx.ctx)
+        sig_off()
+        return z
+
+    def pow_rational(self, e):
+        """
+        ``self ** e`` for rational ``e``.
+
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: ca_from_rational(2).pow_rational(QQ(1/2)).mul(
+            ....:     ca_from_rational(2).pow_rational(QQ(1/2))).equal(ca_from_rational(2))
+            True
+            sage: ca_from_rational(0).pow_rational(QQ(-1))
+            Traceback (most recent call last):
+            ...
+            ZeroDivisionError: negative power of zero
+        """
+        cdef Rational q = <Rational> QQ(e)
+        cdef Integer n = q.numerator()
+        if q < 0:
+            self._guard_zero('negative power of zero')
+        cdef Ca z = _new_ca()
+        cdef fmpq_t t
+        if q.denominator() == 1 and mpz_fits_slong_p(n.value):
+            sig_on()
+            ca_pow_si(z.x, self.x, <slong> mpz_get_si(n.value), _ctx.ctx)
+            sig_off()
+            return z
+        fmpq_init(t)
+        fmpq_set_mpq(t, q.value)
+        sig_on()
+        ca_pow_fmpq(z.x, self.x, t, _ctx.ctx)
+        sig_off()
+        fmpq_clear(t)
+        return z
+
+    def _binop(self, Ca o, op):
+        """
+        Dispatch on an ``operator`` module function.
+
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: import operator
+            sage: ca_from_rational(2)._binop(ca_from_rational(3), operator.mul)
+            Ca(6)
+        """
+        if op is operator.add:
+            return self.add(o)
+        if op is operator.sub:
+            return self.sub(o)
+        if op is operator.mul:
+            return self.mul(o)
+        if op is operator.truediv:
+            return self.div(o)
+        raise ValueError('unsupported operator')
+
+    def is_zero(self):
+        """
+        Return ``True``/``False``, or ``None`` if Calcium cannot decide.
+
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: ca_from_rational(0).is_zero()
+            True
+            sage: s = ca_from_rational(2).sqrt()
+            sage: s.mul(s).sub(ca_from_rational(2)).is_zero()
+            True
+        """
+        return _truth(ca_check_is_zero(self.x, _ctx.ctx))
+
+    def equal(self, Ca o):
+        """
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: a = ca_from_rational(2).sqrt().add(ca_from_rational(3).sqrt())
+            sage: b = ca_from_rational(3).sqrt().add(ca_from_rational(2).sqrt())
+            sage: a.equal(b)
+            True
+            sage: a.equal(ca_from_rational(2))
+            False
+        """
+        return _truth(ca_check_equal(self.x, o.x, _ctx.ctx))
+
+    def is_real(self):
+        """
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: ca_from_rational(2).sqrt().is_real()
+            True
+            sage: ca_from_rational(-2).sqrt().is_real()
+            False
+        """
+        return _truth(ca_check_is_real(self.x, _ctx.ctx))
+
+    def sign_real(self):
+        """
+        Sign of the real part: `-1`, `0`, `1`, or ``None`` if undecided.
+
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: ca_from_rational(-5).sign_real()
+            -1
+            sage: ca_from_rational(-1).sqrt().sign_real()
+            0
+        """
+        cdef Ca r = self.real()
+        return r._sign_of_real_value()
+
+    def sign_imag(self):
+        """
+        Sign of the imaginary part: `-1`, `0`, `1`, or ``None``.
+
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: ca_from_rational(-1).sqrt().sign_imag()
+            1
+            sage: ca_from_rational(3).sign_imag()
+            0
+        """
+        cdef Ca r = self.imag()
+        return r._sign_of_real_value()
+
+    def _sign_of_real_value(self):
+        # sign of self, which the caller promises is real-valued
+        z = _truth(ca_check_is_zero(self.x, _ctx.ctx))
+        if z is True:
+            return 0
+        if z is None:
+            return None
+        cdef Ca zero = ca_from_rational(0)
+        lt = _truth(ca_check_lt(self.x, zero.x, _ctx.ctx))
+        if lt is True:
+            return -1
+        if lt is False:
+            return 1
+        return None
+
+    def cmp_lex(self, Ca o):
+        """
+        Compare lexicographically by (real, imaginary) parts, QQbar's
+        ordering. Return `-1`, `0`, `1`, or ``None`` if undecided.
+
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: i = ca_from_rational(-1).sqrt()
+            sage: i.cmp_lex(ca_from_rational(1))
+            -1
+            sage: i.cmp_lex(i.neg())
+            1
+            sage: ca_from_rational(2).cmp_lex(ca_from_rational(2))
+            0
+        """
+        cdef Ca d = self.sub(o)
+        s = d.sign_real()
+        if s is None:
+            return None
+        if s != 0:
+            return s
+        return d.sign_imag()
+
+    def get_rational(self):
+        """
+        Return this value as a Rational, or ``None`` if it is not rational.
+
+        EXAMPLES::
+
+            sage: from sage.rings.qqbar_calcium import ca_from_rational
+            sage: s = ca_from_rational(2).sqrt()
+            sage: s.mul(s).get_rational()
+            2
+            sage: s.get_rational() is None
+            True
+        """
+        cdef fmpq_t t
+        cdef Rational res
+        fmpq_init(t)
+        sig_on()
+        ok = ca_get_fmpq(t, self.x, _ctx.ctx)
+        sig_off()
+        if not ok:
+            fmpq_clear(t)
+            return None
+        res = Rational.__new__(Rational)
+        fmpq_get_mpq(res.value, t)
+        fmpq_clear(t)
         return res
 
 


### PR DESCRIPTION
This adds an **opt-in** FLINT/Calcium (`ca_t`) engine for arithmetic on `QQbar` and `AA`, as proposed in #42261 (see also the discussion in #30222). It uses Sage's existing `sage.libs.flint` declarations directly — no dependency on python-flint.

### Design

- New module `sage.rings.qqbar_calcium` with a `Ca` cdef wrapper around one `ca_t` (plus the module-global `ca_ctx_t` owner), a bidirectional bridge `descriptor -> ca_t` / `ca_t -> (minpoly, enclosure)`, and a new descriptor class `ANCalcium` that slots into the existing `ANDescr` machinery of `sage.rings.qqbar`.
- `sage.rings.qqbar.set_algebraic_backend('calcium')` (or `SAGE_ALGEBRAIC_BACKEND=calcium` in the environment, or the `algebraic_backend_context` context manager) redirects the `_binop_algo` dispatch for sums/differences/products/quotients to Calcium, and adds guarded fast paths to `__bool__`, `_richcmp_` (both `AlgebraicNumber` and `AlgebraicReal`) and `sign()`.
- **The default backend is unchanged.** With the backend off, no code path differs; with it on, every Calcium decision that comes back `T_UNKNOWN` falls through to the unchanged native algorithm, so `ca_t`'s undecidability never leaks into answers. Elements created under either backend keep working after switching in either direction, and can be mixed.

```
sage: from sage.rings.qqbar import set_algebraic_backend
sage: set_algebraic_backend('calcium')
sage: rt = [QQbar(p).sqrt() for p in [2, 3, 5, 7, 11, 13, 17]]
sage: sum(rt) == sum(reversed(rt))      # 84s with the native backend
True
```

### Why `ca_t`

The native implementation exactifies through a common number field whose degree is the product of the operand degrees, so structurally simple identities blow up exponentially: deciding the `k = 7` sum-of-square-roots identity above takes 84s natively (degree-128 field reached through repeated composita) and under a millisecond through Calcium — a >10,000x speedup. `qqbar_t` (each operation factoring an annihilating polynomial) would be slower than the native code here; `ca_t`'s multivariate-field representation is the right tool, as Fredrik Johansson's own QQbar benchmarks showed on sage-devel.


### Follow-up benchmarks

Measured on the same checkout and machine, comparing `5e98adbb81c` (before the review fixes) with `eac447a744b`:

| Scenario | Before | After | Change |
| --- | ---: | ---: | ---: |
| 200-bit close-root conversion, first call | 41.134 ms | 35.724 ms | 1.15x faster |
| 200-bit close-root conversion, median of 5 | 0.822 ms | 0.168 ms | 4.9x faster |
| Exact cross-field build + equality (degrees 5 and 7), first call | 6.730 ms | 3.333 ms | 2.0x faster |
| Exact cross-field build + equality (degrees 5 and 7), median of 5 | 0.959 ms | 0.483 ms | 2.0x faster |
| Degree-32 by degree-32 build + equality | 28.163 ms | 25.040 ms | 1.12x faster |
| Hot `Ca.equal()` | 0.073 us | 0.073 us | no measurable regression |

The close-root case now stays on the `ANCalcium` path instead of falling back to `ANBinaryExpr`. Independently exactified elements from different fields likewise produce `ANCalcium`, while operations within an already shared field retain the native exact fast path.

### Validation

- Merge gate: `sage -t src/sage/rings/qqbar.py src/sage/rings/qqbar_calcium.pyx` with the default backend — 1703 + 176 doctests, all pass.
- `TestSuite` runs on Calcium-backed `QQbar`/`AA` elements (skipping `_test_category`, which fails for *all* composite qqbar elements, native ones included — a pre-existing property unrelated to this change).
- Diagnostic run of the whole qqbar.py test file with the backend forced on: no wrong answers, no exceptions; the differences are representational (eager exactness in printing, interval widths, `sage_input` forms, choice of non-minimal field in `number_field_elements_from_algebraics(minimal=False)`), plus one known adversarial timeout, below.
- Differential validation of 11 representative native/Calcium expressions passed, and `git diff --check` is clean.

### Notable implementation points

- Root conversion preserves the precision of the supplied isolating enclosure, so roots separated by less than double precision no longer force a native fallback.
- Exact elements first use the existing same-field native fast paths; when their fields have not been combined, dispatch continues through Calcium instead of creating a lazy `ANBinaryExpr`.
- Potentially expensive `ca_check_*` predicates are wrapped in `sig_on()` / `sig_off()` so equality, zero, reality and sign decisions remain interruptible.
- `Ca` is declared `@cython.no_gc_clear`: its `__dealloc__` needs the context reference, which Cython's generated `tp_clear` would otherwise null first when a value is reachable only through a reference cycle (this segfaulted during validation).
- `ca_get_qqbar` refuses values whose *a-priori* degree bound (product of extension degrees, `CA_OPT_QQBAR_DEG_LIMIT`, default 120) is exceeded even when the true degree is small; the export retries once with the limit raised to 4096 and restores it after.

### Known limitations (opt-in backend)

- One adversarial regression test in qqbar.py (`bool(d*(a-b))` with `d = sum(AA(k)**(1/k) for k in 2..100)`) exploits the native engine's structural zero shortcut; Calcium works in a ~99-generator field there and does not decide within the doctest timeout. A future mitigation is bounding Calcium's effort via context options so such decisions degrade to Unknown and fall through to the native machinery.
- Converting extremely deep native expression trees (thousands of nested operations) recurses per node, like native `exactify` already does.

### 📝 Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have added / updated documentation and checked the documentation preview.