### PR TITLE
Doc: explain doctest seeding and set_random_seed in the "# random" guidance

### DIFF
--- a/src/doc/en/developer/coding_basics.rst
+++ b/src/doc/en/developer/coding_basics.rst
@@ -1151,7 +1151,10 @@ framework. Here is a comprehensive list:
       This doctest passes too, as the output is not checked
 
   Doctests are expected to pass with any state of the pseudorandom number
-  generators (PRNGs).
+  generators (PRNGs): the doctest framework starts each run from a randomly
+  chosen seed, which is echoed in the ``sage -t`` output as
+  ``--random-seed=SEED`` and can be passed back to ``sage -t`` to reproduce
+  a failure (see :ref:`chapter-doctesting`).
   When possible, avoid the problem, e.g.: rather than checking the value of the
   hash in a doctest, one could illustrate successfully using it as a key in a
   dict.
@@ -1177,6 +1180,14 @@ framework. Here is a comprehensive list:
   This is mathematically correct, as it is
   guaranteed to terminate. However, there is a
   nonzero probability of a timeout.
+
+  As a last resort, an example that needs reproducible pseudorandom values
+  can fix the seed explicitly with
+  :func:`~sage.misc.randstate.set_random_seed`::
+
+      sage: set_random_seed(0)
+      sage: ZZ.random_element(100)
+      75
 
 - **long time:** The line is only tested if the ``--long`` option is given, e.g.
   ``sage -t --long f.py``.


### PR DESCRIPTION
The `# random` bullet in `developer/coding_basics.rst` tells authors that doctests must pass with any PRNG state, but never explains the mechanism behind that requirement — the doctest framework starts each run from a randomly chosen seed, echoed in the `sage -t` output as `--random-seed=SEED` and reusable to reproduce a failure — nor does it mention `set_random_seed()` for the case where an example genuinely needs reproducible pseudorandom values.

This PR extends the PRNG-expectation sentence with the seed mechanics (cross-referencing the doctesting chapter, which documents the reproduce-with-same-seed workflow) and adds a short last-resort `set_random_seed(0)` example after the existing avoid-randomness techniques, preserving their priority.

Validation:
- `sage -t --random-seed=0`, `--random-seed=31337`, and `--random-seed=424242` on the file — all tests passed (the added example is seed-independent by construction)
- The example's output is stable across versions: seed 0 keeps GMP's default Mersenne-Twister state, and `randstate.pyx` / `ZZ.random_element` are identical between 10.9 and current develop
