### PR TITLE
Fix GMP temporary leak in rational reconstruction on the failing path

### DIFF
--- a/src/sage/matrix/matrix_rational_dense.pyx
+++ b/src/sage/matrix/matrix_rational_dense.pyx
@@ -2301,16 +2301,18 @@ cdef class Matrix_rational_dense(Matrix_dense):
         cdef mpq_t tmp2
         mpz_init(tmp)
         mpq_init(tmp2)
-        ZA = _lift_crt(res, mm)
-        QA = Matrix_rational_dense.__new__(Matrix_rational_dense, self.parent(), None, None, None)
-        m = mm.prod()
-        for i in range(ZA._nrows):
-            for j in range(ZA._ncols):
-                fmpz_get_mpz(tmp, fmpz_mat_entry(ZA._matrix,i,j))
-                mpq_rational_reconstruction(tmp2, tmp, m.value)
-                fmpq_set_mpq(fmpq_mat_entry(QA._matrix, i, j), tmp2)
-        mpz_clear(tmp)
-        mpq_clear(tmp2)
+        try:
+            ZA = _lift_crt(res, mm)
+            QA = Matrix_rational_dense.__new__(Matrix_rational_dense, self.parent(), None, None, None)
+            m = mm.prod()
+            for i in range(ZA._nrows):
+                for j in range(ZA._ncols):
+                    fmpz_get_mpz(tmp, fmpz_mat_entry(ZA._matrix,i,j))
+                    mpq_rational_reconstruction(tmp2, tmp, m.value)
+                    fmpq_set_mpq(fmpq_mat_entry(QA._matrix, i, j), tmp2)
+        finally:
+            mpz_clear(tmp)
+            mpq_clear(tmp2)
         return QA
 
     def randomize(self, density=1, num_bound=2, den_bound=2,

--- a/src/sage/matrix/misc.pyx
+++ b/src/sage/matrix/misc.pyx
@@ -54,6 +54,62 @@ def matrix_integer_sparse_rational_reconstruction(Matrix_integer_sparse A, Integ
         Traceback (most recent call last):
         ...
         ZeroDivisionError: The modulus cannot be zero
+
+    Check that :issue:`42533` is fixed: the GMP temporaries must be released
+    even when reconstruction of an entry fails, which is the normal signal
+    that not enough primes have been used yet::
+
+        sage: import resource
+        sage: A = matrix(ZZ, 1, 1, {(0, 0): 12345}, sparse=True)
+
+    The entry is genuinely not reconstructible modulo 13 (it reduces to 8,
+    while the bound on numerator and denominator is 2), so every call below
+    really does take the failing path::
+
+        sage: matrix_integer_sparse_rational_reconstruction(A, 13)
+        Traceback (most recent call last):
+        ...
+        ValueError: rational reconstruction does not exist
+
+    ::
+
+        sage: def leak(N):
+        ....:     before = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        ....:     for _ in range(N):
+        ....:         try:
+        ....:             matrix_integer_sparse_rational_reconstruction(A, 13)
+        ....:         except ValueError:
+        ....:             pass
+        ....:     after = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        ....:     return (after - before) * 1024   # ru_maxrss is in kilobytes
+
+    Loop (at most 30 times) until we have 6 consecutive zeros when calling
+    ``leak(10000)``. Before the fix each failing call leaked about 113 bytes,
+    so 10000 iterations grew the resident set by more than a megabyte::
+
+        sage: zeros = 0
+        sage: for i in range(30):  # long time
+        ....:     n = leak(10000)
+        ....:     print("Leaked {} bytes".format(n))
+        ....:     if n == 0:
+        ....:         zeros += 1
+        ....:         if zeros >= 6:
+        ....:             break
+        ....:     else:
+        ....:         zeros = 0
+        Leaked...
+        Leaked 0 bytes
+        Leaked 0 bytes
+        Leaked 0 bytes
+        Leaked 0 bytes
+        Leaked 0 bytes
+
+    Since ``ru_maxrss`` is a high-water mark, the printed lines alone would
+    also match a run that exhausted the 30 iterations without ever reaching
+    six consecutive zeros, so check that explicitly::
+
+        sage: zeros >= 6  # long time
+        True
     """
     if not N:
         raise ZeroDivisionError("The modulus cannot be zero")
@@ -73,51 +129,53 @@ def matrix_integer_sparse_rational_reconstruction(Matrix_integer_sparse A, Integ
     mpz_init_set_si(denom, 1)
     mpz_init(a)
     mpz_init(other_bnd)
+    mpz_init(bnd)
 
-    _bnd = (N//2).isqrt()
-    mpz_init_set(bnd, _bnd.value)
-    mpz_sub(other_bnd, N.value, bnd)
+    try:
+        _bnd = (N//2).isqrt()
+        mpz_set(bnd, _bnd.value)
+        mpz_sub(other_bnd, N.value, bnd)
 
-    for i in range(A._nrows):
-        sig_check()
-        A_row = &A._matrix[i]
-        R_row = &R._matrix[i]
-        reallocate_mpq_vector(R_row, A_row.num_nonzero)
-        R_row.num_nonzero = A_row.num_nonzero
-        R_row.degree = A_row.degree
-        for j in range(A_row.num_nonzero):
+        for i in range(A._nrows):
             sig_check()
-            mpz_set(a, A_row.entries[j])
-            if mpz_cmp_ui(denom, 1) != 0:
-                mpz_mul(a, a, denom)
-            mpz_fdiv_r(a, a, N.value)
-            do_it = 0
-            if mpz_cmp(a, bnd) <= 0:
-                do_it = 1
-            elif mpz_cmp(a, other_bnd) >= 0:
-                mpz_sub(a, a, N.value)
-                do_it = 1
-            if do_it:
-                mpz_set(mpq_numref(t), a)
+            A_row = &A._matrix[i]
+            R_row = &R._matrix[i]
+            reallocate_mpq_vector(R_row, A_row.num_nonzero)
+            R_row.num_nonzero = A_row.num_nonzero
+            R_row.degree = A_row.degree
+            for j in range(A_row.num_nonzero):
+                sig_check()
+                mpz_set(a, A_row.entries[j])
                 if mpz_cmp_ui(denom, 1) != 0:
-                    mpz_set(mpq_denref(t), denom)
-                    mpq_canonicalize(t)
+                    mpz_mul(a, a, denom)
+                mpz_fdiv_r(a, a, N.value)
+                do_it = 0
+                if mpz_cmp(a, bnd) <= 0:
+                    do_it = 1
+                elif mpz_cmp(a, other_bnd) >= 0:
+                    mpz_sub(a, a, N.value)
+                    do_it = 1
+                if do_it:
+                    mpz_set(mpq_numref(t), a)
+                    if mpz_cmp_ui(denom, 1) != 0:
+                        mpz_set(mpq_denref(t), denom)
+                        mpq_canonicalize(t)
+                    else:
+                        mpz_set_si(mpq_denref(t), 1)
+                    mpq_set(R_row.entries[j], t)
+                    R_row.positions[j] = A_row.positions[j]
                 else:
-                    mpz_set_si(mpq_denref(t), 1)
-                mpq_set(R_row.entries[j], t)
-                R_row.positions[j] = A_row.positions[j]
-            else:
-                # Otherwise have to do it the hard way
-                mpq_rational_reconstruction(t, A_row.entries[j], N.value)
-                mpq_set(R_row.entries[j], t)
-                R_row.positions[j] = A_row.positions[j]
-                mpz_lcm(denom, denom, mpq_denref(t))
-
-    mpq_clear(t)
-    mpz_clear(denom)
-    mpz_clear(a)
-    mpz_clear(other_bnd)
-    mpz_clear(bnd)
+                    # Otherwise have to do it the hard way
+                    mpq_rational_reconstruction(t, A_row.entries[j], N.value)
+                    mpq_set(R_row.entries[j], t)
+                    R_row.positions[j] = A_row.positions[j]
+                    mpz_lcm(denom, denom, mpq_denref(t))
+    finally:
+        mpq_clear(t)
+        mpz_clear(denom)
+        mpz_clear(a)
+        mpz_clear(other_bnd)
+        mpz_clear(bnd)
 
     return R
 

--- a/src/sage/matrix/misc_flint.pyx
+++ b/src/sage/matrix/misc_flint.pyx
@@ -47,6 +47,60 @@ def matrix_integer_dense_rational_reconstruction(Matrix_integer_dense A, Integer
         Traceback (most recent call last):
         ...
         ZeroDivisionError: The modulus cannot be zero
+
+    Check that :issue:`42533` is fixed: the GMP temporaries must be released
+    even when reconstruction of an entry fails::
+
+        sage: import resource
+        sage: A = matrix(ZZ, 1, 1, [12345])
+
+    The entry is genuinely not reconstructible modulo 13 (it reduces to 8,
+    while the bound on numerator and denominator is 2), so every call below
+    really does take the failing path::
+
+        sage: matrix_integer_dense_rational_reconstruction(A, 13)
+        Traceback (most recent call last):
+        ...
+        ValueError: rational reconstruction does not exist
+
+    ::
+
+        sage: def leak(N):
+        ....:     before = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        ....:     for _ in range(N):
+        ....:         try:
+        ....:             matrix_integer_dense_rational_reconstruction(A, 13)
+        ....:         except ValueError:
+        ....:             pass
+        ....:     after = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        ....:     return (after - before) * 1024   # ru_maxrss is in kilobytes
+
+    Loop (at most 30 times) until we have 6 consecutive zeros when calling
+    ``leak(10000)``. Before the fix each failing call leaked about 190 bytes::
+
+        sage: zeros = 0
+        sage: for i in range(30):  # long time
+        ....:     n = leak(10000)
+        ....:     print("Leaked {} bytes".format(n))
+        ....:     if n == 0:
+        ....:         zeros += 1
+        ....:         if zeros >= 6:
+        ....:             break
+        ....:     else:
+        ....:         zeros = 0
+        Leaked...
+        Leaked 0 bytes
+        Leaked 0 bytes
+        Leaked 0 bytes
+        Leaked 0 bytes
+        Leaked 0 bytes
+
+    Since ``ru_maxrss`` is a high-water mark, the printed lines alone would
+    also match a run that exhausted the 30 iterations without ever reaching
+    six consecutive zeros, so check that explicitly::
+
+        sage: zeros >= 6  # long time
+        True
     """
     if not N:
         raise ZeroDivisionError("The modulus cannot be zero")
@@ -65,43 +119,45 @@ def matrix_integer_dense_rational_reconstruction(Matrix_integer_dense A, Integer
     mpz_init(tmp)
     mpz_init(other_bnd)
     mpq_init(qtmp)
+    mpz_init(bnd)
 
-    _bnd = (N//2).isqrt()
-    mpz_init_set(bnd, _bnd.value)
-    mpz_sub(other_bnd, N.value, bnd)
+    try:
+        _bnd = (N//2).isqrt()
+        mpz_set(bnd, _bnd.value)
+        mpz_sub(other_bnd, N.value, bnd)
 
-    for i in range(A._nrows):
-        for j in range(A._ncols):
-            sig_check()
-            A.get_unsafe_mpz(i, j, a)
-            if mpz_cmp_ui(denom, 1) != 0:
-                mpz_mul(a, a, denom)
-            mpz_fdiv_r(a, a, N.value)
-            do_it = 0
-            if mpz_cmp(a, bnd) <= 0:
-                do_it = 1
-            elif mpz_cmp(a, other_bnd) >= 0:
-                mpz_sub(a, a, N.value)
-                do_it = 1
-            if do_it:
-                fmpz_set_mpz(fmpq_mat_entry_num(R._matrix, i, j), a)
+        for i in range(A._nrows):
+            for j in range(A._ncols):
+                sig_check()
+                A.get_unsafe_mpz(i, j, a)
                 if mpz_cmp_ui(denom, 1) != 0:
-                    fmpz_set_mpz(fmpq_mat_entry_den(R._matrix, i, j), denom)
-                    fmpq_canonicalise(fmpq_mat_entry(R._matrix, i, j))
+                    mpz_mul(a, a, denom)
+                mpz_fdiv_r(a, a, N.value)
+                do_it = 0
+                if mpz_cmp(a, bnd) <= 0:
+                    do_it = 1
+                elif mpz_cmp(a, other_bnd) >= 0:
+                    mpz_sub(a, a, N.value)
+                    do_it = 1
+                if do_it:
+                    fmpz_set_mpz(fmpq_mat_entry_num(R._matrix, i, j), a)
+                    if mpz_cmp_ui(denom, 1) != 0:
+                        fmpz_set_mpz(fmpq_mat_entry_den(R._matrix, i, j), denom)
+                        fmpq_canonicalise(fmpq_mat_entry(R._matrix, i, j))
+                    else:
+                        fmpz_one(fmpq_mat_entry_den(R._matrix, i, j))
                 else:
-                    fmpz_one(fmpq_mat_entry_den(R._matrix, i, j))
-            else:
-                # Otherwise have to do it the hard way
-                A.get_unsafe_mpz(i, j, tmp)
-                mpq_rational_reconstruction(qtmp, tmp, N.value)
-                mpz_lcm(denom, denom, mpq_denref(qtmp))
-                fmpq_set_mpq(fmpq_mat_entry(R._matrix, i, j), qtmp)
-
-    mpz_clear(denom)
-    mpz_clear(a)
-    mpz_clear(tmp)
-    mpz_clear(other_bnd)
-    mpz_clear(bnd)
-    mpq_clear(qtmp)
+                    # Otherwise have to do it the hard way
+                    A.get_unsafe_mpz(i, j, tmp)
+                    mpq_rational_reconstruction(qtmp, tmp, N.value)
+                    mpz_lcm(denom, denom, mpq_denref(qtmp))
+                    fmpq_set_mpq(fmpq_mat_entry(R._matrix, i, j), qtmp)
+    finally:
+        mpz_clear(denom)
+        mpz_clear(a)
+        mpz_clear(tmp)
+        mpz_clear(other_bnd)
+        mpq_clear(qtmp)
+        mpz_clear(bnd)
 
     return R


### PR DESCRIPTION
Fixes #42533.

### Root cause

`matrix_integer_sparse_rational_reconstruction` (`sage/matrix/misc.pyx`) initializes five GMP temporaries (`mpq_t t`, `mpz_t a, bnd, other_bnd, denom`) and clears them only after the loop. Two paths leave the function early and skip the clears:

- `mpq_rational_reconstruction` raising `ValueError` when an entry has no rational reconstruction modulo `N`;
- `sig_check()` raising `KeyboardInterrupt`.

As the issue notes, the first is not an exotic path: `matrix_rational_echelon_form_multimodular` treats a failed reconstruction as the *normal* signal that not enough primes have been used yet, so the retry loop hits it many times per echelon-form computation.

### Fix

Wrap the body in `try:`/`finally:` with the clears in the `finally` block — the idiom `mpq_rational_reconstruction` itself already uses (`sage/arith/rational_reconstruction.pyx`, from #17180).

`bnd` was previously created with `mpz_init_set(bnd, _bnd.value)` *after* `_bnd = (N//2).isqrt()`. It is now `mpz_init(bnd)` before the `try` with `mpz_set` inside, so it is always in a clearable state. This additionally fixes a negative-modulus leak: `isqrt()` raises `ValueError` for negative `N`, which previously leaked the four temporaries initialized before it.

### Scope

The issue names only the sparse function; the same defect exists in two more places, fixed here as well:

- `matrix_integer_dense_rational_reconstruction` (`sage/matrix/misc_flint.pyx`) — the copy-pasted dense counterpart, measured at ~192 bytes per failing call;
- `Matrix_rational_dense._lift_crt_rr` — same shape, clears `tmp`/`tmp2` only after a loop calling `mpq_rational_reconstruction`. It has no in-tree caller but is a public method.

Happy to split these out if reviewers would rather keep the PR to the reported function.

### Verification

Measured over 200,000 failing calls each:

| function | before | after |
|---|---|---|
| `matrix_integer_sparse_rational_reconstruction` | 114 bytes/call | 0 |
| `matrix_integer_dense_rational_reconstruction` | 192 bytes/call | 0 |

The 114 bytes/call matches the ~113 reported in the issue.

I confirmed the new regression doctests genuinely bite by reverting the `try:`/`finally:` while keeping the tests: the loop reports ~1.5 MB leaked per 10,000 calls and never converges, so the doctest fails.

I also checked that the partially filled result matrix abandoned when the exception propagates mid-loop is not a *second* leak — a 5x5 case failing on the last row leaks 0 bytes/call, since `__cinit__` pre-initializes every row and `mpq_vector_clear` returns early on `NULL` entries.

### Doctests

The regression doctests follow the established Sage idiom (`sage/libs/singular/polynomial.pyx`), with two additions:

- an explicit `ValueError` check first, so the measurement loop cannot pass vacuously if the input ever became reconstructible;
- an explicit `zeros >= 6` assertion, because `ru_maxrss` is a high-water mark and the printed lines alone would also match a run that exhausted all 30 iterations without ever converging.

`--long` doctests pass for the three touched files plus `matrix_rational_sparse`, `matrix_integer_sparse`, `matrix_integer_dense`, `arith/rational_reconstruction` and `modular/modsym`.

### 📝 Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### ⌛ Dependencies

None.
