### PR TITLE
Use Kitty protocol to display plots inline when supported

### DIFF
--- a/src/sage/all.py
+++ b/src/sage/all.py
@@ -362,6 +362,7 @@ sage.misc.lazy_import.finish_startup()
 if hasattr(sys, "set_int_max_str_digits"):
     sys.set_int_max_str_digits(0)
 
+
 def sage_globals():
     r"""
     Return the Sage namespace.

--- a/src/sage/all.py
+++ b/src/sage/all.py
@@ -362,7 +362,6 @@ sage.misc.lazy_import.finish_startup()
 if hasattr(sys, "set_int_max_str_digits"):
     sys.set_int_max_str_digits(0)
 
-
 def sage_globals():
     r"""
     Return the Sage namespace.

--- a/src/sage/repl/interpreter.py
+++ b/src/sage/repl/interpreter.py
@@ -293,6 +293,7 @@ class SageTerminalInteractiveShell(SageShellOverride, TerminalInteractiveShell):
             sage: from sage.repl.interpreter import SageTerminalInteractiveShell
             sage: SageTerminalInteractiveShell().init_display_formatter()   # not tested
         """
+        super().init_display_formatter()
         from sage.repl.rich_output.backend_ipython import BackendIPythonCommandline
         backend = BackendIPythonCommandline()
         backend.get_display_manager().switch_backend(backend, shell=self)

--- a/src/sage/repl/interpreter.py
+++ b/src/sage/repl/interpreter.py
@@ -196,7 +196,7 @@ def inline_plots(on=None):
     """
     Turn on or off the inline plots via Kitty when supported.
 
-    - ``on`` -- boolean; whether to turn on preparsing, returns the current state if None
+    - ``on`` -- boolean; whether to turn on inline plots, returns the current state if None
 
     EXAMPLES::
 

--- a/src/sage/repl/interpreter.py
+++ b/src/sage/repl/interpreter.py
@@ -205,7 +205,7 @@ def inline_plots(on=None):
         sage: from sage.repl.interpreter import inline_plots
         sage: type(inline_plots()) is bool
         True
-        sage: inline_plots(False)
+        sage: inline_plots(False) # random
         sage: inline_plots()
         False
     """

--- a/src/sage/repl/interpreter.py
+++ b/src/sage/repl/interpreter.py
@@ -212,16 +212,21 @@ def inline_plots(on=None):
     if on is None:
         return hasattr(IP, 'mime_renderers') and 'image/png' in IP.mime_renderers
     if not hasattr(IP, 'mime_renderers'):
+        print('Inline plots are not supported in the current IPython version')
         return
     if on:
         try:
             from IPython.core.kitty import kitty_png_render, supports_kitty_graphics
         except ImportError:
+            print('Inline plots are not supported in the current IPython version')
             return
         if supports_kitty_graphics:
             IP.mime_renderers['image/png'] = kitty_png_render
+        else:
+            print('Inline plots are not supported in the current terminal')
     elif 'image/png' in IP.mime_renderers:
         del IP.mime_renderers['image/png']
+
 
 ##############################
 # Sage[Terminal]InteractiveShell

--- a/src/sage/repl/interpreter.py
+++ b/src/sage/repl/interpreter.py
@@ -209,21 +209,17 @@ def inline_plots(on=None):
     """
     from IPython.core.getipython import get_ipython
     IP = get_ipython()
+    try:
+        from IPython.core.kitty import kitty_png_render, supports_kitty_graphics
+    except ImportError:
+        supports_kitty_graphics = False
     if on is None:
-        return hasattr(IP, 'mime_renderers') and 'image/png' in IP.mime_renderers
-    if not hasattr(IP, 'mime_renderers'):
-        print('Inline plots are not supported in the current IPython version')
+        return supports_kitty_graphics and hasattr(IP, 'mime_renderers') and 'image/png' in IP.mime_renderers
+    if not supports_kitty_graphics:
+        print('Inline plots are not supported for the current terminal and IPython version')
         return
     if on:
-        try:
-            from IPython.core.kitty import kitty_png_render, supports_kitty_graphics
-        except ImportError:
-            print('Inline plots are not supported in the current IPython version')
-            return
-        if supports_kitty_graphics:
-            IP.mime_renderers['image/png'] = kitty_png_render
-        else:
-            print('Inline plots are not supported in the current terminal')
+        IP.mime_renderers['image/png'] = kitty_png_render
     elif 'image/png' in IP.mime_renderers:
         del IP.mime_renderers['image/png']
 

