### PR TITLE
gh-38632: Fix .degrees() to return ETuple and add as_ETuples parameter

### DIFF
--- a/src/sage/rings/polynomial/multi_polynomial_element.py
+++ b/src/sage/rings/polynomial/multi_polynomial_element.py
@@ -535,33 +535,53 @@ class MPolynomial_polydict(Polynomial_singular_repr, MPolynomial_element):
         macaulay2.use(m2_parent)
         return macaulay2('substitute(%s,%s)' % (repr(self), m2_parent._name))
 
-    def degrees(self):
+    def degrees(self, as_ETuples=True):
         r"""
-        Return a tuple (precisely - an ``ETuple``) with the
-        degree of each variable in this polynomial. The list of degrees is,
-        of course, ordered by the order of the generators.
+        Return the maximal degree of each variable in this polynomial.
+
+        The degree of each variable is the maximum degree of that variable
+        appearing in any monomial of ``self``.
+
+        INPUT:
+
+        - ``as_ETuples`` -- boolean (default: ``True``); if ``True``, return
+          the result as an :class:`~sage.rings.polynomial.polydict.ETuple`,
+          otherwise return a plain :class:`tuple`
+
+        OUTPUT: an :class:`~sage.rings.polynomial.polydict.ETuple` or a
+        :class:`tuple` with the degree of each variable
 
         EXAMPLES::
 
-            sage: R.<x,y,z> = PolynomialRing(QQbar)
-            sage: f = 3*x^2 - 2*y + 7*x^2*y^2 + 5
-            sage: f.degrees()
+            sage: R.<x,y,z> = PolynomialRing(QQbar)                                     # needs sage.rings.number_field
+            sage: f = 3*x^2 - 2*y + 7*x^2*y^2 + 5                                      # needs sage.rings.number_field
+            sage: f.degrees()                                                            # needs sage.rings.number_field
             (2, 2, 0)
-            sage: f = x^2 + z^2
-            sage: f.degrees()
+            sage: type(f.degrees())                                                      # needs sage.rings.number_field
+            <class 'sage.rings.polynomial.polydict.ETuple'>
+            sage: f.degrees(as_ETuples=False)                                            # needs sage.rings.number_field
+            (2, 2, 0)
+            sage: type(f.degrees(as_ETuples=False))                                     # needs sage.rings.number_field
+            <class 'tuple'>
+            sage: f = x^2 + z^2                                                          # needs sage.rings.number_field
+            sage: f.degrees()                                                            # needs sage.rings.number_field
             (2, 0, 2)
-            sage: f.total_degree()  # this simply illustrates that total degree is not the sum of the degrees
+            sage: f.total_degree()  # this simply illustrates that total degree is not the sum of the degrees  # needs sage.rings.number_field
             2
-            sage: R.<x,y,z,u> = PolynomialRing(QQbar)
-            sage: f = (1-x) * (1+y+z+x^3)^5
-            sage: f.degrees()
+            sage: R.<x,y,z,u> = PolynomialRing(QQbar)                                   # needs sage.rings.number_field
+            sage: f = (1-x) * (1+y+z+x^3)^5                                             # needs sage.rings.number_field
+            sage: f.degrees()                                                            # needs sage.rings.number_field
             (16, 5, 5, 0)
-            sage: R(0).degrees()
+            sage: R(0).degrees()                                                         # needs sage.rings.number_field
             (0, 0, 0, 0)
         """
         if not self:
-            return polydict.ETuple({}, self.parent().ngens())
-        return self._MPolynomial_element__element.max_exp()
+            e = polydict.ETuple({}, self.parent().ngens())
+        else:
+            e = self._MPolynomial_element__element.max_exp()
+        if as_ETuples:
+            return e
+        return tuple(e)
 
     def degree(self, x=None, std_grading=False):
         """

--- a/src/sage/rings/polynomial/multi_polynomial_element.py
+++ b/src/sage/rings/polynomial/multi_polynomial_element.py
@@ -535,7 +535,7 @@ class MPolynomial_polydict(Polynomial_singular_repr, MPolynomial_element):
         macaulay2.use(m2_parent)
         return macaulay2('substitute(%s,%s)' % (repr(self), m2_parent._name))
 
-    def degrees(self, as_ETuples=True):
+    def degrees(self, as_ETuples=False):
         r"""
         Return the maximal degree of each variable in this polynomial.
 
@@ -544,7 +544,7 @@ class MPolynomial_polydict(Polynomial_singular_repr, MPolynomial_element):
 
         INPUT:
 
