### PR TITLE
Scalar and weight distinction for Plethysm

### DIFF
--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -1046,12 +1046,29 @@ class Stream_function(Stream_inexact):
             ....:     return g.input_streams()
             sage: fun()
             [<sage.data_structures.stream.Stream_exact object at 0x...>]
+
+        Streams captured inside a list or tuple in the closure are
+        detected as well (used by species composition)::
+
+            sage: def fun():
+            ....:     f = Stream_exact([1,3,5], constant=7)
+            ....:     streams = [f]
+            ....:     g = Stream_function(lambda n: streams[0][n]^2, False, 0)
+            ....:     return g.input_streams()
+            sage: fun()
+            [<sage.data_structures.stream.Stream_exact object at 0x...>]
         """
         closure = self.get_coefficient.__closure__
         if closure is None:
             return []
-        return [cell.cell_contents for cell in closure
-                if isinstance(cell.cell_contents, Stream)]
+        result = []
+        for cell in closure:
+            content = cell.cell_contents
+            if isinstance(content, Stream):
+                result.append(content)
+            elif isinstance(content, (list, tuple)):
+                result.extend(item for item in content if isinstance(item, Stream))
+        return result
 
     def __hash__(self):
         """
@@ -1488,6 +1505,63 @@ class CoefficientRing(UniqueRepresentation, FractionField_generic):
             FESDUMMY_0
         """
         return self._element_class(self, self._R.gen()[i])
+
+    def _power_sum_plethysm(self, c, k):
+        r"""
+        Return the `k`-th power-sum plethysm (Adams operation) `p_k[c]`.
+
+        The undetermined coefficients are the coefficients of the
+        molecular decomposition of an (implicitly defined) species;
+        they are counts, hence *constants* of the `\lambda`-ring, so
+        `p_k` fixes them.  The generators of the base ring, on the
+        other hand, are treated as *monomials* and are raised to the
+        `k`-th power.
+
+        This matches the convention used by :meth:`_exponential`, where
+        a scalar multiplicity ``c`` plays the role of the constant in
+        `E(cX)`; indeed ``_exponential([c], [d])`` computes `(E^c)_d`.
+
+        INPUT:
+
+        - ``c`` -- an element of ``self`` (or its base ring)
+        - ``k`` -- positive integer
+
+        EXAMPLES::
+
+            sage: from sage.data_structures.stream import CoefficientRing, VariablePool
+            sage: PF = CoefficientRing(QQ["q"])
+            sage: q = PF.base_ring().gen()
+            sage: pool = VariablePool(PF.base())
+            sage: c = PF(pool.new_variable()); c
+            FESDUMMY_0
+            sage: PF._power_sum_plethysm(c, 1) == c
+            True
+
+        The undetermined coefficient is fixed, while the base ring
+        variable ``q`` is treated as a monomial::
+
+            sage: PF._power_sum_plethysm(q*c, 2)
+            q^2*FESDUMMY_0
+            sage: PF._power_sum_plethysm(q*c, 2) == q^2 * c
+            True
+            sage: PF._power_sum_plethysm(PF(q + 1), 3)
+            q^3 + 1
+        """
+        if k == 1:
+            return self(c)
+        c = self(c)
+        base = self.base().base_ring()
+        base_gens = [g for g in base.gens() if g != base.one()]
+        if not base_gens:
+            # nothing to stretch: every coefficient is a constant
+            return c
+
+        def base_adams(b):
+            return b(*[g**k for g in base_gens])
+
+        num = c.numerator().map_coefficients(base_adams)
+        den = c.denominator().map_coefficients(base_adams)
+        return self(num) / self(den)
 
     def _get_action_(self, S, op, self_on_left):
         """

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -6819,7 +6819,7 @@ class LazySymmetricFunction(LazyCompletionGradedAlgebraElement):
             return False
         return self[0].is_unit()
 
