### PR TITLE
Relax doctest matrix transpose tolerance

### DIFF
--- a/src/sage/matrix/matrix_double_dense.pyx
+++ b/src/sage/matrix/matrix_double_dense.pyx
@@ -1923,7 +1923,7 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
             [3.0 4.0]
             [5.0 6.0]
             sage: U,S,V = m.SVD()
-            sage: U*S*V.transpose()  # tol 1e-15
+            sage: U*S*V.transpose()  # tol 1e-14
             [0.9999999999999996 1.9999999999999998]
             [               3.0 3.9999999999999996]
             [ 4.999999999999999  6.000000000000001]


### PR DESCRIPTION
When testing on Darwin and aarch64 the previous tolerance is too strict and flakes up the test. The tolerance value is chosen to match the other similar values in the file, though empirically just tripling the previous value seems enough.

Following #37043

See also: NixOS/nixpkgs#545650

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


