### PR TITLE
DOC: Fix IPython documentation links

### DIFF
--- a/src/doc/en/tutorial/interactive_shell.rst
+++ b/src/doc/en/tutorial/interactive_shell.rst
@@ -379,7 +379,7 @@ Other IPython tricks
 
 As noted above, Sage uses IPython as its front end, and so you can use
 any of IPython's commands and features.  You can read the `full
-IPython documentation <http://ipython.scipy.org/moin/Documentation>`_.
+IPython documentation <https://ipython.readthedocs.io/en/stable/>`_.
 Meanwhile, here are some fun tricks -- these are called "Magic
 commands" in IPython:
 

--- a/src/doc/ja/tutorial/interactive_shell.rst
+++ b/src/doc/ja/tutorial/interactive_shell.rst
@@ -348,7 +348,7 @@ IPythonトリック
 
 すでに述べたように，SageはそのフロントエンドとしてIPythonを援用しており，ユーザはIPythonのコマンドと独自機能を自由に利用することができる．
 その全貌については， ご自分で `full IPython documentation
-<http://ipython.scipy.org/moin/Documentation>`_ を読んみてほしい．
+<https://ipython.readthedocs.io/en/stable/>`_ を読んみてほしい．
 そのかわり，ここではIPythonの「マジックコマンド」と呼ばれる，お便利なトリックをいくつか紹介させていただこう:
 
 - ``%edit`` (``%ed`` や ``ed`` でもいい)を使ってエディタを起動すれば，複雑なコードの入力が楽になる．

--- a/src/doc/pt/tutorial/interactive_shell.rst
+++ b/src/doc/pt/tutorial/interactive_shell.rst
@@ -370,7 +370,7 @@ Outras Dicas para o IPython
 Como observado acima, o Sage usa o IPython como interface, logo você
 pode usar quaisquer comandos e recursos do IPython. Você pode ler a
 `Documentação completa do IPython
-<http://ipython.scipy.org/moin/Documentation>`_ (em inglês).
+<https://ipython.readthedocs.io/en/stable/>`_ (em inglês).
 
 - Você pode usar ``%edit`` (ou ``%ed`` ou ``ed``) para abrir um
   editor, se você desejar digitar algum código mais complexo. Antes de

--- a/src/doc/zh/tutorial/interactive_shell.rst
+++ b/src/doc/zh/tutorial/interactive_shell.rst
@@ -337,7 +337,7 @@ GMP 表现稍好（预料之中，因为为 Sage 构建的 PARI 版本使用 GMP
 
 如上文所述，Sage 使用 IPython 作为前端，因此你可以使用任何 IPython 的命令和功能。
 你可以阅读
-`完整的 IPython 文档 <http://ipython.scipy.org/moin/Documentation>`_ 。
+`完整的 IPython 文档 <https://ipython.readthedocs.io/en/stable/>`_ 。
 下面是一些有趣的技巧 -- 在 IPython 中，这些被称为 "Magic 命令"：
 
 - 如果你想输入一些复杂代码，可以使用 ``%edit`` （或 ``%ed`` 或 ``ed``）打开一个编辑器。


### PR DESCRIPTION
## What changed

Replace the defunct `ipython.scipy.org` documentation link with the current official IPython documentation URL in the English, Japanese, Portuguese, and Chinese tutorials.

## Why

The old SciPy-hosted MoinMoin page no longer works. Pointing readers to `https://ipython.readthedocs.io/en/stable/` restores the link and keeps these translations aligned with the existing French tutorial.

## User impact

Readers following the tutorial's “full IPython documentation” link now reach the maintained IPython documentation.

## Validation

- `./sage -t src/doc/en/tutorial/interactive_shell.rst src/doc/ja/tutorial/interactive_shell.rst src/doc/pt/tutorial/interactive_shell.rst src/doc/zh/tutorial/interactive_shell.rst` (41 tests passed)
- `git diff --check`
- Confirmed the replacement is the official current IPython documentation endpoint
