### PR TITLE
Add Alpoge's counterexample to the Jacobian conjecture as a doctest

### DIFF
--- a/src/sage/calculus/functions.py
+++ b/src/sage/calculus/functions.py
@@ -137,6 +137,19 @@ def jacobian(functions, variables):
         [    x^3*cos(y)   3*x^2*sin(y)]
         [ cos(x)*cos(y) -sin(x)*sin(y)]
         [             0            e^x]
+        
+    We verify Alpoge's counterexample to the Jacobian conjecture::
+
+        sage: x,y,z = var('x,y,z')
+        sage: l = [(1+x*y)^3*z + y^2*(1+x*y)*(4+3*x*y), y+3*x*(1+x*y)^2*z + 3*x*y^2*(4+3*x*y), 2*x-3*x^2*y-x^3*z]
+        sage: M = jacobian(l, (x,y,z))
+        sage: M.det().expand()
+        -2
+        sage: [f(x=0,y=0,z=-1/4) for f in l]
+        [-1/4, 0, 0]
+        sage: [f(x=1,y=-3/2,z=13/2) for f in l]
+        [-1/4, 0, 0]
+
     """
     if isinstance(functions, Matrix) and (functions.nrows() == 1
                                           or functions.ncols() == 1):

--- a/src/sage/calculus/functions.py
+++ b/src/sage/calculus/functions.py
@@ -137,7 +137,7 @@ def jacobian(functions, variables):
         [    x^3*cos(y)   3*x^2*sin(y)]
         [ cos(x)*cos(y) -sin(x)*sin(y)]
         [             0            e^x]
-        
+
     We verify Alpoge's counterexample to the Jacobian conjecture::
 
         sage: x,y,z = var('x,y,z')

--- a/src/sage/rings/polynomial/polynomial_ring.py
+++ b/src/sage/rings/polynomial/polynomial_ring.py
@@ -111,6 +111,18 @@ to the default FLINT implementation, but not vice versa::
     sage: (R.0 + S.0).parent() is S                                                     # needs sage.libs.flint sage.libs.ntl
     True
 
+We verify Alpoge's counterexample to the Jacobian conjecture::
+
+    sage: P.<x,y,z> = QQ[]
+    sage: l = [(1+x*y)^3*z + y^2*(1+x*y)*(4+3*x*y), y+3*x*(1+x*y)^2*z + 3*x*y^2*(4+3*x*y), 2*x-3*x^2*y-x^3*z]
+    sage: M = Matrix([[l[i].derivative(j) for j in [x,y,z]] for i in range(3)])
+    sage: M.det()
+    -2
+    sage: [f(0,0,-1/4) for f in l]
+    [-1/4, 0, 0]
+    sage: [f(1,-3/2,13/2) for f in l]
+    [-1/4, 0, 0]
+
 TESTS::
 
     sage: K.<x> = FractionField(QQ['x'])


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Alpöge announced a counterexample to the Jacobian conjecture (in dimension 3) via X/Twitter on July 20, 2026. We add a doctest to sage/src/sage/rings/polynomial/polynomial_ring.py to verify it.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->

None.