### PR TITLE
Speed up p-adic L-series precision bounds

### DIFF
--- a/src/sage/schemes/elliptic_curves/padic_lseries.py
+++ b/src/sage/schemes/elliptic_curves/padic_lseries.py
@@ -64,8 +64,7 @@ from sage.matrix.constructor import matrix
 import sage.schemes.hyperelliptic_curves.monsky_washnitzer
 
 from sage.arith.functions import lcm as LCM
-from sage.arith.misc import (binomial,
-                             GCD as gcd,
+from sage.arith.misc import (GCD as gcd,
                              prime_divisors,
                              kronecker as kronecker_symbol,
                              valuation)
@@ -620,15 +619,23 @@ class pAdicLseries(SageObject):
             [+Infinity, 3, 2, 2, 1, 1, 1, 1, 0, 0]
             sage: Lp._e_bounds(4,10)
             [+Infinity, 4, 3, 3, 2, 2, 2, 2, 1, 1]
+
+            sage: Lp = E.padic_lseries(3)
+            sage: Lp._e_bounds(0, 4)
+            [+Infinity, 0, 0, 0]
+            sage: Lp._e_bounds(2, 12)
+            [+Infinity, 2, 2, 1, 1, 1, 1, 1, 1, 0, 0, 0]
         """
-        # trac 10280: replace with new corrected code, note that the sequence has to be decreasing.
-        pn = self._p**n
-        enj = infinity
-        res = [enj]
-        for j in range(1,prec):
-            bino = valuation(binomial(pn,j),self._p)
-            enj = min(bino, enj)
-            res.append(enj)
+        # For 1 <= j < p^n, v_p(binomial(p^n, j)) = n - v_p(j).
+        # Its prefix minimum drops by one exactly at powers of p.
+        bound = ZZ(n)
+        next_drop = self._p
+        res = [infinity]
+        for j in range(1, prec):
+            if bound and j == next_drop:
+                bound -= 1
+                next_drop *= self._p
+            res.append(bound)
         return res
 
     def _get_series_from_cache(self, n, prec, D, eta):


### PR DESCRIPTION
## Summary

`pAdicLseries._e_bounds` currently constructs an exact `binomial(p^n, j)` for every requested coefficient and then takes prefix-minimum valuations.

For `1 <= j < p^n`,

```
v_p(binomial(p^n, j)) = n - v_p(j).
```

Therefore the prefix minimum changes only when `j` reaches a power of `p`. This PR walks those thresholds instead of constructing binomial integers. The bound reaches zero at `j = p^n` and stays zero for later indices, preserving the existing tail when `prec > p^n`.

The doctests add coverage for `n = 0`, an odd prime, and a precision crossing `p^n`.

## Verification

Built the branch from current `develop` (`842f12bada41bbae3498a8ead95006cfc4c04946`, SageMath 10.10.beta6) using the repository's pinned Apple-silicon Conda environment and editable install:

```console
conda env create --file environment-3.12-macos.yml --name sage-e-bounds-dev
conda run -n sage-e-bounds-dev python -m pip install --no-build-isolation --editable .
conda run -n sage-e-bounds-dev ./sage -t src/sage/schemes/elliptic_curves/padic_lseries.py
conda run -n sage-e-bounds-dev ./sage -t src/sage/schemes/elliptic_curves/padics.py src/sage/schemes/elliptic_curves/sha_tate.py
conda run -n sage-e-bounds-dev ./sage -tox -e pycodestyle-minimal -- src/sage/schemes/elliptic_curves/padic_lseries.py
conda run -n sage-e-bounds-dev ./sage -tox -e relint -- src/sage/schemes/elliptic_curves/padic_lseries.py
```

Results:

- `padic_lseries.py`: 231 tests passed.
- Direct consumer modules: 328 tests passed.
- `pycodestyle-minimal`: passed.
- `relint`: passed.
- In Sage, an independent exact valuation recurrence matched the branch for `p = 2, 3, 5, 7`, `0 <= n <= 8`, and every output entry through `prec = p^n + 3`: 36 cases and 7,224,342 entries. All 36 cases checked the three-entry zero tail. For the 20 cases with `n <= 4`, the result also matched the literal legacy binomial implementation. Full-gate digest: `2552a25ad1483d63bbb2ae3e2a2121e04782d193d53834dd3b25fce0229e5c60`.

## Benchmark

Each sample ran in a fresh Sage process on macOS arm64. The timer covered only the function call for `p = 3`, `n = 8`, `prec = 6564`; all outputs had digest `d34ef208d898de2e02838023d3ddbe60e8ab036d781f8c3512c5d085a3a49f5c`.

| Implementation | Times (seconds) | Median |
|---|---:|---:|
| Existing binomial loop | 0.335263833, 0.256117709, 0.183842667 | 0.256117709 |
| Threshold walk | 0.000386709, 0.000358958, 0.000318208 | 0.000358958 |

This workload was 713.50x faster by median time.