-        - ``as_ETuples`` -- boolean (default: ``True``); if ``True``, return
+        - ``as_ETuples`` -- boolean (default: ``False``); if ``True``, return
           the result as an :class:`~sage.rings.polynomial.polydict.ETuple`,
           otherwise return a plain :class:`tuple`
 
@@ -558,11 +558,11 @@ class MPolynomial_polydict(Polynomial_singular_repr, MPolynomial_element):
             sage: f.degrees()                                                            # needs sage.rings.number_field
             (2, 2, 0)
             sage: type(f.degrees())                                                      # needs sage.rings.number_field
-            <class 'sage.rings.polynomial.polydict.ETuple'>
-            sage: f.degrees(as_ETuples=False)                                            # needs sage.rings.number_field
-            (2, 2, 0)
-            sage: type(f.degrees(as_ETuples=False))                                     # needs sage.rings.number_field
             <class 'tuple'>
+            sage: f.degrees(as_ETuples=True)                                             # needs sage.rings.number_field
+            (2, 2, 0)
+            sage: type(f.degrees(as_ETuples=True))                                      # needs sage.rings.number_field
+            <class 'sage.rings.polynomial.polydict.ETuple'>
             sage: f = x^2 + z^2                                                          # needs sage.rings.number_field
             sage: f.degrees()                                                            # needs sage.rings.number_field
             (2, 0, 2)

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -2912,7 +2912,7 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             return Integer(result)
         return Integer(singular_polynomial_deg(p, NULL, r))
 
-    def degrees(self, as_ETuples=True):
+    def degrees(self, as_ETuples=False):
         r"""
         Return the maximal degree of each variable in this polynomial.
 
@@ -2922,7 +2922,7 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
 
         INPUT:
 
-        - ``as_ETuples`` -- boolean (default: ``True``); if ``True``, return
+        - ``as_ETuples`` -- boolean (default: ``False``); if ``True``, return
           the result as an :class:`~sage.rings.polynomial.polydict.ETuple`,
           otherwise return a plain :class:`tuple`
 
@@ -2937,11 +2937,11 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             sage: q.degrees()
             (1, 2, 1)
             sage: type(q.degrees())
-            <class 'sage.rings.polynomial.polydict.ETuple'>
-            sage: q.degrees(as_ETuples=False)
-            (1, 2, 1)
-            sage: type(q.degrees(as_ETuples=False))
             <class 'tuple'>
+            sage: q.degrees(as_ETuples=True)
+            (1, 2, 1)
+            sage: type(q.degrees(as_ETuples=True))
+            <class 'sage.rings.polynomial.polydict.ETuple'>
             sage: (q + y0^5).degrees()
             (5, 2, 1)
 

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -2912,11 +2912,22 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             return Integer(result)
         return Integer(singular_polynomial_deg(p, NULL, r))
 
-    def degrees(self):
-        """
-        Return a tuple with the maximal degree of each variable in
-        this polynomial.  The list of degrees is ordered by the order
-        of the generators.
+    def degrees(self, as_ETuples=True):
+        r"""
+        Return the maximal degree of each variable in this polynomial.
+
+        The degree of each variable is the maximum degree of that variable
+        appearing in any monomial of ``self``. The list of degrees is ordered
+        by the order of the generators.
+
+        INPUT:
+
+        - ``as_ETuples`` -- boolean (default: ``True``); if ``True``, return
+          the result as an :class:`~sage.rings.polynomial.polydict.ETuple`,
+          otherwise return a plain :class:`tuple`
+
+        OUTPUT: an :class:`~sage.rings.polynomial.polydict.ETuple` or a
+        :class:`tuple` with the degree of each variable
 
         EXAMPLES::
 
@@ -2925,6 +2936,12 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             3*y0*y1^2*y2
             sage: q.degrees()
             (1, 2, 1)
+            sage: type(q.degrees())
+            <class 'sage.rings.polynomial.polydict.ETuple'>
+            sage: q.degrees(as_ETuples=False)
+            (1, 2, 1)
+            sage: type(q.degrees(as_ETuples=False))
+            <class 'tuple'>
             sage: (q + y0^5).degrees()
             (5, 2, 1)
 
@@ -2939,6 +2956,7 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             sage: type(f.degrees()[0])
             <class 'sage.rings.integer.Integer'>
         """
+        from sage.rings.polynomial.polydict import ETuple
         cdef poly *p = self._poly
         cdef ring *r = self._parent_ring
         cdef int i
@@ -2947,7 +2965,11 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             for i from 0 <= i < r.N:
                 d[i] = max(d[i],p_GetExp(p, i+1, r))
             p = pNext(p)