-    def __call__(self, *args):
+    def __call__(self, *args, include=None, exclude=None):
         r"""
         Return the composition of ``self`` with ``g``.
 
@@ -6848,10 +6848,13 @@ class LazySymmetricFunction(LazyCompletionGradedAlgebraElement):
         INPUT:
 
         - ``g`` -- other (lazy) symmetric functions
+        - ``include`` -- list of coefficient-ring variables to be treated
+          as degree one elements. If specified, variables not in this list
+          are treated as scalars
+        - ``exclude`` -- list of coefficient-ring variables to be treated
+          as scalars, overriding the default degree one variables
 
-        .. TODO::
-
-            Allow specification of degree one elements.
+        Specify at most one of ``include`` and ``exclude``.
 
         EXAMPLES::
 
@@ -6872,6 +6875,25 @@ class LazySymmetricFunction(LazyCompletionGradedAlgebraElement):
             sage: g = s[1] + s[2,2]
             sage: L(f)(L(q*g)) - L(f(q*g))
             0
+
+        The optional ``include`` and ``exclude`` arguments control which
+        coefficient-ring variables are treated as degree one under plethysm::
+
+            sage: R.<q> = QQ[]
+            sage: p = SymmetricFunctions(R).p()
+            sage: L = LazySymmetricFunctions(p)
+            sage: f = L(p[2])
+            sage: g = L(lambda n: q*p[1] if n == 1 else 0, valuation=1)
+            sage: f(g)[2]
+            q^2*p[2]
+            sage: f(g, include=[])[2]
+            q*p[2]
+            sage: f(g, exclude=[q])[2]
+            q*p[2]
+            sage: f(g, include=[], exclude=[q])
+            Traceback (most recent call last):
+            ...
+            ValueError: include and exclude cannot be specified together
 
         The Frobenius character of the permutation action on set
         partitions is a plethysm::
@@ -6957,6 +6979,9 @@ class LazySymmetricFunction(LazyCompletionGradedAlgebraElement):
         if len(args) != fP._arity:
             raise ValueError("arity must be equal to the number of arguments provided")
 
+        if include is not None and exclude is not None:
+            raise ValueError("include and exclude cannot be specified together")
+
         # Find a good parent for the result
         from sage.structure.element import get_coercion_model
         cm = get_coercion_model()
@@ -6984,13 +7009,13 @@ class LazySymmetricFunction(LazyCompletionGradedAlgebraElement):
 
                 if not isinstance(g, LazySymmetricFunction):
                     f = self.symmetric_function()
-                    return f(g)
+                    return f(g, include=include, exclude=exclude)
 
-                if (isinstance(g._coeff_stream, Stream_exact)
+            if (isinstance(g._coeff_stream, Stream_exact)
                     and not g._coeff_stream._constant):
-                    f = self.symmetric_function()
-                    gs = g.symmetric_function()
-                    return P(f(gs))
+                f = self.symmetric_function()
+                gs = g.symmetric_function()
+                return P(f(gs, include=include, exclude=exclude))
 
             if isinstance(g, LazySymmetricFunction):
                 R = P._laurent_poly_ring
@@ -7010,9 +7035,17 @@ class LazySymmetricFunction(LazyCompletionGradedAlgebraElement):
             if P._arity == 1:
                 ps = R.realization_of().p()
             else:
-                ps = tensor([R._sets[0].realization_of().p()]*P._arity)
-            coeff_stream = Stream_plethysm(self._coeff_stream, g._coeff_stream,
-                                           P.is_sparse(), ps, R)
+                ps = tensor([R._sets[0].realization_of().p()] * P._arity)
+
+            coeff_stream = Stream_plethysm(
+                self._coeff_stream,
+                g._coeff_stream,
+                P.is_sparse(),
+                ps,
+                R,
+                include=include,
+                exclude=exclude,
+            )
             return P.element_class(P, coeff_stream)
 
         raise NotImplementedError("only implemented for arity 1")

--- a/src/sage/rings/lazy_series.py
+++ b/src/sage/rings/lazy_series.py
@@ -7005,17 +7005,17 @@ class LazySymmetricFunction(LazyCompletionGradedAlgebraElement):
         if len(args) == 1:
             g = args[0]
             if (isinstance(self._coeff_stream, Stream_exact)
-                and not self._coeff_stream._constant):
+                    and not self._coeff_stream._constant):
 
                 if not isinstance(g, LazySymmetricFunction):
                     f = self.symmetric_function()
                     return f(g, include=include, exclude=exclude)
 
-            if (isinstance(g._coeff_stream, Stream_exact)
-                    and not g._coeff_stream._constant):
-                f = self.symmetric_function()
-                gs = g.symmetric_function()
-                return P(f(gs, include=include, exclude=exclude))
+                if (isinstance(g._coeff_stream, Stream_exact)
+                        and not g._coeff_stream._constant):
+                    f = self.symmetric_function()
+                    gs = g.symmetric_function()
+                    return P(f(gs, include=include, exclude=exclude))
 
             if isinstance(g, LazySymmetricFunction):
                 R = P._laurent_poly_ring

--- a/src/sage/rings/lazy_species.py
+++ b/src/sage/rings/lazy_species.py
@@ -702,7 +702,7 @@ class LazyCombinatorialSpeciesElement(LazyCompletionGradedAlgebraElement):
         return R.sum(self[:m])
 
     def __call__(self, *args):
-        """
+        r"""
         Evaluate ``self`` at ``*args``.
 
         EXAMPLES::
@@ -765,14 +765,55 @@ class LazyCombinatorialSpeciesElement(LazyCompletionGradedAlgebraElement):
             sage: E(X)
             1 + X + E_2(X) + E_3(X) + E_4(X) + E_5(X) + E_6(X) + O^7
 
-        It would be extremely nice to allow the following, but this
-        poses theoretical problems::
+        An implicitly defined species may appear inside a composition
+        (see :issue:`40113`).  For example, the compositional inverse
+        of `E_{\geq 1}` may be defined implicitly via `E_{\geq
+        1}(\Omega) = X`::
 
             sage: L.<X> = LazyCombinatorialSpecies(QQ)
             sage: E1 = L.Sets().restrict(1)
             sage: Omega = L.undefined(1)
             sage: L.define_implicitly([Omega], [E1(Omega) - X])
-            sage: Omega[1]  # not tested
+            sage: Omega[1], Omega[2]
+            (X, -E_2)
+            sage: Omega[:6] == E1.revert()[:6]
+            True
+
+        Defining a species implicitly, with the unknown appearing
+        inside a composition, agrees with defining it explicitly -- for
+        example for the species of rooted trees `A = X \cdot E(A)`::
+
+            sage: E = L.Sets()
+            sage: A = L.undefined(1); A.define(X*E(A))
+            sage: B = L.undefined(1); L.define_implicitly([B], [B - X*E(B)])
+            sage: all(A[n] == B[n] for n in range(8))
+            True
+
+        This also works with weights::
+
+            sage: R.<q> = QQ[]
+            sage: Lq.<Y> = LazyCombinatorialSpecies(R)
+            sage: Eq = Lq.Sets()
+            sage: D = Lq.undefined(1)
+            sage: Lq.define_implicitly([D], [D - Y*Eq(q*D)])
+            sage: D[1], D[2]
+            (Y, q*Y^2)
+            sage: Dx = Lq.undefined(1); Dx.define(Y*Eq(q*Dx))
+            sage: all(D[n] == Dx[n] for n in range(6))
+            True
+
+        When the unknown appears, scaled, inside a composition by a
+        species of valuation one, the solution may involve denominators
+        and one has to work over the fraction field; the solution then
+        satisfies its defining equation::
+
+            sage: F = QQ['q'].fraction_field(); z = F.gen()
+            sage: Lf.<Y> = LazyCombinatorialSpecies(F)
+            sage: Ef = Lf.Sets()
+            sage: C = Lf.undefined(1)
+            sage: Lf.define_implicitly([C], [C - Y - (Ef(z*C) - 1)])
+            sage: all((C - Y - (Ef(z*C) - 1))[n] == 0 for n in range(6))
+            True
         """
         fP = self.parent()
         if len(args) != fP._arity:
