### PR TITLE
Doc: tell terminal users how to get inline figures before the tutorial's first plot

### DIFF
--- a/src/doc/en/a_tour_of_sage/index.rst
+++ b/src/doc/en/a_tour_of_sage/index.rst
@@ -59,7 +59,9 @@ The result is a list of equalities.
     sage: S[0].rhs()  # right hand side of the equation
     -1/2*sqrt(4*a + 1) - 1/2
 
-Sage can plot various useful functions, of course.
+Sage can plot various useful functions, of course. (In the Jupyter
+notebook or the Sage Cell Server the figure appears inline; at the
+``sage`` terminal prompt, ``show`` opens it with an external viewer.)
 
 ::
 

--- a/src/doc/en/tutorial/tour_plotting.rst
+++ b/src/doc/en/tutorial/tour_plotting.rst
@@ -7,6 +7,13 @@ Plotting
 
 Sage can produce two-dimensional and three-dimensional plots.
 
+.. note::
+
+   Figures appear inline if you are using the Jupyter notebook (started
+   with ``sage -n jupyter``) or the Sage Cell Server. At the plain ``sage``
+   terminal prompt, a plot command prints ``Graphics object ...`` instead,
+   and ``show()`` opens the figure with an external viewer.
+
 Two-dimensional Plots
 ---------------------
 


### PR DESCRIPTION
`tutorial/tour_plotting.rst` presents `circle()`/`plot()`/`show()` as if a figure appears, but at the plain `sage` terminal prompt a plot command prints `Graphics object consisting of 1 graphics primitive` and `show()` hands off to an external viewer. The installation guide separately notes Jupyter is needed for graphics, but nothing at the point of first contact says so.

This PR adds a short note at the top of the plotting tour (inline figures appear in the Jupyter notebook, started with `sage -n jupyter`, or the Sage Cell Server; the terminal prints a `Graphics object ...` line and `show()` uses an external viewer) and a one-sentence parenthetical at the corresponding plot example in "A Tour of Sage".

Validation:
- `sage -t src/doc/en/tutorial/tour_plotting.rst src/doc/en/a_tour_of_sage/index.rst` — All tests passed!
- The terminal behavior quoted is reproduced from a live run; "external viewer" is Sage's own wording in `backend_ipython.py`/`graphics.py`; `sage -n jupyter` matches `installation/launching.rst`
