### PR TITLE
Pin action-gh-release to v3.0.1

### DIFF
--- a/.github/workflows/doc-build-livedoc.yml
+++ b/.github/workflows/doc-build-livedoc.yml
@@ -102,7 +102,7 @@ jobs:
           path: livedoc.zip
 
       - name: Upload docs to release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@v3.0.1
         with:
           files: livedoc.zip
           token: ${{ secrets.RELEASE_CREATION_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
           echo "$release_notes" > release_notes
 
       - name: Create release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@v3.0.1
         with:
           preserve_order: true
           files: |
@@ -156,7 +156,6 @@ jobs:
           token: ${{ secrets.RELEASE_CREATION_TOKEN }}
           body_path: release_notes
           prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
-          max_retries: 3
 
   build_wheels:
     # Temporarily disabled due to build errors


### PR DESCRIPTION
The release job for `10.10.beta7` failed while creating the GitHub release:

https://github.com/sagemath/sage/actions/runs/30219480939/job/89840469383

`softprops/action-gh-release` v3.0.2 added a fallback that scans release pages when a direct tag lookup returns 404. For Sage, the first 100-release response is unusually large and the request can time out before a new release is created. This pins both release-action call sites to v3.0.1, before that fallback was introduced.

The `max_retries` setting is also removed because it is not a declared action input and was ignored. The retry count in v3.0.2 is internal rather than configurable through `with`.

Upstream references:

- https://github.com/softprops/action-gh-release/releases/tag/v3.0.2
- https://github.com/softprops/action-gh-release/pull/801
- https://github.com/softprops/action-gh-release/blob/3d0d9888cb7fd7b750713d6e236d1fcb99157228/action.yml

Validation:

- `git diff --check`
- `actionlint` 1.7.12 on both edited workflows; it reports no new diagnostics compared with `develop`

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

None.
