### PR TITLE
Fix small_roots lattice dimensions

### DIFF
--- a/src/sage/rings/polynomial/polynomial_modn_dense_ntl.pyx
+++ b/src/sage/rings/polynomial/polynomial_modn_dense_ntl.pyx
@@ -604,6 +604,21 @@ def small_roots(self, X=None, beta=1.0, epsilon=None, **kwds):
         sage: q == qbar - d                                                             # needs sage.symbolic
         True
 
+    TESTS:
+
+    The lattice has no trailing zero columns when `t < \delta`
+    (:issue:`42590`)::
+
+        sage: R.<x> = PolynomialRing(Zmod(17), implementation='NTL')
+        sage: f = x^2 - 5*x + 6
+        sage: from sage.misc.verbose import set_verbose
+        sage: set_verbose(1)
+        sage: f.small_roots()
+        verbose 1 (<module>) LLL of 8x8 matrix (algorithm ...)
+        verbose 1 (<module>) LLL finished (time = ...)
+        [2]
+        sage: set_verbose(0)
+
     REFERENCES:
 
     Don Coppersmith. *Finding a small root of a univariate modular equation.*
@@ -653,7 +668,7 @@ def small_roots(self, X=None, beta=1.0, epsilon=None, **kwds):
     g  = [x**j * N**(m-i) * f**i for i in range(m) for j in range(delta)]
     g.extend([x**i * f**m for i in range(t)])  # h
 
-    B = Matrix(ZZ, len(g), delta*m + max(delta,t) )
+    B = Matrix(ZZ, len(g), delta*m + t)
     for i in range(B.nrows()):
         for j in range( g[i].degree()+1 ):
             B[i, j] = g[i][j]*X**j


### PR DESCRIPTION
Fixes #42590

`small_roots()` creates `delta*m + t` basis polynomials, with maximum degree `delta*m + t - 1`

The matrix currently allocates `delta*m + max(delta, t)` columns, which leaves trailing zero columns whenever `t < delta` and sends an unnecessarily rectangular basis to LLL

This uses the exact coefficient count and adds a regression doctest for the `t = 0` case

Tests:

- full editable Meson build against current `develop`
- `python -m sage.doctest -p 2 -T 0 --long --file-iterations 3 src/sage/rings/polynomial/polynomial_modn_dense_ntl.pyx`
- the same long doctest with random seeds `0`, `1`, and `8675309`
- the repository Ruff, relint, and RST workflow commands

### :memo: Checklist

- [x] The title is concise and informative
- [x] The description explains in detail what this PR is about
- [x] I have linked a relevant issue or discussion
- [x] I have created tests covering the changes
- [x] I have updated the documentation and checked the documentation preview

### :hourglass: Dependencies

None