### PR TITLE
Doc: add a base-ring decision guide to the linear algebra constructions page

### DIFF
--- a/src/doc/en/constructions/linear_algebra.rst
+++ b/src/doc/en/constructions/linear_algebra.rst
@@ -4,6 +4,93 @@
 Linear algebra
 **************
 
+.. index::
+   pair: matrix; base ring
+
+.. _section-base-ring:
+
+Choosing the base ring: exact vs. numerical
+===========================================
+
+Every vector or matrix in Sage is defined over a *base ring*, and the
+same computation can behave very differently depending on which one you
+choose. The most common choices are:
+
+================  ==========================================================
+Base ring         When to use it
+================  ==========================================================
+``ZZ``            Integers: exact. Determinants, Smith/Hermite normal
+                  forms, lattice problems.
+``QQ``            Rationals: exact. The default for structural questions:
+                  rank, kernel, echelon form, inverse, exact solving.
+``GF(q)``         Finite fields: exact modular arithmetic, e.g. for
+                  coding theory and cryptography.
+``RR``, ``CC``    Floating-point with adjustable precision (53 bits by
+                  default, any precision via ``RealField(prec)``), but
+                  without fast matrix decompositions.
+``RDF``, ``CDF``  Hardware double-precision floats: fast numerical
+                  linear algebra via LAPACK (SVD, QR, Cholesky, Schur,
+                  ...).
+``RBF``, ``CBF``  Ball arithmetic: floating-point intervals with
+                  certified error bounds.
+================  ==========================================================
+
+Exact rings give exact answers::
+
+    sage: A = matrix(QQ, [[1, 1/2], [1/3, 1/4]])
+    sage: A.det()
+    1/12
+    sage: A.inverse()
+    [ 3 -6]
+    [-4 12]
+
+The same matrix over ``RDF`` computes with floating-point rounding::
+
+    sage: A = matrix(QQ, [[1, 1/2], [1/3, 1/4]])
+    sage: Ad = A.change_ring(RDF)
+    sage: Ad.det()  # abs tol 1e-15
+    0.08333333333333334
+
+so exact equality tests that hold over ``QQ`` can fail over ``RDF``::
+
+    sage: matrix(QQ, [[1/10]]) * 3 == matrix(QQ, [[3/10]])
+    True
+    sage: matrix(RDF, [[0.1]]) * 3 == matrix(RDF, [[0.3]])
+    False
+
+Over an exact ring, eigenvalues are returned as exact algebraic numbers
+(the trailing ``?`` marks an element of ``QQbar``, printed to its known
+precision); over ``RDF`` they are ordinary floats::
+
+    sage: B = matrix(QQ, [[0, 1], [2, 0]])
+    sage: B.eigenvalues()
+    [-1.414213562373095?, 1.414213562373095?]
+    sage: sorted(B.change_ring(RDF).eigenvalues())  # abs tol 1e-14
+    [-1.414213562373095, 1.4142135623730951]
+
+Over ``RDF`` and ``CDF``, numerical decompositions such as ``SVD``, ``QR``,
+``cholesky`` and ``schur`` are computed by optimized LAPACK routines, and
+some of them (``SVD``, ``schur``) are available over no other ring::
+
+    sage: Ad = matrix(RDF, [[1, 1/2], [1/3, 1/4]])
+    sage: U, S, V = Ad.SVD()
+    sage: S.diagonal()  # abs tol 1e-14
+    [1.1910987498956362, 0.0699634126394936]
+
+For floating-point results carrying rigorous error bounds, use the ball
+fields ``RBF``/``CBF``::
+
+    sage: M = matrix(RBF, [[1, 1/3], [1/3, 1]])
+    sage: M.det()
+    [0.888888888888889 +/- ...]
+
+As a rule of thumb: start with ``QQ`` when you want exact structural
+answers; switch to ``RDF``/``CDF`` for speed on large matrices and for
+the numerical decompositions; use ``RR``/``CC`` when you need a
+nondefault precision; and use ``RBF``/``CBF`` when you need
+floating-point answers you can certify.
+
+
 .. index:
    pair: vector space; basis
    pair: vector space; subspace


### PR DESCRIPTION
Choosing a base ring (`ZZ`/`QQ` vs `GF(q)` vs `RR`/`CC` vs `RDF`/`CDF` vs `RBF`/`CBF`) determines what a linear-algebra computation means and how fast it runs, but the docs offer no guidance — newcomers routinely compute over `RR` expecting LAPACK behavior, or over `RDF` expecting exact ranks.

This PR opens `constructions/linear_algebra.rst` with a "Choosing the base ring: exact vs. numerical" section: a table of the six common choices and when to use each, followed by runnable examples — exact `QQ` determinant/inverse, the same matrix under `RDF` rounding, the exact-vs-float equality pitfall, exact `QQbar` eigenvalues vs `RDF` floats, LAPACK-backed decompositions over `RDF`/`CDF` (some, like `SVD` and `schur`, exist over no other ring), and certified error bounds with `RBF` — closing with a rule-of-thumb paragraph.

Validation: `sage -t src/doc/en/constructions/linear_algebra.rst` — All tests passed, verified under multiple `--random-seed` values (floating outputs guarded with `# abs tol`; the `RDF` eigenvalue example is `sorted()` so LAPACK ordering cannot break it).
