### PR TITLE
Many random_cone() improvements

### DIFF
--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6160,45 +6160,44 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
 
     A :exc:`ValueError` will be thrown under the following conditions:
 
-    * Any of ``min_ambient_dim``, ``max_ambient_dim``, ``min_rays``, or
-      ``max_rays`` are negative.
+    * Any of ``min_ambient_dim``, ``max_ambient_dim``, ``min_rays``,
+      or ``max_rays`` are negative.
 
     * ``max_ambient_dim`` is less than ``min_ambient_dim``.
 
     * ``max_rays`` is less than ``min_rays``.
 
-
-    * ``min_rays`` is greater than four but ``max_ambient_dim`` is less than
-      three.
-
-    * ``min_rays`` is greater than four but ``lattice`` has dimension
-      less than three.
-
-    * ``min_rays`` is greater than two but ``max_ambient_dim`` is less than
-      two.
-
-    * ``min_rays`` is greater than two but ``lattice`` has dimension less
-      than two.
-
-    * ``min_rays`` is positive but ``max_ambient_dim`` is zero.
-
-    * ``min_rays`` is positive but ``lattice`` has dimension zero.
-
-    * A trivial lattice is supplied and a non-strictly-convex cone
-      is requested.
-
     * A non-strictly-convex cone is requested but ``max_rays`` is less
       than two.
+
+    * ``max_ambient_dim`` is two or less, and ``min_rays`` is
+      greater than ``2*max_ambient_dim``.
+
+    * ``lattice`` has dimension two or less, and ``min_rays`` is
+      larger than twice that dimension.
+
+    * A strictly-convex cone is requested with ``max_ambient_dim <=
+      2``, and ``min_rays`` is greater than ``max_ambient_dim``.
+
+    * A strictly-convex cone is requested in a ``lattice`` that has
+      dimension two or less, and ``min_rays`` is greater than that
+      dimension.
+
+    * A non-strictly-convex cone is requested and ``max_ambient_dim``
+      is zero.
+
+    * A non-strictly-convex cone is requested in a trivial lattice.
+
+    * A non-solid cone is requested but ``max_ambient_dim`` is zero.
+
+    * A non-solid cone is requested but ``lattice`` has dimension
+      zero.
 
     * A solid cone is requested but ``max_rays`` is less than
       ``min_ambient_dim``.
 
     * A solid cone is requested but ``max_rays`` is less than the
       dimension of ``lattice``.
-
-    * A non-solid cone is requested but ``max_ambient_dim`` is zero.
-
-    * A non-solid cone is requested but ``lattice`` has dimension zero.
 
     ALGORITHM:
 
@@ -6333,43 +6332,43 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         sage: random_cone(max_ambient_dim=0, min_rays=1)
         Traceback (most recent call last):
         ...
-        ValueError: all cones in zero dimensions have no generators.
-        Please increase max_ambient_dim to at least 1, or decrease min_rays.
+        ValueError: all cones in dimension d <= 2 have 2d or fewer rays.
+        Please increase max_ambient_dim or decrease min_rays.
 
         sage: random_cone(max_ambient_dim=1, min_rays=3)
         Traceback (most recent call last):
         ...
-        ValueError: all cones in zero/one dimensions have two or fewer
-        generators. Please increase max_ambient_dim to at least 2, or decrease
-        min_rays.
+        ValueError: all cones in dimension d <= 2 have 2d or fewer rays.
+        Please increase max_ambient_dim or decrease min_rays.
 
         sage: random_cone(max_ambient_dim=2, min_rays=5)
         Traceback (most recent call last):
         ...
-        ValueError: all cones in zero/one/two dimensions have four or fewer
-        generators. Please increase max_ambient_dim to at least 3, or decrease
-        min_rays.
+        ValueError: all cones in dimension d <= 2 have 2d or fewer rays.
+        Please increase max_ambient_dim or decrease min_rays.
+
+    This happens with a lattice, too::
 
         sage: L = ToricLattice(0)
         sage: random_cone(lattice=L, min_rays=1)
         Traceback (most recent call last):
         ...
-        ValueError: all cones in the given lattice have no generators.
+        ValueError: all cones in this lattice have 0 or fewer rays.
         Please decrease min_rays.
 
         sage: L = ToricLattice(1)
         sage: random_cone(lattice=L, min_rays=3)
         Traceback (most recent call last):
         ...
-        ValueError: all cones in the given lattice have two or fewer
-        generators. Please decrease min_rays.
+        ValueError: all cones in this lattice have 2 or fewer rays.
+        Please decrease min_rays.
 
         sage: L = ToricLattice(2)
         sage: random_cone(lattice=L, min_rays=5)
         Traceback (most recent call last):
         ...
-        ValueError: all cones in the given lattice have four or fewer
-        generators. Please decrease min_rays.
+        ValueError: all cones in this lattice have 4 or fewer
+        rays. Please decrease min_rays.
 
     Ensure that we can obtain a cone in three dimensions with a large
     number (in particular, more than 2*dim) rays. Note that at least
@@ -6388,20 +6387,35 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         3
         sage: set_random_seed(_initial_seed)
 
-    It is an error to request a non-strictly-convex trivial cone::
+    It is an error to request a non-strictly-convex cone in a trivial
+    lattice::
+
+        sage: random_cone(max_ambient_dim=0, strictly_convex=False)
+        Traceback (most recent call last):
+        ...
+        ValueError: all cones are strictly convex when max_ambient_dim
+        is zero.
 
         sage: L = ToricLattice(0, "L")
         sage: random_cone(lattice=L, strictly_convex=False)
         Traceback (most recent call last):
         ...
-        ValueError: all cones in this lattice are strictly convex (trivial).
+        ValueError: all cones in the trivial lattice are strictly
+        convex (trivial).
 
     Or a non-strictly-convex cone with fewer than two rays::
 
         sage: random_cone(max_rays=1, strictly_convex=False)
         Traceback (most recent call last):
         ...
-        ValueError: all cones are strictly convex when ``max_rays`` is
+        ValueError: all cones are strictly convex when max_rays is
+        less than two.
+
+        sage: L = ToricLattice(5)
+        sage: random_cone(lattice=L, max_rays=1, strictly_convex=False)
+        Traceback (most recent call last):
+        ...
+        ValueError: all cones are strictly convex when max_rays is
         less than two.
 
     But fine to ask for a strictly convex trivial cone::
@@ -6417,7 +6431,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         sage: random_cone(lattice=L, solid=False)
         Traceback (most recent call last):
         ...
-        ValueError: all cones in the given lattice are solid.
+        ValueError: all cones in the trivial lattice are solid.
 
         sage: random_cone(max_ambient_dim=0, solid=False)
         Traceback (most recent call last):
@@ -6430,7 +6444,8 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         sage: random_cone(min_ambient_dim=4, max_rays=3, solid=True)
         Traceback (most recent call last):
         ...
-        ValueError: max_rays must be at least min_ambient_dim for a solid cone.
+        ValueError: max_rays must be at least min_ambient_dim for a
+        solid cone.
 
         sage: L = ToricLattice(5)
         sage: random_cone(lattice=L, max_rays=3, solid=True)
@@ -6439,104 +6454,122 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         ValueError: max_rays must be at least 5 for a solid cone in this
         lattice.
 
+    A :exc:`ValueError` is thrown if a cone with too many rays is
+    requested in dimension less than three::
+
+        sage: K = random_cone(max_ambient_dim=1,
+        ....:                 min_rays=3,
+        ....:                 max_rays=3)
+        Traceback (most recent call last):
+        ...
+        ValueError: all cones in dimension d <= 2 have 2d or fewer
+        rays. Please increase max_ambient_dim or decrease min_rays.
+
+    A :exc:`ValueError` is thrown if a strictly convex cone is
+    requested with too many rays in dimension less than three (the
+    bound is lower than if we did not specify
+    ``strictly_convex=True``)::
+
+        sage: K = random_cone(max_ambient_dim=2,
+        ....:                 min_rays=3,
+        ....:                 max_rays=3,
+        ....:                 strictly_convex=True)
+        Traceback (most recent call last):
+        ...
+        ValueError: in dimension d <= 2, all strictly convex cones
+        have d rays. Please increase max_ambient_dim, or decrease
+        min_rays.
+
     """
     from sage.misc.prandom import randint, sample
 
     # Catch obvious mistakes so that we can generate clear error
-    # messages.
-
-    if min_ambient_dim < 0:
-        raise ValueError('min_ambient_dim must be nonnegative.')
+    # messages. We sanity check the min_rays and max_rays parameters
+    # first, since they do not depend on whether or not a lattice
+    # was specified.
 
     if min_rays < 0:
-        raise ValueError('min_rays must be nonnegative.')
-
-    if max_ambient_dim < 0:
-        raise ValueError('max_ambient_dim must be nonnegative.')
-
-    if (max_ambient_dim < min_ambient_dim):
-        msg = 'max_ambient_dim cannot be less than min_ambient_dim.'
-        raise ValueError(msg)
-
-    # The next three checks prevent an infinite loop (a futile
-    # search for more rays) in zero, one, or two dimensions.
-    if min_rays > 4 and max_ambient_dim < 3:
-        msg = 'all cones in zero/one/two dimensions have four or fewer '
-        msg += 'generators. Please increase max_ambient_dim to at least '
-        msg += '3, or decrease min_rays.'
-        raise ValueError(msg)
-
-    if min_rays > 2 and max_ambient_dim < 2:
-        msg = 'all cones in zero/one dimensions have two or fewer '
-        msg += 'generators. Please increase max_ambient_dim to at least '
-        msg += '2, or decrease min_rays.'
-        raise ValueError(msg)
-
-    if min_rays > 0 and max_ambient_dim == 0:
-        msg = 'all cones in zero dimensions have no generators. '
-        msg += 'Please increase max_ambient_dim to at least 1, or '
-        msg += 'decrease min_rays.'
-        raise ValueError(msg)
+        raise ValueError("min_rays must be nonnegative.")
 
     if max_rays < 0:
-        raise ValueError('max_rays must be nonnegative.')
+        raise ValueError("max_rays must be nonnegative.")
 
-    if (max_rays < min_rays):
-        raise ValueError('max_rays cannot be less than min_rays.')
+    if max_rays < min_rays:
+        raise ValueError("max_rays cannot be less than min_rays.")
 
-    # Also perform the "futile search" checks when a lattice is given,
-    # using its dimension rather than max_ambient_dim as the indicator.
-    if lattice is not None:
-        if min_rays > 4 and lattice.dimension() < 3:
-            msg = 'all cones in the given lattice have four or fewer '
-            msg += 'generators. Please decrease min_rays.'
-            raise ValueError(msg)
+    if strictly_convex is False and max_rays < 2:
+        raise ValueError("all cones are strictly convex when "
+                         "max_rays is less than two.")
 
-        if min_rays > 2 and lattice.dimension() < 2:
-            msg = 'all cones in the given lattice have two or fewer '
-            msg += 'generators. Please decrease min_rays.'
-            raise ValueError(msg)
+    if lattice is None:
+        if min_ambient_dim < 0:
+            raise ValueError("min_ambient_dim must be nonnegative.")
 
-        if min_rays > 0 and lattice.dimension() == 0:
-            msg = 'all cones in the given lattice have no generators. '
-            msg += 'Please decrease min_rays.'
-            raise ValueError(msg)
+        if max_ambient_dim < 0:
+            raise ValueError("max_ambient_dim must be nonnegative.")
 
-    # Sanity checks for strictly_convex.
-    if strictly_convex is not None and not strictly_convex:
-        if lattice is not None and lattice.dimension() == 0:
-            msg = 'all cones in this lattice are strictly convex (trivial).'
-            raise ValueError(msg)
-        if max_rays < 2:
-            msg = 'all cones are strictly convex when ``max_rays`` is '
-            msg += 'less than two.'
-            raise ValueError(msg)
+        if max_ambient_dim < min_ambient_dim:
+            raise ValueError("max_ambient_dim cannot be less than "
+                             "min_ambient_dim.")
 
-    # Sanity checks for solid cones.
-    if solid is not None and solid:
-        # The user wants a solid cone.
-        if lattice is None:
-            if max_rays < min_ambient_dim:
-                msg = 'max_rays must be at least min_ambient_dim for '
-                msg += 'a solid cone.'
-                raise ValueError(msg)
-        else:
-            # Repeat the checks above when a lattice is given.
-            if max_rays < lattice.dimension():
-                msg = "max_rays must be at least {0} for a solid cone "
-                msg += "in this lattice."
-                raise ValueError(msg.format(lattice.dimension()))
+        # The next check prevents an infinite loop (a futile search
+        # for more rays) in zero, one, or two dimensions.
+        if max_ambient_dim <= 2:
+            if min_rays > 2*max_ambient_dim:
+                raise ValueError("all cones in dimension d <= 2 have "
+                                 "2d or fewer rays. Please increase "
+                                 "max_ambient_dim or decrease "
+                                 "min_rays.")
 
-    # Sanity checks for non-solid cones.
-    if solid is not None and not solid:
-        if lattice is None:
+            elif strictly_convex and min_rays > max_ambient_dim:
+                raise ValueError("in dimension d <= 2, all strictly "
+                                 "convex cones have d rays. Please "
+                                 "increase max_ambient_dim, or "
+                                 "decrease min_rays.")
+
             if max_ambient_dim == 0:
-                msg = 'all cones are solid when max_ambient_dim is zero.'
-                raise ValueError(msg)
-        else:
-            if lattice.dimension() == 0:
-                msg = 'all cones in the given lattice are solid.'
-                raise ValueError(msg)
+                if strictly_convex is False:
+                    raise ValueError("all cones are strictly convex "
+                                     "when max_ambient_dim is zero.")
+                if solid is False:
+                    raise ValueError("all cones are solid when "
+                                     "max_ambient_dim is zero.")
+
+        if solid and max_rays < min_ambient_dim:
+            raise ValueError("max_rays must be at least "
+                             "min_ambient_dim for a solid cone.")
+    else:
+        # Also perform the "futile search" checks when a lattice is
+        # given, using its dimension rather than max_ambient_dim.
+        d = lattice.dimension()
+
+        if d <= 2:
+            if min_rays > 2*d:
+                raise ValueError("all cones in this lattice have "
+                                 f"{2*d} or fewer rays. Please "
+                                 "decrease min_rays.")
+            elif strictly_convex and min_rays > d:
+                raise ValueError("all strictly convex cones in "
+                                 f"this lattice have {d} or fewer "
+                                 "rays. Please decrease min_rays.")
+
+            if d.is_zero():
+                if strictly_convex is False:
+                    raise ValueError("all cones in the trivial lattice "
+                                     "are strictly convex (trivial).")
+                if solid is False:
+                    raise ValueError("all cones in the trivial lattice "
+                                     "are solid.")
+
+        if solid and max_rays < d:
+            raise ValueError(f"max_rays must be at least {d} for a "
+                             "solid cone in this lattice.")
+
+
+    # Parameter adjustment. In some cases are are able to adjust the
+    # dim/ray bounds to eliminate impossible combinations. We are
+    # going to attempt those combinations at random, so avoiding the
+    # ones that are doomed to fail should improve the average runtime.
 
     if solid:
         # If the user wants a solid cone, we need at least as many
@@ -6575,14 +6608,14 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
     # until we have a valid cone and occasionally throw everything out
     # and start over from scratch.
     while True:
+        # d = lattice.dimension() is already set above if
+        # the lattice is not None
         L = lattice
 
         if lattice is None:
             # No lattice given, make our own.
             d = randint(min_ambient_dim, max_ambient_dim)
             L = ToricLattice(d)
-        else:
-            d = L.dimension()
 
         _min_rays_this_iter = min_rays
         if solid:

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6593,25 +6593,8 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         #
         # Let's begin with an easier question: how many rays should we
         # start with? If we want to attain r rays in this iteration,
-        # then surely r is a good number to start with, even if some
-        # of them will be redundant?
-        #
-        # Not quite, because after 2*d rays, there is a greater
-        # tendency for them to be redundant. If, for example, the
-        # maximum number of rays is unbounded, then r could be enormous
-        # Ultimately that won't be a problem, because almost all of
-        # those rays will be thrown out. However, as we discovered in
-        # Issue #24517, simply generating the random rays in the first
-        # place (and storing them in a list) is problematic.
-        #
-        # Since the returns fall off around 2*d, we start with the
-        # smaller of the two numbers 2*d or r to ensure that we don't
-        # pay a huge performance penalty for things we're going to
-        # throw out anyway. This has a side effect, namely that if you
-        # ask for more than 2*d rays, then you'll probably get the
-        # minimum amount, because we'll start with 2*d and add them
-        # one-at-a-time (see below).
-        rays = [L.random_element() for i in range(min(r,2*d))]
+        # then surely r is a good number to start with?
+        rays = [L.random_element() for _ in range(r)]
 
         # The lattice parameter is required when no rays are given, so
         # we pass it in case r == 0 or d == 0 (or d == 1 but we're

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6426,7 +6426,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         lattice.
 
     """
