### PR TITLE
fix: handle missing weight in modular_characteristic

### DIFF
--- a/src/sage/combinat/root_system/integrable_representations.py
+++ b/src/sage/combinat/root_system/integrable_representations.py
@@ -1040,23 +1040,27 @@ class IntegrableRepresentation(UniqueRepresentation, CategoryObject):
 
         EXAMPLES::
 
+            sage: R = RootSystem(['A',1,1])
+            sage: chi = IntegrableRepresentation(
+            ....:     R.weight_lattice(extended=true).fundamental_weight(0)
+            ....: )
+            sage: chi.modular_characteristic()
+            -1/24
+
             sage: Lambda = RootSystem(['A',1,1]).weight_lattice(extended=true).fundamental_weights()
             sage: V = IntegrableRepresentation(3*Lambda[0]+2*Lambda[1])
             sage: [V.modular_characteristic(x) for x in V.dominant_maximal_weights()]
             [11/56, -1/280, 111/280]
         """
-        if isinstance(mu, tuple):
-            n = mu
-        else:
-            n = self.from_weight(mu)
         k = self.level()
         hd = self.dual_coxeter_number()
         rho = self._P.rho()
         m_Lambda = self._inner_pp(self._Lam_rho, self._Lam_rho) / (2*(k+hd)) \
                    - self._inner_pp(rho, rho) / (2*hd)
-        if n is None:
+        if mu is None:
             return m_Lambda
-        mu = self.to_weight(n)
+        if isinstance(mu, tuple):
+            mu = self.to_weight(mu)
         return m_Lambda - self._inner_pp(mu,mu) / (2*k)
 
     def branch(self, i=None, weyl_character_ring=None, sequence=None, depth=5):


### PR DESCRIPTION
Fix `IntegrableRepresentation.modular_characteristic()` when called without `mu`.

Previously, `mu=None` was passed to `from_weight()`, causing a TypeError.

This change:
- returns `m_Lambda` directly when `mu` is not provided;
- converts tuple inputs directly to weights without the unnecessary round-trip through `from_weight()`.

Added a regression doctest for the reported case.

Fixes #42582

Tests:
- `./sage -t src/sage/combinat/root_system/integrable_representations.py`
- 159 tests passed