### PR TITLE
Fix GitHub Codespaces setup

### DIFF
--- a/.devcontainer/codespaces-conda-forge/devcontainer.json
+++ b/.devcontainer/codespaces-conda-forge/devcontainer.json
@@ -1,0 +1,20 @@
+// See https://aka.ms/devcontainer.json for format details.
+{
+    "name": "SageMath",
+    "image": "condaforge/miniforge3:latest",
+    // Install the conda-forge package in a dedicated environment.
+    "onCreateCommand": ".devcontainer/codespaces-conda-forge/onCreate.sh",
+    "remoteEnv": {
+        "PATH": "/opt/conda/envs/sage/bin:${containerEnv:PATH}"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python"
+            ],
+            "settings": {
+                "python.defaultInterpreterPath": "/opt/conda/envs/sage/bin/python"
+            }
+        }
+    }
+}

--- a/.devcontainer/codespaces-conda-forge/onCreate.sh
+++ b/.devcontainer/codespaces-conda-forge/onCreate.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -eu
+
+environment_name=sage
+conda_dir=${CONDA_DIR:-/opt/conda}
+environment_prefix="$conda_dir/envs/$environment_name"
+
+if [ -d "$environment_prefix/conda-meta" ]; then
+    "$conda_dir/bin/mamba" install --yes --name "$environment_name" sage
+else
+    "$conda_dir/bin/mamba" create --yes --name "$environment_name" sage
+fi
+
+"$environment_prefix/bin/sage" --version
+"$conda_dir/bin/conda" clean --all --yes
+
+activation_command=". $conda_dir/etc/profile.d/conda.sh && conda activate $environment_name"
+touch "$HOME/.bashrc"
+if ! grep -Fqx "$activation_command" "$HOME/.bashrc"; then
+    printf '\n%s\n' "$activation_command" >> "$HOME/.bashrc"
+fi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,20 +6,28 @@
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
+	"remoteEnv": {
+		"PATH": "/opt/conda/envs/sage-dev/bin:${containerEnv:PATH}"
+	},
 
