### PR TITLE
Refactor get_include_dirs() and tidy up config.py

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -214,9 +214,6 @@ for path in file_paths:
 ]
 run_command(create_files_command, check: true)
 
-root = meson.current_source_dir()
-root_build = meson.current_build_dir()
-
 subdir('src')
 
 py.install_sources(

--- a/src/doc/meson.build
+++ b/src/doc/meson.build
@@ -39,7 +39,7 @@ doc_bootstrap = custom_target(
     files('../../tools/bootstrap-docs.py'),
     meson.current_build_dir(),
   ],
-  env: {'SAGE_ROOT': root},
+  env: {'SAGE_ROOT': meson.global_source_root()},
   # doc_src is not really a dependency of the bootstrap, but we want to make sure
   # that all the source files are present before running the actual doc build
   # so let's collect all source-related targets here.

--- a/src/sage/config.py.in
+++ b/src/sage/config.py.in
@@ -57,23 +57,6 @@ rankwidth_enabled = @RANKWIDTH_ENABLED@
 sirocco_enabled = @SIROCCO_ENABLED@
 tdlib_enabled = @TDLIB_ENABLED@
 
-def is_editable_install() -> bool:
-    """
-    Check whether this is an editable install of Sage.
-
-    EXAMPLES::
-
-        sage: from sage.config import is_editable_install
-        sage: is_editable_install()
-        False
-    """
-    # This function relies on the fact that meson-python sets up a custom
-    # loader for editable installs
-    # Alternatively, one could use the distribution metadata as in:
-    #  https://github.com/scientific-python/spin/blob/89e581c7201d0f6597ffc92c3e84894f99fc133b/spin/cmds/meson.py#L39
-    return type(sage.__loader__).__module__ == "_sagemath_editable_loader"
-
-
 def get_editable_root() -> tuple[Path, Path] | None:
     """
     Return the path to the Sage directory when using an editable

--- a/src/sage/config.py.in
+++ b/src/sage/config.py.in
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 # In an editable install, these replace what (in a non-editable
 # install) would have been the installation path. The cython()
 # function needs them so that it can locate headers and such.
@@ -54,37 +52,3 @@ meataxe_enabled = @MEATAXE_ENABLED@
 rankwidth_enabled = @RANKWIDTH_ENABLED@
 sirocco_enabled = @SIROCCO_ENABLED@
 tdlib_enabled = @TDLIB_ENABLED@
-
-def get_include_dirs() -> list[Path]:
-    """
-    Return a list of directories to be used as include directories
-    when compiling Cython extensions that depend on Sage.
-
-    Headers should be included with the prefix "sage/", e.g.,
-    ``#include <sage/cpython/cython_metaclass.h>``.
-
-    EXAMPLES::
-
-        sage: from sage.config import get_include_dirs
-        sage: dirs = get_include_dirs()
-        sage: dirs # random
-        [
-            WindowsPath('<python>/site-packages'),
-            WindowsPath('<path_to_sage>/src'),
-            WindowsPath('<path_to_sage>/build/cp312/src'),
-            WindowsPath('<python>/site-packages/numpy/core/include')
-        ]
-    """
-    dirs: list[Path] = [p
-                        for d in sage.__path__
-                        if (p := Path(d).parent)
-                        if p.is_dir()]
-
-    from sage.features.meson_editable import MesonEditable
-    if  MesonEditable().is_present():
-        dirs.extend([p
-                     for d in (MESON_BUILD_ROOT, MESON_SOURCE_ROOT)
-                     if d  # Path() turns "" into "."
-                     if (p := Path(d).resolve() / "src")
-                     if p.is_dir() ])
-    return dirs

--- a/src/sage/config.py.in
+++ b/src/sage/config.py.in
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-import sage
-
 # In an editable install, these replace what (in a non-editable
 # install) would have been the installation path. The cython()
 # function needs them so that it can locate headers and such.
@@ -57,31 +55,6 @@ rankwidth_enabled = @RANKWIDTH_ENABLED@
 sirocco_enabled = @SIROCCO_ENABLED@
 tdlib_enabled = @TDLIB_ENABLED@
 
-def get_editable_root() -> tuple[Path, Path] | None:
-    """
-    Return the path to the Sage directory when using an editable
-    install.
-    Both the actual source directory and the build directory are returned, and are
-    guaranteed to exist.
-    If not using an editable install, or if the source/build directories do not
-    exist, return None.
-
-    EXAMPLES::
-
-        sage: from sage.config import get_editable_root
-        sage: get_editable_root() # random
-        (WindowsPath('<path_to_sage>/sage'), WindowsPath('<path_to_sage>/sage/build/cp312'))
-    """
-    if not all((is_editable_install(), MESON_SOURCE_ROOT, MESON_BUILD_ROOT)):
-        return None
-
-    src = Path(MESON_SOURCE_ROOT).resolve()
-    build = Path(MESON_BUILD_ROOT).resolve()
-    if src.is_dir() and build.is_dir():
-        return src, build
-    return None
-
-
 def get_include_dirs() -> list[Path]:
     """
     Return a list of directories to be used as include directories
@@ -102,10 +75,16 @@ def get_include_dirs() -> list[Path]:
             WindowsPath('<python>/site-packages/numpy/core/include')
         ]
     """
-    dirs: list[Path] = [Path(dir).parent for dir in sage.__path__]
-    editable_root = get_editable_root()
-    if editable_root is not None:
-        # We return both the source and build directory,
-        # because some headers are generated in the build directory.
-        dirs.extend([root / "src" for root in editable_root])
-    return [dir for dir in dirs if dir.is_dir()]
+    dirs: list[Path] = [p
+                        for d in sage.__path__
+                        if (p := Path(d).parent)
+                        if p.is_dir()]
+
+    from sage.features.meson_editable import MesonEditable
+    if  MesonEditable().is_present():
+        dirs.extend([p
+                     for d in (MESON_BUILD_ROOT, MESON_SOURCE_ROOT)
+                     if d  # Path() turns "" into "."
+                     if (p := Path(d).resolve() / "src")
+                     if p.is_dir() ])
+    return dirs

--- a/src/sage/config.py.in
+++ b/src/sage/config.py.in
@@ -85,13 +85,13 @@ def get_editable_root() -> tuple[Path, Path] | None:
     """
     if (
         not is_editable_install()
-        or r"@EDITABLE_SRC@" == ""
-        or r"@EDITABLE_BUILD@" == ""
+        or r"@MESON_SOURCE_ROOT@" == ""
+        or r"@MESON_BUILD_ROOT@" == ""
     ):
         return None
 