-    from sage.misc.prandom import randint
+    from sage.misc.prandom import randint, sample
 
     # Catch obvious mistakes so that we can generate clear error
     # messages.
@@ -6682,14 +6682,31 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
                 L = K.lattice()
 
         if strictly_convex is False and K.is_strictly_convex():
-            # The user requested that the cone be NOT strictly
-            # convex. So it should contain some line, but it
-            # doesn't. If K has at least two rays, we can just
-            # make the second one a multiple of the first -- then
-            # K will contain a line. If K has fewer than two rays,
-            # we punt.
-            if len(rays) >= 2:
-                rays[1] = -rays[0]
+            # To make a pointed cone not-pointed is easy: add a
+            # negative multiple of an existing ray. Or if you're at
+            # max_rays already, replace an existing ray. Below we do
+            # this with a random number of new rays or replacements.
+            ray_slots = max_rays - K.n_rays()
+            if ray_slots == 0:
+                # Replace some rays with flipped copies of other rays.
+                if K.n_rays() >= 2:
+                    # Divide by four because highly un-pointed cones
+                    # are also un-interesting. (We have to divide by
+                    # at least two: if we flip half, we need the other
+                    # half for storage.)
+                    num_to_flip = randint(1, max(1, K.n_rays()//4))
+                    rays = [
+                        -K.ray(K.n_rays() - i - 1) if i <= num_to_flip
+                        else K.ray(i)
+                        for i in range(K.n_rays())
+                    ]
+                    K = Cone(rays, lattice=L)
+            elif K.n_rays() >= 1:
+                # Append negative multiples of some existing rays to
+                # guarantee that the cone contains lines.
+                num_to_flip = randint(1, min(K.n_rays(), ray_slots))
+                rays = list(K.rays())
+                rays.extend( -r for r in sample(rays, num_to_flip) )
                 K = Cone(rays, lattice=L)
 
         if is_valid(K):

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6187,9 +6187,6 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
 
     * A non-solid cone is requested but ``lattice`` has dimension zero.
 
-    * A non-solid cone is requested but ``min_rays`` is so large that
-      it guarantees a solid cone.
-
     ALGORITHM:
 
     First, a lattice is determined from ``min_ambient_dim`` and
@@ -6437,20 +6434,6 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         ValueError: max_rays must be at least 5 for a solid cone in this
         lattice.
 
-    A :exc:`ValueError` is thrown if a non-solid cone is requested but
-    ``min_rays`` guarantees a solid cone::
-
-        sage: random_cone(max_ambient_dim=4, min_rays=10, solid=False)
-        Traceback (most recent call last):
-        ...
-        ValueError: every cone is solid when min_rays > 2*(max_ambient_dim - 1).
-
-        sage: L = ToricLattice(4)
-        sage: random_cone(lattice=L, min_rays=10, solid=False)
-        Traceback (most recent call last):
-        ...
-        ValueError: every cone is solid when min_rays > 2*(d - 1) where d
-        is the dimension of the given lattice.
     """
 
     # Catch obvious mistakes so that we can generate clear error
@@ -6549,18 +6532,9 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
             if max_ambient_dim is not None and max_ambient_dim == 0:
                 msg = 'all cones are solid when max_ambient_dim is zero.'
                 raise ValueError(msg)
-            if (max_ambient_dim is not None and
-                    min_rays > 2 * (max_ambient_dim - 1)):
-                msg = 'every cone is solid when '
-                msg += 'min_rays > 2*(max_ambient_dim - 1).'
-                raise ValueError(msg)
         else:
             if lattice.dimension() == 0:
                 msg = 'all cones in the given lattice are solid.'
-                raise ValueError(msg)
-            if min_rays > 2 * (lattice.dimension() - 1):
-                msg = 'every cone is solid when min_rays > 2*(d - 1) '
-                msg += 'where d is the dimension of the given lattice.'
                 raise ValueError(msg)
 
     # Now that we've sanity-checked our parameters, we can massage the

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6193,43 +6193,92 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
 
     ALGORITHM:
 
-    First, a lattice is determined from ``min_ambient_dim`` and
-    ``max_ambient_dim`` (or from the supplied ``lattice``).
+    Loop until a valid cone is found.
 
-    Then, lattice elements are generated in batches and added to a
-    cone. This continues until either the cone meets the user's
-    requirements, or the cone is equal to the entire space (at which
-    point it is futile to generate more).
+    The first step inside the loop is to decide on a lattice. If a
+    ``lattice`` was supplied, it is used. Otherwise, we construct a new
+    lattice whose dimension is sampled randomly from the interval
+    ``[min_ambient_dim, max_ambient_dim]``.
 
-    We check whether or not the resulting cone meets the user's
-    requirements; if it does, it is returned. If not, we throw it away
-    and start over. This process repeats indefinitely until an
-    appropriate cone is generated.
+    Next we decide the number of rays to seek in this iteration. This
+    number is chosen randomly from ``[min_rays, max_rays]``. In both
+    cases (dimension and number of rays), minor adjustments may be
+    made to the interval to avoid impossible combinations.
+
+    With the lattice dimension and number of rays fixed, random
+    lattice elements (rays) are generated in batches and added to a
+    cone. This continues until the cone either has enough rays or
+    becomes the entire ambient space, at which point it is futile to
+    append more.
+
+    If the cone is equal to the ambient space, we check to see if it
+    meets the user's requirements. If it does, it is returned; if not,
+    we throw it away and start over with a new (random, admissible)
+    dimension and number of rays in mind.
+
+    If the cone is *not* equal to the ambient space, and if ``solid``
+    or ``strictly_convex`` is not ``None``, we attempt some
+    adjustments:
+
+    * make a non-solid cone solid by adding more rays,
+
+    * make a solid cone non-solid by embedding it in a space
+      of higher dimension,
+
+    * make a pointed cone non-pointed by appending negative
+      multiples of existing rays (if there's room for more rays),
+
+    * make a pointed cone non-pointed by replacing existing rays
+      with negative multiples of others (if we are at max_rays).
+
+    (We do *not* use
+    :meth:`ConvexRationalPolyhedralCone.solid_restriction` to make a
+    non-solid cone solid. The solid restriction does not affect the
+    ray count, but it does involve a change of basis that turns your
+    existing rays into boring standard basis vectors.)
+
+    Afterwards the cone is checked against the requirements. If it is
+    valid, we return it; otherwise we throw it out and begin anew.
+
+    Building a cone that meets the user's critereia is inherently a
+    bottom-up process. We cannot know how many rays in a given set are
+    extreme until we reduce them with :func:`Cone`, but in the
+    current implementation, reducing the rays also happens to
+    normalize them. If we desire ``r`` rays and generate ``r`` at
+    random, we are likely to discover that some are redundant and that
+    we need to append more. On the other hand, if generate more than
+    ``r`` with the expectation that some will be eliminated, we
+    increase the likelihood that :func:`Cone` normalizes them to
+    boring standard basis vectors.
+
+    This bottom-up approach motivates fixing the number of rays ``r``
+    attempted in each iteration. If ``r`` were not fixed -- if we were
+    willing to accept any number of rays between the min/max in any
+    iteration -- then we would almost always stop as soon as we hit
+    ``min_rays``. That would be legal, but perhaps unexpected: it is
+    reasonable to assume that the result will have a number of rays
+    distributed throughout ``[min_rays, max_rays]``. That said, this
+    approach greatly increases the failure rate of the loop.
 
     The default upper bounds on the ambient dimension and number of
-    rays are chosen so that each iteration of this process remains
-    fast. The following should be considered an implementation detail,
-    but at the beginning of each iteration we fix the number of rays
-    to attempt for the duration of that iteration. This is necessary
-    because we begin with a cone that likely has too few rays, and add
-    rays to it in batches: if we did not have a fixed number of rays
-    in mind, we would tend to stop as soon as we reached the minimum
-    allowable number of rays. That would be legal, but not what people
-    expect.
+    rays ensure that failed iterations remain fast. Adding rays to the
+    cone consists of appending vectors to the ray set, and calling
+    :func:`Cone` on the result. This can be quite slow, and we may
+    have to do it many times. As the speed of :func:`Cone` depends
+    mainly on the degree and number of rays given to it, those are the
+    critical factors in the worst-case performance.
 
-    Adding rays to the cone consists of appending vectors to the ray
-    set, and calling :func:`Cone` on the result. This can be quite
-    slow, and we may have to do it many times. As the speed of
-    :func:`Cone` depends mainly on the degree and number of rays given
-    to it, those are the critical factors in the worst-case
-    performance.
+    For the time being, we forego the following adjustments because
+    they remove the cone's :meth:`ConvexRationalPolyhedralCone.lines`,
+    thereby skewing the number of rays towards the lower end of
+    ``[min_rays, max_rays]``:
 
-    Keep in mind however that if you are looking for a cone with
-    hard-to-generate properties (a strictly-convex cone with at least
-    twenty extreme rays, for example), we can make no promises about
-    the overall runtime. The default bounds allow unsatisfactory cones
-    to be contructed/discarded quickly, but we may have to
-    construct/discard them for eternity.
+    * Using :meth:`ConvexRationalPolyhedralCone.strict_quotient` to
+      make a non-pointed cone pointed.
+
+    * Projecting a non-pointed cone onto the orthogonal complement
+      of its :meth:`ConvexRationalPolyhedralCone.lines` to obtain a
+      pointed cone.
 
     EXAMPLES:
 

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6366,23 +6366,22 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         return len(self.irreducible_factors()) > 1
 
 
-def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=None,
-                min_rays=0, max_rays=None, strictly_convex=None, solid=None):
+def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
+                min_rays=0, max_rays=16, strictly_convex=None, solid=None):
     r"""
     Generate a random convex rational polyhedral cone.
 
-    Lower and upper bounds may be provided for both the dimension of the
-    ambient space and the number of generating rays of the cone. If a
-    lower bound is left unspecified, it defaults to zero. Unspecified
-    upper bounds will be chosen randomly, unless you set ``solid``, in
-    which case they are chosen a little more wisely.
+    Lower and upper bounds may be provided for both the dimension of
+    the ambient space and the number of generating rays that the cone
+    will possess. If lower bounds are not provided, they default to
+    zero. Unspecified upper bounds default to reasonable values. You
+    can additionally request that the cone be strictly convex (or
+    not) or solid (or not).
 
-    You may specify the ambient ``lattice`` for the returned cone. In
-    that case, the ``min_ambient_dim`` and ``max_ambient_dim``
-    parameters are ignored.
-
-    You may also request that the returned cone be strictly convex (or
-    not). Likewise you may request that it be (non-)solid.
+    As an alternative to the dimension bounds, you can provide a
+    ``lattice`` for the returned cone to live in. In that case, the
+    ``min_ambient_dim`` and ``max_ambient_dim`` parameters are
+    ignored.
 
     .. WARNING::
 
@@ -6416,14 +6415,16 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=None,
     - ``min_ambient_dim`` -- (default: zero) a nonnegative integer
       representing the minimum dimension of the ambient lattice
 
-    - ``max_ambient_dim`` -- (default: random) a nonnegative integer
-      representing the maximum dimension of the ambient lattice
+    - ``max_ambient_dim`` -- (default: 8) a nonnegative integer
+      representing the maximum dimension of the ambient lattice,
+      or ``None`` for no maximum.
 
     - ``min_rays`` -- (default: zero) a nonnegative integer representing
       the minimum number of generating rays of the cone
 
-    - ``max_rays`` -- (default: random) a nonnegative integer representing
-      the maximum number of generating rays of the cone
+    - ``max_rays`` -- (default: 16) a nonnegative integer representing
+      the maximum number of generating rays of the cone, or ``None``
+      for no maximum.
 
     - ``strictly_convex`` -- (default: random) whether or not to make the
       returned cone strictly convex. Specify ``True`` for a strictly convex
@@ -6433,6 +6434,22 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=None,
     - ``solid`` -- (default: random) whether or not to make the returned
       cone solid. Specify ``True`` for a solid cone, ``False`` for a
       non-solid cone, or ``None`` if you don't care.
+
+    The ``max_ambient_dim`` and ``max_rays`` should be chosen
+    carefully. While in theory it is possible for `n+1` rays to
+    generate an `n`-dimensional vector space, if you actually try it,
+    they will normalized to a set containing `2n` rays (plus/minus a
+    basis). If the ambient space is to be generated randomly,
+    ``max_rays`` must therefore be at least twice ``max_ambient_dim``.
+
+    On the other hand, the higher ``max_rays`` is, the less likely we
+    are in a given iteration (see the ALGORITHM) to find a satisfatory
+    cone. As we attempt to find more than `2n` independent rays in an
+    `n`-dimensional space, it becomes increasingly likely that we will
+    generate the entire vector space, fail, and be forced start
+    over. While there do exist pointed cones (solid or not) in `n \ge
+    3` dimensions with more than `2n` rays, they are unusually hard to
+    find, and not comparably interesting.
 
     OUTPUT: a new, randomly generated cone
 
@@ -6496,6 +6513,30 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=None,
     requirements; if it does, it is returned. If not, we throw it away
     and start over. This process repeats indefinitely until an
     appropriate cone is generated.
+
+    The default upper bounds on the ambient dimension and number of
+    rays are chosen so that each iteration of this process remains
+    fast. The following should be considered an implementation detail,
+    but at the beginning of each iteration we fix the number of
+    rays to attempt for the duration of that iteration. This is
+    necessary because we add rays to the cone one at a time: if we did
+    not have a fixed number of rays in mind, we would often stop as
+    soon as we reached the minimum allowable number of rays. That
+    would be legal, but not what people expect.
+
+    Adding a ray to the cone consists of appending a vector to the ray
+    set, and calling :func:`Cone` on the result. This can be quite
+    slow, and we may have to do it many times. As the speed of
+    :func:`Cone` depends mainly on the degree and number of rays given
+    to it, those are the critical factors in the worst-case
+    performance.
+
+    Keep in mind however that if you are looking for a cone with
+    hard-to-generate properties (a strictly-convex cone with at least
+    twenty extreme rays, for example), we can make no promises about
+    the overall runtime. The default bounds ensure that each
+    unsatisfactory cone can be contructed/discarded quickly, but we
+    may have to construct/discard them for eternity.
 
     EXAMPLES:
 

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6633,36 +6633,16 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
             rays.extend(L.random_element() for _ in range(ray_gap))
             K = Cone(rays, lattice=L)
 
-        if strictly_convex is not None:
-            if strictly_convex:
-                if not K.is_strictly_convex():
-                    # The user wants a strictly convex cone, but
-                    # didn't get one. So let's take our rays, and give
-                    # them all either (strictly) positive or negative
-                    # leading coordinates. This makes the resulting
-                    # cone strictly convex. Whether or not those
-                    # coordinates become positive/negative is chosen
-                    # randomly.
-                    pm = 1 - 2*randint(0,1)  # plus or minus one
-
-                    # rays has immutable elements
-                    rays = [copy(ray) for ray in rays]
-
-                    for i, ray in enumerate(rays):
-                        rays[i][0] = pm * (ray[0].abs() + 1)
-
-                    K = Cone(rays, lattice=L)
-            else:
-                # The user requested that the cone be NOT strictly
-                # convex. So it should contain some line...
-                if K.is_strictly_convex():
-                    # ...but it doesn't. If K has at least two rays,
-                    # we can just make the second one a multiple of
-                    # the first -- then K will contain a line. If K
-                    # has fewer than two rays, we punt.
-                    if len(rays) >= 2:
-                        rays[1] = -rays[0]
-                        K = Cone(rays, lattice=L)
+        if strictly_convex is False and K.is_strictly_convex():
+            # The user requested that the cone be NOT strictly
+            # convex. So it should contain some line, but it
+            # doesn't. If K has at least two rays, we can just
+            # make the second one a multiple of the first -- then
+            # K will contain a line. If K has fewer than two rays,
+            # we punt.
+            if len(rays) >= 2:
+                rays[1] = -rays[0]
+                K = Cone(rays, lattice=L)
 
         if is_valid(K):
             # Loop if we don't have a valid cone.

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6425,6 +6425,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         lattice.
 
     """
+    from sage.misc.prandom import choice, randint
 
     # Catch obvious mistakes so that we can generate clear error
     # messages.
@@ -6538,19 +6539,6 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         if max_rays < max_ambient_dim:
             max_ambient_dim = max_rays
 
-    def random_min_max(l, u):
-        r"""
-        We need to handle two cases for the upper bounds, and we need
-        to do the same thing for max_ambient_dim/max_rays. So we consolidate
-        the logic here.
-        """
-        # We have an upper bound, and it's greater than or equal
-        # to our lower bound. So we generate a random integer in
-        # [0,u-l], and then add it to l to get something in
-        # [l,u]. To understand the "+1", check the
-        # ZZ.random_element() docs.
-        return l + ZZ.random_element(u - l + 1)
-
     def is_valid(K):
         r"""
         Check if the given cone is valid; that is, if its ambient
@@ -6579,7 +6567,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
 
         if lattice is None:
             # No lattice given, make our own.
-            d = random_min_max(min_ambient_dim, max_ambient_dim)
+            d = randint(min_ambient_dim, max_ambient_dim)
             L = ToricLattice(d)
         else:
             d = L.dimension()
@@ -6597,7 +6585,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
             _min_rays_this_iter = d
 
         # The number of rays that we will try to attain in this iteration.
-        r = random_min_max(_min_rays_this_iter, max_rays)
+        r = randint(_min_rays_this_iter, max_rays)
 
         # The rays are trickier to generate, since we could generate v and
         # 2*v as our "two rays." In that case, the resulting cone would
@@ -6656,7 +6644,6 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
                     # cone strictly convex. Whether or not those
                     # coordinates become positive/negative is chosen
                     # randomly.
-                    from sage.misc.prandom import choice
                     pm = choice([-1,1])
 
                     # rays has immutable elements

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -1000,7 +1000,7 @@ class IntegralRayCollection(SageObject, Hashable, Iterable):
         The dual lattice of the dual lattice of a random cone should be
         the original lattice::
 
-            sage: K = random_cone(max_ambient_dim=8, max_rays=10)
+            sage: K = random_cone()
             sage: K.dual_lattice().dual() is K.lattice()
             True
         """
@@ -1194,7 +1194,7 @@ class IntegralRayCollection(SageObject, Hashable, Iterable):
         The codimension of a cone should be an integer between zero and
         the dimension of the ambient space, inclusive::
 
-            sage: K = random_cone(max_ambient_dim = 8)
+            sage: K = random_cone()
             sage: c = K.codim()
             sage: c in ZZ
             True
@@ -1203,13 +1203,13 @@ class IntegralRayCollection(SageObject, Hashable, Iterable):
 
         A solid cone should have codimension zero::
 
-            sage: K = random_cone(max_ambient_dim = 8, solid = True)
+            sage: K = random_cone(solid=True)
             sage: K.codim()
             0
 
         The codimension of a cone is equal to the lineality of its dual::
 
-            sage: K = random_cone(max_ambient_dim = 8)
+            sage: K = random_cone()
             sage: K.codim() == K.dual().lineality()
             True
         """
@@ -1266,7 +1266,7 @@ class IntegralRayCollection(SageObject, Hashable, Iterable):
 
         The span of a solid cone is the entire ambient space::
 
-            sage: K = random_cone(max_ambient_dim=6, max_rays=8, solid=True)
+            sage: K = random_cone(solid=True)
             sage: K.span().vector_space() == K.lattice().vector_space()
             True
         """
@@ -2295,7 +2295,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         The dual cone of a (random) dual cone is the original cone::
 
-            sage: K = random_cone(max_ambient_dim=8, max_rays=10)
+            sage: K = random_cone(max_ambient_dim=6, max_rays=15)
             sage: K.dual().dual() is K
             True
         """
@@ -3100,7 +3100,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         A random cone is equivalent to itself::
 
-            sage: K = random_cone(max_ambient_dim=8, max_rays=10)
+            sage: K = random_cone()
             sage: K.is_equivalent(K)
             True
         """
@@ -3147,7 +3147,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         Any cone is a face of itself::
 
-            sage: K = random_cone(max_ambient_dim=8, max_rays=10)
+            sage: K = random_cone()
             sage: K.is_face_of(K)
             True
         """
@@ -3238,7 +3238,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         A random (strictly convex) cone is isomorphic to itself::
 
-            sage: K = random_cone(max_ambient_dim=6, strictly_convex=True)
+            sage: K = random_cone(strictly_convex=True)
             sage: K.is_isomorphic(K)                                                    # needs sage.graphs
             True
         """
@@ -3408,7 +3408,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         Random test for the claim made in the ``OUTPUT`` block::
 
-            sage: K = random_cone(max_ambient_dim = 8)
+            sage: K = random_cone()
             sage: K.is_pointed() == K.lineality().is_zero()
             True
 
@@ -3435,7 +3435,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         The linear subspace of any closed convex cone can be identified
         with the orthogonal complement of the span of its dual::
 
-            sage: K = random_cone(max_ambient_dim = 8)
+            sage: K = random_cone()
             sage: expected = K.dual().span().vector_space().complement()
             sage: K.linear_subspace() == expected
             True
@@ -3477,7 +3477,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         responses.) By testing it here, we "guarantee" that it is a
         safe assumption to make in user code::
 
-            sage: K = random_cone(max_ambient_dim=12, max_rays=10)
+            sage: K = random_cone()
             sage: V = K.lattice().vector_space()
             sage: L = [V(l) for l in K.lines()]
             sage: all( L[i].inner_product(L[j]).is_zero()
@@ -3487,9 +3487,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             True
 
             sage: K = random_cone(strictly_convex=False,
-            ....:                 min_ambient_dim=4,
-            ....:                 max_ambient_dim=12,
-            ....:                 max_rays=15)
+            ....:                 min_ambient_dim=4)
             sage: V = K.lattice().vector_space()
             sage: L = [V(l) for l in K.lines()]
             sage: all( L[i].inner_product(L[j]).is_zero()
@@ -3500,8 +3498,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
             sage: K = random_cone(strictly_convex=False,
             ....:                 min_ambient_dim=8,
-            ....:                 max_ambient_dim=12,
-            ....:                 min_rays=4, max_rays=15)
+            ....:                 min_rays=4)
             sage: V = K.lattice().vector_space()
             sage: L = [V(l) for l in K.lines()]
             sage: all( L[i].inner_product(L[j]).is_zero()
@@ -3654,19 +3651,19 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         The strict quotient of any cone should be strictly convex::
 
-            sage: K = random_cone(max_ambient_dim=6)
+            sage: K = random_cone()
             sage: K.strict_quotient().is_strictly_convex()
             True
 
         If the original cone is solid, then its strict quotient is proper::
 
-            sage: K = random_cone(max_ambient_dim=6, solid=True)
+            sage: K = random_cone(solid=True)
             sage: K.strict_quotient().is_proper()
             True
 
         The strict quotient of a strictly convex cone is itself::
 
-            sage: K = random_cone(max_ambient_dim=6, strictly_convex=True)
+            sage: K = random_cone(strictly_convex=True)
             sage: K.strict_quotient() is K
             True
 
@@ -3674,13 +3671,13 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         our dual, so the strict quotient cannot have a larger dimension
         than our dual::
 
-            sage: K = random_cone(max_ambient_dim=6)
+            sage: K = random_cone()
             sage: K.strict_quotient().dim() <= K.dual().dim()
             True
 
         The strict quotient is idempotent::
 
-            sage: K = random_cone(max_ambient_dim=6)
+            sage: K = random_cone()
             sage: K1 = K.strict_quotient()
             sage: K2 = K1.strict_quotient()
             sage: K1 is K2
@@ -3765,42 +3762,42 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         The solid restriction of any cone is solid::
 
-            sage: K = random_cone(max_ambient_dim=6)
+            sage: K = random_cone()
             sage: K.solid_restriction().is_solid()
             True
 
         If a cone :meth:`is_strictly_convex`, then its solid restriction
         :meth:`is_proper`::
 
-            sage: K = random_cone(max_ambient_dim=6, strictly_convex=True)
+            sage: K = random_cone(strictly_convex=True)
             sage: K.solid_restriction().is_proper()
             True
 
         The solid restriction of a cone has the same dimension as the
         original::
 
-            sage: K = random_cone(max_ambient_dim=6)
+            sage: K = random_cone()
             sage: K.solid_restriction().dim() == K.dim()
             True
 
         The solid restriction of a cone has the same number of rays as
         the original::
 
-            sage: K = random_cone(max_ambient_dim=6)
+            sage: K = random_cone()
             sage: K.solid_restriction().n_rays() == K.n_rays()
             True
 
         The solid restriction of a cone has the same lineality as the
         original::
 
-            sage: K = random_cone(max_ambient_dim=6)
+            sage: K = random_cone()
             sage: K.solid_restriction().lineality() == K.lineality()
             True
 
         The solid restriction of a cone has the same number of facets as
         the original::
 
-            sage: K = random_cone(max_ambient_dim=6)
+            sage: K = random_cone()
             sage: len(K.solid_restriction().facets()) == len(K.facets())                # needs sage.graphs
             True
         """
@@ -4717,7 +4714,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         A closed convex cone is solid if and only if its dual is
         strictly convex::
 
-            sage: K = random_cone(max_ambient_dim=8)
+            sage: K = random_cone()
             sage: K.is_solid() == K.dual().is_strictly_convex()
             True
         """
@@ -4869,7 +4866,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         The lineality of a cone should be an integer between zero and the
         dimension of the ambient space, inclusive::
 
-            sage: K = random_cone(max_ambient_dim=8)
+            sage: K = random_cone()
             sage: l = K.lineality()
             sage: l in ZZ
             True
@@ -4878,7 +4875,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         A strictly convex cone should have lineality zero::
 
-            sage: K = random_cone(max_ambient_dim=8, strictly_convex=True)
+            sage: K = random_cone(strictly_convex=True)
             sage: K.lineality()
             0
         """
@@ -5284,7 +5281,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         Any cone should contain a random element of itself::
 
-            sage: K = random_cone(max_ambient_dim=8)
+            sage: K = random_cone()
             sage: K.contains(K.random_element())
             True
             sage: K.contains(K.random_element(ring=QQ))
@@ -5293,7 +5290,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         The ambient vector space of the cone should contain a random
         element of the cone::
 
-            sage: K = random_cone(max_ambient_dim=8)
+            sage: K = random_cone()
             sage: K.random_element() in K.lattice().vector_space()
             True
             sage: K.random_element(ring=QQ) in K.lattice().vector_space()
@@ -5301,21 +5298,21 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         By default, the random element should live in this cone's lattice::
 
-            sage: K = random_cone(max_ambient_dim=8)
+            sage: K = random_cone()
             sage: K.random_element() in K.lattice()
             True
 
         A strictly convex cone contains no lines, and thus no negative
         multiples of any of its elements besides zero::
 
-            sage: K = random_cone(max_ambient_dim=8, strictly_convex=True)
+            sage: K = random_cone(strictly_convex=True)
             sage: x = K.random_element()
             sage: x.is_zero() or not K.contains(-x)
             True
 
         The sum of random elements of a cone lies in the cone::
 
-            sage: K = random_cone(max_ambient_dim=8)
+            sage: K = random_cone()
             sage: K.contains(sum(K.random_element() for i in range(10)))
             True
             sage: K.contains(sum(K.random_element(QQ) for i in range(10)))
@@ -5324,7 +5321,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         The sum of random elements of a cone belongs to its ambient
         vector space::
 
-            sage: K = random_cone(max_ambient_dim=8)
+            sage: K = random_cone()
             sage: V = K.lattice().vector_space()
             sage: sum(K.random_element() for i in range(10)) in V
             True
@@ -5334,7 +5331,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         By default, the sum of random elements of the cone should live
         in the cone's lattice::
 
-            sage: K = random_cone(max_ambient_dim=8)
+            sage: K = random_cone()
             sage: sum(K.random_element() for i in range(10)) in K.lattice()
             True
         """
@@ -6338,8 +6335,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
         Reducibility is preserved under linear isomorphisms::
 
             sage: # long time
-            sage: K = random_cone(strictly_convex=True,
-            ....:                 max_ambient_dim=6)
+            sage: K = random_cone(strictly_convex=True)
             sage: n = K.ambient_dim()
             sage: q = QQ._random_nonzero_element()
             sage: A = q*matrix.random(QQ, n, algorithm='unimodular')
@@ -6355,7 +6351,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: # long time
             sage: K = random_cone(strictly_convex=True,
             ....:                 solid=True,
-            ....:                 max_ambient_dim=6,
             ....:                 min_rays=1)
             sage: K.is_reducible() == (K.lyapunov_rank() != 1)
             True
@@ -6599,7 +6594,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
     It's hard to test the output of a random process, but we can at
     least make sure that we get a cone back::
 
-        sage: K = random_cone(max_ambient_dim=6, max_rays=10)
+        sage: K = random_cone()
         sage: isinstance(K, sage.geometry.abc.ConvexRationalPolyhedralCone)
         True
 

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6633,6 +6633,17 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
             rays.extend(L.random_element() for _ in range(ray_gap))
             K = Cone(rays, lattice=L)
 
+        if K.is_full_space():
+            # When K is the full space, Cone() normalizes its rays to
+            # plus/minus the standard basis. If the full space is an
+            # acceptable result, OK, whatever, return it. But
+            # otherwise, do not try to tweak the world's most
+            # uninteresting set of generators.
+            if is_valid(K):
+                return K
+            else:
+                continue
+
         if strictly_convex is False and K.is_strictly_convex():
             # The user requested that the cone be NOT strictly
             # convex. So it should contain some line, but it

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6537,19 +6537,21 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
                 msg = 'all cones in the given lattice are solid.'
                 raise ValueError(msg)
 
-    # Now that we've sanity-checked our parameters, we can massage the
-    # min/maxes for (non-)solid cones. It doesn't violate the user's
-    # expectation to increase a minimum, decrease a maximum, or fix an
-    # "I don't care" parameter.
-    if solid is not None:
-        if solid:
-            # If max_ambient_dim is "I don't care", we can set it so that we
-            # guaranteed to generate a solid cone.
-            if max_rays is not None and max_ambient_dim is None:
-                # We won't make max_ambient_dim less than min_ambient_dim,
-                # since we already checked that
-                # min_ambient_dim <= min_rays = max_ambient_dim.
-                max_ambient_dim = min_rays
+    if solid and max_rays is not None:
+        # If the user wants a solid cone, we need at least as many
+        # rays as the dimension. If max_rays was specified, then
+        # above we have already verified that
+        #
+        # (a) max_rays >= min_ambient_dim
+        # (b) max_ambient_dim >= min_ambient_dim, if max_ambient_dim
+        #     is set
+        #
+        # As a result we can fudge the max_ambient_dim down to
+        # max_rays, ensuring that we don't perform any pointless
+        # iterations in a space that's too big for max_rays to
+        # generate a solid cone.
+        if max_ambient_dim is None or max_ambient_dim > max_rays:
+            max_ambient_dim = max_rays
 
     def random_min_max(l, u):
         r"""

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6602,9 +6602,9 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         # making a strictly convex cone).
         K = Cone(rays, lattice=L)
 
-        # Now, some of the rays that we generated were probably redundant,
-        # so we need to come up with more. We can obviously stop if K
-        # becomes the entire ambient vector space.
+        # Now, some of the rays that we generated were probably
+        # redundant, so we need to come up with more. We can obviously
+        # stop if K becomes the entire ambient vector space.
         #
         # We're still not guaranteed to have the correct number of
         # rays after this! Since we normalize the generators in the
@@ -6612,10 +6612,25 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         # adding e.g. (1,1) to [(0,1), (0,-1)]. Rather than trying to
         # mangle what we have, we just start over if we get a cone
         # that won't work.
-        while r > K.n_rays() and not K.is_full_space():
+        while True:
+            # How many more rays do we need? *At least* this many.
+            ray_gap = r - K.n_rays()
+
+            if solid:
+                # But if we need a solid cone, and if the
+                # corresponding "dimension gap" is larger than the
+                # ray_gap, we should use the dimension gap instead
+                # because each additional ray can occupy at most one
+                # vacant dimension.
+                ray_gap = max(ray_gap, d - K.dim())
+
+            # ray_gap can be negative if e.g. r=3 rays that generate
+            # R^2 get normalized to four plus/minus basis vectors.
+            if ray_gap <= 0 or K.is_full_space():
+                break
+
             rays = list(K.rays())
-            rays.extend(L.random_element()
-                        for _ in range(r - K.n_rays()))
+            rays.extend(L.random_element() for _ in range(ray_gap))
             K = Cone(rays, lattice=L)
 
         if strictly_convex is not None:

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6148,9 +6148,12 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
     3` dimensions with more than `2n` rays, they are unusually hard to
     find, and not comparably interesting.
 
-    OUTPUT: a new, randomly generated cone
+    OUTPUT:
 
-    A :exc:`ValueError` will be thrown under the following conditions:
+    In most cases, a new, randomly generated
+    :class:`ConvexRationalPolyhedralCone` will be returned. A
+    :exc:`ValueError` will however be raised under the following
+    conditions:
 
     * Any of ``min_ambient_dim``, ``max_ambient_dim``, ``min_rays``,
       or ``max_rays`` are negative.

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6546,18 +6546,15 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         dimension and number of rays meet the upper and lower bounds
         provided by the user.
         """
-        if lattice is None:
-            # We only care about min/max_ambient_dim when no lattice is given.
-            if not (min_ambient_dim <= K.lattice_dim() <= max_ambient_dim):
-                return False
-        else:
-            if K.lattice() is not lattice:
-                return False
-        return all([K.n_rays() >= min_rays,
-                    K.n_rays() <= max_rays,
-                    solid is None or K.is_solid() == solid,
-                    strictly_convex is None or
-                    K.is_strictly_convex() == strictly_convex])
+        return all((
+          lattice is None or K.lattice() is lattice,
+          lattice is not None
+            or min_ambient_dim <= K.lattice_dim() <= max_ambient_dim,
+          min_rays <= K.n_rays() <= max_rays,
+          solid is None or K.is_solid() == solid,
+          strictly_convex is None
+            or K.is_strictly_convex() == strictly_convex
+        ))
 
     # Now we actually compute the thing. To avoid recursion (and the
     # associated "maximum recursion depth exceeded" error), we loop

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6366,7 +6366,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
 
         sage: # long time
         sage: _initial_seed = initial_seed()
-        sage: set_random_seed(8)
+        sage: set_random_seed(12)
         sage: K = random_cone(max_ambient_dim=3, min_rays=7)
         sage: K.n_rays() >= 7
         True

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6656,6 +6656,31 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
                 # We had to stop because we hit max_rays
                 continue
 
+        if solid is False and K.is_solid():
+            # To go from not-solid to solid, we add rays. But to go
+            # from solid to not-solid? Removing rays sounds like a
+            # good idea at first, but thanks to the normalization that
+            # happens in Cone(), you are likely to wind up with more
+            # boring rays than you would have otherwise. (The ambient
+            # space is a solid cone, but every cone obtained by
+            # deleting generators from it has only orthogonal standard
+            # basis vectors as generators.) In any case, that's why
+            # there is no fallback here for when K is already of
+            # maximum dimension or a lattice was specified.
+            if lattice is None and K.dim() < max_ambient_dim:
+                # Embed what we've got into a space of one greater
+                # dimension. Afterward we hit the cone with a random
+                # unitary matrix, so that the form of the result is
+                # not so predictable.
+                K = Cone([r.list() + [0] for r in K.rays()],
+                         check=False)
+                A = matrix.random(K.lattice().base_field(),
+                                  K.lattice_dim(),
+                                  algorithm="unitary")
+                K = Cone([A*r.dense_vector() for r in K.rays()],
+                         check=False)
+                L = K.lattice()
+
         if strictly_convex is False and K.is_strictly_convex():
             # The user requested that the cone be NOT strictly
             # convex. So it should contain some line, but it

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6550,14 +6550,6 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
                 # since we already checked that
                 # min_ambient_dim <= min_rays = max_ambient_dim.
                 max_ambient_dim = min_rays
-        else:
-            if max_rays is None and max_ambient_dim is not None:
-                # This is an upper limit on the number of rays in a
-                # non-solid cone.
-                max_rays = 2*(max_ambient_dim - 1)
-            if max_rays is None and lattice is not None:
-                # Same thing, except when we're given a lattice.
-                max_rays = 2*(lattice.dimension() - 1)
 
     def random_min_max(l, u):
         r"""

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6612,7 +6612,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
     # going to attempt those combinations at random, so avoiding the
     # ones that are doomed to fail should improve the average runtime.
 
-    if solid:
+    if solid and max_rays < max_ambient_dim:
         # If the user wants a solid cone, we need at least as many
         # rays as the dimension. If max_rays was specified, then
         # above we have already verified that
@@ -6625,8 +6625,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         # max_rays, ensuring that we don't perform any pointless
         # iterations in a space that's too big for max_rays to
         # generate a solid cone.
-        if max_rays < max_ambient_dim:
-            max_ambient_dim = max_rays
+        max_ambient_dim = max_rays
 
     if strictly_convex is False and min_rays < 2:
         # We've already verified that max_rays >= 2. Increase min_rays

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6584,8 +6584,20 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         else:
             d = L.dimension()
 
+        _min_rays_this_iter = min_rays
+        if solid:
+            # If a solid cone was requested, then before the loop, we
+            # set max_ambient_dim to max_rays as a performance hint.
+            # Without more information, that was the best we could do,
+            # but now we know the dimension that we are seeking for
+            # this iteration. If min_rays it too low to achieve it,
+            # we can use a higher lower bound (but still within
+            # max_rays). Note: the aforementioned hint guarantees
+            # that d <= max_rays.
+            _min_rays_this_iter = d
+
         # The number of rays that we will try to attain in this iteration.
-        r = random_min_max(min_rays, max_rays)
+        r = random_min_max(_min_rays_this_iter, max_rays)
 
         # The rays are trickier to generate, since we could generate v and
         # 2*v as our "two rays." In that case, the resulting cone would

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6587,6 +6587,11 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         if max_rays < max_ambient_dim:
             max_ambient_dim = max_rays
 
+    if strictly_convex is False and min_rays < 2:
+        # We've already verified that max_rays >= 2. Increase min_rays
+        # to avoid pointless loops with r=0 or r=1
+        min_rays = 2
+
     def is_valid(K):
         r"""
         Check if the given cone is valid; that is, if its ambient

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6742,8 +6742,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
             # uninteresting set of generators.
             if is_valid(K):
                 return K
-            else:
-                continue
+            continue
 
         if solid and not K.is_solid():
             # Just add rays until we get a solid cone? Adding rays is

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -995,14 +995,6 @@ class IntegralRayCollection(SageObject, Hashable, Iterable):
             Ambient free module of rank 3
             over the principal ideal domain Integer Ring
 
-        TESTS:
-
-        The dual lattice of the dual lattice of a random cone should be
-        the original lattice::
-
-            sage: K = random_cone()
-            sage: K.dual_lattice().dual() is K.lattice()
-            True
         """
         try:
             return self.lattice().dual()
@@ -1189,29 +1181,6 @@ class IntegralRayCollection(SageObject, Hashable, Iterable):
             sage: K.codim()
             2
 
-        TESTS:
-
-        The codimension of a cone should be an integer between zero and
-        the dimension of the ambient space, inclusive::
-
-            sage: K = random_cone()
-            sage: c = K.codim()
-            sage: c in ZZ
-            True
-            sage: 0 <= c <= K.lattice_dim()
-            True
-
-        A solid cone should have codimension zero::
-
-            sage: K = random_cone(solid=True)
-            sage: K.codim()
-            0
-
-        The codimension of a cone is equal to the lineality of its dual::
-
-            sage: K = random_cone()
-            sage: K.codim() == K.dual().lineality()
-            True
         """
         # same as ConvexSet_base.codim; the main point is the much more detailed
         # docstring.
@@ -1264,11 +1233,6 @@ class IntegralRayCollection(SageObject, Hashable, Iterable):
             sage: cones.trivial(0).span()
             Sublattice <>
 
-        The span of a solid cone is the entire ambient space::
-
-            sage: K = random_cone(solid=True)
-            sage: K.span().vector_space() == K.lattice().vector_space()
-            True
         """
         L = self.lattice()
 
@@ -2291,13 +2255,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             Empty collection
             in 2-d lattice M
 
-        TESTS:
-
-        The dual cone of a (random) dual cone is the original cone::
-
-            sage: K = random_cone(max_ambient_dim=6, max_rays=15)
-            sage: K.dual().dual() is K
-            True
         """
         if "_dual" not in self.__dict__:
             rays = list(self.facet_normals())
@@ -3096,13 +3053,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: cone1.is_equivalent(cone2)
             True
 
-        TESTS:
-
-        A random cone is equivalent to itself::
-
-            sage: K = random_cone()
-            sage: K.is_equivalent(K)
-            True
         """
         if self is other:
             return True
@@ -3143,13 +3093,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: cone.is_face_of(octant)
             False
 
-        TESTS:
-
-        Any cone is a face of itself::
-
-            sage: K = random_cone()
-            sage: K.is_face_of(K)
-            True
         """
         if self.lattice() != cone.lattice():
             return False
@@ -3236,11 +3179,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: K.is_isomorphic(K)
             True
 
-        A random (strictly convex) cone is isomorphic to itself::
-
-            sage: K = random_cone(strictly_convex=True)
-            sage: K.is_isomorphic(K)                                                    # needs sage.graphs
-            True
         """
         if self.is_strictly_convex() and other.is_strictly_convex():
             from sage.geometry.fan import Fan
@@ -3404,14 +3342,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: cones.trivial(lattice=L).is_pointed()
             True
 
-        TESTS:
-
-        Random test for the claim made in the ``OUTPUT`` block::
-
-            sage: K = random_cone()
-            sage: K.is_pointed() == K.lineality().is_zero()
-            True
-
         """
         return self.is_strictly_convex()
 
@@ -3430,15 +3360,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             Basis matrix:
             [1 0]
 
-        TESTS:
-
-        The linear subspace of any closed convex cone can be identified
-        with the orthogonal complement of the span of its dual::
-
-            sage: K = random_cone()
-            sage: expected = K.dual().span().vector_space().complement()
-            sage: K.linear_subspace() == expected
-            True
         """
         if self.is_strictly_convex():
             return span([vector(QQ, self.lattice_dim())], QQ)
@@ -3467,45 +3388,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             N(0, 1),
             N(1, 0)
             in 2-d lattice N
-
-        TESTS:
-
-        Ensure that the returned generators are mutually
-        orthogonal. This is not promised by the PPL documentation, but
-        it seems to hold in practice. (There is February 2026 thread
-        about it on the ppl-devel mailing list that received no
-        responses.) By testing it here, we "guarantee" that it is a
-        safe assumption to make in user code::
-
-            sage: K = random_cone()
-            sage: V = K.lattice().vector_space()
-            sage: L = [V(l) for l in K.lines()]
-            sage: all( L[i].inner_product(L[j]).is_zero()
-            ....:      for i in range(len(L))
-            ....:      for j in range(len(L))
-            ....:      if i != j )
-            True
-
-            sage: K = random_cone(strictly_convex=False,
-            ....:                 min_ambient_dim=4)
-            sage: V = K.lattice().vector_space()
-            sage: L = [V(l) for l in K.lines()]
-            sage: all( L[i].inner_product(L[j]).is_zero()
-            ....:      for i in range(len(L))
-            ....:      for j in range(len(L))
-            ....:      if i != j )
-            True
-
-            sage: K = random_cone(strictly_convex=False,
-            ....:                 min_ambient_dim=8,
-            ....:                 min_rays=4)
-            sage: V = K.lattice().vector_space()
-            sage: L = [V(l) for l in K.lines()]
-            sage: all( L[i].inner_product(L[j]).is_zero()
-            ....:      for i in range(len(L))
-            ....:      for j in range(len(L))
-            ....:      if i != j )
-            True
 
         """
         lines = []
@@ -3647,41 +3529,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: K.strict_quotient()
             0-d cone in 4-d lattice N
 
-        TESTS:
-
-        The strict quotient of any cone should be strictly convex::
-
-            sage: K = random_cone()
-            sage: K.strict_quotient().is_strictly_convex()
-            True
-
-        If the original cone is solid, then its strict quotient is proper::
-
-            sage: K = random_cone(solid=True)
-            sage: K.strict_quotient().is_proper()
-            True
-
-        The strict quotient of a strictly convex cone is itself::
-
-            sage: K = random_cone(strictly_convex=True)
-            sage: K.strict_quotient() is K
-            True
-
-        The complement of our linear subspace has the same dimension as
-        our dual, so the strict quotient cannot have a larger dimension
-        than our dual::
-
-            sage: K = random_cone()
-            sage: K.strict_quotient().dim() <= K.dual().dim()
-            True
-
-        The strict quotient is idempotent::
-
-            sage: K = random_cone()
-            sage: K1 = K.strict_quotient()
-            sage: K2 = K1.strict_quotient()
-            sage: K1 is K2
-            True
         """
         if self.is_strictly_convex():
             return self
@@ -3758,48 +3605,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: K.solid_restriction() is K
             True
 
-        TESTS:
-
-        The solid restriction of any cone is solid::
-
-            sage: K = random_cone()
-            sage: K.solid_restriction().is_solid()
-            True
-
-        If a cone :meth:`is_strictly_convex`, then its solid restriction
-        :meth:`is_proper`::
-
-            sage: K = random_cone(strictly_convex=True)
-            sage: K.solid_restriction().is_proper()
-            True
-
-        The solid restriction of a cone has the same dimension as the
-        original::
-
-            sage: K = random_cone()
-            sage: K.solid_restriction().dim() == K.dim()
-            True
-
-        The solid restriction of a cone has the same number of rays as
-        the original::
-
-            sage: K = random_cone()
-            sage: K.solid_restriction().n_rays() == K.n_rays()
-            True
-
-        The solid restriction of a cone has the same lineality as the
-        original::
-
-            sage: K = random_cone()
-            sage: K.solid_restriction().lineality() == K.lineality()
-            True
-
-        The solid restriction of a cone has the same number of facets as
-        the original::
-
-            sage: K = random_cone()
-            sage: len(K.solid_restriction().facets()) == len(K.facets())                # needs sage.graphs
-            True
         """
         if self.is_solid():
             return self
@@ -4709,14 +4514,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: quadrant.is_solid()
             False
 
-        TESTS:
-
-        A closed convex cone is solid if and only if its dual is
-        strictly convex::
-
-            sage: K = random_cone()
-            sage: K.is_solid() == K.dual().is_strictly_convex()
-            True
         """
         return (self.dim() == self.lattice_dim())
 
@@ -4861,23 +4658,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: K.lineality()
             0
 
-        TESTS:
-
-        The lineality of a cone should be an integer between zero and the
-        dimension of the ambient space, inclusive::
-
-            sage: K = random_cone()
-            sage: l = K.lineality()
-            sage: l in ZZ
-            True
-            sage: 0 <= l <= K.lattice_dim()
-            True
-
-        A strictly convex cone should have lineality zero::
-
-            sage: K = random_cone(strictly_convex=True)
-            sage: K.lineality()
-            0
         """
         return self.linear_subspace().dimension()
 
@@ -5277,63 +5057,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             ...
             NotImplementedError: ring must be either ZZ or QQ.
 
-        TESTS:
-
-        Any cone should contain a random element of itself::
-
-            sage: K = random_cone()
-            sage: K.contains(K.random_element())
-            True
-            sage: K.contains(K.random_element(ring=QQ))
-            True
-
-        The ambient vector space of the cone should contain a random
-        element of the cone::
-
-            sage: K = random_cone()
-            sage: K.random_element() in K.lattice().vector_space()
-            True
-            sage: K.random_element(ring=QQ) in K.lattice().vector_space()
-            True
-
-        By default, the random element should live in this cone's lattice::
-
-            sage: K = random_cone()
-            sage: K.random_element() in K.lattice()
-            True
-
-        A strictly convex cone contains no lines, and thus no negative
-        multiples of any of its elements besides zero::
-
-            sage: K = random_cone(strictly_convex=True)
-            sage: x = K.random_element()
-            sage: x.is_zero() or not K.contains(-x)
-            True
-
-        The sum of random elements of a cone lies in the cone::
-
-            sage: K = random_cone()
-            sage: K.contains(sum(K.random_element() for i in range(10)))
-            True
-            sage: K.contains(sum(K.random_element(QQ) for i in range(10)))
-            True
-
-        The sum of random elements of a cone belongs to its ambient
-        vector space::
-
-            sage: K = random_cone()
-            sage: V = K.lattice().vector_space()
-            sage: sum(K.random_element() for i in range(10)) in V
-            True
-            sage: sum(K.random_element(ring=QQ) for i in range(10)) in V
-            True
-
-        By default, the sum of random elements of the cone should live
-        in the cone's lattice::
-
-            sage: K = random_cone()
-            sage: sum(K.random_element() for i in range(10)) in K.lattice()
-            True
         """
         if ring not in [ZZ, QQ]:
             # This cone theoretically lives in a real vector space,
@@ -6330,33 +6053,6 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             sage: K.is_reducible() == (p in [1, n-1])
             True
 
-        TESTS:
-
-        Reducibility is preserved under linear isomorphisms::
-
-            sage: # long time
-            sage: K = random_cone(strictly_convex=True)
-            sage: n = K.ambient_dim()
-            sage: q = QQ._random_nonzero_element()
-            sage: A = q*matrix.random(QQ, n, algorithm='unimodular')
-            sage: AK = Cone([ r*A for r in K.rays() ], lattice=K.lattice())
-            sage: K.is_reducible() == AK.is_reducible()
-            True
-
-        In [GT2014]_ it is shown that a (nontrivial) proper polyhedral
-        cone is irreducible if and only if its Lyapunov rank is one.
-        A related test combines Theorem 4.7 of [HFP1976]_ with the
-        Z-operator algorithm in [Or2018b]_::
-
-            sage: # long time
-            sage: K = random_cone(strictly_convex=True,
-            ....:                 solid=True,
-            ....:                 min_rays=1)
-            sage: K.is_reducible() == (K.lyapunov_rank() != 1)
-            True
-            sage: d = K._cross_positive_operators_dual().dim()
-            sage: K.is_reducible() == (d < K.dim()**2 - 1)
-            True
         """
         return len(self.irreducible_factors()) > 1
 

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6644,6 +6644,21 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
             else:
                 continue
 
+        if solid and not K.is_solid():
+            # Just add rays until we get a solid cone? Adding rays is
+            # allowed. The solid_restriction() would also give us a
+            # solid cone with the same number of rays, but it does a
+            # change of basis that results in extremely boring
+            # generators.
+            while K.n_rays() <= max_rays and not K.is_solid():
+                dim_gap = d - K.dim()
+                rays = list(K.rays())
+                rays.extend(L.random_element() for _ in range(dim_gap))
+                K = Cone(rays, lattice=L)
+            if not K.is_solid():
+                # We had to stop because we hit max_rays
+                continue
+
         if strictly_convex is False and K.is_strictly_convex():
             # The user requested that the cone be NOT strictly
             # convex. So it should contain some line, but it

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6191,7 +6191,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
     First, a lattice is determined from ``min_ambient_dim`` and
     ``max_ambient_dim`` (or from the supplied ``lattice``).
 
-    Then, lattice elements are generated one at a time and added to a
+    Then, lattice elements are generated in batches and added to a
     cone. This continues until either the cone meets the user's
     requirements, or the cone is equal to the entire space (at which
     point it is futile to generate more).
@@ -6204,14 +6204,15 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
     The default upper bounds on the ambient dimension and number of
     rays are chosen so that each iteration of this process remains
     fast. The following should be considered an implementation detail,
-    but at the beginning of each iteration we fix the number of
-    rays to attempt for the duration of that iteration. This is
-    necessary because we add rays to the cone one at a time: if we did
-    not have a fixed number of rays in mind, we would often stop as
-    soon as we reached the minimum allowable number of rays. That
-    would be legal, but not what people expect.
+    but at the beginning of each iteration we fix the number of rays
+    to attempt for the duration of that iteration. This is necessary
+    because we begin with a cone that likely has too few rays, and add
+    rays to it in batches: if we did not have a fixed number of rays
+    in mind, we would tend to stop as soon as we reached the minimum
+    allowable number of rays. That would be legal, but not what people
+    expect.
 
-    Adding a ray to the cone consists of appending a vector to the ray
+    Adding rays to the cone consists of appending vectors to the ray
     set, and calling :func:`Cone` on the result. This can be quite
     slow, and we may have to do it many times. As the speed of
     :func:`Cone` depends mainly on the degree and number of rays given
@@ -6221,9 +6222,9 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
     Keep in mind however that if you are looking for a cone with
     hard-to-generate properties (a strictly-convex cone with at least
     twenty extreme rays, for example), we can make no promises about
-    the overall runtime. The default bounds ensure that each
-    unsatisfactory cone can be contructed/discarded quickly, but we
-    may have to construct/discard them for eternity.
+    the overall runtime. The default bounds allow unsatisfactory cones
+    to be contructed/discarded quickly, but we may have to
+    construct/discard them for eternity.
 
     EXAMPLES:
 
@@ -6611,11 +6612,11 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         # adding e.g. (1,1) to [(0,1), (0,-1)]. Rather than trying to
         # mangle what we have, we just start over if we get a cone
         # that won't work.
-        #
         while r > K.n_rays() and not K.is_full_space():
-            rays.append(L.random_element())
+            rays = list(K.rays())
+            rays.extend(L.random_element()
+                        for _ in range(r - K.n_rays()))
             K = Cone(rays, lattice=L)
-            rays = list(K.rays()) # Avoid re-normalizing next time around
 
         if strictly_convex is not None:
             if strictly_convex:

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6425,7 +6425,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         lattice.
 
     """
-    from sage.misc.prandom import choice, randint
+    from sage.misc.prandom import randint
 
     # Catch obvious mistakes so that we can generate clear error
     # messages.
@@ -6627,7 +6627,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
                     # cone strictly convex. Whether or not those
                     # coordinates become positive/negative is chosen
                     # randomly.
-                    pm = choice([-1,1])
+                    pm = 1 - 2*randint(0,1)  # plus or minus one
 
                     # rays has immutable elements
                     rays = [copy(ray) for ray in rays]

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6521,6 +6521,18 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         have d rays. Please increase max_ambient_dim, or decrease
         min_rays.
 
+    Ensure that we can produce a cone whose :meth:`lines` are not
+    orthogonal::
+
+        sage: set_random_seed(1)
+        sage: K = random_cone(min_ambient_dim=2, strictly_convex=False)
+        sage: V = K.ambient_vector_space()
+        sage: all( V(x).inner_product(V(y)).is_zero()
+        ....:      for x in K.lines()
+        ....:      for y in K.lines()
+        ....:      if not x == y )
+        False
+
     """
     from sage.misc.prandom import randint, sample
 

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6104,18 +6104,18 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
       ``min_ambient_dim`` and ``max_ambient_dim``).
 
     - ``min_ambient_dim`` -- (default: zero) a nonnegative integer
-      representing the minimum dimension of the ambient lattice
+      representing the minimum dimension of the ambient lattice;
+      ignored if ``lattice`` is given explicitly
 
     - ``max_ambient_dim`` -- (default: 8) a nonnegative integer
-      representing the maximum dimension of the ambient lattice,
-      or ``None`` for no maximum.
+      representing the maximum dimension of the ambient lattice;
+      ignored if ``lattice`` is given explicitly
 
     - ``min_rays`` -- (default: zero) a nonnegative integer representing
       the minimum number of generating rays of the cone
 
     - ``max_rays`` -- (default: 16) a nonnegative integer representing
-      the maximum number of generating rays of the cone, or ``None``
-      for no maximum.
+      the maximum number of generating rays of the cone.
 
     - ``strictly_convex`` -- (default: random) whether or not to make the
       returned cone strictly convex. Specify ``True`` for a strictly convex
@@ -6153,7 +6153,6 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
 
     * ``max_rays`` is less than ``min_rays``.
 
-    * Both ``max_ambient_dim`` and ``lattice`` are specified.
 
     * ``min_rays`` is greater than four but ``max_ambient_dim`` is less than
       three.
@@ -6313,15 +6312,6 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         ...
         ValueError: max_rays cannot be less than min_rays.
 
-    Or if we specify both ``max_ambient_dim`` and ``lattice``::
-
-        sage: L = ToricLattice(5, "L")
-        sage: random_cone(lattice=L, max_ambient_dim=10)
-        Traceback (most recent call last):
-        ...
-        ValueError: max_ambient_dim cannot be specified when a lattice is
-        provided.
-
     If the user requests too many rays in zero, one, or two dimensions,
     a :exc:`ValueError` is thrown::
 
@@ -6445,42 +6435,38 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
     if min_rays < 0:
         raise ValueError('min_rays must be nonnegative.')
 
-    if max_ambient_dim is not None:
-        if max_ambient_dim < 0:
-            raise ValueError('max_ambient_dim must be nonnegative.')
-        if (max_ambient_dim < min_ambient_dim):
-            msg = 'max_ambient_dim cannot be less than min_ambient_dim.'
-            raise ValueError(msg)
-        if lattice is not None:
-            msg = 'max_ambient_dim cannot be specified when a lattice is '
-            msg += 'provided.'
-            raise ValueError(msg)
+    if max_ambient_dim < 0:
+        raise ValueError('max_ambient_dim must be nonnegative.')
 
-        # The next three checks prevent an infinite loop (a futile
-        # search for more rays) in zero, one, or two dimensions.
-        if min_rays > 4 and max_ambient_dim < 3:
-            msg = 'all cones in zero/one/two dimensions have four or fewer '
-            msg += 'generators. Please increase max_ambient_dim to at least '
-            msg += '3, or decrease min_rays.'
-            raise ValueError(msg)
+    if (max_ambient_dim < min_ambient_dim):
+        msg = 'max_ambient_dim cannot be less than min_ambient_dim.'
+        raise ValueError(msg)
 
-        if min_rays > 2 and max_ambient_dim < 2:
-            msg = 'all cones in zero/one dimensions have two or fewer '
-            msg += 'generators. Please increase max_ambient_dim to at least '
-            msg += '2, or decrease min_rays.'
-            raise ValueError(msg)
+    # The next three checks prevent an infinite loop (a futile
+    # search for more rays) in zero, one, or two dimensions.
+    if min_rays > 4 and max_ambient_dim < 3:
+        msg = 'all cones in zero/one/two dimensions have four or fewer '
+        msg += 'generators. Please increase max_ambient_dim to at least '
+        msg += '3, or decrease min_rays.'
+        raise ValueError(msg)
 
-        if min_rays > 0 and max_ambient_dim == 0:
-            msg = 'all cones in zero dimensions have no generators. '
-            msg += 'Please increase max_ambient_dim to at least 1, or '
-            msg += 'decrease min_rays.'
-            raise ValueError(msg)
+    if min_rays > 2 and max_ambient_dim < 2:
+        msg = 'all cones in zero/one dimensions have two or fewer '
+        msg += 'generators. Please increase max_ambient_dim to at least '
+        msg += '2, or decrease min_rays.'
+        raise ValueError(msg)
 
-    if max_rays is not None:
-        if max_rays < 0:
-            raise ValueError('max_rays must be nonnegative.')
-        if (max_rays < min_rays):
-            raise ValueError('max_rays cannot be less than min_rays.')
+    if min_rays > 0 and max_ambient_dim == 0:
+        msg = 'all cones in zero dimensions have no generators. '
+        msg += 'Please increase max_ambient_dim to at least 1, or '
+        msg += 'decrease min_rays.'
+        raise ValueError(msg)
+
+    if max_rays < 0:
+        raise ValueError('max_rays must be nonnegative.')
+
+    if (max_rays < min_rays):
+        raise ValueError('max_rays cannot be less than min_rays.')
 
     # Also perform the "futile search" checks when a lattice is given,
     # using its dimension rather than max_ambient_dim as the indicator.
@@ -6505,7 +6491,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         if lattice is not None and lattice.dimension() == 0:
             msg = 'all cones in this lattice are strictly convex (trivial).'
             raise ValueError(msg)
-        if max_rays is not None and max_rays < 2:
+        if max_rays < 2:
             msg = 'all cones are strictly convex when ``max_rays`` is '
             msg += 'less than two.'
             raise ValueError(msg)
@@ -6514,14 +6500,13 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
     if solid is not None and solid:
         # The user wants a solid cone.
         if lattice is None:
-            if max_rays is not None:
-                if max_rays < min_ambient_dim:
-                    msg = 'max_rays must be at least min_ambient_dim for '
-                    msg += 'a solid cone.'
-                    raise ValueError(msg)
+            if max_rays < min_ambient_dim:
+                msg = 'max_rays must be at least min_ambient_dim for '
+                msg += 'a solid cone.'
+                raise ValueError(msg)
         else:
             # Repeat the checks above when a lattice is given.
-            if max_rays is not None and max_rays < lattice.dimension():
+            if max_rays < lattice.dimension():
                 msg = "max_rays must be at least {0} for a solid cone "
                 msg += "in this lattice."
                 raise ValueError(msg.format(lattice.dimension()))
@@ -6529,7 +6514,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
     # Sanity checks for non-solid cones.
     if solid is not None and not solid:
         if lattice is None:
-            if max_ambient_dim is not None and max_ambient_dim == 0:
+            if max_ambient_dim == 0:
                 msg = 'all cones are solid when max_ambient_dim is zero.'
                 raise ValueError(msg)
         else:
@@ -6537,7 +6522,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
                 msg = 'all cones in the given lattice are solid.'
                 raise ValueError(msg)
 
-    if solid and max_rays is not None:
+    if solid:
         # If the user wants a solid cone, we need at least as many
         # rays as the dimension. If max_rays was specified, then
         # above we have already verified that
@@ -6550,7 +6535,7 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         # max_rays, ensuring that we don't perform any pointless
         # iterations in a space that's too big for max_rays to
         # generate a solid cone.
-        if max_ambient_dim is None or max_ambient_dim > max_rays:
+        if max_rays < max_ambient_dim:
             max_ambient_dim = max_rays
 
     def random_min_max(l, u):
@@ -6559,10 +6544,6 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         to do the same thing for max_ambient_dim/max_rays. So we consolidate
         the logic here.
         """
-        if u is None:
-            # The upper bound is unspecified; return a random integer
-            # in [l,infinity).
-            return l + ZZ.random_element().abs()
         # We have an upper bound, and it's greater than or equal
         # to our lower bound. So we generate a random integer in
         # [0,u-l], and then add it to l to get something in
@@ -6578,16 +6559,13 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
         """
         if lattice is None:
             # We only care about min/max_ambient_dim when no lattice is given.
-            if K.lattice_dim() < min_ambient_dim:
-                return False
-            if (max_ambient_dim is not None and
-                    K.lattice_dim() > max_ambient_dim):
+            if not (min_ambient_dim <= K.lattice_dim() <= max_ambient_dim):
                 return False
         else:
             if K.lattice() is not lattice:
                 return False
         return all([K.n_rays() >= min_rays,
-                    max_rays is None or K.n_rays() <= max_rays,
+                    K.n_rays() <= max_rays,
                     solid is None or K.is_solid() == solid,
                     strictly_convex is None or
                     K.is_strictly_convex() == strictly_convex])

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -3374,8 +3374,7 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
 
         - :class:`tuple` of primitive vectors in the lattice of ``self``
           giving directions of lines that span the linear subspace of
-          ``self``. These lines are arbitrary, but fixed and orthogonal
-          to one another.
+          ``self``.
 
         EXAMPLES::
 
@@ -3388,6 +3387,21 @@ class ConvexRationalPolyhedralCone(IntegralRayCollection, Container, ConvexSet_c
             N(0, 1),
             N(1, 0)
             in 2-d lattice N
+
+        TESTS:
+
+        The line generators are not necessary orthogonal to one
+        another::
+
+            sage: K = Cone([(-1, 0, 0),
+            ....:           (1, 0, 1),
+            ....:           (-1, 0, -1),
+            ....:           (1, 1, 0),
+            ....:           (-1, -1, 0)])
+            sage: K.lines()
+            N(1, 0, 1),
+            N(1, 1, 0)
+            in 3-d lattice N
 
         """
         lines = []

--- a/src/sage/geometry/cone.py
+++ b/src/sage/geometry/cone.py
@@ -6091,24 +6091,16 @@ def random_cone(lattice=None, min_ambient_dim=0, max_ambient_dim=8,
     .. WARNING::
 
         If you request a large number of rays in a low-dimensional
-        space, you might be waiting for a while. For example, in three
-        dimensions, it is possible to obtain an octagon raised up to height
-        one (all z-coordinates equal to one). But in practice, we usually
-        generate the entire three-dimensional space with six rays before we
-        get to the eight rays needed for an octagon. We therefore have to
-        throw the cone out and start over from scratch. This process repeats
-        until we get lucky.
+        space, you may be waiting for a while.
 
-        We also refrain from "adjusting" the min/max parameters given to
-        us when a (non-)strictly convex or (non-)solid cone is
-        requested. This means that it may take a long time to generate
-        such a cone if the parameters are chosen unwisely.
-
-        For example, you may want to set ``min_rays`` close to
-        ``min_ambient_dim`` if you desire a solid cone. Or, if you desire a
-        non-strictly-convex cone, then they all contain at least two
-        generating rays. So that might be a good candidate for
-        ``min_rays``.
+        In three dimensions, and ignoring for the moment the need for
+        rational coordinates, it is possible to obtain an "octagon"
+        raised up to height one (all z-coordinates equal to one). But
+        in practice we usually generate the entire three-dimensional
+        ambient vector space (having six rays) before we obtain the
+        eight that we want. At that point it is futile to add more
+        rays; we have to throw the cone out and start from
+        scratch. This process repeats until we get lucky.
 
     INPUT:
 

--- a/src/sage/geometry/cone_test.py
+++ b/src/sage/geometry/cone_test.py
@@ -28,11 +28,8 @@ def _gen_ops_test_cones():
     J2 = random_cone(max_ambient_dim=5, max_rays=10)
     J3 = random_cone(max_ambient_dim=5, max_rays=10)
 
-    J2_dual = J2.dual()
-    J3_dual = J3.dual()
-
-    worst_dim = J2.dim() * max(J2_dual.dim(), J3_dual.dim())
-    worst_npairs = J2.nrays() * max(J2_dual.nrays(), J2_dual.nrays())
+    worst_dim = J2.dim() * max(J2.dual().dim(), J3.dual().dim())
+    worst_npairs = J2.nrays() * max(J2.dual().nrays(), J2.dual().nrays())
 
     # How many pairs is too many pairs, in a given dimension? Note
     # that the maximum ambient dimension for both cones is 5, so there
@@ -56,13 +53,6 @@ def _gen_ops_test_cones():
             if worst_npairs >= limits[worst_dim]:
                 return _gen_ops_test_cones()
 
-
-    # Monkey patch both dual() methods with the already-computed
-    # (cached) values, so we don't have recompute them later.
-    J2_dual_meth = lambda s: J2_dual
-    J3_dual_meth = lambda s: J3_dual
-    J2.dual = J2_dual_meth.__get__(J2)
-    J3.dual = J3_dual_meth.__get__(J3)
 
     # We _also_ need to check that the dual we're going to take a dual
     # of is not too complicated: the complexity of dual() is bad in

--- a/src/sage/geometry/cone_test.py
+++ b/src/sage/geometry/cone_test.py
@@ -1,4 +1,5 @@
 import pytest
+from random import randint
 
 from itertools import chain
 from sage.geometry.cone import Cone, random_cone
@@ -327,8 +328,6 @@ def test_random_element_membership(K):
     vector space, and its lattice. The same is true for conic
     combinations of random elements.
     """
-    from random import randint
-
     L = K.lattice()
     V = L.vector_space()
     F = L.base_field()
@@ -842,3 +841,51 @@ def test_discrete_complementarity_set_is_complementary(K):
     """
     dcs = K.discrete_complementarity_set()
     assert sum((s*x).abs() for (x,s) in dcs) == 0
+
+
+def test_random_cone_params_are_respected(K):
+    r"""
+    The dim/ray bounds and pointed/solid constraints should
+    actually be met by the result.
+    """
+    solid = bool(randint(0,1))
+    pointed = bool(randint(0,1))
+    min_ambient_dim = randint(5,10)
+    min_rays = randint(0,8)
+
+    # Start with random maxima, but fudge them a bit so that they
+    # don't contradict the minima.
+    max_rays = randint(min_rays,2*min_rays)
+    max_rays = max(max_rays, min_ambient_dim+3)
+    max_ambient_dim = randint(min_ambient_dim, 2*min_ambient_dim)
+    max_ambient_dim = max(max_ambient_dim, min_ambient_dim+4)
+
+    C = random_cone(min_rays=min_rays,
+                    max_rays=max_rays,
+                    solid=solid,
+                    strictly_convex=pointed,
+                    min_ambient_dim=min_ambient_dim,
+                    max_ambient_dim=max_ambient_dim)
+
+    assert all((
+        min_rays <= C.n_rays() <= max_rays,
+        min_ambient_dim <= C.lattice_dim() <= max_ambient_dim,
+        solid == C.is_solid(),
+        pointed == C.is_strictly_convex()
+    ))
+
+    # Again with a fixed lattice (in which we know a satisfactory cone
+    # exists, because we just found one) rather than dimension bounds.
+    L = C.lattice()
+    C = random_cone(min_rays=min_rays,
+                    max_rays=max_rays,
+                    solid=solid,
+                    strictly_convex=pointed,
+                    lattice=L)
+
+    assert all((
+        min_rays <= C.n_rays() <= max_rays,
+        C.lattice() is L,
+        solid == C.is_solid(),
+        pointed == C.is_strictly_convex()
+    ))

--- a/src/sage/geometry/cone_test.py
+++ b/src/sage/geometry/cone_test.py
@@ -15,7 +15,7 @@ def _gen_ops_test_cones():
     Generate two cones that are suitable for testing (cross)
     positive, Lyapunov-like, and Z-operators.
 
-    This extends :meth:`sage.geomtry.cone.random_cone` by choosing
+    This extends :func:`sage.geometry.cone.random_cone` by choosing
     conservative parameters, and by rejecting any cone that looks too
     complicated for these methods to be computed in a reasonable
     amount of time. We generate two cones simultaneously because,

--- a/src/sage/geometry/cone_test.py
+++ b/src/sage/geometry/cone_test.py
@@ -176,6 +176,250 @@ def K2_K3_posops_cone(K2, K3, K2_K3_posops_gens):
 def K2_ll_basis(K2):
     return K2.lyapunov_like_basis()
 
+def test_dual_lattice_dual_is_original(K):
+    r"""
+    The dual lattice of a dual lattice is the original.
+    """
+    assert K.dual_lattice().dual() is K.lattice()
+
+def test_codimension_bounds(K):
+    r"""
+    Codimension is an integer between zero and the ambient
+    (lattice or vector space) dimension.
+    """
+    c = K.codim()
+    assert c.is_integral() and 0 <= c <= K.lattice_dim()
+
+def test_codim_is_zero_iff_cone_is_solid(K):
+    r"""
+    A cone is solid if and only if it has codimension zero.
+    """
+    assert K.is_solid() == K.codim().is_zero()
+
+def test_codim_is_dual_lineality(K):
+    r"""
+    The codimension of a cone is equal to the lineality of its
+    dual.
+    """
+    assert K.codim() == K.dual().lineality()
+
+def test_cone_is_solid_iff_it_spans_its_lattice(K):
+    r"""
+    The span of a cone is the entire ambient space if and only if
+    that cone is solid.
+    """
+    V1 = K.lattice().vector_space()
+    V2 = K.span().vector_space()
+    assert K.is_solid() == (V1 == V2)
+
+def test_dual_of_dual_is_original(K):
+    r"""
+    The dual cone of a dual cone is the original cone.
+    """
+    assert K.dual().dual() is K
+
+def test_cones_are_equivalent_to_themselves(K):
+    r"""
+    Sanity check: a cone is always equivalent to itself.
+    """
+    assert K.is_equivalent(K)
+
+def test_cones_are_faces_of_themselves(K):
+    r"""
+    Every cone is (trivially) a face of itself.
+    """
+    assert K.is_face_of(K)
+
+def pointed_cones_are_isomorphic_to_themselves(K):
+    r"""
+    Sanity check: a cone is always isomorphic to itself.
+
+    Isomorphism is implemented only for pointed cones, so
+    we use the strict quotient of the arbitrary (random)
+    cone ``K``.
+    """
+    K_p = K.strict_quotient()
+    assert K_p.is_isomorphic(K_p)
+
+def test_lineality_bounds(K):
+    r"""
+    Lineality is an integer between zero and the ambient
+    dimension.
+    """
+    l = K.lineality()
+    assert l.is_integral() and 0 <= l <= K.lattice_dim()
+
+def test_lineality_zero_iff_pointed(K):
+    r"""
+    The lineality of a pointed cone is zero, essentially by
+    definition.
+    """
+    assert K.is_pointed() == K.lineality().is_zero()
+
+def test_lineality_space_is_dual_perp(K):
+    r"""
+    The linear subspace of any closed convex cone can be identified
+    with the orthogonal complement of the span of its dual.
+    """
+    expected = K.dual().span().vector_space().complement()
+    assert K.linear_subspace() == expected
+
+def test_strict_quotient_is_pointed(K):
+    r"""
+    The strict quotient of any cone should be pointed (that's the
+    point of the method).
+    """
+    assert K.strict_quotient().is_strictly_convex()
+
+def test_strict_quotient_of_pointed_is_itself(K):
+    r"""
+    The strict quotient of a cone is itself if and only if that
+    cone is pointed (strictly convex).
+    """
+    assert K.is_strictly_convex() == (K.strict_quotient() is K)
+
+def test_strict_quotient_dim_bound(K):
+    r"""
+    The orthogonal complement of a cone's linear subspace has the
+    same dimension as its dual, so the strict quotient cannot have a
+    larger dimension than the dual.
+    """
+    assert K.strict_quotient().dim() <= K.dual().dim()
+
+def test_strict_quotient_is_idempotent(K):
+    r"""
+    As corollary of the strict quotient being pointed and the
+    strict quotient of a pointed cone being itself, the strict
+    quotient is idempotent.
+    """
+    C = K.strict_quotient()
+    assert C.strict_quotient() == C
+
+def test_solid_restriction_is_solid(K):
+    r"""
+    The solid restriction of a cone is itself if and only if that
+    cone is solid.
+    """
+    assert K.is_solid() == (K.solid_restriction() is K)
+
+def test_solid_restriction_has_same_properties_as_original(K):
+    r"""
+    The solid restriction of a cone has the same dimension,
+    number of rays, etc. as the the original cone. (The restriction
+    changes only its representation and ambient space.)
+    """
+    sr = K.solid_restriction()
+    assert all((sr.dim() == K.dim(),
+                sr.n_rays() == K.n_rays(),
+                sr.lineality() == K.lineality(),
+                len(sr.facets()) == len(K.facets())))
+
+def test_solid_iff_dual_pointed(K):
+    r"""
+    A closed convex cone is solid if and only if its dual is
+    strictly convex.
+    """
+    assert K.is_solid() == K.dual().is_strictly_convex()
+
+def test_random_element_membership(K):
+    r"""
+    Random elements of a cone belong to the cone, its ambient
+    vector space, and its lattice. The same is true for conic
+    combinations of random elements.
+    """
+    from random import randint
+
+    L = K.lattice()
+    V = L.vector_space()
+    F = L.base_field()
+
+    # Note that after the change of ring (from ZZ to QQ), we lose
+    # membership in the lattice.
+    e1 = sum((K.random_element()
+              for _ in range(randint(0,10))),
+             start=L.zero())
+    e2 = sum((K.random_element(ring=F)
+              for _ in range(randint(0,10))),
+             start=L.zero())
+
+    assert all(x in K and x in V for x in (e1,e2))
+    assert e1 in L
+
+def test_pointed_cones_contain_no_random_line(K):
+    r"""
+    A pointed cone contains no lines, and thus no negative
+    multiples of any of its elements (besides the origin).
+
+    The input cone ``K`` is arbitrary (random), so we take
+    its strict quotient to obtain a pointed cone.
+    """
+    K_p = K.strict_quotient()
+    x = K_p.random_element()
+    assert x.is_zero() or not K_p.contains(-x)
+
+@pytest.mark.long
+def test_reducibility_preserved_by_isomorphism(K):
+    r"""
+    Reducibility is preserved under linear isomorphisms. We take
+    the strict quotient of ``K`` to ensure that we have a pointed cone
+    for which reducibility is well-defined.
+    """
+    C = K.strict_quotient()
+
+    n = C.ambient_dim()
+    F = C.lattice().base_field()
+    q = F._random_nonzero_element()
+    A = q*matrix.random(F, n, algorithm='unimodular')
+    AC = Cone([ r*A for r in C.rays() ], lattice=C.lattice())
+    assert C.is_reducible() == AC.is_reducible()
+
+@pytest.mark.long
+def test_reducibility_criteria(K,J,P,Q,K2,K3):
+    r"""
+    In [GT2014]_ it is shown that a (nontrivial) proper polyhedral
+    cone is irreducible if and only if its Lyapunov rank is one.
+    A related test combines Theorem 4.7 of [HFP1976]_ with the
+    Z-operator algorithm in [Or2018b]_.
+
+    Loop through several fixtures to increase the chances that one of
+    them is both proper AND nontrivial. If not, just make a new one.
+    """
+    winners = ( C for C in (P,Q,K,J,K2,K3)
+                if not C.is_trivial() and C.is_proper() )
+    try:
+        C = next(winners)
+    except StopIteration:
+        C = random_cone(strictly_convex=True,
+                        solid=True,
+                        max_ambient_dim=5,
+                        min_rays=1,
+                        max_rays=7)
+
+    assert C.is_reducible() == (C.lyapunov_rank() != 1)
+    d = C._cross_positive_operators_dual().dim()
+    assert C.is_reducible() == (d < C.dim()**2 - 1)
+
+@pytest.mark.long
+def test_lines_gens_are_orthogonal(K,J,K2,K3):
+    r"""
+    Ensure that the returned generators are mutually
+    orthogonal. This is not promised by the PPL documentation, but
+    it seems to hold in practice. (There is February 2026 thread
+    about it on the ppl-devel mailing list that received no
+    responses.) By testing it here, we "guarantee" that it is a
+    safe assumption to make in user code.
+
+    Run a few times, since this is really the only guarantee that we
+    have for the claim made in our documentation.
+    """
+    for C in (K,J,K2,K3):
+        V = C.ambient_vector_space()
+        L = [V(l) for l in C.lines()]
+        assert all(L[i].inner_product(L[j]).is_zero()
+                   for i in range(len(L))
+                   for j in range(len(L))
+                   if i != j)
+
 @pytest.mark.longlong
 def test_is_cross_positive(K2, K2_cp_gens):
     r"""
@@ -343,7 +587,7 @@ def test_posops_dual_linspace(K2):
     its dual [Or2018b]_.
     """
     pi_dual = K2._positive_operators_dual(K2)
-    V = pi_dual.lattice().vector_space()
+    V = pi_dual.ambient_vector_space()
     actual = pi_dual.linear_subspace()
     U1 = ( V((s.tensor_product(x)).list())
            for x in K2.lines()
@@ -543,8 +787,7 @@ def test_lyapunov_rank_automorphism_invariance(K):
 @pytest.mark.long
 def test_lyapunov_rank_dual_invariance(K):
     r"""
-    Lyapunov rank should be invariant under
-    :meth:`sage.geometry.cone.ConvexRationalPolyhedralCone.dual`
+    Lyapunov rank is invariant under the duality operator
     [RNPA2011]_.
     """
     assert K.lyapunov_rank() == K.dual().lyapunov_rank()

--- a/src/sage/geometry/cone_test.py
+++ b/src/sage/geometry/cone_test.py
@@ -399,27 +399,6 @@ def test_reducibility_criteria(K,J,P,Q,K2,K3):
     d = C._cross_positive_operators_dual().dim()
     assert C.is_reducible() == (d < C.dim()**2 - 1)
 
-@pytest.mark.long
-def test_lines_gens_are_orthogonal(K,J,K2,K3):
-    r"""
-    Ensure that the returned generators are mutually
-    orthogonal. This is not promised by the PPL documentation, but
-    it seems to hold in practice. (There is February 2026 thread
-    about it on the ppl-devel mailing list that received no
-    responses.) By testing it here, we "guarantee" that it is a
-    safe assumption to make in user code.
-
-    Run a few times, since this is really the only guarantee that we
-    have for the claim made in our documentation.
-    """
-    for C in (K,J,K2,K3):
-        V = C.ambient_vector_space()
-        L = [V(l) for l in C.lines()]
-        assert all(L[i].inner_product(L[j]).is_zero()
-                   for i in range(len(L))
-                   for j in range(len(L))
-                   if i != j)
-
 @pytest.mark.longlong
 def test_is_cross_positive(K2, K2_cp_gens):
     r"""

--- a/src/sage/geometry/cone_test.py
+++ b/src/sage/geometry/cone_test.py
@@ -103,17 +103,14 @@ def K():
     The baseline random cone fixture, meant to be used in tests
     that do not explode computationally.
     """
-    return random_cone(max_ambient_dim=12, max_rays=15)
+    return random_cone()
 
 @pytest.fixture
 def P():
     r"""
     Like :func:`K`, but guaranteed to be proper.
     """
-    return random_cone(max_ambient_dim=12,
-                       max_rays=15,
-                       solid=True,
-                       strictly_convex=True)
+    return random_cone(solid=True, strictly_convex=True)
 
 @pytest.fixture
 def J():
@@ -122,17 +119,14 @@ def J():
     similar nature.
 
     """
-    return random_cone(max_ambient_dim=12, max_rays=15)
+    return random_cone()
 
 @pytest.fixture
 def Q():
     r"""
     Like :func:`J`, but guaranteed to be proper.
     """
-    return random_cone(max_ambient_dim=12,
-                       max_rays=15,
-                       solid=True,
-                       strictly_convex=True)
+    return random_cone(solid=True, strictly_convex=True)
 
 @pytest.fixture
 def K2_and_K3():


### PR DESCRIPTION
A few CI failures in recent months motivate changes to `random_cone()`:

* Set upper bounds on the dimension/rays by default so that we don't have to specify them in every test.
* No longer support absent upper bounds (unlimited rays in unlimited dimensions)
* Move most random tests to pytest where a single cached fixture can be reused (so that we don't have to re-run `random_cone()` over and over again).
* Make the random cone generation more efficient by adding rays in batches.
* Re-think and properly document some of the hacks that go into satisfying the `solid` and `strictly_convex` parameters.
* Fully document the algorithm
* Refactor the sanity checks to cover more cases
* Combine several sanity checks that named the dimension {0,1,2} explicitly
* Un-claim that a cone's `lines()` are orthogonal. The new `random_cone()` implementation finds a counterexample.
* Add a few more tests.

**Documentation shortcut**:
* https://doc-pr-42573--sagemath.netlify.app/html/en/reference/discrete_geometry/sage/geometry/cone#sage.geometry.cone.random_cone