### PR TITLE
Fix matrix0 documentation reference and compiler warnings

### DIFF
--- a/src/sage/matrix/matrix0.pyx
+++ b/src/sage/matrix/matrix0.pyx
@@ -160,7 +160,7 @@ cdef class Matrix(sage.structure.element.Matrix):
 
         .. SEEALSO::
 
-            :meth:`_set_to_product`
+            The backend-specific Cython hook ``_set_to_product``.
 
         TESTS:
 
@@ -1147,7 +1147,7 @@ cdef class Matrix(sage.structure.element.Matrix):
         cdef list row_list
         cdef list col_list
         cdef Py_ssize_t i
-        cdef int row, col
+        cdef int row = 0, col = 0
         cdef int nrows = self._nrows
         cdef int ncols = self._ncols
         cdef tuple key_tuple
@@ -1624,7 +1624,7 @@ cdef class Matrix(sage.structure.element.Matrix):
         cdef list value_list
         cdef bint value_list_one_dimensional = 0
         cdef Py_ssize_t i
-        cdef Py_ssize_t row, col
+        cdef Py_ssize_t row = 0, col = 0
         cdef Py_ssize_t nrows = self._nrows
         cdef Py_ssize_t ncols = self._ncols
         cdef tuple key_tuple


### PR DESCRIPTION
## Summary

- replace the unresolved Sphinx method reference to the Cython-only `_set_to_product` hook with literal documentation
- initialize the row and column indices used by `Matrix.__getitem__` and `Matrix.__setitem__`

## Root cause

`_set_to_product` is a `cdef` method and is not exposed as a Python class member, so Sphinx cannot resolve it as a `py:meth` target. The uninitialized-index warnings are false positives from the generated C control flow, but they fail to prove to the compiler that the variables are assigned whenever their corresponding flags are set.

## Validation

- rebuilt `matrix0.pyx` with no `-Wmaybe-uninitialized` warnings
- `python -m sage.doctest --warn-long 60 src/sage/matrix/matrix0.pyx` (990 tests passed)
- rebuilt `reference/matrices` HTML documentation successfully; the original unresolved-reference warning is gone