-    src = Path(r"@EDITABLE_SRC@").resolve()
-    build = Path(r"@EDITABLE_BUILD@").resolve()
+    src = Path(r"@MESON_SOURCE_ROOT@").resolve()
+    build = Path(r"@MESON_BUILD_ROOT@").resolve()
     if src.is_dir() and build.is_dir():
         return src, build
     return None

--- a/src/sage/config.py.in
+++ b/src/sage/config.py.in
@@ -2,6 +2,12 @@ from pathlib import Path
 
 import sage
 
+# In an editable install, these replace what (in a non-editable
+# install) would have been the installation path. The cython()
+# function needs them so that it can locate headers and such.
+MESON_SOURCE_ROOT = r"@MESON_SOURCE_ROOT@"
+MESON_BUILD_ROOT = r"@MESON_BUILD_ROOT@"
+
 VERSION = "@PACKAGE_VERSION@"
 
 # The path to the standalone maxima executable.
@@ -83,15 +89,11 @@ def get_editable_root() -> tuple[Path, Path] | None:
         sage: get_editable_root() # random
         (WindowsPath('<path_to_sage>/sage'), WindowsPath('<path_to_sage>/sage/build/cp312'))
     """
-    if (
-        not is_editable_install()
-        or r"@MESON_SOURCE_ROOT@" == ""
-        or r"@MESON_BUILD_ROOT@" == ""
-    ):
+    if not all((is_editable_install(), MESON_SOURCE_ROOT, MESON_BUILD_ROOT)):
         return None
 
-    src = Path(r"@MESON_SOURCE_ROOT@").resolve()
-    build = Path(r"@MESON_BUILD_ROOT@").resolve()
+    src = Path(MESON_SOURCE_ROOT).resolve()
+    build = Path(MESON_BUILD_ROOT).resolve()
     if src.is_dir() and build.is_dir():
         return src, build
     return None

--- a/src/sage/config.py.in
+++ b/src/sage/config.py.in
@@ -52,3 +52,10 @@ meataxe_enabled = @MEATAXE_ENABLED@
 rankwidth_enabled = @RANKWIDTH_ENABLED@
 sirocco_enabled = @SIROCCO_ENABLED@
 tdlib_enabled = @TDLIB_ENABLED@
+
+
+def get_include_dirs():
+    from sage.misc.superseded import deprecation
+    deprecation(42525, "sage.config.get_include_dirs() has been moved to sage.misc.cython.get_include_dirs()")
+    from sage.misc.cython import get_include_dirs as _gid
+    return _gid()

--- a/src/sage/env.py
+++ b/src/sage/env.py
@@ -28,7 +28,6 @@ from platformdirs import site_data_dir, user_data_dir
 
 import sage.config
 from sage import version
-from sage.config import get_include_dirs
 
 # All variables set by var() appear in this SAGE_ENV dict
 SAGE_ENV = dict()
@@ -246,71 +245,6 @@ if DOT_SAGE is not None and ' ' in DOT_SAGE:
     print("is to set the environment variable HOME to a")
     print("directory with no spaces that you have write")
     print("permissions to before you start sage.")
-
-
-def sage_include_directories(use_sources=False):
-    """
-    Return the list of include directories for compiling Sage extension modules.
-
-    INPUT:
-
-    - ``use_sources`` -- boolean (default: ``False``)
-
-    OUTPUT:
-
-    a list of include directories to be used to compile sage code
-    1. while building sage (use_sources='True')
-    2. while using sage (use_sources='False')
-
-    EXAMPLES:
-
-    Expected output while using Sage::
-
-        sage: import sage.env
-        sage: sage.env.sage_include_directories()
-        doctest:warning...
-        DeprecationWarning: use sage.config.get_include_dirs() instead
-        ...
-        ['...',
-         '.../numpy/...core/include',
-         '.../include/python...']
-
-    To check that C/C++ files are correctly found, we verify that we can
-    always find the include file ``sage/cpython/cython_metaclass.h``,
-    with both values for ``use_sources``::
-
-        sage: file = os.path.join("sage", "cpython", "cython_metaclass.h")
-        sage: dirs = sage.env.sage_include_directories(use_sources=True)
-        sage: any(os.path.isfile(os.path.join(d, file)) for d in dirs)
-        True
-
-    ::
-
-        sage: # optional - !meson_editable (no need, see :issue:`39275`)
-        sage: dirs = sage.env.sage_include_directories(use_sources=False)
-        sage: any(os.path.isfile(os.path.join(d, file)) for d in dirs)
-        True
-    """
-    from sage.misc.superseded import deprecation
-    deprecation(40765, 'use sage.config.get_include_dirs() instead')
-
-    if use_sources:
-        dirs = [SAGE_SRC]
-    else:
-        import sage
-        dirs = [os.path.dirname(directory)
-                for directory in sage.__path__]
-    try:
-        import numpy
-        dirs.append(numpy.get_include())
-    except ModuleNotFoundError:
-        pass
-
-    dirs.append(sysconfig.get_config_var('INCLUDEPY'))
-
-    dirs.extend([dir.as_posix() for dir in get_include_dirs()])
-
-    return dirs
 
 
 default_required_modules = ('fflas-ffpack', 'givaro', 'gsl', 'linbox', 'Singular',

--- a/src/sage/features/meson_editable.py
+++ b/src/sage/features/meson_editable.py
@@ -1,8 +1,6 @@
 r"""
 Feature for testing if Meson editable install is used.
 """
-from sage.config import is_editable_install
-
 from . import Feature, FeatureTestResult
 
 
@@ -37,7 +35,9 @@ class MesonEditable(Feature):
             sage: MesonEditable()._is_present()  # random
             FeatureTestResult('meson_editable', True)
         """
