### PR TITLE
Fix #42508: Prevent unnecessary rewrites of meson.build files

### DIFF
--- a/tools/update-meson.py
+++ b/tools/update-meson.py
@@ -347,11 +347,23 @@ def apply_changes(self: Rewriter):
         elif i["action"] == "add":
             files[i["file"]]["raw"] += i["str"] + "\n"
 
-    # Write the files back
+       # Write the files back (only if content actually changed)
     for key, val in files.items():
-        mlog.log("Rewriting", mlog.yellow(key))
-        with open(val["path"], "w", encoding="utf-8") as fp:
-            fp.write(val["raw"])
+        # Read the current file content from disk
+        try:
+            with open(val["path"], "r", encoding="utf-8") as fp:
+                existing_content = fp.read()
+        except FileNotFoundError:
+            existing_content = None
+
+        # Only write to disk if the new content is different
+        if existing_content != val["raw"]:
+            mlog.log("Rewriting", mlog.yellow(key))
+            with open(val["path"], "w", encoding="utf-8") as fp:
+                fp.write(val["raw"])
+        else:
+            # Identical content - do absolutely nothing to keep Git clean
+            pass
 
 
 # Monkey patch the apply_changes method until https://github.com/mesonbuild/meson/pull/12899 is merged


### PR DESCRIPTION
Fixes #42508

The tools/update-meson.py script was blindly rewriting all meson.build files, causing Git to detect them as uncommitted changes during the CI run.

This PR modifies the apply_changes() function to read the existing file from disk first. If the newly generated content matches what is already on disk, the script now skips writing to the file entirely. This keeps the Git working tree clean and resolves the CI error.

