### PR TITLE
Remove SAGE_LOCAL from sage.config

### DIFF
--- a/src/sage/config.py.in
+++ b/src/sage/config.py.in
@@ -4,28 +4,22 @@ import sage
 
 VERSION = "@PACKAGE_VERSION@"
 
-# The following must not be used during build to determine source or installation
-# location of sagelib.  See comments in SAGE_ROOT/src/Makefile.in
-# These variables come first so that other substituted variable values can refer
-# to it.
-SAGE_LOCAL = "@prefix@"
-
 # The path to the standalone maxima executable.
-MAXIMA = "@SAGE_MAXIMA@".replace("${prefix}", SAGE_LOCAL)
+MAXIMA = "@SAGE_MAXIMA@"
 
 # Set this to the empty string if your ECL can load maxima without
 # further prodding.
-MAXIMA_FAS = "@SAGE_MAXIMA_FAS@".replace("${prefix}", SAGE_LOCAL)
-MAXIMA_PREFIX = "@SAGE_MAXIMA_PREFIX@".replace("${prefix}", SAGE_LOCAL)
+MAXIMA_FAS = "@SAGE_MAXIMA_FAS@"
+MAXIMA_PREFIX = "@SAGE_MAXIMA_PREFIX@"
 
-# Delete this line if your ECL can load Kenzo without further prodding.
-KENZO_FAS = "@SAGE_KENZO_FAS@".replace("${prefix}", SAGE_LOCAL)
+# Set this to the empty string if your ECL can load Kenzo without further prodding.
+KENZO_FAS = @SAGE_KENZO_FAS@
 
 NTL_INCDIR = "@NTL_INCDIR@"
 NTL_LIBDIR = "@NTL_LIBDIR@"
 
 # Path to the ecl-config script
-ECL_CONFIG = "@SAGE_ECL_CONFIG@".replace("${prefix}", SAGE_LOCAL)
+ECL_CONFIG = "@SAGE_ECL_CONFIG@"
 
 # Path to the nauty binaries; of the form "/path/to/" or "/path/to/nauty-" 
 SAGE_NAUTY_BINS_PREFIX = "@SAGE_NAUTY_BINS_PREFIX@"
@@ -34,10 +28,10 @@ SAGE_ECMBIN = "@SAGE_ECMBIN@"
 
 # for sage_setup.setenv
 SAGE_ARCHFLAGS = "@SAGE_ARCHFLAGS@"
-SAGE_PKG_CONFIG_PATH = "@SAGE_PKG_CONFIG_PATH@".replace("$SAGE_LOCAL", SAGE_LOCAL)
+SAGE_PKG_CONFIG_PATH = "@SAGE_PKG_CONFIG_PATH@"
 
 # Used in sage.repl.ipython_kernel.install
-THREEJS_DIR = SAGE_LOCAL + "/share/threejs-sage"
+THREEJS_DIR = @SAGE_THREEJS_DIR@
 
 # OpenMP flags, if available.
 OPENMP_CFLAGS = "@OPENMP_CFLAGS@"

--- a/src/sage/env.py
+++ b/src/sage/env.py
@@ -155,7 +155,8 @@ SAGE_LIB = var("SAGE_LIB", os.path.dirname(os.path.dirname(__file__)))
 SAGE_EXTCODE = var("SAGE_EXTCODE", join(SAGE_LIB, "sage", "ext_data"))
 
 # prefix hierarchy where non-Python packages are installed
-SAGE_LOCAL = var("SAGE_LOCAL")
+# Sage-the-Distro sets SAGE_LOCAL; pure Python installs use the active prefix.
+SAGE_LOCAL = var("SAGE_LOCAL", os.path.abspath(sys.prefix))
 SAGE_SHARE = var("SAGE_SHARE", join(SAGE_LOCAL, "share"))
 SAGE_DOC = var("SAGE_DOC", join(SAGE_SHARE, "doc", "sage"))
 SAGE_LOCAL_SPKG_INST = var("SAGE_LOCAL_SPKG_INST", join(SAGE_LOCAL, "var", "lib", "sage", "installed"))

--- a/src/sage/meson.build
+++ b/src/sage/meson.build
@@ -7,7 +7,6 @@ conf_data.set('EDITABLE_BUILD', root_build)
 conf_data.set('PACKAGE_VERSION', '1.2.3')
 # We use Python's prefix here to make it work with conda
 prefix = fs.as_posix(py.get_variable('prefix', ''))
-conf_data.set('prefix', prefix)
 datadir = fs.expanduser(get_option('datadir'))
 if not fs.is_absolute(datadir)
   datadir = prefix / datadir
@@ -17,8 +16,19 @@ if not fs.exists(datadir / 'cremona')
     'Warning: The specified datadir does not contain the necessary Cremona database. Either specify a different datadir or specify the correct path via the environment variable SAGE_SHARE during runtime.',
   )
 endif
-# Kenzo cannot yet be provided by the system, so we always use the SAGE_LOCAL path for now.
-conf_data.set('SAGE_KENZO_FAS', '\'${prefix}\'/lib/ecl/kenzo.fas')
+sage_local = get_option('SAGE_LOCAL')
+if sage_local == ''
+  # Pure Meson builds rely on ECL's search path to find Kenzo.
+  kenzo_fas = ''
+  threejs_dir = prefix / 'share' / 'threejs-sage'
+else
+  # Sage-the-Distro installs non-Python artifacts below SAGE_LOCAL.
+  sage_local = fs.as_posix(sage_local)
+  kenzo_fas = sage_local / 'lib' / 'ecl' / 'kenzo.fas'
+  threejs_dir = sage_local / 'share' / 'threejs-sage'
+endif
+conf_data.set_quoted('SAGE_KENZO_FAS', kenzo_fas)
+conf_data.set_quoted('SAGE_THREEJS_DIR', threejs_dir)
 # It can be found, so we don't have to set anything here:
 conf_data.set('NTL_INCDIR', '')
 conf_data.set('NTL_LIBDIR', '')


### PR DESCRIPTION
Fixes #42459.

`sage.config` contains build-time configuration, while `SAGE_LOCAL` is a runtime environment setting with a different meaning in Sage-the-Distro. Keeping `SAGE_LOCAL` in both places made the generated Kenzo path use the Python venv instead of the non-Python installation prefix.

This PR now:

- removes `SAGE_LOCAL` from `sage.config`;
- configures `KENZO_FAS` directly in Meson from an explicit `-DSAGE_LOCAL` option used by Sage-the-Distro;
- leaves `KENZO_FAS` empty in pure Meson builds so that ECL uses its normal search path;
- configures the ThreeJS directory directly instead of deriving it from `sage.config.SAGE_LOCAL`;
- keeps `sage.env.SAGE_LOCAL` runtime-based, with the environment taking precedence and the active Python prefix as the pure-Python fallback;
- removes obsolete runtime placeholder replacements now that Meson supplies complete values.

The runtime fallback restores the behavior that existed before `sage.config.SAGE_LOCAL` became unconditional: Sage-the-Distro still exports its non-Python prefix, while pure Python installations use their active `sys.prefix`.

### Testing

- `python -m pytest -q src/sage/config_test.py` — 2 passed
- `git diff --check upstream/develop...HEAD`
- pure Meson reconfiguration and runtime smoke tests with `SAGE_LOCAL` unset
- fresh Meson setup with `-DSAGE_LOCAL="/tmp/sage 42606 local"`; generated `config.py` compiled and its Kenzo/ThreeJS paths were verified

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

None.
