### PR TITLE
Unify graph plotting documentation

### DIFF
--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -21232,7 +21232,7 @@ class GenericGraph(GenericGraph_pyx):
 
         - ``layout`` -- string (default: ``None``); specifies a layout algorithm
           among ``'acyclic'``, ``'acyclic_dummy'``, ``'circular'``,
-          ``'ranked'``, ``'graphviz'``, ``'planar'``, ``'spring'``,
+          ``'ranked'``, ``'graphviz'``, ``'planar'``, ``'tutte'``, ``'spring'``,
           ``'forest'`` or ``'tree'``
 
         - ``pos`` -- dictionary (default: ``None``); a dictionary of positions
@@ -21300,15 +21300,15 @@ class GenericGraph(GenericGraph_pyx):
             ....:     print("option {} : {}".format(key, value))
             option by_component : Whether to do the spring layout by connected component -- boolean.
             option dim : The dimension of the layout -- 2 or 3.
-            option external_face : A list of the vertices of the external face of the graph, used for Tutte embedding layout.
-            option external_face_pos : A dictionary specifying the positions of the external face of the graph, used for Tutte embedding layout. If none specified, theexternal face is a regular polygon.
+            option external_face : A list of the vertices of the external face of the graph if used for Tutte embedding layout; or an edge on the external face if used for the 'planar' layout.
+            option external_face_pos : A dictionary specifying the positions of the external face of the graph, used for Tutte embedding layout. If none specified, the external face is a regular polygon.
             option forest_roots : An iterable specifying which vertices to use as roots for the ``layout='forest'`` option. If no root is specified for a tree, then one is chosen close to the center of the tree. Ignored unless ``layout='forest'``.
             option heights : A dictionary mapping heights to the list of vertices at this height.
             option iterations : The number of times to execute the spring layout algorithm.
