### PR TITLE
gh-42477: Normalize temporary path in docbuild doctest

### DIFF
--- a/src/sage_docbuild/builders.py
+++ b/src/sage_docbuild/builders.py
@@ -1847,7 +1847,7 @@ def _extend_over_namespace_packages(directory, parts):
         ....:     sys.path.insert(0, root)
         ....:     answer = _extend_over_namespace_packages(inner, ['mod'])
         ....:     sys.path.remove(root)
-        sage: answer[0] == root, answer[1]
+        sage: answer[0] == os.path.realpath(root), answer[1]
         (True, ['mod', 'inner', 'ns_2718'])
 
     A directory that no entry of ``sys.path`` leads to is left alone::


### PR DESCRIPTION
## Summary

- compare the namespace-package import root with the canonical temporary path
- make the doctest portable to macOS, where a temporary path under `/var` may resolve under `/private/var`

## Root cause

`_extend_over_namespace_packages()` deliberately canonicalizes both `sys.path` entries and the input directory with `os.path.realpath()`. The doctest compared the returned canonical path with the unnormalized string returned by `TemporaryDirectory()`. These strings can differ on macOS even though they identify the same directory.

This changes only the doctest expectation; runtime behavior is unchanged.

Follow-up to #42477.

## Testing

- `python src/bin/sage-runtests --warn-long 5.0 src/sage_docbuild/builders.py`
  - 136 tests passed
