### PR TITLE
gh-40928: Avoid swallowing AlarmInterrupt in matrix destructor

### DIFF
--- a/src/sage/matrix/matrix_modn_dense_flint.pyx
+++ b/src/sage/matrix/matrix_modn_dense_flint.pyx
@@ -128,9 +128,9 @@ cdef class Matrix_modn_dense_flint(Matrix_dense):
             sage: A = matrix(Zmod(36), 3, 3, range(9))
             sage: del A
         """
-        sig_on()
+        # Destructors cannot propagate exceptions, so this must not be
+        # wrapped in sig_on()/sig_off().
         nmod_mat_clear(self._matrix)
-        sig_off()
 
     cdef void set_unsafe_int(self, Py_ssize_t i, Py_ssize_t j, int value) noexcept:
         nmod_mat_set_entry(self._matrix, i, j, value)
@@ -903,7 +903,7 @@ cdef class Matrix_modn_dense_flint(Matrix_dense):
             [9223372036854775800]
         """
         cdef Py_ssize_t i, j, m = self._nrows, n = self._ncols
-        cdef mp_limb_t x, preN, preshift, N = modulus
+        cdef mp_limb_t x, preN, preshift = 0, N = modulus
         preN = n_preinvert_limb(N)
         if not mul:
             preshift = n_preinvert_limb(shift)


### PR DESCRIPTION
Fixes #40928.

### Root cause

`linear_code.py` deliberately interrupts a costly canonical-representative
computation after 0.5 seconds.  When the alarm arrived while a temporary FLINT
matrix was being destroyed, `Matrix_modn_dense_flint.__dealloc__` entered a
`sig_on()` region.  This raised `AlarmInterrupt` from the destructor, where the
exception could not propagate and was reported as ignored.  Because the alarm
was one-shot, the computation then continued until the doctest file timeout.

This follows #18087, which established that `__dealloc__` methods cannot raise
exceptions and therefore must not enter `sig_on()` regions.

### Changes

- Do not wrap `nmod_mat_clear()` in `sig_on()`/`sig_off()` during destruction.
- Initialize `_shift_mod`'s `preshift` temporary explicitly, eliminating the
  compiler's `-Wmaybe-uninitialized` warning.

### Validation

- Rebuilt `matrix_modn_dense_flint` successfully; the compiler warning is gone.
- `src/sage/matrix/matrix_modn_dense_flint.pyx`: 175 doctests passed.
- `src/sage/coding/linear_code.py`: 424 doctests passed.
- Repeated the linear-code doctests with all four random seeds from recent CI
  timeouts; all passed.

Local validation used Linux with Python 3.12; CI will additionally exercise the
macOS/Python 3.14 configuration where this occurred frequently.
