### PR TITLE
Fix cache invalidation and mutability in add_to_entry

### DIFF
--- a/src/sage/matrix/matrix0.pyx
+++ b/src/sage/matrix/matrix0.pyx
@@ -611,7 +611,23 @@ cdef class Matrix(sage.structure.element.Matrix):
             sage: m
             [0 2]
             [0 0]
+
+        The cache is cleared and immutable matrices cannot be changed
+        (:issue:`42532`)::
+
+            sage: m = matrix(ZZ, [[1, 2], [3, 4]])
+            sage: m.det()
+            -2
+            sage: m.add_to_entry(0, 0, 10)
+            sage: m.det()
+            38
+            sage: m.set_immutable()
+            sage: m.add_to_entry(0, 0, 1)
+            Traceback (most recent call last):
+            ...
+            ValueError: matrix is immutable; please change a copy instead (i.e., use copy(M) to change a copy of M).
         """
+        self.check_mutability()
         elt = self.base_ring()(elt)
         if i < 0:
             i += self._nrows

--- a/src/sage/matrix/matrix_rational_dense.pyx
+++ b/src/sage/matrix/matrix_rational_dense.pyx
@@ -245,7 +245,23 @@ cdef class Matrix_rational_dense(Matrix_dense):
             sage: m
             [-1/3    0]
             [   0    0]
+
+        The cache is cleared and immutable matrices cannot be changed
+        (:issue:`42532`)::
+
+            sage: m = matrix(QQ, [[1, 2], [3, 4]])
+            sage: m.det()
+            -2
+            sage: m.add_to_entry(0, 0, 10)
+            sage: m.det()
+            38
+            sage: m.set_immutable()
+            sage: m.add_to_entry(0, 0, 1)
+            Traceback (most recent call last):
+            ...
+            ValueError: matrix is immutable; please change a copy instead (i.e., use copy(M) to change a copy of M).
         """
+        self.check_mutability()
         if not isinstance(elt, Rational):
             elt = Rational(elt)
         if i < 0:

--- a/src/sage/matrix/matrix_rational_sparse.pyx
+++ b/src/sage/matrix/matrix_rational_sparse.pyx
@@ -185,7 +185,23 @@ cdef class Matrix_rational_sparse(Matrix_sparse):
             [0 0]
             sage: m.nonzero_positions()
             []
+
+        The cache is cleared and immutable matrices cannot be changed
+        (:issue:`42532`)::
+
+            sage: m = matrix(QQ, [[1, 2], [3, 4]], sparse=True)
+            sage: m.det()
+            -2
+            sage: m.add_to_entry(0, 0, 10)
+            sage: m.det()
+            38
+            sage: m.set_immutable()
+            sage: m.add_to_entry(0, 0, 1)
+            Traceback (most recent call last):
+            ...
+            ValueError: matrix is immutable; please change a copy instead (i.e., use copy(M) to change a copy of M).
         """
+        self.check_mutability()
         if not isinstance(elt, Rational):
             elt = Rational(elt)
         if i < 0:


### PR DESCRIPTION
Fixes #42532.

## Summary

- Run the standard matrix mutability/cache gate in every `add_to_entry` implementation.
- Cover the generic, rational dense, and rational sparse implementations with regression doctests.
- Verify both cache invalidation and rejection of writes to immutable matrices.

## Root cause

The three `add_to_entry` implementations updated their backing storage without first calling `Matrix.check_mutability()`. Consequently, cached invariants such as the determinant remained stale after a mutable update, and matrices marked immutable could still be changed.

`check_mutability()` both rejects immutable matrices and clears the property cache for mutable matrices, matching the ordering and behavior of other matrix mutation methods.

## User impact

After this change, `add_to_entry` recomputes cached matrix properties after a successful update and preserves the hash and cache guarantees of immutable matrices.