### PR TITLE
some details in matrix_integer_dense.pyx

### DIFF
--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -48,7 +48,7 @@ TESTS::
     []
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2006,2007 William Stein
 #       Copyright (C) 2014 Marc Masdeu
 #       Copyright (C) 2014 Jeroen Demeyer
@@ -58,8 +58,8 @@ TESTS::
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from libc.stdint cimport int64_t
 from libc.string cimport strcpy, strlen
@@ -94,7 +94,8 @@ from cypari2.paridecl cimport *
 from sage.libs.pari import pari
 from sage.libs.pari.convert_gmp cimport INT_to_mpz
 from sage.libs.pari.convert_flint cimport (_new_GEN_from_fmpz_mat_t,
-           _new_GEN_from_fmpz_mat_t_rotate90, integer_matrix)
+                                           _new_GEN_from_fmpz_mat_t_rotate90,
+                                           integer_matrix)
 from sage.libs.pari.convert_sage_matrix import gen_to_sage_matrix
 #########################################################
 
@@ -137,13 +138,12 @@ import sys
 # Used for modular HNF
 from sage.rings.fast_arith cimport arith_int
 cdef arith_int ai = arith_int()
-from sage.libs.flint.ulong_extras cimport n_precompute_inverse
 from sage.libs.flint.nmod_mat cimport nmod_mat_set_entry
 
-######### linbox interface ##########
+# ######## linbox interface ##########
 from sage.libs.linbox.linbox_flint_interface cimport *
 
