### PR TITLE
make "yes"  default value for darwin-accelerate option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 #                     2014-2017 François Bissey
 #                     2016-2022 Matthias Koeppe
 #                     2017-2018 Erik M. Bray
-#                     2018      Dima Pasechnik
+#                     2018-2026 Dima Pasechnik
 #                     2020      Jonathan Kliem
 #                     2021-2023 Michael Orlitzky
 #
@@ -342,20 +342,21 @@ m4_pushdef([SAGE_BOOTSTRAP_URL],[See https://doc.sagemath.org/html/en/reference/
    ])
 
 # choose BLAS/LAPACK on Darwin
-AC_ARG_WITH([darwin-accelerate],
+SAGE_DARWIN_PKG_CONFIG_PATH=
+case $host in
+  *-*-darwin*)
+   AC_ARG_WITH([darwin-accelerate],
             [AS_HELP_STRING([--with-darwin-accelerate={yes (default)},no}],
                             [use Darwin (macOS) Accelerate BLAS/LAPACK])],
             [SAGE_DARWIN_ACCELERATE="$withval"],
             [SAGE_DARWIN_ACCELERATE="yes"])
-AC_SUBST([SAGE_DARWIN_ACCELERATE])
-
-SAGE_DARWIN_PKG_CONFIG_PATH=
-case $host in
-    *-*-darwin*)
+   AC_SUBST([SAGE_DARWIN_ACCELERATE])
    AS_IF([test x$SAGE_DARWIN_ACCELERATE = xyes],
     [SAGE_DARWIN_PKG_CONFIG_PATH=`pwd`"/build/platform/darwin/accelerate/pkgconfig:"])
     ;;
-    *)
+  *)
+   SAGE_DARWIN_ACCELERATE="no"
+   ;;
 esac
 
 # Check for zlib

--- a/configure.ac
+++ b/configure.ac
@@ -343,10 +343,10 @@ m4_pushdef([SAGE_BOOTSTRAP_URL],[See https://doc.sagemath.org/html/en/reference/
 
 # choose BLAS/LAPACK on Darwin
 AC_ARG_WITH([darwin-accelerate],
-            [AS_HELP_STRING([--with-darwin-accelerate={no (default)},yes}],
+            [AS_HELP_STRING([--with-darwin-accelerate={yes (default)},no}],
                             [use Darwin (macOS) Accelerate BLAS/LAPACK])],
             [SAGE_DARWIN_ACCELERATE="$withval"],
-            [SAGE_DARWIN_ACCELERATE="no"])
+            [SAGE_DARWIN_ACCELERATE="yes"])
 AC_SUBST([SAGE_DARWIN_ACCELERATE])
 
 SAGE_DARWIN_PKG_CONFIG_PATH=


### PR DESCRIPTION
it works well on macOS, less hassle than OpenBLAS, and most Homebrew formulae which need BLAS use it too.

See also #42096

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


