### PR TITLE
ci: pin netlify/actions/cli to a full commit SHA

### DIFF
--- a/.github/workflows/doc-publish-livedoc.yml
+++ b/.github/workflows/doc-publish-livedoc.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Deploy to netlify with doc-TAG alias
         id: deploy-netlify
-        uses: netlify/actions/cli@master
+        uses: netlify/actions/cli@3185065f4ab2f6df6f2ef41ee013626e1c02a426 # master
         with:
           args: deploy --dir=livedoc/doc --message ${NETLIFY_MESSAGE} --alias ${NETLIFY_ALIAS}
         env:
@@ -87,7 +87,7 @@ jobs:
         if: steps.download-doc.outcome == 'success'
 
       - name: Deploy to netlify with doc-release alias
-        uses: netlify/actions/cli@master
+        uses: netlify/actions/cli@3185065f4ab2f6df6f2ef41ee013626e1c02a426 # master
         with:
           args: deploy --dir=livedoc/doc --message doc-release --alias doc-release
         env:

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Deploy to Netlify
         id: deploy-netlify
-        uses: netlify/actions/cli@master
+        uses: netlify/actions/cli@3185065f4ab2f6df6f2ef41ee013626e1c02a426 # master
         with:
           args: deploy --dir=doc/doc --message ${NETLIFY_MESSAGE} --alias ${NETLIFY_ALIAS}
         env:


### PR DESCRIPTION
### What
Pin `netlify/actions/cli@master` → `3185065…` in `doc-publish.yml` and `doc-publish-livedoc.yml`
(tag kept in a comment).

### Why
These steps pass the production Netlify deploy credentials to a third-party action on the moving
`@master` ref:
```yaml
uses: netlify/actions/cli@master
env:
  NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
  NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
```
If `netlify/actions`' `master` were moved (compromise or an accidental change), the new code would run
with those credentials and could exfiltrate them or deploy arbitrary content to the Sage documentation
site — the class of issue behind the 2025 `tj-actions/changed-files` incident. Pinning to a SHA removes
that.

### Scope / safety
Behaviour unchanged (SHA = current tip of master). Signed-off. Per GitHub's [pin-to-SHA guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflows, the NETLIFY token exposure, and the pinned SHA myself.</sub>