-########## iml -- integer matrix library ###########
+# ######### iml -- integer matrix library ###########
 from sage.libs.iml cimport *
 
 fplll_fp_map = {None: None,
@@ -599,7 +599,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
                         sig_free(s)
                         s = tmp
                         t = s + len_so_far
-                    #endif
+                    # endif
                     fmpz_get_str(t, base, fmpz_mat_entry(self._matrix,i,j))
                     m = strlen(t)
                     len_so_far = len_so_far + m + 1
@@ -1674,10 +1674,9 @@ cdef class Matrix_integer_dense(Matrix_dense):
             return res_d
         elif p > MAX_MODULUS_FLINT:
             raise ValueError("p too large")
-        R = IntegerModRing(p)
         cdef Matrix_modn_dense_flint ans = Matrix_modn_dense_flint.__new__(Matrix_modn_dense_flint, parent)
         ans._parent = parent
-        cdef double pinv = n_precompute_inverse(p)
+        # useless: cdef double pinv = n_precompute_inverse(p)
         for i in range(self._nrows):
             for j in range(self._ncols):
                 nmod_mat_set_entry(
@@ -1686,7 +1685,6 @@ cdef class Matrix_integer_dense(Matrix_dense):
         return ans
 
     def _reduce(self, moduli):
-        from sage.matrix.matrix_modn_dense_float import MAX_MODULUS as MAX_MODULUS_FLOAT
         from sage.matrix.matrix_modn_dense_double import MAX_MODULUS as MAX_MODULUS_DOUBLE
         from sage.matrix.matrix_modn_dense_flint import MAX_MODULUS as MAX_MODULUS_FLINT
 
@@ -1696,26 +1694,28 @@ cdef class Matrix_integer_dense(Matrix_dense):
             moduli = MultiModularBasis(moduli)
 
         cdef MultiModularBasis mm
-        cdef Matrix_modn_dense_flint mat
         mm = moduli
 
         res = []
         for p in mm:
             parent = matrix_space.MatrixSpace(IntegerModRing(p), self._nrows, self._ncols, sparse=False)
             if parent.Element is Matrix_modn_dense_float:
-                res.append( Matrix_modn_dense_float.__new__(Matrix_modn_dense_float,
-                                                            matrix_space.MatrixSpace(IntegerModRing(p), self._nrows, self._ncols, sparse=False),
-                                                            None, None, None, zeroed_alloc=False) )
+                res.append(Matrix_modn_dense_float.__new__(
+                    Matrix_modn_dense_float,
+                    matrix_space.MatrixSpace(IntegerModRing(p), self._nrows, self._ncols, sparse=False),
+                    None, None, None, zeroed_alloc=False))
             elif parent.Element is Matrix_modn_dense_double and p < MAX_MODULUS_DOUBLE:
-                res.append( Matrix_modn_dense_double.__new__(Matrix_modn_dense_double,
-                                                             matrix_space.MatrixSpace(IntegerModRing(p), self._nrows, self._ncols, sparse=False),
-                                                             None, None, None, zeroed_alloc=False) )
+                res.append(Matrix_modn_dense_double.__new__(
+                    Matrix_modn_dense_double,
+                    matrix_space.MatrixSpace(IntegerModRing(p), self._nrows, self._ncols, sparse=False),
+                    None, None, None, zeroed_alloc=False))
             elif p <= MAX_MODULUS_FLINT:
-                res.append( Matrix_modn_dense_flint.__new__(Matrix_modn_dense_flint,
-                                                             matrix_space.MatrixSpace(IntegerModRing(p), self._nrows, self._ncols, sparse=False),
-                                                             None, None, None, zeroed_alloc=False) )
+                res.append(Matrix_modn_dense_flint.__new__(
+                    Matrix_modn_dense_flint,
+                    matrix_space.MatrixSpace(IntegerModRing(p), self._nrows, self._ncols, sparse=False),
+                    None, None, None, zeroed_alloc=False))
             else:
-                raise ValueError("p=%d too big." % p)
+                raise ValueError("p=%d too big" % p)
 
         cdef Py_ssize_t i, j, k, n
         cdef Py_ssize_t nr, nc
@@ -2128,8 +2128,9 @@ cdef class Matrix_integer_dense(Matrix_dense):
                     H_m = H_m[:r]
                     U = U[:r]
             else:
-                H_m, pivots = matrix_integer_dense_hnf.hnf(self,
-                                   include_zero_rows=include_zero_rows, proof=proof)
+                H_m, pivots = matrix_integer_dense_hnf.hnf(
+                    self, include_zero_rows=include_zero_rows, proof=proof
+                )
         elif transformation:
             raise ValueError("transformation matrix only available with p-adic algorithm")
         elif algorithm in ["pari", "pari0", "pari1", "pari4"]:
@@ -2147,7 +2148,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
             try:
                 w1 = v.HNF(D=D)
-            except RuntimeError: # HNF may fail if a nxm matrix has rank < m
+            except RuntimeError:  # HNF may fail if a nxm matrix has rank < m
                 raise ValueError("ntl only computes HNF for square matrices of full rank.")
 
             if include_zero_rows:
@@ -2342,7 +2343,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
         self.cache('pivots', p)
         return p
 
-    #### Elementary divisors
+    # Elementary divisors
 
     def elementary_divisors(self, algorithm='pari'):
         """
@@ -3340,7 +3341,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
             from sage.libs.ntl.ntl_mat_ZZ import ntl_mat_ZZ as mat_ZZ
 
             A = mat_ZZ(self.nrows(),self.ncols(),
-                    [ntl_ZZ(z) for z in self.list()])
+                       [ntl_ZZ(z) for z in self.list()])
 
             if algorithm == "NTL:LLL":
                 if transformation:
@@ -3668,17 +3669,17 @@ cdef class Matrix_integer_dense(Matrix_dense):
             # each entry is set until it's nonzero.
             sig_on()
             if density == 1:
-                for i from 0 <= i < self._nrows:
-                    for j from 0 <= j < self._ncols:
+                for i in range(self._nrows):
+                    for j in range(self._ncols):
                         while fmpz_sgn(fmpz_mat_entry(self._matrix,i,j)) == 0:
                             the_integer_ring._randomize_mpz(tmp,
-                                x, y, distribution)
+                                                            x, y, distribution)
                             self.set_unsafe_mpz(i,j,tmp)
             else:
                 nc = self._ncols
                 num_per_row = int(density * nc)
-                for i from 0 <= i < self._nrows:
-                    for j from 0 <= j < num_per_row:
+                for i in range(self._nrows):
+                    for _ in range(num_per_row):
                         k = rstate.c_random() % nc
                         while fmpz_sgn(fmpz_mat_entry(self._matrix,i,k)) == 0:
                             the_integer_ring._randomize_mpz(tmp,
@@ -3688,7 +3689,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
             sig_off()
         mpz_clear(tmp)
 
-    #### Rank
+    # Rank
 
     def rank(self, algorithm='modp'):
         """
@@ -3784,7 +3785,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
         A = self._mod_int_c(p)
         return A.rank()
 
-    #### Determinant
+    # Determinant
 
     def determinant(self, algorithm='default', proof=None, stabilize=2):
         r"""
@@ -4413,15 +4414,15 @@ cdef class Matrix_integer_dense(Matrix_dense):
             raise NotFullRankError
 
         if not self.is_square():
-            raise NotImplementedError("the input matrix must be square.")
+            raise NotImplementedError("the input matrix must be square")
 
         if isinstance(B, Vector):
             if self.nrows() != B.degree():
-                raise ValueError("number of rows of self must equal degree of B.")
+                raise ValueError("number of rows of self must equal degree of B")
         elif self.nrows() != B.nrows():
-                raise ValueError("number of rows of self must equal number of rows of B.")
+            raise ValueError("number of rows of self must equal number of rows of B")
 
-        if self.nrows() == 0:
+        if not self.nrows():
             return B
 
         matrix = True
@@ -4441,7 +4442,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         if algorithm == 'flint':
             X, d = self._solve_flint(C, right=True)
-        elif algorithm == 'iml': # iml
+        elif algorithm == 'iml':  # iml
             X, d = self._solve_iml(C, right = True)
         else:
             raise ValueError("Unknown algorithm '%s'" % algorithm)
@@ -4567,7 +4568,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
             solu_pos = RightSolu
 
-        else: # left
+        else:  # left
             if self._nrows != B._ncols:
                 raise ArithmeticError("B's number of columns must match self's number of rows")
 
@@ -4585,7 +4586,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
 
         sig_check()
         verbose("Initializing mp_N and mp_D")
-        mp_N = <mpz_t *> sig_malloc( n * m * sizeof(mpz_t) )
+        mp_N = <mpz_t *> sig_malloc(n * m * sizeof(mpz_t))
         for i in range(n * m):
             mpz_init(mp_N[i])
         mpz_init(mp_D)
@@ -4723,7 +4724,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
             sig_off()
             return M,den
 
-        else: # left
+        else:  # left
             if self._nrows != B._ncols:
                 raise ArithmeticError("B's number of columns must match self's number of rows")
 
@@ -4907,7 +4908,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
                 for j in reversed(range(X.nrows())):
                     if X[j,z] != 0:
                         if j < np:
-                            break # we're good -- go on to next column of X
+                            break  # we're good -- go on to next column of X
                         else:
                             pivots_are_right = False
                             break
@@ -5167,7 +5168,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
         return res
 
     cdef int _hnf_modn(Matrix_integer_dense self, Matrix_integer_dense res,
-            unsigned int det) except -1:
+                       unsigned int det) except -1:
         """
         Puts ``self`` into HNF form modulo det. Changes ``self`` in place.
         """
@@ -5182,7 +5183,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
         sig_free(res_l)
 
     cdef int* _hnf_modn_impl(Matrix_integer_dense self, unsigned int det,
-            Py_ssize_t nrows, Py_ssize_t ncols) except NULL:
+                             Py_ssize_t nrows, Py_ssize_t ncols) except NULL:
         # NOTE: det should be at most 2^31-1, such that anything modulo
         # det fits in a 32-bit signed integer. To avoid overflow, we
         # need 64-bit arithmetic for some intermediate computations.
@@ -5276,7 +5277,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
                 i += 1
                 j = i
                 if i == nrows:
-                    break # return res
+                    break  # return res
                 if T_rows[i][i] == 0:
                     T_rows[i][i] = R
                 continue


### PR DESCRIPTION
as suggested by cython-lint, so that

`cython-lint --ignore=E231,E501,E741 src/sage/matrix/matrix_integer_dense.pyx`

almos passes

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.

