### PR TITLE
Default to Accelerate BLAS/LAPACK on macOS only

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -351,8 +351,8 @@ AS_CASE([$host],
         [*-*-darwin*], [sage_darwin_accelerate_default=yes],
         [sage_darwin_accelerate_default=no])
 AC_ARG_WITH([darwin-accelerate],
-            [AS_HELP_STRING([--without-darwin-accelerate],
-                            [on macOS, use OpenBLAS rather than the Accelerate framework for BLAS/LAPACK (default: use Accelerate)])],
+            [AS_HELP_STRING([--with-darwin-accelerate={no,yes}],
+                            [use Darwin (macOS) Accelerate BLAS/LAPACK (default: yes on macOS, no elsewhere)])],
             [SAGE_DARWIN_ACCELERATE="$withval"],
             [SAGE_DARWIN_ACCELERATE="$sage_darwin_accelerate_default"])
 AS_CASE([$host],

--- a/configure.ac
+++ b/configure.ac
@@ -342,11 +342,24 @@ m4_pushdef([SAGE_BOOTSTRAP_URL],[See https://doc.sagemath.org/html/en/reference/
    ])
 
 # choose BLAS/LAPACK on Darwin
+dnl Accelerate is always available on macOS, works well, and avoids picking up
+dnl a third-party OpenBLAS whose openblas.pc advertises compile flags that are
+dnl not ours to pass on; see https://github.com/sagemath/sage/issues/42096.
+dnl The framework does not exist on any other platform, so the option must
+dnl remain "no" there.
+AS_CASE([$host],
+        [*-*-darwin*], [sage_darwin_accelerate_default=yes],
+        [sage_darwin_accelerate_default=no])
 AC_ARG_WITH([darwin-accelerate],
-            [AS_HELP_STRING([--with-darwin-accelerate={no (default)},yes}],
-                            [use Darwin (macOS) Accelerate BLAS/LAPACK])],
+            [AS_HELP_STRING([--without-darwin-accelerate],
+                            [on macOS, use OpenBLAS rather than the Accelerate framework for BLAS/LAPACK (default: use Accelerate)])],
             [SAGE_DARWIN_ACCELERATE="$withval"],
-            [SAGE_DARWIN_ACCELERATE="no"])
+            [SAGE_DARWIN_ACCELERATE="$sage_darwin_accelerate_default"])
+AS_CASE([$host],
+        [*-*-darwin*], [],
+        [AS_IF([test x$SAGE_DARWIN_ACCELERATE = xyes],
+               [AC_MSG_WARN([--with-darwin-accelerate is only supported on macOS; ignoring it on $host])])
+         SAGE_DARWIN_ACCELERATE=no])
 AC_SUBST([SAGE_DARWIN_ACCELERATE])
 
 SAGE_DARWIN_PKG_CONFIG_PATH=


### PR DESCRIPTION
Fixes #42096.

On macOS, make `yes` the default value of `--with-darwin-accelerate`. Accelerate
is always available there, needs no separate BLAS build, and avoids picking up a
third-party OpenBLAS whose `openblas.pc` advertises compile flags that are not
ours to pass on — which is what makes the default build fail in #42096.

`--without-darwin-accelerate` still selects OpenBLAS for anyone who wants it.

### Why the default is derived from `$host`

This is the difference from #42571, which sets the default unconditionally.
`build/pkgs/openblas/spkg-configure.m4` tests `SAGE_DARWIN_ACCELERATE` without a
Darwin guard:

```m4
SAGE_SPKG_CONFIGURE([openblas], [dnl CHECK
 AS_IF([test x$SAGE_DARWIN_ACCELERATE = xyes],
 [AC_CHECK_HEADER([Accelerate/Accelerate.h], [dnl macOS
  ], [AC_MSG_ERROR([Cannot locate Accelerate headers. ...])])],
```

so an unconditional `yes` turns every non-macOS build into a hard configure
error:

```
Checking whether SageMath should install SPKG openblas...
checking for Accelerate/Accelerate.h... no
configure: error: Cannot locate Accelerate headers. Make sure XCode CL tools are installed.
```

On #42571 that fails all 8 Linux distro jobs while both macOS jobs pass.
`AC_CANONICAL_HOST` already runs well before this point, so the default is
simply taken from `$host` instead.

For the same reason, an explicit `--with-darwin-accelerate` on a non-Darwin host
is now warned about and ignored rather than passed down to the openblas check.

### Behaviour

| host | flag | `SAGE_DARWIN_ACCELERATE` |
|---|---|---|
| Darwin | *(none)* | `yes` |
| Darwin | `--with-darwin-accelerate` | `yes` |
| Darwin | `--without-darwin-accelerate` | `no` |
| Linux / FreeBSD | *(none)* | `no` |
| Linux / FreeBSD | `--with-darwin-accelerate` | `no` + warning |

Verified by running the generated block from `real_configure` against each of
these combinations.

### Relation to other PRs

- Supersedes #42571, which this carries the intent of; that one can be closed in
  favour of this.
- #42096 also has an underlying cause that this PR does not address: Homebrew's
  `openblas.pc` lists `-Xpreprocessor -fopenmp` in `Cflags:`, Sage's `blas.pc` /
  `cblas.pc` are symlinks to it, and `fflas_ffpack/spkg-install.in` forwards
  those flags into `--with-blas-cflags`, where libtool splits the pair at link
  time and leaves a bare `-fopenmp` that Apple clang rejects. Flipping the
  default means a plain `./configure` no longer hits that path, but
  `--without-darwin-accelerate` still does.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview. (Only the `configure --help` string here; the installation-guide section on the macOS BLAS default comes with the follow-up PR.)