### PR TITLE
Add algorithm to compute the generating function of plane partitions

### DIFF
--- a/src/sage/combinat/plane_partition.py
+++ b/src/sage/combinat/plane_partition.py
@@ -1679,8 +1679,7 @@ class PlanePartitions_box(PlanePartitions):
 
         .. MATH::
 
-            \prod_{i=1}^{a} \prod_{j=1}^{b} \prod_{k=1}^{c}
-            \frac{i+j+k-1}{i+j+k-2}.
+            \prod_{i=1}^{a} \prod_{j=1}^{b} \frac{i+j+c-1}{i+j-1}.
 
         EXAMPLES::
 
@@ -1688,17 +1687,13 @@ class PlanePartitions_box(PlanePartitions):
             sage: P.cardinality()
             116424
         """
-        A = self._box[0]
-        B = self._box[1]
-        C = self._box[2]
-        return Integer(prod(i + j + k - 1
-                            for i in range(1, A + 1)
-                            for j in range(1, B + 1)
-                            for k in range(1, C + 1)) //
-                       prod(i + j + k - 2
-                            for i in range(1, A + 1)
-                            for j in range(1, B + 1)
-                            for k in range(1, C + 1)))
+        a, b, c = sorted(self._box)
+        return Integer(prod(i + j + c - 1
+                            for i in range(1, a + 1)
+                            for j in range(1, b + 1)) //
+                       prod(i + j - 1
+                            for i in range(1, a + 1)
+                            for j in range(1, b + 1)))
 
     def generating_series(self, q=None):
         r"""

--- a/src/sage/combinat/plane_partition.py
+++ b/src/sage/combinat/plane_partition.py
@@ -1753,7 +1753,6 @@ class PlanePartitions_box(PlanePartitions):
             sage: P.cardinality() == P.generating_series()(1)
             True
         """
-
         from sage.rings.polynomial.cyclotomic import cyclotomic_value
 
         if q is None:

--- a/src/sage/combinat/plane_partition.py
+++ b/src/sage/combinat/plane_partition.py
@@ -1700,6 +1700,83 @@ class PlanePartitions_box(PlanePartitions):
                             for j in range(1, B + 1)
                             for k in range(1, C + 1)))
 
+    def generating_polynomial(self, q=None):
+        r"""
+        Return the generating polynomial of plane partitions in this box.
+
+        The generating function of plane partitions inside an `a \times b \times c`
+        box is equal to
+
+        .. MATH::
+            \prod_{i=1}^{a} \prod_{j=1}^{b} \frac{1-q^{i+j+c-1}}{1-q^{i+j-1}}.
+
+        INPUT:
+
+        - ``q`` -- (default: ``None``) the variable `q`; if ``None``, then use a
+          default variable in `\ZZ[q]`
+
+        ALGORITHM:
+
+        This function computes the generating polynomial `N_q(a,b,c)` by factoring it
+        into cyclotomic polynomials:
+
+        .. MATH::
+
+            N_q(a, b, c) = \prod_{d=1}^{a+b+c-1} \Phi_d(q)^{e_d}
+
+        where
+
+        .. MATH::
+            e_d = \sum_{i=0}^{a-1} \left\lfloor \frac{b+c+i}{d} \right\rfloor -
+            \left\lfloor \frac{c+i}{d} \right\rfloor +
+            \left\lfloor \frac{i}{d} \right\rfloor -
+            \left\lfloor \frac{b+i}{d} \right\rfloor.
+
+        EXAMPLES::
+
+            sage: P = PlanePartitions([2, 2, 2])
+            sage: P.generating_polynomial()
+            q^8 + q^7 + 3*q^6 + 3*q^5 + 4*q^4 + 3*q^3 + 3*q^2 + q + 1
+
+            sage: R.<t> = ZZ[]
+            sage: P = PlanePartitions([3, 1, 1])
+            sage: P.generating_polynomial(q=t)
+            t^3 + t^2 + t + 1
+
+        TESTS::
+
+            sage: PlanePartitions([1, 1, 1]).generating_polynomial()
+            q + 1
+
+            sage: PlanePartitions([0, 1, 1]).generating_polynomial()
+            1
+
+            sage: PlanePartitions([1, 8, 5]).generating_polynomial() == q_binomial(8+5, 5)
+            True
+
+            sage: P = PlanePartitions([4, 6, 3])
+            sage: P.cardinality() == P.generating_polynomial()(1)
+            True
+        """
+        if q is None:
+            R = ZZ['q']
+        else:
+            R = q.parent()
+
+        a, b, c = sorted(self._box)
+
+        if a == 0:
+            return R.one()
+
+        factors = []
+
+        for d in range(1, a + b + c):
+            e = sum((b+c+i)//d + i//d - (c+i)//d - (b+i)//d for i in range(a))
+            if e > 0:
+                factors.append(R.cyclotomic_polynomial(d) ** e)
+
+        return prod(factors)
+
     def random_element(self) -> PP:
         r"""
         Return a uniformly random plane partition inside a box.

--- a/src/sage/combinat/plane_partition.py
+++ b/src/sage/combinat/plane_partition.py
@@ -1700,9 +1700,9 @@ class PlanePartitions_box(PlanePartitions):
                             for j in range(1, B + 1)
                             for k in range(1, C + 1)))
 