-        return FeatureTestResult(self, is_editable_install())
+        from sage import __loader__ as ldr
+        result = (type(ldr).__module__ == "_sagemath_editable_loader")
+        return FeatureTestResult(self, result)
 
 
 def all_features():

--- a/src/sage/meson.build
+++ b/src/sage/meson.build
@@ -2,8 +2,8 @@ sage_install_dir = py.get_install_dir() / 'sage'
 
 # Generate the configuration file
 conf_data = configuration_data()
-conf_data.set('EDITABLE_SRC', root)
-conf_data.set('EDITABLE_BUILD', root_build)
+conf_data.set('EDITABLE_SRC', meson.global_source_root())
+conf_data.set('EDITABLE_BUILD', meson.global_build_root())
 conf_data.set('PACKAGE_VERSION', '1.2.3')
 # We use Python's prefix here to make it work with conda
 prefix = fs.as_posix(py.get_variable('prefix', ''))

--- a/src/sage/meson.build
+++ b/src/sage/meson.build
@@ -2,8 +2,8 @@ sage_install_dir = py.get_install_dir() / 'sage'
 
 # Generate the configuration file
 conf_data = configuration_data()
-conf_data.set('EDITABLE_SRC', meson.global_source_root())
-conf_data.set('EDITABLE_BUILD', meson.global_build_root())
+conf_data.set('MESON_SOURCE_ROOT', meson.global_source_root())
+conf_data.set('MESON_BUILD_ROOT', meson.global_build_root())
 conf_data.set('PACKAGE_VERSION', '1.2.3')
 # We use Python's prefix here to make it work with conda
 prefix = fs.as_posix(py.get_variable('prefix', ''))

