### PR TITLE
plot3d: require scalar-valued plotting functions

### DIFF
--- a/src/sage/plot/plot3d/plot3d.py
+++ b/src/sage/plot/plot3d/plot3d.py
@@ -302,10 +302,10 @@ class _Coordinates:
             sage: [h(u=1,v=2) for h in T.to_cartesian(operator.mul)]
             [3.0, -1.0, 2.0]
 
-        The output of the function ``func`` is coerced to a float when
-        it is evaluated if the function is something like a lambda or
-        python callable. This takes care of situations like f returning a
-        singleton numpy array, for example.
+        The output of a Python callable ``func`` is coerced to a float when
+        it is evaluated. Thus it must return a scalar or another object
+        accepted by ``float()``. For example, extract the scalar value
+        returned by a SciPy interpolant explicitly (:issue:`42539`)::
 
             sage: from numpy import array
             sage: v_phi=array([ 0.,  1.57079637,  3.14159274, 4.71238911,  6.28318548])
@@ -316,7 +316,8 @@ class _Coordinates:
             ....: [ 0.16763356,  0.19993708,  0.31403568,  0.47359696, 0.55282422],
             ....: [ 0.16763356,  0.25683223,  0.16649297,  0.10594339, 0.55282422]])
             sage: import scipy.interpolate
-            sage: f=scipy.interpolate.RectBivariateSpline(v_phi,v_theta,m_r).ev
+            sage: spline = scipy.interpolate.RectBivariateSpline(v_phi, v_theta, m_r)
+            sage: f = lambda x, y: spline.ev(x, y).item()
             sage: spherical_plot3d(f,(0,2*pi),(0,pi))
             Graphics3d Object
         """


### PR DESCRIPTION
Fixes #42539.

## Description

`plot3d` expects Python plotting callables to return scalar values. A long-standing doctest instead claimed that one-element NumPy arrays were supported, relying on their implicit conversion to scalars. NumPy 2.4 removed that deprecated conversion for arrays with positive dimension.

SciPy 1.18.0 exposed the stale assumption through an unintended change in `RectBivariateSpline.ev()`: for scalar inputs, it returns an array of shape `(1,)` instead of the previous zero-dimensional result. This regression is tracked in [scipy/scipy#25471](https://github.com/scipy/scipy/issues/25471), with a proposed upstream fix in [scipy/scipy#25542](https://github.com/scipy/scipy/pull/25542).

This PR takes the narrow approach:

- construct the spline once;
- explicitly extract the scalar plotting value with `.item()`;
- remove the stale claim that singleton NumPy arrays are accepted.

The earlier general singleton-array conversion changes have been dropped. Sage now deliberately documents the simpler contract that plotting callables return scalars; callers receiving a one-element array from an external library should scalarize it explicitly.

## Impact

Existing scalar-valued plotting functions are unaffected. Functions returning one-element arrays must extract the value, for example with `.item()`.

The doctest works with both the established SciPy behavior and SciPy 1.18.0's temporary shape-`(1,)` regression, without adding broad implicit array conversion to Sage's plotting code.

## Testing

All 245 doctests in `src/sage/plot/plot3d/plot3d.py` pass with NumPy 2.4.6 under:

- SciPy 1.17.1
- SciPy 1.18.0