-	// Setup conda environment
-	"onCreateCommand": ".devcontainer/onCreate-conda.sh || true",
+	// Initialize Conda once, then synchronize the development environment
+	// whenever the checked-out content changes.
+	"onCreateCommand": ".devcontainer/onCreate-conda.sh",
+	"updateContentCommand": ".devcontainer/updateContent-conda.sh",
 
 	// Install additional features.
 	"features": {
 		// For config options, see https://github.com/devcontainers/features/tree/main/src/conda
-		"ghcr.io/devcontainers/features/conda": {
-            "version": "latest",
-			"addCondaForge": "true"
-        }
+		"ghcr.io/devcontainers/features/conda:2": {
+			"version": "latest",
+			"addCondaForge": true
+		}
 	},
 	"customizations": {
 		"vscode": {
+			"settings": {
+				"python.defaultInterpreterPath": "/opt/conda/envs/sage-dev/bin/python"
+			},
 			"extensions": [
 				"guyskk.language-cython",
 				"ms-toolsai.jupyter",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,9 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/debian
+// For format details, see https://aka.ms/devcontainer.json. For image variants, see:
+// https://github.com/devcontainers/images/tree/main/src/base-debian
 {
 	"name": "Conda",
-	"image": "mcr.microsoft.com/vscode/devcontainers/base:0-bullseye",
+	// The generated Linux environment currently requires glibc 2.39 or newer.
+	"image": "mcr.microsoft.com/devcontainers/base:2-trixie",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",

--- a/.devcontainer/downstream-conda-forge-latest/devcontainer.json
+++ b/.devcontainer/downstream-conda-forge-latest/devcontainer.json
@@ -1,19 +1,20 @@
 // See https://aka.ms/devcontainer.json for format details.
 {
-    "name": "condaforge/mambaforge:latest downstream Sage",
-    "image": "condaforge/mambaforge:latest",
+    "name": "condaforge/miniforge3:latest downstream Sage",
+    "image": "condaforge/miniforge3:latest",
     // Install Sage from the conda-forge package.
-    "onCreateCommand": "mamba install --yes sage",
-    // * If the workspace directory looks like a copy of the Sage source tree (SAGE_ROOT):
-    //   - it bootstraps and configures the Sage distribution,
-    //   - thus, the script ``./sage`` and the symlinks ``prefix``, ``venv`` are set as expected,
-    //   - the source tree is prepared for rebuilding Sage based from the source tree on
-    //     top of the existing installation from the Docker image.
-    //   - however, it does not start the build.
-    // * Otherwise, it does nothing. This is so that users can copy this devcontainer.json file as is
-    //   into their projects.
-    "updateContentCommand": "if [ -d pkgs/sagemath-standard ]; then make configure && ln -sf $CONDA_PREFIX venv; else echo 'Edit .devcontainer/devcontainer.json (updateContentCommand) to run project-specific startup commands'; fi",
-    "extensions": [
-        "ms-python.python"
-    ]
+    "onCreateCommand": "mamba install --yes --name base sage",
+    // If this is a Sage source tree, bootstrap it and use the conda-forge
+    // installation as its virtual environment, without starting a build.
+    "updateContentCommand": "if [ -d src/sage ]; then make configure && ln -sfn \"$(conda info --base)\" venv; else echo 'Edit .devcontainer/devcontainer.json (updateContentCommand) to run project-specific startup commands'; fi",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python"
+            ],
+            "settings": {
+                "python.defaultInterpreterPath": "/opt/conda/bin/python"
+            }
+        }
+    }
 }

--- a/.devcontainer/onCreate-conda.sh
+++ b/.devcontainer/onCreate-conda.sh
@@ -1,13 +1,10 @@
-# Do not keep running on errors
-set -e
+#!/bin/sh
 
-# Create conda environment
-conda config --env --add channels conda-forge
-conda config --env --set channel_priority strict
-conda update -y --all --override-channels -c conda-forge
-conda install mamba=1 -n base -y
-mamba env create -y --file environment-3.12-linux.yml || mamba env update --file environment-3.12-linux.yml
-conda init bash
+set -eu
 
-# Build sage
-conda run -n sage-dev pip install --no-build-isolation -v -v -e . --config-settings=build-dir="build/conda-cp312"
+# Interactive shells should enter the development environment rather than
+# Conda's base environment.  The environment itself is synchronized by the
+# updateContentCommand, which also runs when a prebuild is refreshed.
+conda_dir=${CONDA_DIR:-/opt/conda}
+"$conda_dir/bin/conda" config --set auto_activate_base false
+"$conda_dir/bin/conda" init bash

--- a/.devcontainer/updateContent-conda.sh
+++ b/.devcontainer/updateContent-conda.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+
+set -eu
+
+environment_name=sage-dev
+environment_file=environment-3.12-linux.yml
+conda_dir=${CONDA_DIR:-/opt/conda}
+conda_command="$conda_dir/bin/conda"
+environment_prefix="$conda_dir/envs/$environment_name"
+environment_stamp="$environment_prefix/conda-meta/sage-environment.sha256"
+
+expected_python=$(
+    sed -n 's/^  - python=\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' "$environment_file" |
+        head -n 1
+)
+if [ -z "$expected_python" ]; then
+    echo >&2 "cannot determine the Python version from $environment_file"
+    exit 1
+fi
+
+environment_hash=$(sha256sum "$environment_file" | awk '{print $1}')
+environment_changed=yes
+current_python=
+replace_environment=no
+
+if [ -d "$environment_prefix/conda-meta" ]; then
+    if [ -x "$environment_prefix/bin/python" ]; then
+        current_python=$(
+            "$environment_prefix/bin/python" -c \
+                'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' \
+                2>/dev/null || true
+        )
+    fi
+
+    if [ "$current_python" != "$expected_python" ]; then
+        echo "Replacing $environment_name: Python $current_python does not match $expected_python"
+        replace_environment=yes
+    elif [ -r "$environment_stamp" ] &&
+         [ "$(sed -n '1p' "$environment_stamp")" = "$environment_hash" ]; then
+        environment_changed=no
+    fi
+fi
+
+if [ "$environment_changed" = yes ]; then
+    # Leave the old stamp absent until dependency synchronization, the
+    # editable build, and the Sage smoke test have all succeeded.
+    rm -f "$environment_stamp"
+
+    # Meson build directories cannot be reused across a Conda lock or Python
+    # ABI change.  Remove them before resolving packages so they cannot make
+    # the environment repair itself exhaust a Codespaces disk.
+    for stale_build_dir in build/conda-cp*; do
+        if [ -d "$stale_build_dir" ]; then
+            echo "Removing stale build directory $stale_build_dir"
+            rm -rf -- "$stale_build_dir"
+        fi
+    done
+
+    # Free caches before asking Conda to write transaction metadata; a stale
+    # prebuild may already have filled the Codespaces disk.
+    "$conda_command" clean --all --yes
+    if [ "$replace_environment" = yes ]; then
+        "$conda_command" env remove --yes --prefix "$environment_prefix"
+        "$conda_command" clean --all --yes
+    fi
+
+    if [ -d "$environment_prefix/conda-meta" ]; then
+        "$conda_command" env update --prune \
+            --prefix "$environment_prefix" --file "$environment_file"
+    else
+        "$conda_command" env create --yes \
+            --prefix "$environment_prefix" --file "$environment_file"
+    fi
+
+    actual_python=$(
+        "$environment_prefix/bin/python" -c \
+            'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")'
+    )
+    if [ "$actual_python" != "$expected_python" ]; then
+        echo >&2 "expected Python $expected_python in $environment_name, found $actual_python"
+        exit 1
+    fi
+
+    "$conda_command" clean --all --yes
+fi
+
+python_tag=$(
+    "$environment_prefix/bin/python" -c \
+        'import sys; print(f"cp{sys.version_info.major}{sys.version_info.minor}")'
+)
+build_dir="build/conda-$python_tag"
+
+# Reinstall the editable metadata and entry point for the current checkout.
+"$conda_command" run --no-capture-output --prefix "$environment_prefix" \
+    python -m pip install --no-build-isolation --no-deps --verbose --editable . \
+    --config-settings="builddir=$build_dir"
+"$conda_command" run --no-capture-output --prefix "$environment_prefix" \
+    python -m pip check
+
+# Force the editable loader to compile now and verify the installed console
+# entry point before Codespaces reports that the environment is ready.
+"$conda_command" run --no-capture-output --prefix "$environment_prefix" \
+    env MESONPY_EDITABLE_VERBOSE=1 \
+    sage -c 'assert ZZ(2) + ZZ(2) == 4'
+
+printf '%s\n' "$environment_hash" > "$environment_stamp"
+
+activation_command="conda activate $environment_name"
+touch "$HOME/.bashrc"
+if ! grep -Fqx "$activation_command" "$HOME/.bashrc"; then
+    printf '\n%s\n' "$activation_command" >> "$HOME/.bashrc"
+fi

--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ Getting Started
 Those who are impatient may use prebuilt Sage available online from any of
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/sagemath/sage-binder-env/master
-) &nbsp; [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/sagemath/sage/tree/master
-) &nbsp; [![Open in GitHub Codespaces](https://img.shields.io/badge/Open_in_GitHub_Codespaces-black?logo=github)](https://codespaces.new/sagemath/sage/tree/master)
+) &nbsp; [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sagemath/sage/tree/develop?devcontainer_path=.devcontainer%2Fcodespaces-conda-forge%2Fdevcontainer.json)
 
 without local installation. Otherwise read on.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Getting Started
 Those who are impatient may use prebuilt Sage available online from any of
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/sagemath/sage-binder-env/master
-) &nbsp; [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sagemath/sage/tree/develop?devcontainer_path=.devcontainer%2Fcodespaces-conda-forge%2Fdevcontainer.json)
+) &nbsp; [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sagemath/sage/tree/master?devcontainer_path=.devcontainer%2Fcodespaces-conda-forge%2Fdevcontainer.json)
 
 without local installation. Otherwise read on.
 