--- a/src/sage/meson.build
+++ b/src/sage/meson.build
@@ -103,7 +103,6 @@ py.install_sources(
   'all.py',
   'all_cmdline.py',
   'all_test.py',
-  'config_test.py',
   'env.py',
   'version.py',
   subdir: 'sage',

--- a/src/sage/misc/cython.py
+++ b/src/sage/misc/cython.py
@@ -27,12 +27,47 @@ import sys
 import webbrowser
 from pathlib import Path
 
-from sage.config import get_include_dirs
 from sage.env import SAGE_LOCAL, cython_aliases
 from sage.misc.cachefunc import cached_function
 from sage.misc.sage_ostools import redirection, restore_cwd
 from sage.misc.temporary_file import spyx_tmp, tmp_filename
 from sage.repl.user_globals import get_globals
+
+
+def get_include_dirs() -> list[Path]:
+    """
+    Return a list of directories to be used as include directories
+    when compiling Cython extensions that depend on Sage.
+
+    Headers should be included with the prefix "sage/", e.g.,
+    ``#include <sage/cpython/cython_metaclass.h>``.
+
+    EXAMPLES::
+
+        sage: from sage.misc.cython import get_include_dirs
+        sage: get_include_dirs()  # random
+        [
+            WindowsPath('<python>/site-packages'),
+            WindowsPath('<path_to_sage>/src'),
+            WindowsPath('<path_to_sage>/build/cp312/src'),
+            WindowsPath('<python>/site-packages/numpy/core/include')
+        ]
+    """
+    from sage import __path__ as sage_path
+    dirs: list[Path] = [p
+                        for d in sage_path
+                        if (p := Path(d).parent)
+                        if p.is_dir()]
+
+    from sage.features.meson_editable import MesonEditable
+    from sage.config import MESON_BUILD_ROOT, MESON_SOURCE_ROOT
+    if  MesonEditable().is_present():
+        dirs.extend([p
+                     for d in (MESON_BUILD_ROOT, MESON_SOURCE_ROOT)
+                     if d  # Path() turns "" into "."
+                     if (p := Path(d).resolve() / "src")
+                     if p.is_dir() ])
+    return dirs
 
 
 @cached_function

--- a/src/sage/misc/cython_test.py
+++ b/src/sage/misc/cython_test.py
@@ -1,4 +1,4 @@
-from sage.config import get_include_dirs
+from sage.misc.cython import get_include_dirs
 
 
 def test_cython_metaclass_header_found():

--- a/src/sage/misc/meson.build
+++ b/src/sage/misc/meson.build
@@ -32,6 +32,7 @@ py.install_sources(
   'converting_dict.py',
   'copying.py',
   'cython.py',
+  'cython_test.py',
   'decorators.py',
   'defaults.py',
   'derivative.pyx',


### PR DESCRIPTION
I've wanted to tidy up sage.config for a while, so that it only contains build-time variables and is as fast as possible to import. The include dirs stuff wound up there because, when we did the meson migration, it lived in `sage.env`, and most of `sage.env` moved to `config.py.in`. Then the editable root stuff followed because it is used (only) to search for include dirs.

The main goals were to,

* Use `meson.global_source_root()` and `meson.global_build_root()` instead of setting `root = ...` and `root_build = ...` at the top level.
* Move the one-line `is_editable_install()` into the `MesonEditable` feature.
* Inline `get_editable_root()` into `get_include_dirs()`. The latter is the only user of the former, and all they're doing is building a list of paths. It's a lot easier to do it in a list comprehension/extend than with two functions and a combination of lists, tuples, and `None`.
* Move `get_include_dirs()` to `sage.misc.cython` where it is used internally, and where I think it makes the most sense externally (you don't need it unless you're compiling cython extensions that depend on sage).

And as part of that,

* Remove the deprecated `sage.env.sage_include_directories()`
* Deprecate the old name `sage.config.get_include_dirs()`
* Rename a pytest file