--- a/src/sage/repl/interpreter.py
+++ b/src/sage/repl/interpreter.py
@@ -215,10 +215,11 @@ def inline_plots(on=None):
         return
     if on:
         try:
-            from IPython.core.kitty import kitty_png_render
+            from IPython.core.kitty import kitty_png_render, supports_kitty_graphics
         except ImportError:
             return
-        IP.mime_renderers['image/png'] = kitty_png_render
+        if supports_kitty_graphics:
+            IP.mime_renderers['image/png'] = kitty_png_render
     elif 'image/png' in IP.mime_renderers:
         del IP.mime_renderers['image/png']
 

--- a/src/sage/repl/interpreter.py
+++ b/src/sage/repl/interpreter.py
@@ -200,6 +200,7 @@ def inline_plots(on=None):
 
     EXAMPLES::
 
+        sage: from sage.repl.interpreter import inline_plots
         sage: type(inline_plots()) is bool
         True
         sage: inline_plots(False)

--- a/src/sage/repl/interpreter.py
+++ b/src/sage/repl/interpreter.py
@@ -194,7 +194,9 @@ def preparser(on=True):
 
 def inline_plots(on=None):
     """
-    Turn on or off the inline plots via Kitty when supported.
+    Turn inline plots on or off if supported. This feature requires IPython
+    v9.13 or later running in a terminal emulator that implements the
+    `kitty graphics protocol <https://sw.kovidgoyal.net/kitty/graphics-protocol/>`__.
 
     - ``on`` -- boolean; whether to turn on inline plots, returns the current state if None
 

--- a/src/sage/repl/interpreter.py
+++ b/src/sage/repl/interpreter.py
@@ -192,6 +192,35 @@ def preparser(on=True):
     _do_preparse = on is True
 
 
+def inline_plots(on=None):
+    """
+    Turn on or off the inline plots via Kitty when supported.
+
+    - ``on`` -- boolean; whether to turn on preparsing, returns the current state if None
+
+    EXAMPLES::
+
+        sage: type(inline_plots()) is bool
+        True
+        sage: inline_plots(False)
+        sage: inline_plots()
+        False
+    """
+    from IPython.core.getipython import get_ipython
+    IP = get_ipython()
+    if on is None:
+        return hasattr(IP, 'mime_renderers') and 'image/png' in IP.mime_renderers
+    if not hasattr(IP, 'mime_renderers'):
+        return
+    if on:
+        try:
+            from IPython.core.kitty import kitty_png_render
+        except ImportError:
+            return
+        IP.mime_renderers['image/png'] = kitty_png_render
+    elif 'image/png' in IP.mime_renderers:
+        del IP.mime_renderers['image/png']
+
 ##############################
 # Sage[Terminal]InteractiveShell
 ##############################

--- a/src/sage/repl/rich_output/backend_ipython.py
+++ b/src/sage/repl/rich_output/backend_ipython.py
@@ -245,9 +245,9 @@ class BackendIPythonCommandline(BackendIPython):
         if isinstance(rich_output, OutputLatex):
             return ({'text/plain': rich_output.latex.get_str()}, {})
         if isinstance(rich_output, OutputImagePng):
-            IP = get_ipython()
-            # IPython>=9.3 supports inline plots
-            if hasattr(IP, 'mime_renderers') and 'image/png' in IP.mime_renderers:
+           # IPython>=9.3 supports inline plots
+            from sage.repl.interpreter import inline_plots
+            if inline_plots():
                 return ({'text/plain': '', 'image/png': rich_output.png.get()}, {})
             msg = self.launch_viewer(
                 rich_output.png.filename(ext='png'), plain_text.text.get_str())

--- a/src/sage/repl/rich_output/backend_ipython.py
+++ b/src/sage/repl/rich_output/backend_ipython.py
@@ -245,18 +245,14 @@ class BackendIPythonCommandline(BackendIPython):
         if isinstance(rich_output, OutputLatex):
             return ({'text/plain': rich_output.latex.get_str()}, {})
         if isinstance(rich_output, OutputImagePng):
-            try:
-                # requires IPython 9.13:
-                from IPython.core.kitty import supports_kitty_graphics
-            except ImportError:
-                # fallback for older IPython versions:
-                supports_kitty_graphics = False
-            if supports_kitty_graphics:
-                msg = ''
+            IP = get_ipython()
+            # IPython>=9.3 supports inline plots
+            if hasattr(IP, 'mime_renderers') and 'image/png' in IP.mime_renderers:
+                return ({'text/plain': '', 'image/png': rich_output.png.get()}, {})
             else:
                 msg = self.launch_viewer(
                     rich_output.png.filename(ext='png'), plain_text.text.get_str())
-            return ({'text/plain': msg, 'image/png': rich_output.png.get()}, {})
+                return ({'text/plain': msg}, {})
         if isinstance(rich_output, OutputImageGif):
             msg = self.launch_viewer(
                 rich_output.gif.filename(ext='gif'), plain_text.text.get_str())

--- a/src/sage/repl/rich_output/backend_ipython.py
+++ b/src/sage/repl/rich_output/backend_ipython.py
@@ -300,7 +300,7 @@ class BackendIPythonCommandline(BackendIPython):
             Example plain text output
         """
         formatdata, metadata = self.displayhook(plain_text, rich_output)