-        return tuple(map(Integer, d))
+        d = list(map(Integer, d))
+        if as_ETuples:
+            return ETuple(d)
+        return tuple(d)
+
 
     def coefficient(self, degrees):
         """

--- a/src/sage/rings/polynomial/plural.pyx
+++ b/src/sage/rings/polynomial/plural.pyx
@@ -2033,13 +2033,20 @@ cdef class NCPolynomial_plural(RingElement):
         cdef ring *r = (<NCPolynomialRing_plural>self._parent)._ring
         return singular_polynomial_deg(p, NULL, r)
 
-    def degrees(self):
-        """
-        Return a tuple with the maximal degree of each variable in
-        this polynomial.
+    def degrees(self, as_ETuples=True):
+        r"""
+        Return the maximal degree of each variable in this polynomial.
 
-        The list of degrees is ordered by the order
-        of the generators.
+        The list of degrees is ordered by the order of the generators.
+
+        INPUT:
+
+        - ``as_ETuples`` -- boolean (default: ``True``); if ``True``, return
+          the result as an :class:`~sage.rings.polynomial.polydict.ETuple`,
+          otherwise return a plain :class:`tuple`
+
+        OUTPUT: an :class:`~sage.rings.polynomial.polydict.ETuple` or a
+        :class:`tuple` with the degree of each variable
 
         EXAMPLES::
 
@@ -2051,9 +2058,16 @@ cdef class NCPolynomial_plural(RingElement):
             3*y0*y1^2*y2
             sage: q.degrees()
             (1, 2, 1)
+            sage: type(q.degrees())
+            <class 'sage.rings.polynomial.polydict.ETuple'>
+            sage: q.degrees(as_ETuples=False)
+            (1, 2, 1)
+            sage: type(q.degrees(as_ETuples=False))
+            <class 'tuple'>
             sage: (q + y0^5).degrees()
             (5, 2, 1)
         """
+        from sage.rings.polynomial.polydict import ETuple
         cdef poly *p = self._poly
         cdef ring *r = (<NCPolynomialRing_plural>self._parent)._ring
         cdef int i
@@ -2062,7 +2076,10 @@ cdef class NCPolynomial_plural(RingElement):
             for i from 0 <= i < r.N:
                 d[i] = max(d[i], p_GetExp(p, i+1, r))
             p = pNext(p)
+        if as_ETuples:
+            return ETuple(d)
         return tuple(d)
+
 
     def coefficient(self, degrees):
         """

--- a/src/sage/rings/polynomial/plural.pyx
+++ b/src/sage/rings/polynomial/plural.pyx
@@ -2033,7 +2033,7 @@ cdef class NCPolynomial_plural(RingElement):
         cdef ring *r = (<NCPolynomialRing_plural>self._parent)._ring
         return singular_polynomial_deg(p, NULL, r)
 
-    def degrees(self, as_ETuples=True):
+    def degrees(self, as_ETuples=False):
         r"""
         Return the maximal degree of each variable in this polynomial.
 
@@ -2041,7 +2041,7 @@ cdef class NCPolynomial_plural(RingElement):
 
         INPUT:
 
-        - ``as_ETuples`` -- boolean (default: ``True``); if ``True``, return
+        - ``as_ETuples`` -- boolean (default: ``False``); if ``True``, return
           the result as an :class:`~sage.rings.polynomial.polydict.ETuple`,
           otherwise return a plain :class:`tuple`
 
@@ -2059,11 +2059,11 @@ cdef class NCPolynomial_plural(RingElement):
             sage: q.degrees()
             (1, 2, 1)
             sage: type(q.degrees())
-            <class 'sage.rings.polynomial.polydict.ETuple'>
-            sage: q.degrees(as_ETuples=False)
-            (1, 2, 1)
-            sage: type(q.degrees(as_ETuples=False))
             <class 'tuple'>
+            sage: q.degrees(as_ETuples=True)
+            (1, 2, 1)
+            sage: type(q.degrees(as_ETuples=True))
+            <class 'sage.rings.polynomial.polydict.ETuple'>
             sage: (q + y0^5).degrees()
             (5, 2, 1)
         """


### PR DESCRIPTION
The `.degrees()` method on multivariate polynomials is documented to return
an `ETuple`, but in practice most backends returned a plain `tuple`, making
the behavior inconsistent and the documentation incorrect.

### What problem does this solve?

```python
sage: R.<x,y,z> = QQ[]
sage: type(x.degrees())
<class 'tuple'>   # ← was wrong, should be ETuple
```