### PR DESCRIPTION
## Summary

- add a dedicated Codespaces configuration that installs the prebuilt conda-forge Sage package in an activated environment
- make the default contributor container refresh its Conda environment and editable build when repository content or a prebuild changes
- move the contributor container from the legacy Bullseye image to the official Debian Trixie image required by the generated Conda lock
- expose provisioning and Ninja failures instead of swallowing them, and select the correct terminal and VS Code Python environment
- update the downstream conda-forge configuration from retired Mambaforge to Miniforge and remove the retired Gitpod badge

## Root cause

The default container performed dependency setup and the editable install only in `onCreateCommand`, which runs once when a prebuild is created. Setup failures were hidden by `|| true`, and later terminals stayed in Conda's base environment. A reused stale prebuild could therefore combine an old Python environment and Meson build directory with a newer Sage checkout, producing the Python 3.11/Ninja failure reported in #42201.

A live Codespaces launch also exposed a second incompatibility: the old Debian Bullseye base provides glibc 2.31, while the generated Linux lock pins `sysroot_linux-64=2.39`, whose package metadata requires `__glibc >=2.39`. The contributor configuration now uses the official major-pinned Debian Trixie image, which provides glibc 2.41 while preserving the `vscode` user and Debian-based setup.

The new `updateContentCommand` hashes the complete Conda lock, detects a mismatched Python environment, frees generated Meson builds and caches before Conda transactions, synchronizes dependencies, reinstalls Sage editable, runs `pip check`, and forces a real Sage smoke test before recording success.

The README now uses a separate Miniforge configuration for users who want prebuilt Sage rather than a contributor source build.

## Validation

- live Codespaces launch reached the fail-fast `updateContentCommand` and reproduced the Bullseye/glibc incompatibility
- exact `sysroot_linux-64=2.39=hc4b9eeb_6` dry-run solve fails with a simulated glibc 2.31 and succeeds with glibc 2.39
- complete `environment-3.12-linux.yml` dry-run solve succeeds with Trixie's glibc 2.41
- the `mcr.microsoft.com/devcontainers/base:2-trixie` manifest exists for amd64 and arm64
- `@devcontainers/cli@0.83.3 read-configuration` (the Codespaces log version) parses the updated contributor configuration
- `sh -n` and `bash -n` for all lifecycle hooks
- `@devcontainers/cli@0.86.0 read-configuration` for the default, downstream, and dedicated Codespaces configurations
- controlled lifecycle checks for fresh creation, an unchanged rerun, a changed lock, and recovery from a stale Python 3.11 environment
- verified stale generated builds are removed before environment replacement
- `sage -c 'assert ZZ(2) + ZZ(2) == 4'`
- `git diff --check`

The PR remains a draft pending one fresh live Codespaces rebuild on the Trixie image.

Fixes #42201