-        print(formatdata['text/plain'])
+        publish_display_data(data=formatdata, metadata=metadata)
 
     def launch_viewer(self, image_file, plain_text):
         """

--- a/src/sage/repl/rich_output/backend_ipython.py
+++ b/src/sage/repl/rich_output/backend_ipython.py
@@ -249,10 +249,9 @@ class BackendIPythonCommandline(BackendIPython):
             # IPython>=9.3 supports inline plots
             if hasattr(IP, 'mime_renderers') and 'image/png' in IP.mime_renderers:
                 return ({'text/plain': '', 'image/png': rich_output.png.get()}, {})
-            else:
-                msg = self.launch_viewer(
-                    rich_output.png.filename(ext='png'), plain_text.text.get_str())
-                return ({'text/plain': msg}, {})
+            msg = self.launch_viewer(
+                rich_output.png.filename(ext='png'), plain_text.text.get_str())
+            return ({'text/plain': msg}, {})
         if isinstance(rich_output, OutputImageGif):
             msg = self.launch_viewer(
                 rich_output.gif.filename(ext='gif'), plain_text.text.get_str())

--- a/src/sage/repl/rich_output/backend_ipython.py
+++ b/src/sage/repl/rich_output/backend_ipython.py
@@ -245,7 +245,7 @@ class BackendIPythonCommandline(BackendIPython):
         if isinstance(rich_output, OutputLatex):
             return ({'text/plain': rich_output.latex.get_str()}, {})
         if isinstance(rich_output, OutputImagePng):
-           # IPython>=9.3 supports inline plots
+           # IPython>=9.13 supports inline plots
             from sage.repl.interpreter import inline_plots
             if inline_plots():
                 return ({'text/plain': '', 'image/png': rich_output.png.get()}, {})

--- a/src/sage/repl/rich_output/backend_ipython.py
+++ b/src/sage/repl/rich_output/backend_ipython.py
@@ -245,9 +245,18 @@ class BackendIPythonCommandline(BackendIPython):
         if isinstance(rich_output, OutputLatex):
             return ({'text/plain': rich_output.latex.get_str()}, {})
         if isinstance(rich_output, OutputImagePng):
-            msg = self.launch_viewer(
-                rich_output.png.filename(ext='png'), plain_text.text.get_str())
-            return ({'text/plain': msg}, {})
+            try:
+                # requires IPython 9.13:
+                from IPython.core.kitty import supports_kitty_graphics
+            except ImportError:
+                # fallback for older IPython versions:
+                supports_kitty_graphics = False
+            if supports_kitty_graphics:
+                msg = ''
+            else:
+                msg = self.launch_viewer(
+                    rich_output.png.filename(ext='png'), plain_text.text.get_str())
+            return ({'text/plain': msg, 'image/png': rich_output.png.get()}, {})
         if isinstance(rich_output, OutputImageGif):
             msg = self.launch_viewer(
                 rich_output.gif.filename(ext='gif'), plain_text.text.get_str())

--- a/src/sage/repl/rich_output/backend_ipython.py
+++ b/src/sage/repl/rich_output/backend_ipython.py
@@ -245,7 +245,7 @@ class BackendIPythonCommandline(BackendIPython):
         if isinstance(rich_output, OutputLatex):
             return ({'text/plain': rich_output.latex.get_str()}, {})
         if isinstance(rich_output, OutputImagePng):
-           # IPython>=9.13 supports inline plots
+            # IPython>=9.13 supports inline plots
             from sage.repl.interpreter import inline_plots
             if inline_plots():
                 return ({'text/plain': '', 'image/png': rich_output.png.get()}, {})


### PR DESCRIPTION
Requires IPython >=9.13

Setting as draft as this probably needs to be configurable.

Implements #42054 

<img width="1396" height="1025" alt="Screenshot_20260725_125247" src="https://github.com/user-attachments/assets/d798b289-20cd-4c48-81b5-6da52eaf4642" />


