### PR TITLE
Link ntl directly to fix darwin builds

### DIFF
--- a/src/sage/libs/eclib/meson.build
+++ b/src/sage/libs/eclib/meson.build
@@ -29,7 +29,7 @@ foreach name, pyx : extension_data_cpp
     install: true,
     override_options: ['cython_language=cpp'],
     include_directories: [inc_cpython, inc_ext, inc_flint, inc_ntl, inc_rings],
-    dependencies: [py_dep, cysignals, ec, ecl, flint, gmp],
+    dependencies: [py_dep, cysignals, ec, ecl, flint, gmp, ntl],
   )
 endforeach
 

--- a/src/sage/rings/polynomial/meson.build
+++ b/src/sage/rings/polynomial/meson.build
@@ -196,11 +196,11 @@ foreach name, pyx : extension_data_cpp
   elif name == 'plural'
     deps += [singular]
   elif name == 'polynomial_zz_pex'
-    deps += [cypari2]
+    deps += [cypari2, ntl]
   elif name == 'polynomial_integer_dense_ntl' or name == 'polynomial_modn_dense_ntl'
-    deps += [cypari2]
+    deps += [cypari2, ntl]
   elif name == 'polynomial_gf2x'
-    deps += [cypari2]
+    deps += [cypari2, ntl]
   elif name == 'evaluation_ntl'
     deps += [ntl, mpfr, mpfi]    # Runtime dependencies
   endif


### PR DESCRIPTION
Fixes #40898

Fix building sage on Darwin (see NixOS/nixpkgs#546056) by explicitly passing `ntl` to the linker.

Without this change the linker hard-fails:

```
clang++  -o src/sage/libs/eclib/mwrank.cpython-314-darwin.so src/sage/libs/eclib/mwrank.cpython-314-darwin.so.p/meson-generated_src_sage_libs_eclib_mwrank.pyx.cpp.o -Wl,-dead_strip_dylibs -Wl,-headerpad_max_install_names -Wl,-undefined,dynamic_lookup -bundle -Wl,-undefined,dynamic_lookup
/nix/store/rdygrnmrxhmzsrg63wb6m8mx8mcmad7n-eclib-20250627/lib/libec.dylib -lecl
/nix/store/saaj0vlz8bmxd8z5l3a6wm85ss8fdbv8-flint-3.6.0/lib/libflint.dylib
/nix/store/c8i80yixjlm4ljgyg96bx57nalcbpsly-gmp-with-cxx-6.3.0/lib/libgmp.dylib
/nix/store/72vjb4bvkbb0ykglvdndvqplrhpsl8v7-mpfr-4.2.2/lib/libmpfr.dylib
ld: illegal thread local variable reference to regular symbol __ZN3NTL2RR4precE for architecture arm64
```

Apparently this is not a problem on Linux as `ntl` is indirectly referenced by dependencies such as eclib. The symbol in question is a thread-local variable provided by the `ntl` lib. It appears there are some differences in how GCC/Linux and CLang/Darwin handle thread-locals.

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->


### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