-    def generating_polynomial(self, q=None):
+    def generating_series(self, q=None):
         r"""
-        Return the generating polynomial of plane partitions in this box.
+        Return the generating function of plane partitions in this box.
 
         The generating function of plane partitions inside an `a \times b \times c`
         box is equal to
@@ -1717,7 +1717,7 @@ class PlanePartitions_box(PlanePartitions):
 
         ALGORITHM:
 
-        This function computes the generating polynomial `N_q(a,b,c)` by factoring it
+        This function computes the generating function `N_q(a,b,c)` by factoring it
         into cyclotomic polynomials:
 
         .. MATH::
@@ -1735,31 +1735,35 @@ class PlanePartitions_box(PlanePartitions):
         EXAMPLES::
 
             sage: P = PlanePartitions([2, 2, 2])
-            sage: P.generating_polynomial()
+            sage: P.generating_series()
             q^8 + q^7 + 3*q^6 + 3*q^5 + 4*q^4 + 3*q^3 + 3*q^2 + q + 1
 
             sage: R.<t> = ZZ[]
             sage: P = PlanePartitions([3, 1, 1])
-            sage: P.generating_polynomial(q=t)
+            sage: P.generating_series(q=t)
             t^3 + t^2 + t + 1
 
         TESTS::
 
-            sage: PlanePartitions([1, 1, 1]).generating_polynomial()
+            sage: PlanePartitions([1, 1, 1]).generating_series()
             q + 1
 
-            sage: PlanePartitions([0, 1, 1]).generating_polynomial()
+            sage: PlanePartitions([0, 1, 1]).generating_series()
             1
 
-            sage: PlanePartitions([1, 8, 5]).generating_polynomial() == q_binomial(8+5, 5)
+            sage: PlanePartitions([1, 8, 5]).generating_series() == q_binomial(8+5, 5)
             True
 
             sage: P = PlanePartitions([4, 6, 3])
-            sage: P.cardinality() == P.generating_polynomial()(1)
+            sage: P.cardinality() == P.generating_series()(1)
             True
         """
+
+        from sage.rings.polynomial.cyclotomic import cyclotomic_value
+
         if q is None:
             R = ZZ['q']
+            q = R.gen()
         else:
             R = q.parent()
 
@@ -1773,7 +1777,7 @@ class PlanePartitions_box(PlanePartitions):
         for d in range(1, a + b + c):
             e = sum((b+c+i)//d + i//d - (c+i)//d - (b+i)//d for i in range(a))
             if e > 0:
-                factors.append(R.cyclotomic_polynomial(d) ** e)
+                factors.append(cyclotomic_value(d, q) ** e)
 
         return prod(factors)
 


### PR DESCRIPTION
This PR implements an efficient algorithm to compute the generating polynomial $N_q(a, b, c)$ for plane partitions contained in an $a \times b \times c$ box, based on MacMahon's formula:

$$N_q(a, b, c) = \prod_{i=1}^{a} \prod_{j=1}^{b} \frac{1-q^{i+j+c-1}}{1-q^{i+j-1}}$$

### Mathematical approach
To avoid the computational cost of naive polynomial multiplication and division, we factorize the generating function into cyclotomic polynomials $\Phi_d(q)$:

$$N_q(a, b, c) = \prod_{d=1}^{a+b+c-1} \Phi_d(q)^{e_d}$$

The exponents $e_d$ can be computed directly : 

$$e_d = \sum_{i=0}^{a-1} \left( \left\lfloor \frac{b+c+i}{d} \right\rfloor - \left\lfloor \frac{c+i}{d} \right\rfloor + \left\lfloor \frac{i}{d} \right\rfloor - \left\lfloor \frac{b+i}{d} \right\rfloor \right)$$

#### Proof of this formula
Using the identity $1-q^n = \prod_{d|n} \Phi_d(q)$, the expression can be rewritten as:

$$N_q(a, b, c) = \prod_{i=1}^a \prod_{j=1}^b \frac{\prod_{d|i+j+c-1} \Phi_d(q)}{\prod_{d|i+j-1} \Phi_d(q)}$$

For a fixed $i$ and $d$, the factor $\Phi_d(q)$ appears in the numerator for each $j$ such that $d$ divides $i+j+c-1$. This corresponds to the number of multiples of $d$ in the interval $[i+c, i+c+b-1]$, which is:
$$\left\lfloor \frac{i+c+b-1}{d} \right\rfloor - \left\lfloor \frac{i+c-1}{d} \right\rfloor$$

Similarly, the number of times $\Phi_d(q)$ appears in the denominator is:
$$\left\lfloor \frac{i+b-1}{d} \right\rfloor - \left\lfloor \frac{i-1}{d} \right\rfloor$$

Summing the difference over $i=1$ to $a$ gives the total exponent $e_d$:
$$e_d = \sum_{i=1}^a \left( \left\lfloor \frac{i+c+b-1}{d} \right\rfloor - \left\lfloor \frac{i+c-1}{d} \right\rfloor - \left\lfloor \frac{i+b-1}{d} \right\rfloor + \left\lfloor \frac{i-1}{d} \right\rfloor \right)$$

We get the formula by the change of index $i \leftarrow i-1$.

### Implementation details
This approach is analogous to the existing implementation of the $q$-binomial coefficient in SageMath.

Tests and edge cases (empty boxes, 1D boxes checking against `q_binomial`, and evaluation at $q=1$ for cardinality) have been added to ensure correctness.