### PR TITLE
Fix setup-uv failure on Void Linux CI (missing version field in os-release)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
             xbps-install -yu
             # node-based actions require libstdc++.so.6
             xbps-install -Sy libstdc++ bash git
+            # setup-uv needs a version field in os-release to build its cache
+            # key, but rolling-release Void ships none (only ID); give it the
+            # same BUILD_ID that Arch uses (see astral-sh/setup-uv#773)
+            echo 'BUILD_ID=rolling' >> /etc/os-release
           fi
           if [ "${{ matrix.container }}" = "archlinux" ]; then
             # The archlinux container is configured to not install docs by default


### PR DESCRIPTION
### What is this about?

The `Build and Test (ghcr.io/void-linux/void-glibc-full)` job of the uv-based CI workflow fails in the *Install uv* step since `astral-sh/setup-uv` was bumped to v8.3.0 (first hit on the 10.10.beta6 tag run: https://github.com/sagemath/sage/actions/runs/29456228986/job/87489892141):

```
##[error]Failed to determine Linux distribution. Could not read /etc/os-release or /usr/lib/os-release
```

The message is misleading: the file is readable. Since v7.3, setup-uv includes the distro name/version in its cache key via `getLinuxOSNameVersion()`, which requires `ID` plus one of `VERSION_ID`, `VERSION_CODENAME` or `BUILD_ID` in os-release, and throws the above error otherwise. Void Linux is a rolling release whose os-release contains only `ID="void"` — none of the version fields — so the step always fails now. Arch (also rolling) passes because it ships `BUILD_ID=rolling`. The case is still unhandled in setup-uv v8.3.2/main (cf. astral-sh/setup-uv#773, which only added the `VERSION_CODENAME`/`BUILD_ID` fallbacks).

This PR appends `BUILD_ID=rolling` to `/etc/os-release` in the *Prepare container* step for the Void container, mirroring Arch's convention. This keeps uv caching enabled (the alternative workaround, `enable-cache: false`, would disable it) and yields the cache key component `void-rolling`.