### PR TITLE
Search the full pivot row in block LDLT

### DIFF
--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -15199,8 +15199,10 @@ cdef class Matrix(Matrix1):
 
             # Continuing the "else" branch of Higham's Step (1), and
             # onto B&K's Step (3) where we find the largest
-            # off-diagonal entry (in magnitude) in row "r" of the
-            # active submatrix.
+            # off-diagonal entry (in magnitude) in column "r" of the
+            # active submatrix. Since the matrix is Hermitian, we search
+            # row "r", whose corresponding entries have the same
+            # magnitudes.
             #
             # Note: omega_r is defined as a C double, but the abs()
             # below would make a complex number approximate anyway.
@@ -15395,12 +15397,11 @@ cdef class Matrix(Matrix1):
         the following Schur-complement update::
 
             sage: # needs scipy
-            sage: import math
             sage: H = RDF(1e200)
             sage: A = matrix(RDF, [[0, 1, 0], [1, 1, H], [0, H, 1]])
             sage: P, L, D = A.block_ldlt()
-            sage: all(math.isfinite(x) for x in L.list() + D.list())
-            True
+            sage: any(x.is_infinity() or x.is_NaN() for x in L.list() + D.list())
+            False
             sage: P.T * A * P == L * D * L.T
             True
 

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -15199,15 +15199,15 @@ cdef class Matrix(Matrix1):
 
             # Continuing the "else" branch of Higham's Step (1), and
             # onto B&K's Step (3) where we find the largest
-            # off-diagonal entry (in magnitude) in column "r". Since
-            # the matrix is Hermitian, we need only look at the
-            # above-diagonal entries to find the off-diagonal of
-            # maximal magnitude.
+            # off-diagonal entry (in magnitude) in row "r" of the
+            # active submatrix.
             #
             # Note: omega_r is defined as a C double, but the abs()
             # below would make a complex number approximate anyway.
             omega_r = 0
-            for j in range(k, r):
+            for j in range(k, n):
+                if j == r:
+                    continue
                 a_rj_abs = A.get_unsafe(r, j).abs()
                 if a_rj_abs > omega_r:
                     omega_r = a_rj_abs
@@ -15375,20 +15375,33 @@ cdef class Matrix(Matrix1):
             ....:                  [0, 2, 0]])
             sage: P,L,D = A.block_ldlt()
             sage: P
-            [0 0 1]
             [1 0 0]
             [0 1 0]
+            [0 0 1]
             sage: L
-            [  1   0   0]
-            [  2   1   0]
-            [  1 1/2   1]
+            [1 0 0]
+            [0 1 0]
+            [2 0 1]
             sage: D
-            [ 1| 0| 0]
-            [--+--+--]
-            [ 0|-4| 0]
-            [--+--+--]
-            [ 0| 0| 0]
+            [0 1|0]
+            [1 1|0]
+            [---+-]
+            [0 0|0]
             sage: P.transpose()*A*P == L*D*L.transpose()
+            True
+
+        The complete pivot row must be searched.  Ignoring entries after
+        its diagonal can select an unstable one-by-one pivot and overflow
+        the following Schur-complement update::
+
+            sage: # needs scipy
+            sage: import math
+            sage: H = RDF(1e200)
+            sage: A = matrix(RDF, [[0, 1, 0], [1, 1, H], [0, H, 1]])
+            sage: P, L, D = A.block_ldlt()
+            sage: all(math.isfinite(x) for x in L.list() + D.list())
+            True
+            sage: P.T * A * P == L * D * L.T
             True
 
         This two-by-two matrix has no classical factorization, but it


### PR DESCRIPTION
## Problem

In the Bunch--Kaufman pivot strategy, `omega_r` is the largest off-diagonal magnitude in row `r` of the active submatrix. The existing loop only examines entries before the diagonal and ignores `A[r, j]` for `j > r`.

This can select an unsafe one-by-one pivot. In the added RDF regression, the omitted entry is much larger than the scanned entries, and the resulting Schur-complement update overflows.

## Change

Scan the complete active pivot row while skipping its diagonal. The existing 3-by-3 example is updated for the corrected pivot choice, and a regression verifies that all factors remain finite and reconstruct the input matrix.

This PR deliberately does not change `alpha`, the published pivot inequalities, Schur-complement operation ordering, or output construction.

## Scope split

- The AA and QQbar float-conversion issue from #42545 has moved to #42710.
- Small exact entries whose magnitudes underflow to a C double remain covered by #42665.
- This PR now contains only the missing full-row `omega_r` scan.

## Verification

- Targeted Cython compilation of `matrix2.pyx` completed successfully.
- The new RDF overflow regression passes and satisfies `P.T * A * P == L * D * L.T`.
- The updated rational 3-by-3 factorization output was verified.
- The full `matrix2.pyx` doctest run executed 3197 tests; all LDLT tests passed. Four unrelated `Matrix.exp` tests failed because the local Maxima installation could not load `load-linearalgebra-lisp-files.lisp`.

### Checklist

- [x] The title is concise and informative.
- [x] The description explains the concrete failure.
- [x] The implementation follows the published pivot inequalities.
- [x] A regression test covers the change.