### PR TITLE
Doc: update solver-backend guidance in the linear programming tutorial

### DIFF
--- a/src/doc/en/thematic_tutorials/linear_programming.rst
+++ b/src/doc/en/thematic_tutorials/linear_programming.rst
@@ -489,7 +489,7 @@ following libraries are currently supported:
 * `GLPK <http://www.gnu.org/software/glpk/>`_: A solver from `GNU
   <http://www.gnu.org/>`_
 
-  Licensed under the GPLv3. This solver is always installed, as the default one, in Sage.
+  Licensed under the GPLv3. This solver is always installed in Sage.
 
 * `Gurobi <https://www.gurobi.com/>`_:
   Proprietary, but available for free for researchers and students via Gurobi's
@@ -515,8 +515,26 @@ following libraries are currently supported:
 
     $ sage -i -c sage_numerical_backends_gurobi
 
+* `HiGHS <https://highs.dev/>`_: An open-source solver for large-scale linear
+  and mixed-integer programs, always installed in Sage.
+
+  Licensed under the MIT License.
+
 * `PPL <http://bugseng.com/products/ppl>`_: A solver from bugSeng.
 
   This solver provides exact (arbitrary precision) computation, always installed in Sage.
 
   Licensed under the GPLv3.
+
+* `SCIP <https://scipopt.org/>`_: A solver from Zuse Institute Berlin covering
+  linear, mixed-integer, and mixed-integer nonlinear programs. It is not
+  installed by default; install it with the optional ``pyscipopt`` package
+  (which also builds SCIP)::
+
+    $ sage -i pyscipopt
+
+  Licensed under the Apache 2.0 License.
+
+On a standard installation, HiGHS is the default backend, with GLPK as the next
+fallback. If an optional solver such as CPLEX, Gurobi, or CBC is installed, Sage
+uses that instead.

--- a/src/sage/numerical/mip.pyx
+++ b/src/sage/numerical/mip.pyx
@@ -2794,7 +2794,8 @@ cdef class MixedIntegerLinearProgram(SageObject):
         The solver parameters are by essence solver-specific, which means their
         meaning heavily depends on the solver used.
 
-        (If you do not know which solver you are using, then you use GLPK).
+        (If you do not know which solver you are using, then you are using the
+        default; see :func:`default_mip_solver`.)
 
         Aliases:
 


### PR DESCRIPTION

The thematic tutorial `linear_programming.rst` still presents GLPK as Sage's default MILP solver. Since the HiGHS backend was added, `default_mip_solver()` prefers HiGHS when it is available, with GLPK as the standard fallback (optional commercial/CBC/SCIP backends take precedence when installed — see the selection order in `sage/numerical/backends/generic_backend.pyx`). This PR updates the tutorial's solver section accordingly and makes one sentence in `mip.pyx` solver-agnostic instead of naming GLPK as the default.

Validation:

- `sage -t src/doc/en/thematic_tutorials/linear_programming.rst` — 47/47 tests pass
- `sage -t src/sage/numerical/mip.pyx` — 747/747 tests pass
- Selection-order claim verified against `generic_backend.pyx` and `build/pkgs/{highs,glpk}/type` (standard) on current develop
