### PR TITLE
matroids: add beta invariant method

### DIFF
--- a/src/sage/matroids/linear_matroid.pyx
+++ b/src/sage/matroids/linear_matroid.pyx
@@ -1124,7 +1124,7 @@ cdef class LinearMatroid(BasisExchangeMatroid):
             Traceback (most recent call last):
             ...
             AttributeError: 'sage.matroids.linear_matroid.LinearMatroid'
-            object has no attribute '_invariant'
+            object has no attribute '_invariant'...
             sage: M1._fast_isom_test(M3) is None
             True
             sage: Matroid(graphs.WheelGraph(6), regular=True)._fast_isom_test(          # needs sage.graphs

--- a/src/sage/matroids/matroid.pxd
+++ b/src/sage/matroids/matroid.pxd
@@ -225,6 +225,7 @@ cdef class Matroid(SageObject):
     cpdef _external(self, B)
     cpdef tutte_polynomial(self, x=*, y=*)
     cpdef characteristic_polynomial(self, la=*)
+    cpdef beta_invariant(self)
     cpdef flat_cover(self, solver=*, verbose=*, integrality_tolerance=*)
 
     # misc

--- a/src/sage/matroids/matroid.pyx
+++ b/src/sage/matroids/matroid.pyx
@@ -134,6 +134,7 @@ additional functionality (e.g. linear extensions).
 - Invariants
     - :meth:`tutte_polynomial() <sage.matroids.matroid.Matroid.tutte_polynomial>`
     - :meth:`characteristic_polynomial() <sage.matroids.matroid.Matroid.characteristic_polynomial>`
+    - :meth:`beta_invariant() <sage.matroids.matroid.Matroid.beta_invariant>`
     - :meth:`flat_cover() <sage.matroids.matroid.Matroid.flat_cover>`
 
 - Visualization
@@ -8000,6 +8001,41 @@ cdef class Matroid(SageObject):
         if la is not None:
             return chi(la)
         return chi
+
+    cpdef beta_invariant(self):
+        r"""
+        Return the beta invariant of the matroid.
+
+        The *beta invariant* of a matroid `M` is defined by
+
+        .. MATH::
+
+            \beta(M) = (-1)^{r(M)} \sum_{X \subseteq E} (-1)^{|X|} r(X).
+
+        Equivalently, it can be computed from the characteristic polynomial via
+
+        .. MATH::
+
+            \beta(M) = (-1)^{r(M)-1} \left. \frac{d}{d\lambda} \chi_M(\lambda) \right|_{\lambda=1}.
+
+        The beta invariant is nonnegative and vanishes if and only if `M` is
+        disconnected, empty, or a loop.
+
+        OUTPUT: integer
+
+        EXAMPLES::
+
+            sage: M = matroids.Uniform(4, 10)
+            sage: M.beta_invariant()
+            56
+            sage: M.dual().beta_invariant() == M.beta_invariant()
+            True
+            sage: M = Matroid(groundset=[0], circuits=[[0]])
+            sage: M.beta_invariant()
+            0
+        """
+        chi = self.characteristic_polynomial()
+        return ZZ((-1) ** (self.full_rank() - 1) * chi.derivative()(1))
 
     cpdef flat_cover(self, solver=None, verbose=0, integrality_tolerance=1e-3):
         """


### PR DESCRIPTION
This is a standard matroid invariant, an implementation of which was lacking. It uses the preexisting characteristic polynomial implementation.
