### PR TITLE
Add annulus example to region_plot documentation

### DIFF
--- a/src/sage/plot/contour_plot.py
+++ b/src/sage/plot/contour_plot.py
@@ -1631,6 +1631,20 @@ def region_plot(f, xrange, yrange, **options):
         g = region_plot(x**2 + y**2 < 100, (x,1,10), (y,1,10), scale='loglog')
         sphinx_plot(g)
 
+    Combining an outer disk with an excluded inner disk produces the
+    region between two circles, that is, an annulus (or ring)::
+
+        sage: region_plot([x^2 + y^2 < 4, x^2 + y^2 > 1], (x,-3,3), (y,-3,3),
+        ....:             incol='yellow', bordercol='black')
+        Graphics object consisting of 2 graphics primitives
+
+    .. PLOT::
+
+        x, y = var("x y")
+        g = region_plot([x**2 + y**2 < 4, x**2 + y**2 > 1], (x,-3,3), (y,-3,3),
+                        incol='yellow', bordercol='black')
+        sphinx_plot(g)
+
     TESTS:
 
     To check that :issue:`16907` is fixed::


### PR DESCRIPTION
Adds a documentation example to `region_plot` showing how to plot an annulus (a ring), i.e. the region between two circles, by combining an outer disk condition with an excluded inner disk condition.

This picks up on the discussion in the issue: an attempt was made a while back but was never finished (the inner/outer regions weren't clearly identified as an annulus, `^` was used instead of `**` inside the `.. PLOT::` block, and the `.. PLOT::` directive was missing its leading space so the plot wasn't actually rendered). This adds a single, self-contained example instead:

```
sage: region_plot([x^2 + y^2 < 4, x^2 + y^2 > 1], (x,-3,3), (y,-3,3),
....:             incol='yellow', bordercol='black')
Graphics object consisting of 2 graphics primitives
```

with a matching `.. PLOT::` block for the rendered documentation image.

Fixes #22615
