### PR TITLE
Bump degree in multi_polynomial_libsingular.pyx alarm test

### DIFF
--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -4659,7 +4659,7 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
         Ensure interrupt does not make the internal state inconsistent::
 
             sage: R.<x,y,z> = QQ[]
-            sage: n = 11  # chosen so that the computation takes > 1 second but not excessively long.
+            sage: n = 12  # chosen so that the computation takes > 1 second but not excessively long.
             ....: # when Singular improves the algorithm or hardware gets faster, increase n.
             sage: alarm(0.5); h = (x^2^n-y^2^n).factor()
             Traceback (most recent call last):
@@ -4671,7 +4671,7 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             AlarmInterrupt
             sage: h = (x^2^n-y^2^n).factor()
             sage: h
-            (x - y) * (x + y) * (x^2 + y^2) * (x^4 + y^4) * (x^8 + y^8) * (x^16 + y^16) * (x^32 + y^32) * (x^64 + y^64) * (x^128 + y^128) * (x^256 + y^256) * (x^512 + y^512) * (x^1024 + y^1024)
+            (x - y) * (x + y) * (x^2 + y^2) * (x^4 + y^4) * (x^8 + y^8) * (x^16 + y^16) * (x^32 + y^32) * (x^64 + y^64) * (x^128 + y^128) * (x^256 + y^256) * (x^512 + y^512) * (x^1024 + y^1024) * (x^2048 + y^2048)
         """
         cdef ring *_ring = self._parent_ring
         cdef intvec *iv


### PR DESCRIPTION
This PR relates to the following comment in multi_polynomial_libsingular.pyx:

```
            sage: R.<x,y,z> = QQ[]
            sage: n = 11  # chosen so that the computation takes > 1 second but not excessively long.
            ....: # when Singular improves the algorithm or hardware gets faster, increase n.
```

The test tries to factor a bivariate polynomial of degree 2^n, and checks that this takes longer than 0.5s to do. A big improvement to polynomial factoring was made in FLINT 3.6 (flintlib/flint#2698), and now this test permafails on my machine. I've increased the limit to `n = 12`, which fixes the test for me.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


