### PR TITLE
ci: Ignore Docker cache export errors

### DIFF
--- a/.github/workflows/docker_hub.yml
+++ b/.github/workflows/docker_hub.yml
@@ -92,6 +92,6 @@ jobs:
           push: ${{ steps.login.outcome == 'success' }}
           tags: ${{ env.TAG_LIST }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
         # run even if there are no push credentials (just don't push)
         if: (success() || failure()) && env.JOB_DONE == 'false'


### PR DESCRIPTION
## Summary

- make the GitHub Actions BuildKit cache export best-effort
- allow Docker image publication to continue when the optional cache backend fails

## Root cause

In [workflow run 30219481026](https://github.com/sagemath/sage/actions/runs/30219481026/job/89839327760), the `make-build` Docker stage completed successfully, but the subsequent GitHub Actions cache export returned `not_found`. Because cache-export errors are fatal by default, BuildKit canceled the concurrent Docker Hub push.

The scheduled [retry on the same commit](https://github.com/sagemath/sage/actions/runs/30320842622/job/90156202564) succeeded, confirming that this was a transient cache-service failure rather than a Sage build failure.

The `ignore-error=true` cache exporter option keeps the cache as a performance optimization without making release image publication depend on it.

## Validation

- `git diff --check`
- parsed `.github/workflows/docker_hub.yml` with PyYAML
- verified the branch differs from `develop` by only this workflow line
