### PR TITLE
Doc: point newcomers at the Sage Cell Server at the top of the first-hour pages

### DIFF
--- a/src/doc/en/a_tour_of_sage/index.rst
+++ b/src/doc/en/a_tour_of_sage/index.rst
@@ -4,6 +4,12 @@
 Welcome to Sage
 ===============
 
+.. note::
+
+   You can try the examples below in your browser right away, with nothing
+   to install: just type them into the Sage Cell Server at
+   https://sagecell.sagemath.org.
+
 This is a short tour of Sage as a calculator.
 
 The Sage command line has a prompt "``sage:``". To experiment with the

--- a/src/doc/en/tutorial/introduction.rst
+++ b/src/doc/en/tutorial/introduction.rst
@@ -2,6 +2,11 @@
 Introduction
 ************
 
+.. note::
+
+   To try the examples in this tutorial without installing anything, use
+   the Sage Cell Server in your browser: https://sagecell.sagemath.org.
+
 This tutorial should take at most 3-4 hours to fully
 work through. You can read it in HTML or PDF versions, or from the
 Sage notebook click ``Help``, then click ``Tutorial`` to interactively
@@ -60,7 +65,7 @@ Installation
 ============
 
 If you do not have Sage installed on a computer and just
-want to try some commands, use it online at http://sagecell.sagemath.org.
+want to try some commands, use it online at https://sagecell.sagemath.org.
 
 See the Sage Installation Guide in the documentation section of the
 main Sage webpage [SA]_ for instructions on installing Sage on your


### PR DESCRIPTION
The two "first hour" pages — A Tour of Sage and the tutorial's Introduction — never tell a newcomer that Sage can be tried in the browser with nothing to install: `grep -rn sagecell src/doc/en/{tutorial,a_tour_of_sage,prep}` finds a single mention, an `http://` link buried in the tutorial's Installation section.

This PR adds a short `.. note::` at the top of both pages pointing at the Sage Cell Server, and upgrades the existing link to `https://`.

Rationale: a zero-install trial surface materially lowers the first-contact barrier, and comparable systems put it front and center. The wording invites typing the pages' own examples into the browser, which SageCell handles (including the plots).

Validation:
- `sage -t src/doc/en/a_tour_of_sage/index.rst src/doc/en/tutorial/introduction.rst` — All tests passed!
- https://sagecell.sagemath.org verified live over https
- docutils parse clean; `.. note::` renders in this doc set
