### PR TITLE
Do not advertise kernel subshell support

### DIFF
--- a/src/sage/repl/ipython_kernel/kernel.py
+++ b/src/sage/repl/ipython_kernel/kernel.py
@@ -45,6 +45,29 @@ class SageKernel(IPythonKernel):
 
     shell_class = Type(SageZMQInteractiveShell)
 
+    @property
+    def kernel_info(self):
+        r"""
+        Return information about the Sage kernel.
+
+        Sage does not advertise kernel subshell support.  A subshell runs
+        callbacks in a separate thread, but Sage libraries are not generally
+        safe to call from such a thread.
+
+        TESTS::
+
+            sage: from sage.repl.ipython_kernel.kernel import SageKernel
+            sage: kernel = SageKernel.__new__(SageKernel)
+            sage: kernel.shell_channel_thread = object()
+            sage: "kernel subshells" in kernel.kernel_info["supported_features"]
+            False
+        """
+        info = super().kernel_info
+        features = info.get("supported_features", [])
+        info["supported_features"] = [feature for feature in features
+                                      if feature != "kernel subshells"]
+        return info
+
     def __init__(self, **kwds):
         """
         The Sage Jupyter Kernel.


### PR DESCRIPTION
## Description

Sage now removes `kernel subshells` from the features advertised in its
`kernel_info_reply`.

With ipykernel 7, advertising this feature allows JupyterLab to route widget
comm messages to a kernel subshell running in another OS thread. Sage libraries
are not generally safe to enter from arbitrary threads; in particular, the
`@interact` example in the issue reaches cypari2/PARI from that thread and
segfaults after the initial evaluation.

Filtering the unsupported feature keeps these callbacks on the main kernel
shell while preserving the other features reported by ipykernel.

Fixes #42567.

## Validation

- `./sage -t --force-lib src/sage/repl/ipython_kernel/kernel.py` (16 tests passed)
- Started a temporary Sage kernel and verified that its advertised features
  contain `debugger` but not `kernel subshells`
- `git diff --check`

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

Documentation is unchanged because this only corrects kernel feature
negotiation.

### :hourglass: Dependencies

None.