@@ -1458,16 +1499,33 @@ class CompositionSpeciesElement(LazyCombinatorialSpeciesElementGeneratingSeriesM
                 return left[n]._relabel_sorts(R, sorts)
 
         else:
+            from sage.structure.element import get_coercion_model
             L = fP._internal_poly_ring.base_ring()
 
+            # Streams that ``coefficient`` depends on.  Exposing them in
+            # the closure lets ``Stream_function.input_streams`` (and
+            # hence the implicit solver) find them, so that determined
+            # values are substituted into the caches of the arguments
+            # (in particular derived arguments such as ``q*C``).
+            dep_streams = [left._coeff_stream] + [g._coeff_stream for g in args]
+
+            # Coefficients that are still undetermined (during
+            # :meth:`define_implicitly`) get refined by the implicit
+            # solver, so they must be re-read from the
+            # stream; only determined coefficients (those in ``R``) are
+            # memoized here.
+            _coeff_cache = {}
+
             def coeff(g, i):
+                key = (id(g), i)
+                if key in _coeff_cache:
+                    return _coeff_cache[key]
                 c = g._coeff_stream[i]
                 if not isinstance(c, PolynomialSpecies.Element):
-                    return R(c)
+                    c = R(c)
+                if c.parent() is R:
+                    _coeff_cache[key] = c
                 return c
-
-            # args_flat and weights contain one list for each g
-            weight_exp = [lazy_list(lambda j, g=g: len(coeff(g, j + 1))) for g in args]
 
             def flat(g):
                 # function needed to work around python's scoping rules
@@ -1475,13 +1533,23 @@ class CompositionSpeciesElement(LazyCombinatorialSpeciesElementGeneratingSeriesM
                     coeff(g, j) for j in itertools.count()
                 )
 
-            args_flat1 = [lazy_list(flat(g)) for g in args]
-
             def coefficient(n):
+                # reference ``dep_streams`` so that it is captured in
+                # this closure and thus reported by
+                # :meth:`Stream_function.input_streams`
+                len(dep_streams)
                 if not n:
                     if left[0]:
                         return R(list(left[0])[0][1])
                     return R.zero()
+                # ``weight_exp`` and ``args_flat1`` are rebuilt on each
+                # call (but read lazily) so that coefficients refined by
+                # the implicit solver are seen, rather than memoized
+                # while still undetermined
+                weight_exp = [
+                    lazy_list(lambda j, g=g: len(coeff(g, j + 1))) for g in args
+                ]
+                args_flat1 = [lazy_list(flat(g)) for g in args]
                 result = R.zero()
                 for i in range(1, n // gv + 1):
                     # skip i=0 because it produces a term only for n=0
@@ -1516,7 +1584,20 @@ class CompositionSpeciesElement(LazyCombinatorialSpeciesElementGeneratingSeriesM
                                 names, multiplicities, non_zero_degrees
                             )
                             FG = [(M(*molecules), c) for M, c in FX]
-                            result += R.sum_of_terms(FG)
+                            # The coefficients in ``FG`` may live in a
+                            # larger ring than the base ring of ``R``
+                            # (e.g. they may carry undetermined
+                            # coefficients); build
+                            # the term over the appropriate ring so that
+                            # its parent reflects its coefficients.
+                            cring = get_coercion_model().common_parent(
+                                R.base_ring(), *[c.parent() for _, c in FG]
+                            )
+                            if cring is R.base_ring():
+                                term = R.sum_of_terms(FG)
+                            else:
+                                term = R.change_ring(cring).sum_of_terms(FG)
+                            result += term
                 return result
 
         coeff_stream = Stream_function(coefficient, P._sparse, sorder * gv)

--- a/src/sage/rings/lazy_species.py
+++ b/src/sage/rings/lazy_species.py
@@ -101,6 +101,55 @@ import itertools
 from collections import defaultdict
 
 
+def _singleton_sort(g, P):
+    r"""
+    Return the sort `i` if ``g`` is the singleton `Y_i` of ``P``,
+    and ``None`` otherwise.
+
+    This is used to detect the inclusion of a univariate (or
+    multivariate) species into the multivariate species ``P``, see
+    :issue:`40438`.
+
+    INPUT:
+
+    - ``g`` -- a candidate argument of a composition
+    - ``P`` -- a :class:`LazyCombinatorialSpecies`
+
+    EXAMPLES::
+
+        sage: from sage.rings.lazy_species import _singleton_sort
+        sage: L.<X, Y> = LazyCombinatorialSpecies(QQ)
+        sage: _singleton_sort(X, L), _singleton_sort(Y, L)
+        (0, 1)
+        sage: _singleton_sort(X + Y, L) is None
+        True
+        sage: _singleton_sort(2*X, L) is None
+        True
+        sage: _singleton_sort(X^2, L) is None
+        True
+        sage: _singleton_sort(L.zero(), L) is None
+        True
+    """
+    if not isinstance(g, LazyModuleElement) or g.parent() is not P:
+        return None
+    cs = g._coeff_stream
+    # g must be a single homogeneous term of degree one
+    if (
+        not isinstance(cs, Stream_exact)
+        or cs._constant
+        or cs.order() != 1
+        or cs._degree != 2
+    ):
+        return None
+    md = cs[1].monomial_coefficients()
+    if len(md) != 1:
+        return None
+    ((M, c),) = md.items()
+    if not c.is_one() or sum(M.grade()) != 1:
+        return None
+    return next(i for i, d in enumerate(M.grade()) if d)
+
+
 def weighted_compositions(n, d, weight_multiplicities, _w0=0):
     r"""
     Return all compositions of `n` of weight `d`.
@@ -1357,6 +1406,27 @@ class CompositionSpeciesElement(LazyCombinatorialSpeciesElementGeneratingSeriesM
             sage: L2.<X,Y> = LazyCombinatorialSpecies(QQ)
             sage: F = L.Sets()(X + 2*Y)
             sage: TestSuite(F).run(skip=['_test_category', '_test_pickling'])
+
+        Including a univariate species into a multivariate species
+        only relabels the sorts of the molecular species, see
+        :issue:`40438`::
+
+            sage: L1 = LazyCombinatorialSpecies(QQ, "Z")
+            sage: C = L1.Cycles()
+            sage: C(Y)[10].support()[0].support()[0]._dompart
+            (frozenset(), frozenset({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}))
+            sage: C(Y)[10]
+            C_10(Y)
+
+        The result still knows that it is a composition::
+
+            sage: type(C(Y))
+            <class 'sage.rings.lazy_species.CompositionSpeciesElement'>
+            sage: sorted(C(Y).structures([], [1,2,3]))
+            [((((1, 'Y'),), ((2, 'Y'),), ((3, 'Y'),)),
+              ((Y, ((1,),)), (Y, ((2,),)), (Y, ((3,),)))),
+             ((((1, 'Y'),), ((3, 'Y'),), ((2, 'Y'),)),
+              ((Y, ((1,),)), (Y, ((2,),)), (Y, ((3,),))))]
         """
         fP = left.parent()
         # Find a good parent for the result
@@ -1375,53 +1445,79 @@ class CompositionSpeciesElement(LazyCombinatorialSpeciesElementGeneratingSeriesM
         sorder = left._coeff_stream._approximate_order
         gv = min(g._coeff_stream._approximate_order for g in args)
         R = P._internal_poly_ring.base_ring()
-        L = fP._internal_poly_ring.base_ring()
 
-        def coeff(g, i):
-            c = g._coeff_stream[i]
-            if not isinstance(c, PolynomialSpecies.Element):
-                return R(c)
-            return c
+        # Fast path: composition with singletons (see :issue:`40438`).
+        # If every argument is a single sort `Y_i` of `P`, then
+        # ``left(args)`` is obtained by relabelling the sorts of the
+        # molecular species in the support of ``left``; we only have to
+        # modify their domain partitions.
+        sorts = [_singleton_sort(g, P) for g in args]
+        if all(s is not None for s in sorts):
 
-        # args_flat and weights contain one list for each g
-        weight_exp = [lazy_list(lambda j, g=g: len(coeff(g, j+1)))
-                      for g in args]
+            def coefficient(n):
+                return left[n]._relabel_sorts(R, sorts)
 
-        def flat(g):
-            # function needed to work around python's scoping rules
-            return itertools.chain.from_iterable(coeff(g, j) for j in itertools.count())
+        else:
+            L = fP._internal_poly_ring.base_ring()
 
-        args_flat1 = [lazy_list(flat(g)) for g in args]
+            def coeff(g, i):
+                c = g._coeff_stream[i]
+                if not isinstance(c, PolynomialSpecies.Element):
+                    return R(c)
+                return c
 
-        def coefficient(n):
-            if not n:
-                if left[0]:
-                    return R(list(left[0])[0][1])
-                return R.zero()
-            result = R.zero()
-            for i in range(1, n // gv + 1):
-                # skip i=0 because it produces a term only for n=0
+            # args_flat and weights contain one list for each g
+            weight_exp = [lazy_list(lambda j, g=g: len(coeff(g, j + 1))) for g in args]
 
-                # compute homogeneous components
-                lF = defaultdict(L)
-                for M, c in left[i]:
-                    lF[M.grade()] += L._from_dict({M: c})
-                for mc, F in lF.items():
-                    for degrees in weighted_vector_compositions(mc, n, weight_exp):
-                        args_flat = [list(a[0:len(degrees[j])])
-                                     for j, a in enumerate(args_flat1)]
-                        multiplicities = [c for alpha, g_flat in zip(degrees, args_flat)
-                                          for d, (_, c) in zip(alpha, g_flat) if d]
-                        molecules = [M for alpha, g_flat in zip(degrees, args_flat)
-                                     for d, (M, _) in zip(alpha, g_flat) if d]
-                        non_zero_degrees = [[d for d in alpha if d] for alpha in degrees]
-                        names = ["X%s" % i for i in range(len(molecules))]
-                        FX = F._compose_with_weighted_singletons(names,
-                                                                 multiplicities,
-                                                                 non_zero_degrees)
-                        FG = [(M(*molecules), c) for M, c in FX]
-                        result += R.sum_of_terms(FG)
-            return result
+            def flat(g):
+                # function needed to work around python's scoping rules
+                return itertools.chain.from_iterable(
+                    coeff(g, j) for j in itertools.count()
+                )
+
+            args_flat1 = [lazy_list(flat(g)) for g in args]
+
+            def coefficient(n):
+                if not n:
+                    if left[0]:
+                        return R(list(left[0])[0][1])
+                    return R.zero()
+                result = R.zero()
+                for i in range(1, n // gv + 1):
+                    # skip i=0 because it produces a term only for n=0
+
+                    # compute homogeneous components
+                    lF = defaultdict(L)
+                    for M, c in left[i]:
+                        lF[M.grade()] += L._from_dict({M: c})
+                    for mc, F in lF.items():
+                        for degrees in weighted_vector_compositions(mc, n, weight_exp):
+                            args_flat = [
+                                list(a[0 : len(degrees[j])])
+                                for j, a in enumerate(args_flat1)
+                            ]
+                            multiplicities = [
+                                c
+                                for alpha, g_flat in zip(degrees, args_flat)
+                                for d, (_, c) in zip(alpha, g_flat)
+                                if d
+                            ]
+                            molecules = [
+                                M
+                                for alpha, g_flat in zip(degrees, args_flat)
+                                for d, (M, _) in zip(alpha, g_flat)
+                                if d
+                            ]
+                            non_zero_degrees = [
+                                [d for d in alpha if d] for alpha in degrees
+                            ]
+                            names = ["X%s" % i for i in range(len(molecules))]
+                            FX = F._compose_with_weighted_singletons(
+                                names, multiplicities, non_zero_degrees
+                            )
+                            FG = [(M(*molecules), c) for M, c in FX]
+                            result += R.sum_of_terms(FG)
+                return result
 
         coeff_stream = Stream_function(coefficient, P._sparse, sorder * gv)
         super().__init__(P, coeff_stream)

--- a/src/sage/rings/species.py
+++ b/src/sage/rings/species.py
@@ -2317,6 +2317,17 @@ class PolynomialSpeciesElement(CombinatorialFreeModule.Element):
 
         left = self._compose_with_singletons(names, degrees)
         P = left.parent()
+        # The multiplicities may live in a larger ring than the base
+        # ring of ``self`` -- in particular, they may carry undetermined
+        # coefficients introduced by :meth:`define_implicitly`.  Compute
+        # the plethysm over a common ring.
+        from sage.structure.element import get_coercion_model
+
+        cm = get_coercion_model()
+        B = cm.common_parent(P.base_ring(), *[c.parent() for c in multiplicities])
+        if B is not P.base_ring():
+            P = P.change_ring(B)
+            left = P(left)
         right = P._exponential(multiplicities,
                                list(chain.from_iterable(degrees)))
         return left.hadamard_product(right)
@@ -3025,9 +3036,21 @@ class PolynomialSpecies(CombinatorialFreeModule):
             r"""
             Substitute in ``c`` all variables appearing in the
             base ring with their ``k``-th power.
+
+            If the base ring provides a ``_power_sum_plethysm`` method
+            (i.e. it carries undetermined coefficients introduced by
+            :meth:`define_implicitly`), use it: the undetermined
+            coefficients are constants of the `\lambda`-ring and are
+            fixed by `p_k`, while only the base ring monomials are
+            raised to the `k`-th power.
             """
+            if k == 1:
+                return c
+            B = self.base_ring()
+            psp = getattr(B, "_power_sum_plethysm", None)
+            if psp is not None:
+                return psp(c, k)
             if callable(c):
-                B = self.base_ring()
                 return c(*[g ** k for g in B.gens() if g != B.one()])
             return c
 

--- a/src/sage/rings/species.py
+++ b/src/sage/rings/species.py
@@ -2321,6 +2321,94 @@ class PolynomialSpeciesElement(CombinatorialFreeModule.Element):
                                list(chain.from_iterable(degrees)))
         return left.hadamard_product(right)
 
+    def _relabel_sorts(self, codomain, sorts):
+        r"""
+        Return the image of ``self`` in ``codomain`` obtained by
+        relabelling the sorts according to ``sorts``.
+
+        This implements the substitution of the sorts of ``self`` by
+        singletons of ``codomain``.  In other words, if ``self`` is a
+        species `F` in the sorts `X_0, \ldots, X_{m-1}`, this returns
+        `F(Y_{s_0}, \ldots, Y_{s_{m-1}})`, where the `Y_j` are the
+        sorts of ``codomain`` and ``sorts`` is `(s_0, \ldots,
+        s_{m-1})`.
+
+        Since substituting a singleton for a sort only relabels the
+        domain partitions of the molecular species in the support of
+        ``self``, this is much faster than the generic composition.
+
+        INPUT:
+
+        - ``codomain`` -- a :class:`PolynomialSpecies`
+        - ``sorts`` -- a tuple of length the arity of the parent of
+          ``self``, whose entries are in ``range(codomain._arity)``
+
+        EXAMPLES::
+
+            sage: from sage.rings.species import PolynomialSpecies
+            sage: P = PolynomialSpecies(QQ, "Z")
+            sage: P2 = PolynomialSpecies(QQ, "X, Y")
+            sage: C3 = P(CyclicPermutationGroup(3))
+            sage: C3._relabel_sorts(P2, [0])
+            C_3(X)
+            sage: C3._relabel_sorts(P2, [1])
+            C_3(Y)
+
+        The result is linear in ``self``::
+
+            sage: X = P(SymmetricGroup(1))
+            sage: (3*C3 + X^2)._relabel_sorts(P2, [1])
+            Y^2 + 3*C_3(Y)
+
+        Relabelling may merge sorts::
+
+            sage: X = P2(SymmetricGroup(1), {0: [1]})
+            sage: Y = P2(SymmetricGroup(1), {1: [1]})
+            sage: G = PermutationGroup([[(1,2),(3,4)]])
+            sage: E2XY = P2(G, {0: [1, 2], 1: [3, 4]}); E2XY
+            E_2(X*Y)
+            sage: E2XY._relabel_sorts(P, [0, 0])
+            E_2(Z^2)
+            sage: (X*Y)._relabel_sorts(P, [0, 0])
+            Z^2
+
+        TESTS::
+
+            sage: P.zero()._relabel_sorts(P2, [0])
+            0
+            sage: P.one()._relabel_sorts(P2, [0])
+            1
+            sage: C3._relabel_sorts(P2, [0, 1])
+            Traceback (most recent call last):
+            ...
+            ValueError: the number of sorts must match the arity of the parent of self
+        """
+        P = self.parent()
+        if len(sorts) != P._arity:
+            raise ValueError(
+                "the number of sorts must match the arity of the parent of self"
+            )
+        M = codomain._indices
+        A = M._indices
+        R = codomain.base_ring()
+
+        def relabel_atomic(a):
+            pi = {}
+            for s, block in zip(sorts, a._dompart):
+                if block:
+                    pi.setdefault(s, []).extend(block)
+            return A(a._dis, pi, check=False)
+
+        result = {}
+        for mol, c in self.monomial_coefficients().items():
+            factors = {}
+            for a, e in mol._monomial.items():
+                a_new = relabel_atomic(a)
+                factors[a_new] = factors.get(a_new, ZZ.zero()) + e
+            mol_new = M(factors, check=False)
+            result[mol_new] = result.get(mol_new, R.zero()) + c
+        return codomain._from_dict(result)
+
     def __call__(self, *args):
         r"""
         Substitute the arguments into ``self``.


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

This pr adds functionality to specify degree one elements and scalars explicitly in plethysm of lazy symmetric functions.

This PR also incorporates #42442. #42442 supports implicitly defined species inside compositions while preserving the distinction between molecular multiplicities, which remain scalar under Adams operations, and weight variables, which are raised to the corresponding power. The implementation by @mwhansen is mathematically sound and merges cleanly with the current branch, so it is included without modification.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ x] The title is concise and informative.
- [ x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

#42442: support for implicitly defined species inside compositions is incorporated and adapted in this PR.

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


