### PR TITLE
Convert Python complex values in symbolic interface expressions

### DIFF
--- a/src/sage/symbolic/expression_conversions.py
+++ b/src/sage/symbolic/expression_conversions.py
@@ -457,9 +457,10 @@ class InterfaceInit(Converter):
         In particular, this fixes symbolic matrix inversion after NumPy has
         converted complex scalars to Python objects::
 
-            sage: import numpy                                                        # needs numpy
-            sage: a = numpy.eye(2, dtype=complex)                                     # needs numpy
-            sage: matrix(x * a).inverse()[0, 0].simplify_full()                       # needs numpy
+            sage: # needs numpy
+            sage: import numpy
+            sage: a = numpy.eye(2, dtype=complex)
+            sage: matrix(x * a).inverse()[0, 0].simplify_full()
             1.0/x
         """
         if isinstance(obj, complex):

--- a/src/sage/symbolic/expression_conversions.py
+++ b/src/sage/symbolic/expression_conversions.py
@@ -451,8 +451,6 @@ class InterfaceInit(Converter):
         (:issue:`42608`)::
 
             sage: z = SR(complex(1, 2))
-            sage: InterfaceInit(maxima).pyobject(z, z.pyobject())
-            '1.0000000000000000 + 2.0000000000000000*%i'
             sage: (z * x)._maxima_init_()
             '(_SAGE_VAR_x)*(1.0000000000000000 + 2.0000000000000000*%i)'
 

--- a/src/sage/symbolic/expression_conversions.py
+++ b/src/sage/symbolic/expression_conversions.py
@@ -445,7 +445,28 @@ class InterfaceInit(Converter):
 
             sage: ii.pyobject(pi, pi.pyobject())
             'Pi'
+
+        Python complex numbers need to be converted through a Sage complex
+        field instead of being represented using Python's ``j`` notation
+        (:issue:`42608`)::
+
+            sage: z = SR(complex(1, 2))
+            sage: InterfaceInit(maxima).pyobject(z, z.pyobject())
+            '1.0000000000000000 + 2.0000000000000000*%i'
+            sage: (z * x)._maxima_init_()
+            '(_SAGE_VAR_x)*(1.0000000000000000 + 2.0000000000000000*%i)'
+
+        In particular, this fixes symbolic matrix inversion after NumPy has
+        converted complex scalars to Python objects::
+
+            sage: import numpy                                                        # needs numpy
+            sage: a = numpy.eye(2, dtype=complex)                                     # needs numpy
+            sage: matrix(x * a).inverse()[0, 0].simplify_full()                       # needs numpy
+            1.0/x
         """
+        if isinstance(obj, complex):
+            from sage.rings.complex_double import CDF
+            obj = CDF(obj)
         if (self.interface.name() in ['pari', 'gp'] and isinstance(obj, NumberFieldElement_base)):
             from sage.rings.number_field.number_field_element_quadratic import (
                 NumberFieldElement_gaussian,


### PR DESCRIPTION
Fixes #42608.

## What changed

- Convert Python `complex` values wrapped in symbolic expressions through `CDF` before generating interface input.
- Add regression tests for direct Maxima serialization and inversion of a symbolic matrix created from a NumPy complex array.

## Why

NumPy converts complex scalars to built-in Python `complex` objects when a complex array becomes an object array during symbolic multiplication. `InterfaceInit.pyobject()` previously fell back to `repr()`, which emitted Python's `j` notation. Maxima cannot parse that notation, so symbolic matrix inversion failed while testing a pivot.

Converting the value through `CDF` reuses the existing interface-specific complex-number serialization, including Maxima's `%i` notation.

## User impact

Symbolic expressions containing Python complex values can now be passed safely to external interfaces. In particular, `matrix(x * numpy_array).inverse()` no longer raises the `MACSYMA-QUIT` error for NumPy complex arrays.

## Testing

- `./sage -t src/sage/symbolic/expression_conversions.py` (422 tests passed)
- `.venv/bin/ruff check src/sage/symbolic/expression_conversions.py`
- `.venv/bin/relint -c src/.relint.yml src/sage/symbolic/expression_conversions.py`
- Original 5 by 5 reproducer from #42608
