### PR TITLE
Fix segfault in @interact with complex_roots

### DIFF
--- a/src/sage/repl/ipython_kernel/interact.py
+++ b/src/sage/repl/ipython_kernel/interact.py
@@ -131,7 +131,16 @@ class sage_interactive(interactive):
         for w in widgets:
             s += "\n  %s: %s" % (w._kwarg, w)
         return s
-
+    def update(self, *args, **kwargs):
+        """
+        Override update to force garbage collection after each call.
+        """
+        import gc
+        try:
+            super().update(*args, **kwargs)
+        finally:
+            gc.collect()
+            
     def signature(self):
         """
         Return the fixed signature of the interactive function (after


### PR DESCRIPTION
### Description
Fixed segmentation fault when using `@interact` with `complex_roots()`.

### Fix
- Added `gc.collect()` after each interact callback to free Python objects
- Prevents memory corruption when computing polynomial roots

Fix #42567

### Testing
Verified with minimal reproducer:
```python
from sage.rings.polynomial.complex_roots import complex_roots
from sage.repl.ipython_kernel.interact import interact
x = polygen(ZZ)

@interact
def f(n=(3,100)):
    p = x^20 + x + 1
    print(len(complex_roots(p)))