-            option layout : A layout algorithm -- one of : "acyclic", "circular" (plots the graph with vertices evenly distributed on a circle), "ranked", "graphviz", "planar", "spring" (traditional spring layout, using the graph's current positions as initial positions), or "tree" (the tree will be plotted in levels, depending on minimum distance for the root).
+            option layout : A layout algorithm -- one of: ...
             option prog : Which graphviz layout program to use -- one of "circo", "dot", "fdp", "neato", or "twopi".
             option save_pos : Whether or not to save the computed position for the graph.
-            option spring : Use spring layout to finalize the current layout.
+            option spring : Use spring layout to finalize the current 'ranked' layout.
             option tree_orientation : The direction of tree branches -- 'up', 'down', 'left' or 'right'.
             option tree_root : A vertex designation for drawing trees. A vertex of the tree to be used as the root for the ``layout='tree'`` option. If no root is specified, then one is chosen close to the center of the tree. Ignored unless ``layout='tree'``.
 
@@ -22322,109 +22322,11 @@ class GenericGraph(GenericGraph_pyx):
 
         INPUT:
 
-        - ``pos`` -- an optional positioning dictionary
-
-        - ``layout`` -- string (default: ``None``); specifies a kind of layout
-          to use, takes precedence over pos
-
-          - ``'circular'`` -- plots the graph with vertices evenly distributed
-            on a circle
-
-          - ``'spring'`` -- uses the traditional spring layout, using the
-            graph's current positions as initial positions
-
-          - ``'tree'`` -- the (di)graph must be a tree. One can specify the root
-            of the tree using the keyword tree_root, otherwise a root will be
-            selected at random. Then the tree will be plotted in levels,
-            depending on minimum distance for the root.
-
-          - ``'tutte'`` -- uses the Tutte embedding algorithm. The graph must be
-            a 3-connected, planar graph.
-
-        - ``vertex_labels`` -- boolean (default: ``True``); whether to print
-          vertex labels
-
-        - ``edge_labels`` -- boolean (default: ``False``); whether to print edge
-          labels. If ``True``, the result of ``str(l)`` is printed on the edge
-          for each label `l`. Labels equal to ``None`` are not printed (to set
-          edge labels, see :meth:`set_edge_label`).
-
-        - ``edge_labels_background`` -- the color of the edge labels
-          background. The default is "white". To achieve a transparent
-          background use "transparent".
-
-        - ``vertex_size`` -- size of vertices displayed
-
-        - ``vertex_shape`` -- the shape to draw the vertices, for example
-          ``'o'`` for circle or ``'s'`` for square. Whole list is available at
-          https://matplotlib.org/api/markers_api.html.
-          (Not available for multiedge digraphs.)
-
-        - ``graph_border`` -- boolean (default: ``False``); whether to include a
-          box around the graph
-
-        - ``vertex_colors`` -- dictionary (default: ``None``); optional
-          dictionary to specify vertex colors: each key is a color recognizable
-          by matplotlib, and each corresponding entry is a list of vertices. If
-          a vertex is not listed, it looks invisible on the resulting plot (it
-          doesn't get drawn).
-
-        - ``edge_colors`` -- dictionary (default: ``None``); a dictionary
-          specifying edge colors: each key is a color recognized by matplotlib,
-          and each entry is a list of edges.
-
-        - ``partition`` -- a partition of the vertex set (default: ``None``); if
-          specified, plot will show each cell in a different color.
-          ``vertex_colors`` takes precedence.
-
-        - ``talk`` -- boolean (default: ``False``); if ``True``, prints large
-          vertices with white backgrounds so that labels are legible on slides
-
-        - ``iterations`` -- integer; how many iterations of the spring layout
-          algorithm to go through, if applicable
-
-        - ``color_by_label`` -- boolean or dictionary or function (default:
-          ``False``); whether to color each edge with a different color
-          according to its label; the colors are chosen along a rainbow, unless
-          they are specified by a function or dictionary mapping labels to
-          colors; this option is incompatible with ``edge_color`` and
-          ``edge_colors``.
-
-        - ``heights`` -- dictionary (default: ``None``); if specified, this is a
-          dictionary from a set of floating point heights to a set of vertices
-
-        - ``edge_style`` -- keyword arguments passed into the edge-drawing
-          routine.  This currently only works for directed graphs, since we pass
-          off the undirected graph to networkx
-
-        - ``tree_root`` -- a vertex (default: ``None``); if specified, this
-          vertex is used as the root for the ``layout="tree"`` option.
-          Otherwise, then one is chosen at random. Ignored unless
-          ``layout='tree'``.
-
-        - ``tree_orientation`` -- string (default: ``'down'``); one of "up" or
-          "down".  If "up" (resp., "down"), then the root of the tree will
-          appear on the bottom (resp., top) and the tree will grow upwards
-          (resp. downwards). Ignored unless ``layout='tree'``.
-
-        - ``external_face`` -- list of vertices (default: ``None``); the external face to be made a
-          in the Tutte layout. Ignored unless ``layout='tutte''``.
-
-        - ``external_face_pos`` -- dictionary (default: ``None``). If specified,
-          used as the positions for the external face in the Tutte layout.
-          Ignored unless ``layout='tutte'``.
-
-        - ``save_pos`` -- boolean (default: ``False``); save position computed
-          during plotting
+        See the documentation of the :mod:`sage.graphs.graph_plot` module
+        for supported parameters. In addition, this method supports all
+        parameters of :meth:`sage.plot.graphics.Graphics.show`.
 
         .. NOTE::
-
-            - This method supports any parameter accepted by
-              :meth:`sage.plot.graphics.Graphics.show`.
-
-            - See the documentation of the :mod:`sage.graphs.graph_plot` module
-              for information and examples of how to define parameters that will
-              be applied to **all** graph plots.
 
             - Default parameters for this method *and a specific graph* can also
               be set through the :class:`~sage.misc.decorators.options`

--- a/src/sage/graphs/graph_plot.py
+++ b/src/sage/graphs/graph_plot.py
@@ -48,10 +48,10 @@ Here is the list of options accepted by
 :class:`GraphPlot`. Those two functions also accept all options of
 :meth:`sage.plot.graphics.Graphics.show`.
 
-.. csv-table::
+.. list-table::
     :class: contentstable
-    :widths: 30, 70
-    :delim: |
+    :header-rows: 1
+    :widths: 25, 65, 10
 
 {PLOT_OPTIONS_TABLE}
 
@@ -134,19 +134,38 @@ lazy_import("sage.plot.all", [
 
 
 layout_options = {
-    'layout':
-        'A layout algorithm -- one of : "acyclic", "circular" (plots the '
-        'graph with vertices evenly distributed on a circle), "ranked", '
-        '"graphviz", "planar", "spring" (traditional spring layout, using '
-        'the graph\'s current positions as initial positions), or "tree" '
-        '(the tree will be plotted in levels, depending on minimum distance '
-        'for the root).',
+    'layout': '''A layout algorithm -- one of:
+
+        - :meth:`'circular' <sage.graphs.generic_graph.GenericGraph.layout_circular>` --
+          plots the graph with vertices evenly distributed on a circle
+        - :meth:`'spring' <sage.graphs.generic_graph.GenericGraph.layout_spring>` --
+          uses the traditional spring layout, using the
+          graph's current positions as initial positions
+        - :meth:`'ranked' <sage.graphs.generic_graph.GenericGraph.layout_ranked>` --
+          plots the graph randomly according to the specified
+          ``heights`` dictionary
+        - :meth:`'graphviz' <sage.graphs.generic_graph.GenericGraph.layout_graphviz>` --
+          plots the graph using graphviz
+        - :meth:`'planar' <sage.graphs.generic_graph.GenericGraph.layout_planar>` --
+          computes a planar layout using Schnyder's algorithm
+        - :meth:`'tutte' <sage.graphs.generic_graph.GenericGraph.layout_tutte>` --
+          uses the Tutte embedding algorithm. The graph must be
+          a 3-connected, planar graph.
+        - :meth:`'tree' <sage.graphs.generic_graph.GenericGraph.layout_tree>` --
+          the (di)graph must be a tree. One can specify the root of the tree
+          using the ``tree_root`` parameter and the growth direction
+          using the ``tree_orientation`` parameter.
+        - :meth:`'forest' <sage.graphs.generic_graph.GenericGraph.layout_forest>` --
+          plots each connected component using the 'tree' layout
+        - :meth:`'acyclic' <sage.graphs.digraph.DiGraph.layout_acyclic>` --
+          plots an acyclic digraph so that all edges point upward
+''',
     'iterations':
         'The number of times to execute the spring layout algorithm.',
     'heights':
         'A dictionary mapping heights to the list of vertices at this height.',
     'spring':
-        'Use spring layout to finalize the current layout.',
+        "Use spring layout to finalize the current 'ranked' layout.",
     'tree_root':
         'A vertex designation for drawing trees. A vertex of the tree to '
         'be used as the root for the ``layout=\'tree\'`` option. If no root '
@@ -161,11 +180,12 @@ layout_options = {
         'The direction of tree branches -- \'up\', \'down\', '
         '\'left\' or \'right\'.',
     'external_face':
-        'A list of the vertices of the external face of the graph, '
-        'used for Tutte embedding layout.',
+        'A list of the vertices of the external face of the graph '
+        'if used for Tutte embedding layout; or an edge on the external face '
+        "if used for the 'planar' layout.",
     'external_face_pos':
         'A dictionary specifying the positions of the external face of the '
-        'graph, used for Tutte embedding layout. If none specified, the'
+        'graph, used for Tutte embedding layout. If none specified, the '
         'external face is a regular polygon.',
     'save_pos':
         'Whether or not to save the computed position for the graph.',
@@ -181,7 +201,8 @@ graphplot_options = layout_options.copy()
 
 graphplot_options.update({
     'pos':
-        'The position dictionary of vertices.',
+        'The position dictionary of vertices. Ignored when ``layout`` is '
+        'specified.',
     'vertex_labels':
         'Vertex labels to draw. This can be ``True``/``False`` to indicate '
         'whether to print the vertex string representation of not, '
@@ -201,7 +222,9 @@ graphplot_options.update({
     'vertex_size':
         'The size to draw the vertices.',
     'vertex_shape':
-        'The shape to draw the vertices. '
+        "The shape to draw the vertices, for example ``'o'`` for circle or "
+        "``'s'`` for square. Whole list is available at "
+        'https://matplotlib.org/api/markers_api.html. '
         'Currently unavailable for Multi-edged DiGraphs.',
     'edge_labels':
         'Whether or not to draw edge labels.',
@@ -227,15 +250,16 @@ graphplot_options.update({
         'each key is a color recognized by matplotlib, '
         'and each corresponding value is a list of edges.',
     'color_by_label':
-        'Whether to color the edges according to their labels. This also '
-        'accepts a function or dictionary mapping labels to colors.',
+        'Whether to color the edges according to their labels (the colors are '
+        'chosen along a rainbow). This also accepts a function or dictionary '
+        'mapping labels to colors.',
     'partition':
         'A partition of the vertex set. If specified, plot will show each '
         'cell in a different color; vertex_colors takes precedence.',
     'loop_size':
         'The radius of the smallest loop.',
     'arrowsize':
-        'Size of arrows.',
+        'Size of arrow tips.',
     'dist':
         'The distance between multiedges.',
     'max_dist':
@@ -248,15 +272,6 @@ graphplot_options.update({
         'Whether or not to draw a frame around the graph.',
     'edge_labels_background':
         'The color of the background of the edge labels.'})
-
-_PLOT_OPTIONS_TABLE = ""
-
-for key, value in graphplot_options.items():
-    _PLOT_OPTIONS_TABLE += f"    ``{key}`` | {value}\n"
-
-__doc__ = __doc__.format(PLOT_OPTIONS_TABLE=_PLOT_OPTIONS_TABLE)
-
-DEFAULT_SHOW_OPTIONS = {'figsize': (4, 4)}
 
 DEFAULT_PLOT_OPTIONS = {
     'vertex_size'               : 200,
@@ -283,6 +298,20 @@ DEFAULT_PLOT_OPTIONS = {
     'loop_size'                 : .075,
     'edge_labels_background'    : 'white'}
 
+_PLOT_OPTIONS_TABLE = """
+    - * Parameter
+      * Description
+      * Default"""
+
+for key, value in graphplot_options.items():
+    _PLOT_OPTIONS_TABLE += f"""
+    - * ``{key}``
+      * {value}
+      * {DEFAULT_PLOT_OPTIONS.get(key, '')}"""
+
+__doc__ = __doc__.format(PLOT_OPTIONS_TABLE=_PLOT_OPTIONS_TABLE)
+
+DEFAULT_SHOW_OPTIONS = {'figsize': (4, 4)}
 
 class GraphPlot(SageObject):
     def __init__(self, graph, options):


### PR DESCRIPTION
I noticed that the documentation of [Graph.plot](https://doc-develop--sagemath.netlify.app/html/en/reference/graphs/sage/graphs/generic_graph.html#sage.graphs.generic_graph.GenericGraph.plot) misses a few parameters such as `edge_thickness`. Also, it said that `edge_style` only works for directed graphs, which is apparently not true anymore [for at least 10 years](https://github.com/sagemath/sage/commit/3c7c15501698c2859a2fb2d100d5227097873da8).

More comprehensive and up-to-date coverage of the parameters can be found in the [`graphs.graph_plot`](https://doc-develop--sagemath.netlify.app/html/en/reference/graphs/sage/graphs/graph_plot.html#module-sage.graphs.graph_plot) module, so I decided to merge the parameter lists to reduce maintenance burden.

### :memo: Checklist

- [x] I have checked the documentation preview.

