### PR TITLE
gh-40796: Unify finite ring square root APIs

### DIFF
--- a/src/sage/categories/commutative_rings.py
+++ b/src/sage/categories/commutative_rings.py
@@ -1018,8 +1018,7 @@ class CommutativeRings(CategoryWithAxiom):
                     NotImplementedError: square-root computation requires an enumeration or a specialized decomposition
                 """
                 parent = self.parent()
-                from sage.categories.integral_domains import IntegralDomains
-                is_domain = all and parent in IntegralDomains()
+                is_domain = None
 
                 helper = getattr(self, '_sqrt_finite_decomposition', None)
                 if helper is None:
@@ -1034,6 +1033,9 @@ class CommutativeRings(CategoryWithAxiom):
                     elif result is not None:
                         return result
                 else:
+                    if all:
+                        from sage.categories.integral_domains import IntegralDomains
+                        is_domain = parent in IntegralDomains()
                     if getattr(type(parent), '__iter__', None) is None:
                         raise NotImplementedError(
                             "square-root computation requires an enumeration "
@@ -1068,6 +1070,9 @@ class CommutativeRings(CategoryWithAxiom):
                         return []
                     raise ValueError("element is not a square")
                 if all:
+                    if is_domain is None:
+                        from sage.categories.integral_domains import IntegralDomains
+                        is_domain = parent in IntegralDomains()
                     if not is_domain:
                         raise NotImplementedError(
                             "finding all square roots in extensions of finite "

--- a/src/sage/categories/commutative_rings.py
+++ b/src/sage/categories/commutative_rings.py
@@ -883,17 +883,15 @@ class CommutativeRings(CategoryWithAxiom):
 
                 EXAMPLES::
 
+                    sage: CommutativeRings().Finite().CartesianProducts().extra_super_categories()
+                    [Category of finite commutative rings]
                     sage: R.<x> = GF(3)[]
                     sage: A = R.quotient((x + 1)^2 * (x^2 + 1), 'a')
                     sage: P = cartesian_product([A, Zmod(8)])
                     sage: P in CommutativeRings().Finite()
                     True
-                    sage: q = P((A.one(), 1))
-                    sage: roots = q.sqrt(extend=False, all=True,
-                    ....:                algorithm='backend-default')
-                    sage: len(roots), len(set(roots))
-                    (16, 16)
-                    sage: all(root^2 == q for root in roots)
+                    sage: Q = cartesian_product([P, Zmod(9)])
+                    sage: Q in CommutativeRings().Finite()
                     True
                 """
                 return [CommutativeRings().Finite()]
@@ -949,9 +947,11 @@ class CommutativeRings(CategoryWithAxiom):
                     sage: B = PolynomialQuotientRing_generic(
                     ....:     R, x^2 + 2, 'b', category=IntegralDomains())
                     sage: b = B.gen()
-                    sage: [root^2 == b for root in b.sqrt(
+                    sage: [root**2 == b for root in b.sqrt(
                     ....:     extend=True, all=True, name='w')]
                     [True, True]
+
+                TESTS:
 
                 Cartesian products use the same interface and enumerate all
                 roots in the original ring.  Their factors are searched
@@ -963,7 +963,7 @@ class CommutativeRings(CategoryWithAxiom):
                     ....:     roots = method(extend=False, all=True,
                     ....:                    algorithm='backend-default')
                     ....:     assert isinstance(roots, list) and len(roots) == 4
-                    ....:     assert all(root^2 == q for root in roots)
+                    ....:     assert all(root**2 == q for root in roots)
                     ....:     try:
                     ....:         method(True)
                     ....:     except TypeError:
@@ -971,7 +971,7 @@ class CommutativeRings(CategoryWithAxiom):
                     ....:     else:
                     ....:         raise AssertionError("optional argument was positional")
                     sage: roots = q.sqrt(extend=False, all=True)
-                    sage: expected = [r for r in P if r^2 == q]
+                    sage: expected = [r for r in P if r**2 == q]
                     sage: len(roots) == len(expected) and all(r in expected for r in roots)
                     True
 
@@ -980,7 +980,7 @@ class CommutativeRings(CategoryWithAxiom):
                     sage: Q = cartesian_product([P, Zmod(9)])
                     sage: v = Q((q, 1))
                     sage: roots = v.sqrt(extend=False, all=True)
-                    sage: expected = [r for r in Q if r^2 == v]
+                    sage: expected = [r for r in Q if r**2 == v]
                     sage: len(roots) == len(expected) and all(r in expected for r in roots)
                     True
 
@@ -990,7 +990,7 @@ class CommutativeRings(CategoryWithAxiom):
                     sage: L = cartesian_product([Zmod(2^8), GF(1009), GF(1013)])
                     sage: z = L((1, 4, 4))
                     sage: roots = z.sqrt(extend=False, all=True)
-                    sage: len(roots), all(r^2 == z for r in roots)
+                    sage: len(roots), all(r**2 == z for r in roots)
                     (16, True)
                     sage: z.sqrt(extend=False)**2 == z
                     True
@@ -1074,7 +1074,9 @@ class CommutativeRings(CategoryWithAxiom):
                             "non-domains is not implemented"
                         )
                 from sage.categories.finite_fields import _sqrt_in_extension
-                return _sqrt_in_extension(self, all, name, algorithm)
+                return _sqrt_in_extension(
+                    self, all_roots=all, name=name, algorithm=algorithm
+                )
 
             square_root = sqrt
 

--- a/src/sage/categories/commutative_rings.py
+++ b/src/sage/categories/commutative_rings.py
@@ -899,7 +899,7 @@ class CommutativeRings(CategoryWithAxiom):
                 return [CommutativeRings().Finite()]
 
         class ElementMethods:
-            def sqrt(self, *, extend=True, all=False, algorithm=None,
+            def sqrt(self, *, extend=False, all=False, algorithm=None,
                      name=None):
                 r"""
                 Return square roots using the common finite-ring interface.
@@ -916,18 +916,18 @@ class CommutativeRings(CategoryWithAxiom):
                     sage: signatures = {str(signature(method))
                     ....:               for method in (a.sqrt, a.square_root)}
                     sage: signatures
-                    {'(*, extend=True, all=False, algorithm=None, name=None)'}
+                    {'(*, extend=False, all=False, algorithm=None, name=None)'}
                     sage: roots = A.zero().sqrt(extend=False, all=True,
                     ....:                       algorithm='backend-default')
                     sage: isinstance(roots, list), set(roots) == {i*a for i in GF(5)}
                     (True, True)
                     sage: a.square_root(extend=False, all=True)
                     []
-                    sage: a.sqrt(extend=False)
+                    sage: a.sqrt()
                     Traceback (most recent call last):
                     ...
                     ValueError: element is not a square
-                    sage: root = a.sqrt(name='w'); root**2 == a
+                    sage: root = a.sqrt(extend=True, name='w'); root**2 == a
                     True
 
                 A concrete parent may provide an iterator without claiming
@@ -949,7 +949,8 @@ class CommutativeRings(CategoryWithAxiom):
                     sage: B = PolynomialQuotientRing_generic(
                     ....:     R, x^2 + 2, 'b', category=IntegralDomains())
                     sage: b = B.gen()
-                    sage: [root^2 == b for root in b.sqrt(all=True, name='w')]
+                    sage: [root^2 == b for root in b.sqrt(
+                    ....:     extend=True, all=True, name='w')]
                     [True, True]
 
                 Cartesian products use the same interface and enumerate all

--- a/src/sage/categories/commutative_rings.py
+++ b/src/sage/categories/commutative_rings.py
@@ -927,7 +927,18 @@ class CommutativeRings(CategoryWithAxiom):
                     Traceback (most recent call last):
                     ...
                     ValueError: element is not a square
-                    sage: root = a.sqrt(name='w'); root^2 == a
+                    sage: root = a.sqrt(name='w'); root**2 == a
+                    True
+
+                A concrete parent may provide an iterator without claiming
+                the finite-enumerated-set category; that capability remains a
+                valid fallback when no decomposition is available::
+
+                    sage: from sage.categories.finite_enumerated_sets import FiniteEnumeratedSets
+                    sage: A in FiniteEnumeratedSets(), hasattr(A, '__iter__')
+                    (False, True)
+                    sage: q = (a + 2)**2
+                    sage: q.sqrt(extend=False)**2 == q
                     True
 
                 A finite integral domain that still uses this generic
@@ -980,37 +991,77 @@ class CommutativeRings(CategoryWithAxiom):
                     sage: roots = z.sqrt(extend=False, all=True)
                     sage: len(roots), all(r^2 == z for r in roots)
                     (16, True)
+                    sage: z.sqrt(extend=False)**2 == z
+                    True
+
+                The structured fast paths do not enumerate the full parent,
+                even when only one root is requested::
+
+                    sage: from unittest.mock import patch
+                    sage: with patch.object(type(L), '__iter__',
+                    ....:                   side_effect=AssertionError("full enumeration")):
+                    ....:     assert z.sqrt(extend=False)**2 == z
+
+                The category of finite commutative rings does not itself
+                promise an enumeration.  An unstructured parent must provide
+                a real iterator before the generic fallback can be used::
+
+                    sage: from sage.structure.parent import Parent
+                    sage: U = Parent(category=CommutativeRings().Finite())
+                    sage: class FakeElement:
+                    ....:     def parent(self): return U
+                    sage: CommutativeRings.Finite.ElementMethods.sqrt(
+                    ....:     FakeElement(), extend=False)
+                    Traceback (most recent call last):
+                    ...
+                    NotImplementedError: square-root computation requires an enumeration or a specialized decomposition
                 """
                 parent = self.parent()
-                if all:
-                    from sage.categories.integral_domains import IntegralDomains
-                    is_domain = parent in IntegralDomains()
-                    if is_domain:
-                        for root in parent:
+                from sage.categories.integral_domains import IntegralDomains
+                is_domain = all and parent in IntegralDomains()
+
+                helper = getattr(self, '_sqrt_finite_decomposition', None)
+                if helper is None:
+                    result = NotImplemented
+                else:
+                    result = helper(all=all, algorithm=algorithm)
+
+                if result is not NotImplemented:
+                    if all:
+                        if result:
+                            return result
+                    elif result is not None:
+                        return result
+                else:
+                    if getattr(type(parent), '__iter__', None) is None:
+                        raise NotImplementedError(
+                            "square-root computation requires an enumeration "
+                            "or a specialized decomposition"
+                        )
+                    try:
+                        elements = iter(parent)
+                    except (TypeError, NotImplementedError) as error:
+                        raise NotImplementedError(
+                            "square-root computation requires an enumeration "
+                            "or a specialized decomposition"
+                        ) from error
+
+                    if all and is_domain:
+                        for root in elements:
                             if root * root == self:
                                 negative = -root
                                 if negative == root:
                                     return [root]
                                 return [root, negative]
-                    else:
-                        if parent in CommutativeRings().CartesianProducts():
-                            roots = self._sqrt_all_finite(algorithm=algorithm)
-                        else:
-                            helper = getattr(
-                                self, '_sqrt_all_finite_decomposition', None)
-                            if helper is not None:
-                                roots = helper(algorithm=algorithm)
-                            else:
-                                roots = None
-                            if roots is None:
-                                roots = [root for root in parent
-                                         if root * root == self]
+                    elif all:
+                        roots = [root for root in elements
+                                 if root * root == self]
                         if roots:
                             return roots
-                else:
-                    for root in parent:
-                        if root * root == self:
-                            return root
+                    else:
+                        for root in elements:
+                            if root * root == self:
+                                return root
                 if not extend:
                     if all:
                         return []
@@ -1022,7 +1073,7 @@ class CommutativeRings(CategoryWithAxiom):
                             "non-domains is not implemented"
                         )
                 from sage.categories.finite_fields import _sqrt_in_extension
-                return _sqrt_in_extension(self, all, name)
+                return _sqrt_in_extension(self, all, name, algorithm)
 
             square_root = sqrt
 
@@ -1182,23 +1233,47 @@ class CommutativeRings(CategoryWithAxiom):
             return [CommutativeRings()]
 
         class ElementMethods:
-            def _sqrt_all_finite(self, algorithm=None):
+            def _sqrt_finite_decomposition(self, *, all, algorithm=None):
                 r"""
-                Return all square roots in this finite Cartesian product.
+                Return square roots in this finite Cartesian product.
 
                 The roots are computed by each factor's square-root method,
                 then combined componentwise.  Nested Cartesian products are
                 handled recursively.
+
+                EXAMPLES::
+
+                    sage: P = cartesian_product([Zmod(8), GF(5)])
+                    sage: q = P((1, 4))
+                    sage: roots = q._sqrt_finite_decomposition(all=True)
+                    sage: len(roots), all(root**2 == q for root in roots)
+                    (8, True)
+                    sage: q._sqrt_finite_decomposition(all=False)**2 == q
+                    True
                 """
                 roots_by_factor = []
                 parent = self.parent()
                 for component in self.cartesian_factors():
-                    roots = component.sqrt(extend=False, all=True,
-                                           algorithm=algorithm)
-                    if not roots:
-                        return []
-                    roots_by_factor.append(roots)
+                    if all:
+                        roots = component.sqrt(extend=False, all=True,
+                                               algorithm=algorithm)
+                        if not roots:
+                            return []
+                        roots_by_factor.append(roots)
+                    else:
+                        try:
+                            root = component.sqrt(extend=False, all=False,
+                                                  algorithm=algorithm)
+                        except ValueError as error:
+                            if str(error) != "element is not a square":
+                                raise
+                            return None
+                        roots_by_factor.append((root,))
 
                 from itertools import product
+                combinations = product(*roots_by_factor)
+                if not all:
+                    return parent._cartesian_product_of_elements(
+                        next(combinations))
                 return [parent._cartesian_product_of_elements(roots)
-                        for roots in product(*roots_by_factor)]
+                        for roots in combinations]

--- a/src/sage/categories/commutative_rings.py
+++ b/src/sage/categories/commutative_rings.py
@@ -872,6 +872,160 @@ class CommutativeRings(CategoryWithAxiom):
             from sage.categories.noetherian_rings import NoetherianRings
             return [NoetherianRings()]
 
+        class CartesianProducts(CartesianProductsCategory):
+            def extra_super_categories(self):
+                r"""
+                Declare a finite Cartesian product of finite commutative
+                rings to be a finite commutative ring.
+
+                This does not require the factors to implement the stronger
+                finite-enumerated-set contract.
+
+                EXAMPLES::
+
+                    sage: R.<x> = GF(3)[]
+                    sage: A = R.quotient((x + 1)^2 * (x^2 + 1), 'a')
+                    sage: P = cartesian_product([A, Zmod(8)])
+                    sage: P in CommutativeRings().Finite()
+                    True
+                    sage: q = P((A.one(), 1))
+                    sage: roots = q.sqrt(extend=False, all=True,
+                    ....:                algorithm='backend-default')
+                    sage: len(roots), len(set(roots))
+                    (16, 16)
+                    sage: all(root^2 == q for root in roots)
+                    True
+                """
+                return [CommutativeRings().Finite()]
+
+        class ElementMethods:
+            def sqrt(self, *, extend=True, all=False, algorithm=None,
+                     name=None):
+                r"""
+                Return square roots using the common finite-ring interface.
+
+                The optional ``algorithm`` is a hint.  Optimized
+                decompositions forward it to their components; the generic
+                enumeration fallback ignores unsupported hints.
+
+                EXAMPLES::
+
+                    sage: from inspect import signature
+                    sage: R.<x> = GF(5)[]
+                    sage: A.<a> = R.quotient(x^2)
+                    sage: signatures = {str(signature(method))
+                    ....:               for method in (a.sqrt, a.square_root)}
+                    sage: signatures
+                    {'(*, extend=True, all=False, algorithm=None, name=None)'}
+                    sage: roots = A.zero().sqrt(extend=False, all=True,
+                    ....:                       algorithm='backend-default')
+                    sage: isinstance(roots, list), set(roots) == {i*a for i in GF(5)}
+                    (True, True)
+                    sage: a.square_root(extend=False, all=True)
+                    []
+                    sage: a.sqrt(extend=False)
+                    Traceback (most recent call last):
+                    ...
+                    ValueError: element is not a square
+                    sage: root = a.sqrt(name='w'); root^2 == a
+                    True
+
+                A finite integral domain that still uses this generic
+                fallback has two roots in its quadratic extension::
+
+                    sage: from sage.categories.integral_domains import IntegralDomains
+                    sage: from sage.rings.polynomial.polynomial_quotient_ring import PolynomialQuotientRing_generic
+                    sage: B = PolynomialQuotientRing_generic(
+                    ....:     R, x^2 + 2, 'b', category=IntegralDomains())
+                    sage: b = B.gen()
+                    sage: [root^2 == b for root in b.sqrt(all=True, name='w')]
+                    [True, True]
+
+                Cartesian products use the same interface and enumerate all
+                roots in the original ring.  Their factors are searched
+                separately, avoiding enumeration of the full product::
+
+                    sage: P = cartesian_product([Zmod(4), GF(5)])
+                    sage: q = P((1, 4))
+                    sage: for method in (q.sqrt, q.square_root):
+                    ....:     roots = method(extend=False, all=True,
+                    ....:                    algorithm='backend-default')
+                    ....:     assert isinstance(roots, list) and len(roots) == 4
+                    ....:     assert all(root^2 == q for root in roots)
+                    ....:     try:
+                    ....:         method(True)
+                    ....:     except TypeError:
+                    ....:         pass
+                    ....:     else:
+                    ....:         raise AssertionError("optional argument was positional")
+                    sage: roots = q.sqrt(extend=False, all=True)
+                    sage: expected = [r for r in P if r^2 == q]
+                    sage: len(roots) == len(expected) and all(r in expected for r in roots)
+                    True
+
+                This also applies recursively to nested products::
+
+                    sage: Q = cartesian_product([P, Zmod(9)])
+                    sage: v = Q((q, 1))
+                    sage: roots = v.sqrt(extend=False, all=True)
+                    sage: expected = [r for r in Q if r^2 == v]
+                    sage: len(roots) == len(expected) and all(r in expected for r in roots)
+                    True
+
+                A product can be very large even when its factors are small;
+                only the factors and the resulting roots are enumerated::
+
+                    sage: L = cartesian_product([Zmod(2^8), GF(1009), GF(1013)])
+                    sage: z = L((1, 4, 4))
+                    sage: roots = z.sqrt(extend=False, all=True)
+                    sage: len(roots), all(r^2 == z for r in roots)
+                    (16, True)
+                """
+                parent = self.parent()
+                if all:
+                    from sage.categories.integral_domains import IntegralDomains
+                    is_domain = parent in IntegralDomains()
+                    if is_domain:
+                        for root in parent:
+                            if root * root == self:
+                                negative = -root
+                                if negative == root:
+                                    return [root]
+                                return [root, negative]
+                    else:
+                        if parent in CommutativeRings().CartesianProducts():
+                            roots = self._sqrt_all_finite(algorithm=algorithm)
+                        else:
+                            helper = getattr(
+                                self, '_sqrt_all_finite_decomposition', None)
+                            if helper is not None:
+                                roots = helper(algorithm=algorithm)
+                            else:
+                                roots = None
+                            if roots is None:
+                                roots = [root for root in parent
+                                         if root * root == self]
+                        if roots:
+                            return roots
+                else:
+                    for root in parent:
+                        if root * root == self:
+                            return root
+                if not extend:
+                    if all:
+                        return []
+                    raise ValueError("element is not a square")
+                if all:
+                    if not is_domain:
+                        raise NotImplementedError(
+                            "finding all square roots in extensions of finite "
+                            "non-domains is not implemented"
+                        )
+                from sage.categories.finite_fields import _sqrt_in_extension
+                return _sqrt_in_extension(self, all, name)
+
+            square_root = sqrt
+
         class ParentMethods:
             def cyclotomic_cosets(self, q, cosets=None):
                 r"""
@@ -1026,3 +1180,25 @@ class CommutativeRings(CategoryWithAxiom):
                 True
             """
             return [CommutativeRings()]
+
+        class ElementMethods:
+            def _sqrt_all_finite(self, algorithm=None):
+                r"""
+                Return all square roots in this finite Cartesian product.
+
+                The roots are computed by each factor's square-root method,
+                then combined componentwise.  Nested Cartesian products are
+                handled recursively.
+                """
+                roots_by_factor = []
+                parent = self.parent()
+                for component in self.cartesian_factors():
+                    roots = component.sqrt(extend=False, all=True,
+                                           algorithm=algorithm)
+                    if not roots:
+                        return []
+                    roots_by_factor.append(roots)
+
+                from itertools import product
+                return [parent._cartesian_product_of_elements(roots)
+                        for roots in product(*roots_by_factor)]

--- a/src/sage/categories/finite_fields.py
+++ b/src/sage/categories/finite_fields.py
@@ -14,8 +14,42 @@ Finite fields
 
 from sage.categories.category_with_axiom import CategoryWithAxiom
 from sage.categories.enumerated_sets import EnumeratedSets
-from sage.rings.integer import Integer
 from sage.misc.cachefunc import cached_method
+from sage.rings.integer import Integer
+
+
+def _sqrt_in_extension(element, all, name):
+    r"""
+    Return square roots of ``element`` in a quadratic extension.
+
+    Repeated calls reuse the polynomial quotient parent::
+
+        sage: R.<x> = GF(5)[]
+        sage: K.<a> = R.quotient(x^2 + 2)
+        sage: u = K.quadratic_nonresidue()
+        sage: from sage.categories.finite_fields import _sqrt_in_extension
+        sage: r = _sqrt_in_extension(u, False, 'w')
+        sage: s = _sqrt_in_extension(u, False, 'w')
+        sage: r.parent() is s.parent() and r^2 == u
+        True
+    """
+    from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+    from sage.rings.polynomial.polynomial_quotient_ring import PolynomialQuotientRing
+
+    parent = element.parent()
+    if name is None:
+        name = 'sqrt'
+    polynomial_ring = PolynomialRing(parent, 'x')
+    x = polynomial_ring.gen()
+    extension = PolynomialQuotientRing(
+        polynomial_ring, x**2 - polynomial_ring(element), names=name
+    )
+    square_root = extension.gen()
+    if all:
+        if parent.characteristic() == 2:
+            return [square_root]
+        return [square_root, -square_root]
+    return square_root
 
 
 class FiniteFields(CategoryWithAxiom):
@@ -304,7 +338,7 @@ class FiniteFields(CategoryWithAxiom):
             is_square = character == self.parent().one()
             return is_square
 
-        def _tonelli(self):
+        def _tonelli(self, check=True):
             r"""
             Return a square root of the element if it exists
             using Tonelli's algorithm, only works for finite fields
@@ -326,23 +360,44 @@ class FiniteFields(CategoryWithAxiom):
                 ...
                 ValueError: element is not a square
             """
-            q = self.parent().cardinality()
-            if not self.is_square():
-                raise ValueError("element is not a square")
-            g = self.parent().quadratic_nonresidue()
-            even_exp, odd_order = (q - Integer(1)).val_unit(2)
-            e = 0
-            for i in range(2, even_exp+1):
-                tmp = self * (pow(g, -e))
+            parent = self.parent()
+            if parent.characteristic() == 2:
+                raise ValueError("Tonelli's algorithm requires odd characteristic")
+            if self.is_zero():
+                return self
+            q = parent.cardinality()
+            even_exp, odd_order = (q - 1).val_unit(2)
+            one = parent.one()
+            residue = self**odd_order
+            if check:
+                character = residue
+                for _ in range(even_exp - 1):
+                    character *= character
+                if character != one:
+                    raise ValueError("element is not a square")
+            generator = parent.quadratic_nonresidue()
+            correction = generator**odd_order
+            square_root = self**((odd_order + 1) // 2)
+            exponent = even_exp
 
-                condition = tmp**((q-1)//(2**i)) != self.parent().one()
-                if condition:
-                    e = 2**(i-1) + e
-            h = self * (g**(-e))
-            b = g**(e//2) * h**((odd_order+1)//2)
-            return b
+            while residue != one:
+                i = 1
+                power = residue * residue
+                while i < exponent and power != one:
+                    power *= power
+                    i += 1
+                if i == exponent:
+                    raise ValueError("element is not a square")
+                factor = correction**(2**(exponent - i - 1))
+                square_root *= factor
+                factor *= factor
+                residue *= factor
+                correction = factor
+                exponent = i
 
-        def _cipolla(self):
+            return square_root
+
+        def _cipolla(self, check=True):
             r"""
             Return a square root of the element if it exists
             using Cipolla's algorithm, more suited if order - 1
@@ -366,8 +421,12 @@ class FiniteFields(CategoryWithAxiom):
                 ValueError: element is not a square
             """
             parent = self.parent()
+            if parent.characteristic() == 2:
+                raise ValueError("Cipolla's algorithm requires odd characteristic")
+            if self.is_zero():
+                return self
             q = parent.cardinality()
-            if not self.is_square():
+            if check and not self.is_square():
                 raise ValueError("element is not a square")
             t = parent.random_element()
             root = t**2 - 4 * self
@@ -378,31 +437,40 @@ class FiniteFields(CategoryWithAxiom):
             X = polygen(parent)
             f = X**2 - t*X + self
             b = pow(X, (q+1)//2, f)
-            return b
+            return b[0]
 
-        def sqrt(self, all: bool = False, algorithm: str = 'tonelli'):
+        def sqrt(self, *, extend=True, all=False, algorithm=None, name=None):
             r"""
             Return the square root of the element if it exists.
 
             INPUT:
 
-            - ``all`` -- boolean (default: ``False``); whether to return a list of
-              all square roots or just a square root
+            - ``extend`` -- boolean (default: ``True``); if ``True``, return
+              roots in a quadratic extension when necessary
 
-            - ``algorithm`` -- string (default: 'tonelli'); the algorithm to use
-              among ``'tonelli'``, ``'cipolla'``. Tonelli is typically faster but has
-              a worse worst-case complexity than Cipolla. In particular, if the
-              field cardinality minus 1 is highly divisible by 2 and has a large
-              odd factor then Cipolla may perform better.
+            - ``all`` -- boolean (default: ``False``); whether to return all
+              square roots or just one
+
+            - ``algorithm`` -- optional algorithm hint (default: ``None``).
+              ``'cipolla'`` selects Cipolla's algorithm; ``'tonelli'``,
+              ``None``, and unsupported hints select the backend default,
+              Tonelli's algorithm. Tonelli is typically faster but has a worse
+              worst-case complexity than Cipolla. In particular, if the field
+              cardinality minus 1 is highly divisible by 2 and has a large odd
+              factor then Cipolla may perform better.
+
+            - ``name`` -- string (default: ``None``); name of the generator when
+              a quadratic extension is created
 
             OUTPUT:
 
-            - if ``all=False``, a square root; raises an error if the element is not
-              a square
+            - if ``all=False``, a square root in the parent or, when
+              ``extend=True``, in a quadratic extension; raises an error if no
+              root exists and extension is disabled
 
-            - if ``all=True``, a tuple of all distinct square roots. This tuple can have
-              length 0, 1, or 2 depending on how many distinct square roots the
-              element has.
+            - if ``all=True``, a list of all distinct square roots in the
+              selected parent.  This list can have length 0, 1, or 2 depending
+              on how many distinct square roots the element has.
 
             EXAMPLES::
 
@@ -422,12 +490,107 @@ class FiniteFields(CategoryWithAxiom):
                 True
                 sage: 3 in my_sqrts
                 True
-                sage: k.quadratic_nonresidue().sqrt()
+                sage: k.quadratic_nonresidue().sqrt(extend=False)
                 Traceback (most recent call last):
                 ...
                 ValueError: element is not a square
-                sage: k.quadratic_nonresidue().sqrt(all=True)
-                ()
+                sage: k.quadratic_nonresidue().sqrt(extend=False, all=True)
+                []
+
+            The common finite-field keyword interface is accepted, and roots
+            returned by Cipolla's algorithm belong to the original field::
+
+                sage: for method in ((y^2).sqrt, (y^2).square_root):
+                ....:     r = method(extend=False, algorithm='cipolla')
+                ....:     assert r.parent() is k and r^2 == y^2
+                sage: for method in (k(0).sqrt, k(0).square_root):
+                ....:     for algorithm in ('tonelli', 'cipolla'):
+                ....:         assert method(algorithm=algorithm) == 0
+                ....:         assert method(all=True,
+                ....:                       algorithm=algorithm) == [k(0)]
+                sage: for method in (k(1).sqrt, k(1).square_root):
+                ....:     assert method(algorithm='backend-default')^2 == 1
+
+            A nonsquare can be lifted to a quadratic extension::
+
+                sage: a = k.quadratic_nonresidue()
+                sage: for method in (a.sqrt, a.square_root):
+                ....:     s = method(name='s')
+                ....:     assert s^2 == a and s.parent() in FiniteFields()
+
+            Both method names implement the same keyword contract::
+
+                sage: q = k(4)
+                sage: for method in (q.sqrt, q.square_root):
+                ....:     for algorithm in (None, 'tonelli', 'cipolla'):
+                ....:         roots = method(extend=False, all=True,
+                ....:                        algorithm=algorithm, name='s')
+                ....:         assert isinstance(roots, list)
+                ....:         assert len(roots) == 2
+                ....:         assert all(r.parent() is k and r^2 == q
+                ....:                    for r in roots)
+
+            The contract is uniform across the concrete finite-field
+            implementations::
+
+                sage: from inspect import signature
+                sage: fields = [GF(7),
+                ....:           GF(next_prime(2^40)),
+                ....:           GF(9, 'g', implementation='givaro'),
+                ....:           GF(2^8, 'n', implementation='ntl'),
+                ....:           GF(3^3, 'p', implementation='pari_ffelt')]
+                sage: R.<u> = GF(5)[]
+                sage: fields.append(R.quotient(u^2 + 2, 'q'))
+                sage: signatures = {str(signature(method))
+                ....:               for field in fields
+                ....:               for method in (field.one().sqrt,
+                ....:                              field.one().square_root)}
+                sage: signatures
+                {'(*, extend=True, all=False, algorithm=None, name=None)'}
+                sage: for field in fields:
+                ....:     value = field.gen()^2
+                ....:     for method in (value.sqrt, value.square_root):
+                ....:         roots = method(all=True,
+                ....:                        algorithm='backend-default')
+                ....:         assert isinstance(roots, list)
+                ....:         assert roots and all(root^2 == value
+                ....:                              for root in roots)
+
+            Optional arguments are keyword-only, so old backend-specific
+            positional orders cannot be confused with the common interface::
+
+                sage: for method in (q.sqrt, q.square_root):
+                ....:     try:
+                ....:         method(True)
+                ....:     except TypeError:
+                ....:         pass
+                ....:     else:
+                ....:         raise AssertionError("optional argument was positional")
+
+            The category implementation also handles characteristic two and
+            the exponent shortcut for fields of order congruent to three
+            modulo four::
+
+                sage: R2.<z> = GF(2)[]
+                sage: K2.<b> = R2.quotient(z^3 + z + 1)
+                sage: b._cipolla()
+                Traceback (most recent call last):
+                ...
+                ValueError: Cipolla's algorithm requires odd characteristic
+                sage: for method in (b.sqrt, b.square_root):
+                ....:     roots = method(extend=True, all=True,
+                ....:                    algorithm='cipolla', name='w')
+                ....:     assert isinstance(roots, list) and len(roots) == 1
+                ....:     assert roots[0].parent() is K2 and roots[0]^2 == b
+                sage: R3.<z> = GF(3)[]
+                sage: K3.<b> = R3.quotient(z^3 - z + 1)
+                sage: q3 = b^2
+                sage: for method in (q3.sqrt, q3.square_root):
+                ....:     roots = method(extend=False, all=True,
+                ....:                    algorithm='cipolla')
+                ....:     assert isinstance(roots, list) and len(roots) == 2
+                ....:     assert all(r.parent() is K3 and r^2 == q3
+                ....:                for r in roots)
 
             Here is an example where changing the algorithm results
             in a faster square root::
@@ -452,25 +615,37 @@ class FiniteFields(CategoryWithAxiom):
             - For all other cases we use the algorithm given by the ``algorithm`` parameter.
             """
             cardinality = self.parent().order()
+            if self.is_zero():
+                if all:
+                    return [self]
+                return self
             if self.parent().characteristic() == 2:
                 exponent = cardinality // 2
                 square_root = self**exponent
                 if all:
-                    # we return a 1-tuple because the GF implementation does it
-                    return (square_root,)
+                    return [square_root]
                 return square_root
-            if not self.is_square():
-                if all:
-                    return ()
-                raise ValueError("element is not a square")
+            is_square = True
             if cardinality % 4 == 3:
                 square_root = self**((cardinality+1)//4)
-            elif algorithm == 'tonelli':
-                square_root = self._tonelli()
+                is_square = square_root * square_root == self
+            elif algorithm == 'cipolla':
+                is_square = self.is_square()
+                if is_square:
+                    square_root = self._cipolla(check=False)
             else:
-                square_root = self._cipolla()
+                try:
+                    square_root = self._tonelli()
+                except ValueError:
+                    is_square = False
+            if not is_square:
+                if extend:
+                    return _sqrt_in_extension(self, all, name)
+                if all:
+                    return []
+                raise ValueError("element is not a square")
             if all:
-                return (square_root, -square_root)
+                return [square_root, -square_root]
             return square_root
 
         square_root = sqrt

--- a/src/sage/categories/finite_fields.py
+++ b/src/sage/categories/finite_fields.py
@@ -112,6 +112,44 @@ def _sqrt_extension(parent, name):
     return None
 
 
+@lru_cache(maxsize=256)
+def _sqrt_extension_nonresidue(parent, name):
+    r"""
+    Return a fixed nonsquare and its square root in a quadratic extension.
+
+    Reusing this root reduces later square roots of nonsquares in ``parent``
+    to a square root in ``parent`` and one multiplication in the extension::
+
+        sage: from sage.categories.finite_fields import (
+        ....:     _sqrt_extension, _sqrt_extension_nonresidue)
+        sage: K = GF(1009)
+        sage: nonsquare, radical = _sqrt_extension_nonresidue(K, 'sqrt_ext')
+        sage: extension, embedding = _sqrt_extension(K, 'sqrt_ext')
+        sage: radical**2 == embedding(nonsquare)
+        True
+
+    Return ``None`` when this reduction is not profitable.  In particular,
+    Givaro computes the root directly faster, while polynomial quotient
+    fields may have a comparatively expensive square-root implementation in
+    the source parent.
+    """
+    extension_data = _sqrt_extension(parent, name)
+    if extension_data is None:
+        return None
+    extension, embedding = extension_data
+    from sage.rings.finite_rings.finite_field_base import (
+        FiniteField as FiniteField_base,
+    )
+    from sage.rings.finite_rings.finite_field_givaro import FiniteField_givaro
+    if (not isinstance(parent, FiniteField_base)
+            or isinstance(extension, FiniteField_givaro)
+            or parent.characteristic() == 2):
+        return None
+    nonsquare = parent.quadratic_nonresidue()
+    radical = embedding(nonsquare).sqrt(extend=False)
+    return nonsquare, radical
+
+
 def _sqrt_in_extension(element, *, all_roots, name, algorithm=None):
     r"""
     Return square roots of ``element`` in a quadratic extension.
@@ -154,6 +192,20 @@ def _sqrt_in_extension(element, *, all_roots, name, algorithm=None):
     extension_data = _sqrt_extension(parent, name)
     if extension_data is not None:
         extension, embedding = extension_data
+        nonresidue_data = _sqrt_extension_nonresidue(parent, name)
+        if nonresidue_data is not None and not element.is_square():
+            nonsquare, radical = nonresidue_data
+            # The quotient of two nonsquares in a finite field is a square.
+            if element == nonsquare:
+                square_root = radical
+            else:
+                ratio_root = (element / nonsquare).sqrt(
+                    extend=False, algorithm=algorithm
+                )
+                square_root = embedding(ratio_root) * radical
+            if all_roots:
+                return [square_root, -square_root]
+            return square_root
         return embedding(element).sqrt(extend=False, all=all_roots,
                                        algorithm=algorithm)
 

--- a/src/sage/categories/finite_fields.py
+++ b/src/sage/categories/finite_fields.py
@@ -12,33 +12,151 @@ Finite fields
 #                  https://www.gnu.org/licenses/
 # *****************************************************************************
 
+from functools import lru_cache
+
 from sage.categories.category_with_axiom import CategoryWithAxiom
 from sage.categories.enumerated_sets import EnumeratedSets
 from sage.misc.cachefunc import cached_method
 from sage.rings.integer import Integer
 
 
-def _sqrt_in_extension(element, all, name):
+def _pickleable_quotient_field_morphism(parent, mapping, codomain):
+    r"""
+    Rebuild ``mapping`` as a pickleable morphism defined by generator images.
+
+    The isomorphism returned by polynomial quotient fields can contain local
+    callables.  Rebuilding it from generator images also handles towers of
+    quotient fields and makes the resulting map safe to store in extension
+    parents::
+
+        sage: from sage.categories.finite_fields import _pickleable_quotient_field_morphism
+        sage: R.<x> = GF(5)[]
+        sage: K.<a> = R.quotient(x**2 + 2)
+        sage: _, mapping, F = K._isomorphic_ring()
+        sage: morphism = _pickleable_quotient_field_morphism(K, mapping, F)
+        sage: loads(dumps(morphism))(a) == morphism(a)
+        True
+    """
+    from sage.rings.polynomial.polynomial_quotient_ring import (
+        PolynomialQuotientRing_generic,
+    )
+
+    base = parent.base_ring()
+    if isinstance(base, PolynomialQuotientRing_generic):
+        base_map = _pickleable_quotient_field_morphism(base, mapping,
+                                                       codomain)
+    else:
+        base_map = base.hom([mapping(gen) for gen in base.gens()], codomain,
+                            check=False)
+    return parent.hom([mapping(parent.gen())], codomain, base_map=base_map,
+                      check=False)
+
+
+@lru_cache(maxsize=256)
+def _sqrt_extension(parent, name):
+    r"""
+    Return a reusable quadratic finite-field extension of ``parent``.
+
+    The returned parent is a genuine finite field whenever Sage can construct
+    an embedding of ``parent`` into its absolute representation.  This makes
+    roots of different elements compatible with each other::
+
+        sage: from sage.categories.finite_fields import _sqrt_extension
+        sage: K.<a> = GF(7**3)
+        sage: E, embedding = _sqrt_extension(K, 'sqrt_ext')
+        sage: E in FiniteFields() and E.has_coerce_map_from(K)
+        True
+        sage: embedding(K.gen()).parent() is E
+        True
+
+    Polynomial quotient fields are connected to an isomorphic absolute
+    finite field before the quadratic extension is formed::
+
+        sage: R.<x> = GF(5)[]
+        sage: L.<b> = R.quotient(x**2 + 2)
+        sage: E, embedding = _sqrt_extension(L, 'sqrt_ext')
+        sage: E in FiniteFields() and embedding(L.gen()).parent() is E
+        True
+    """
+    from sage.rings.finite_rings.finite_field_base import (
+        FiniteField as FiniteField_base,
+    )
+
+    if isinstance(parent, FiniteField_base):
+        return parent.extension(2, name, map=True)
+
+    from sage.rings.polynomial.polynomial_quotient_ring import (
+        PolynomialQuotientRing_generic,
+    )
+    if (isinstance(parent, PolynomialQuotientRing_generic)
+            and parent in FiniteFields()):
+        try:
+            _, to_field, field = parent._isomorphic_ring()
+        except NotImplementedError:
+            return None
+        extension, embedding = field.extension(2, name, map=True)
+        mapping = _pickleable_quotient_field_morphism(
+            parent, embedding * to_field, extension
+        )
+        if not extension.has_coerce_map_from(parent):
+            extension.register_coercion(mapping)
+        return extension, extension.coerce_map_from(parent)
+
+    if parent in FiniteFields():
+        from sage.rings.finite_rings.finite_field_constructor import GF
+        extension = GF(parent.order()**2, name)
+        embedding = extension.coerce_map_from(parent)
+        if embedding is not None:
+            return extension, embedding
+
+    return None
+
+
+def _sqrt_in_extension(element, all, name, algorithm=None):
     r"""
     Return square roots of ``element`` in a quadratic extension.
 
-    Repeated calls reuse the polynomial quotient parent::
+    Standard finite fields use a common genuine finite-field parent, so roots
+    of different nonsquares can be combined::
 
-        sage: R.<x> = GF(5)[]
-        sage: K.<a> = R.quotient(x^2 + 2)
-        sage: u = K.quadratic_nonresidue()
+        sage: K.<a> = GF(7**3)
         sage: from sage.categories.finite_fields import _sqrt_in_extension
-        sage: r = _sqrt_in_extension(u, False, 'w')
-        sage: s = _sqrt_in_extension(u, False, 'w')
-        sage: r.parent() is s.parent() and r^2 == u
+        sage: r = _sqrt_in_extension(K(3), False, None)
+        sage: s = _sqrt_in_extension(K(5), False, None)
+        sage: r.parent() is s.parent() and (r + s).parent() is r.parent()
+        True
+        sage: from sage.rings.finite_rings.finite_field_base import FiniteField
+        sage: isinstance(r.parent(), FiniteField)
+        True
+        sage: r.parent().variable_names()
+        ('sqrt_ext',)
+        sage: r.parent().multiplicative_generator().parent() is r.parent()
+        True
+        sage: r**2 == K(3) and s**2 == K(5)
+        True
+
+    For finite non-domains, repeated fallback calls reuse the polynomial
+    quotient parent::
+
+        sage: R.<x> = Zmod(4)[]
+        sage: A.<a> = R.quotient(x**2)
+        sage: r = _sqrt_in_extension(a, False, 'w')
+        sage: s = _sqrt_in_extension(a, False, 'w')
+        sage: r.parent() is s.parent() and r**2 == a
         True
     """
-    from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
     from sage.rings.polynomial.polynomial_quotient_ring import PolynomialQuotientRing
+    from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 
     parent = element.parent()
     if name is None:
-        name = 'sqrt'
+        name = 'sqrt_ext'
+    extension_data = _sqrt_extension(parent, name)
+    if extension_data is not None:
+        extension, embedding = extension_data
+        return embedding(element).sqrt(extend=False, all=all,
+                                       algorithm=algorithm)
+
     polynomial_ring = PolynomialRing(parent, 'x')
     x = polynomial_ring.gen()
     extension = PolynomialQuotientRing(
@@ -338,7 +456,7 @@ class FiniteFields(CategoryWithAxiom):
             is_square = character == self.parent().one()
             return is_square
 
-        def _tonelli(self, check=True):
+        def _tonelli(self, raise_on_failure=True):
             r"""
             Return a square root of the element if it exists
             using Tonelli's algorithm, only works for finite fields
@@ -353,12 +471,15 @@ class FiniteFields(CategoryWithAxiom):
                 sage: k.<a> = GF((5, 10))
                 sage: k(2).is_square()
                 True
-                sage: k(2)._tonelli()^2 == k(2)
+                sage: k(2)._tonelli()**2 == k(2)
                 True
                 sage: k.quadratic_nonresidue()._tonelli()
                 Traceback (most recent call last):
                 ...
                 ValueError: element is not a square
+                sage: k.quadratic_nonresidue()._tonelli(
+                ....:     raise_on_failure=False) is None
+                True
             """
             parent = self.parent()
             if parent.characteristic() == 2:
@@ -369,12 +490,13 @@ class FiniteFields(CategoryWithAxiom):
             even_exp, odd_order = (q - 1).val_unit(2)
             one = parent.one()
             residue = self**odd_order
-            if check:
-                character = residue
-                for _ in range(even_exp - 1):
-                    character *= character
-                if character != one:
+            character = residue
+            for _ in range(even_exp - 1):
+                character *= character
+            if character != one:
+                if raise_on_failure:
                     raise ValueError("element is not a square")
+                return None
             generator = parent.quadratic_nonresidue()
             correction = generator**odd_order
             square_root = self**((odd_order + 1) // 2)
@@ -387,7 +509,7 @@ class FiniteFields(CategoryWithAxiom):
                     power *= power
                     i += 1
                 if i == exponent:
-                    raise ValueError("element is not a square")
+                    raise ArithmeticError("Tonelli's algorithm failed")
                 factor = correction**(2**(exponent - i - 1))
                 square_root *= factor
                 factor *= factor
@@ -413,9 +535,13 @@ class FiniteFields(CategoryWithAxiom):
                 sage: k.<a> = GF((5, 10))
                 sage: k(2).is_square()
                 True
-                sage: k(2)._cipolla()^2 == k(2)
+                sage: k(2)._cipolla()**2 == k(2)
                 True
                 sage: k.quadratic_nonresidue()._cipolla()
+                Traceback (most recent call last):
+                ...
+                ValueError: element is not a square
+                sage: k.quadratic_nonresidue()._cipolla(check=False)
                 Traceback (most recent call last):
                 ...
                 ValueError: element is not a square
@@ -437,7 +563,10 @@ class FiniteFields(CategoryWithAxiom):
             X = polygen(parent)
             f = X**2 - t*X + self
             b = pow(X, (q+1)//2, f)
-            return b[0]
+            square_root = b[0]
+            if square_root * square_root != self:
+                raise ValueError("element is not a square")
+            return square_root
 
         def sqrt(self, *, extend=True, all=False, algorithm=None, name=None):
             r"""
@@ -634,13 +763,11 @@ class FiniteFields(CategoryWithAxiom):
                 if is_square:
                     square_root = self._cipolla(check=False)
             else:
-                try:
-                    square_root = self._tonelli()
-                except ValueError:
-                    is_square = False
+                square_root = self._tonelli(raise_on_failure=False)
+                is_square = square_root is not None
             if not is_square:
                 if extend:
-                    return _sqrt_in_extension(self, all, name)
+                    return _sqrt_in_extension(self, all, name, algorithm)
                 if all:
                     return []
                 raise ValueError("element is not a square")

--- a/src/sage/categories/finite_fields.py
+++ b/src/sage/categories/finite_fields.py
@@ -112,7 +112,7 @@ def _sqrt_extension(parent, name):
     return None
 
 
-def _sqrt_in_extension(element, all, name, algorithm=None):
+def _sqrt_in_extension(element, *, all_roots, name, algorithm=None):
     r"""
     Return square roots of ``element`` in a quadratic extension.
 
@@ -121,8 +121,8 @@ def _sqrt_in_extension(element, all, name, algorithm=None):
 
         sage: K.<a> = GF(7**3)
         sage: from sage.categories.finite_fields import _sqrt_in_extension
-        sage: r = _sqrt_in_extension(K(3), False, None)
-        sage: s = _sqrt_in_extension(K(5), False, None)
+        sage: r = _sqrt_in_extension(K(3), all_roots=False, name=None)
+        sage: s = _sqrt_in_extension(K(5), all_roots=False, name=None)
         sage: r.parent() is s.parent() and (r + s).parent() is r.parent()
         True
         sage: from sage.rings.finite_rings.finite_field_base import FiniteField
@@ -140,8 +140,8 @@ def _sqrt_in_extension(element, all, name, algorithm=None):
 
         sage: R.<x> = Zmod(4)[]
         sage: A.<a> = R.quotient(x**2)
-        sage: r = _sqrt_in_extension(a, False, 'w')
-        sage: s = _sqrt_in_extension(a, False, 'w')
+        sage: r = _sqrt_in_extension(a, all_roots=False, name='w')
+        sage: s = _sqrt_in_extension(a, all_roots=False, name='w')
         sage: r.parent() is s.parent() and r**2 == a
         True
     """
@@ -154,7 +154,7 @@ def _sqrt_in_extension(element, all, name, algorithm=None):
     extension_data = _sqrt_extension(parent, name)
     if extension_data is not None:
         extension, embedding = extension_data
-        return embedding(element).sqrt(extend=False, all=all,
+        return embedding(element).sqrt(extend=False, all=all_roots,
                                        algorithm=algorithm)
 
     polynomial_ring = PolynomialRing(parent, 'x')
@@ -163,7 +163,7 @@ def _sqrt_in_extension(element, all, name, algorithm=None):
         polynomial_ring, x**2 - polynomial_ring(element), names=name
     )
     square_root = extension.gen()
-    if all:
+    if all_roots:
         if parent.characteristic() == 2:
             return [square_root]
         return [square_root, -square_root]
@@ -626,26 +626,28 @@ class FiniteFields(CategoryWithAxiom):
                 sage: k.quadratic_nonresidue().sqrt(all=True)
                 []
 
+            TESTS:
+
             The common finite-field keyword interface is accepted, and roots
             returned by Cipolla's algorithm belong to the original field::
 
-                sage: for method in ((y^2).sqrt, (y^2).square_root):
+                sage: for method in ((y**2).sqrt, (y**2).square_root):
                 ....:     r = method(extend=False, algorithm='cipolla')
-                ....:     assert r.parent() is k and r^2 == y^2
+                ....:     assert r.parent() is k and r**2 == y**2
                 sage: for method in (k(0).sqrt, k(0).square_root):
                 ....:     for algorithm in ('tonelli', 'cipolla'):
                 ....:         assert method(algorithm=algorithm) == 0
                 ....:         assert method(all=True,
                 ....:                       algorithm=algorithm) == [k(0)]
                 sage: for method in (k(1).sqrt, k(1).square_root):
-                ....:     assert method(algorithm='backend-default')^2 == 1
+                ....:     assert method(algorithm='backend-default')**2 == 1
 
             A nonsquare can be lifted to a quadratic extension::
 
                 sage: a = k.quadratic_nonresidue()
                 sage: for method in (a.sqrt, a.square_root):
                 ....:     s = method(extend=True, name='s')
-                ....:     assert s^2 == a and s.parent() in FiniteFields()
+                ....:     assert s**2 == a and s.parent() in FiniteFields()
 
             Both method names implement the same keyword contract::
 
@@ -656,7 +658,7 @@ class FiniteFields(CategoryWithAxiom):
                 ....:                        algorithm=algorithm, name='s')
                 ....:         assert isinstance(roots, list)
                 ....:         assert len(roots) == 2
-                ....:         assert all(r.parent() is k and r^2 == q
+                ....:         assert all(r.parent() is k and r**2 == q
                 ....:                    for r in roots)
 
             The contract is uniform across the concrete finite-field
@@ -677,12 +679,12 @@ class FiniteFields(CategoryWithAxiom):
                 sage: signatures
                 {'(*, extend=False, all=False, algorithm=None, name=None)'}
                 sage: for field in fields:
-                ....:     value = field.gen()^2
+                ....:     value = field.gen()**2
                 ....:     for method in (value.sqrt, value.square_root):
                 ....:         roots = method(all=True,
                 ....:                        algorithm='backend-default')
                 ....:         assert isinstance(roots, list)
-                ....:         assert roots and all(root^2 == value
+                ....:         assert roots and all(root**2 == value
                 ....:                              for root in roots)
 
             Optional arguments are keyword-only, so old backend-specific
@@ -710,16 +712,18 @@ class FiniteFields(CategoryWithAxiom):
                 ....:     roots = method(extend=True, all=True,
                 ....:                    algorithm='cipolla', name='w')
                 ....:     assert isinstance(roots, list) and len(roots) == 1
-                ....:     assert roots[0].parent() is K2 and roots[0]^2 == b
+                ....:     assert roots[0].parent() is K2 and roots[0]**2 == b
                 sage: R3.<z> = GF(3)[]
                 sage: K3.<b> = R3.quotient(z^3 - z + 1)
-                sage: q3 = b^2
+                sage: q3 = b**2
                 sage: for method in (q3.sqrt, q3.square_root):
                 ....:     roots = method(extend=False, all=True,
                 ....:                    algorithm='cipolla')
                 ....:     assert isinstance(roots, list) and len(roots) == 2
-                ....:     assert all(r.parent() is K3 and r^2 == q3
+                ....:     assert all(r.parent() is K3 and r**2 == q3
                 ....:                for r in roots)
+
+            EXAMPLES:
 
             Here is an example where changing the algorithm results
             in a faster square root::
@@ -767,7 +771,9 @@ class FiniteFields(CategoryWithAxiom):
                 is_square = square_root is not None
             if not is_square:
                 if extend:
-                    return _sqrt_in_extension(self, all, name, algorithm)
+                    return _sqrt_in_extension(
+                        self, all_roots=all, name=name, algorithm=algorithm
+                    )
                 if all:
                     return []
                 raise ValueError("element is not a square")

--- a/src/sage/categories/finite_fields.py
+++ b/src/sage/categories/finite_fields.py
@@ -568,13 +568,13 @@ class FiniteFields(CategoryWithAxiom):
                 raise ValueError("element is not a square")
             return square_root
 
-        def sqrt(self, *, extend=True, all=False, algorithm=None, name=None):
+        def sqrt(self, *, extend=False, all=False, algorithm=None, name=None):
             r"""
             Return the square root of the element if it exists.
 
             INPUT:
 
-            - ``extend`` -- boolean (default: ``True``); if ``True``, return
+            - ``extend`` -- boolean (default: ``False``); if ``True``, return
               roots in a quadratic extension when necessary
 
             - ``all`` -- boolean (default: ``False``); whether to return all
@@ -619,11 +619,11 @@ class FiniteFields(CategoryWithAxiom):
                 True
                 sage: 3 in my_sqrts
                 True
-                sage: k.quadratic_nonresidue().sqrt(extend=False)
+                sage: k.quadratic_nonresidue().sqrt()
                 Traceback (most recent call last):
                 ...
                 ValueError: element is not a square
-                sage: k.quadratic_nonresidue().sqrt(extend=False, all=True)
+                sage: k.quadratic_nonresidue().sqrt(all=True)
                 []
 
             The common finite-field keyword interface is accepted, and roots
@@ -644,7 +644,7 @@ class FiniteFields(CategoryWithAxiom):
 
                 sage: a = k.quadratic_nonresidue()
                 sage: for method in (a.sqrt, a.square_root):
-                ....:     s = method(name='s')
+                ....:     s = method(extend=True, name='s')
                 ....:     assert s^2 == a and s.parent() in FiniteFields()
 
             Both method names implement the same keyword contract::
@@ -675,7 +675,7 @@ class FiniteFields(CategoryWithAxiom):
                 ....:               for method in (field.one().sqrt,
                 ....:                              field.one().square_root)}
                 sage: signatures
-                {'(*, extend=True, all=False, algorithm=None, name=None)'}
+                {'(*, extend=False, all=False, algorithm=None, name=None)'}
                 sage: for field in fields:
                 ....:     value = field.gen()^2
                 ....:     for method in (value.sqrt, value.square_root):

--- a/src/sage/libs/ntl/GF2E.pxd
+++ b/src/sage/libs/ntl/GF2E.pxd
@@ -12,6 +12,7 @@ cdef extern from "ntlwrap.h":
     void GF2E_add "add"(GF2E_c x, GF2E_c a, GF2E_c b)
     void GF2E_sub "sub"(GF2E_c x, GF2E_c a, GF2E_c b)
     void GF2E_mul "mul"(GF2E_c x, GF2E_c a, GF2E_c b)
+    void GF2E_sqr "sqr"(GF2E_c x, GF2E_c a)
     void GF2E_div "div"(GF2E_c x, GF2E_c a, GF2E_c b)
     void GF2E_power "NTL::power"(GF2E_c t, GF2E_c x, long e)
     long GF2E_deg "deg"(GF2E_c x)

--- a/src/sage/rings/finite_rings/element_base.pyx
+++ b/src/sage/rings/finite_rings/element_base.pyx
@@ -860,7 +860,7 @@ cdef class FinitePolyExtElement(FiniteRingElement):
         EXAMPLES::
 
             sage: F = FiniteField(7^2, 'a')
-            sage: F(2).square_root()^2
+            sage: F(2).square_root()**2
             2
             sage: F(3).square_root()
             2*a + 6

--- a/src/sage/rings/finite_rings/element_base.pyx
+++ b/src/sage/rings/finite_rings/element_base.pyx
@@ -838,13 +838,13 @@ cdef class FinitePolyExtElement(FiniteRingElement):
         a = self**(n // 2)
         return a == 1 or a == 0
 
-    def sqrt(self, *, extend=True, all=False, algorithm=None, name=None):
+    def sqrt(self, *, extend=False, all=False, algorithm=None, name=None):
         """
         The square root function.
 
         INPUT:
 
-        - ``extend`` -- boolean (default: ``True``); if ``True``, return a
+        - ``extend`` -- boolean (default: ``False``); if ``True``, return a
           square root in an extension ring when necessary
 
         - ``all`` -- boolean (default: ``False``); if ``True``, return all
@@ -860,6 +860,8 @@ cdef class FinitePolyExtElement(FiniteRingElement):
         EXAMPLES::
 
             sage: F = FiniteField(7^2, 'a')
+            sage: F(2).square_root()
+            3
             sage: F(2).square_root()**2
             2
             sage: F(3).square_root()
@@ -869,7 +871,7 @@ cdef class FinitePolyExtElement(FiniteRingElement):
             sage: F(4).square_root()
             2
             sage: K = FiniteField(7^3, 'alpha', implementation='pari_ffelt')
-            sage: K(3).square_root(extend=False)
+            sage: K(3).square_root()
             Traceback (most recent call last):
             ...
             ValueError: element is not a square

--- a/src/sage/rings/finite_rings/element_base.pyx
+++ b/src/sage/rings/finite_rings/element_base.pyx
@@ -874,14 +874,23 @@ cdef class FinitePolyExtElement(FiniteRingElement):
             ...
             ValueError: element is not a square
         """
-        if not self.is_square():
-            if extend:
-                from sage.categories.finite_fields import _sqrt_in_extension
-                return _sqrt_in_extension(self, all, name)
-            if all:
-                return []
-            raise ValueError("must be a perfect square.")
-        return self.nth_root(2, extend=False, all=all)
+        if all:
+            roots = self.nth_root(2, extend=False, all=True)
+            if roots or not extend:
+                return roots
+        else:
+            try:
+                return self.nth_root(2, extend=False, all=False)
+            except ValueError as error:
+                if str(error) != "no nth root":
+                    raise
+
+        if extend:
+            from sage.categories.finite_fields import _sqrt_in_extension
+            return _sqrt_in_extension(self, all, name, algorithm)
+        if all:
+            return []
+        raise ValueError("element is not a square")
 
     square_root = sqrt
 

--- a/src/sage/rings/finite_rings/element_base.pyx
+++ b/src/sage/rings/finite_rings/element_base.pyx
@@ -889,7 +889,9 @@ cdef class FinitePolyExtElement(FiniteRingElement):
 
         if extend:
             from sage.categories.finite_fields import _sqrt_in_extension
-            return _sqrt_in_extension(self, all, name, algorithm)
+            return _sqrt_in_extension(
+                self, all_roots=all, name=name, algorithm=algorithm
+            )
         if all:
             return []
         raise ValueError("element is not a square")

--- a/src/sage/rings/finite_rings/element_base.pyx
+++ b/src/sage/rings/finite_rings/element_base.pyx
@@ -838,32 +838,30 @@ cdef class FinitePolyExtElement(FiniteRingElement):
         a = self**(n // 2)
         return a == 1 or a == 0
 
-    def square_root(self, extend=False, all=False):
+    def sqrt(self, *, extend=True, all=False, algorithm=None, name=None):
         """
         The square root function.
 
         INPUT:
 
         - ``extend`` -- boolean (default: ``True``); if ``True``, return a
-          square root in an extension ring, if necessary. Otherwise, raise a
-          :exc:`ValueError` if the root is not in the base ring.
-
-           .. WARNING::
-
-               This option is not implemented!
+          square root in an extension ring when necessary
 
         - ``all`` -- boolean (default: ``False``); if ``True``, return all
-          square roots of ``self``, instead of just one
+          square roots of ``self``
 
-        .. WARNING::
+        - ``algorithm`` -- optional algorithm hint (default: ``None``);
+          accepted for the common finite-field interface; this implementation
+          always uses its backend default
 
-           The ``'extend'`` option is not implemented (yet).
+        - ``name`` -- string (default: ``None``); name of the generator when
+          a quadratic extension is created
 
         EXAMPLES::
 
             sage: F = FiniteField(7^2, 'a')
-            sage: F(2).square_root()
-            4
+            sage: F(2).square_root()^2
+            2
             sage: F(3).square_root()
             2*a + 6
             sage: F(3).square_root()**2
@@ -871,27 +869,21 @@ cdef class FinitePolyExtElement(FiniteRingElement):
             sage: F(4).square_root()
             2
             sage: K = FiniteField(7^3, 'alpha', implementation='pari_ffelt')
-            sage: K(3).square_root()
+            sage: K(3).square_root(extend=False)
             Traceback (most recent call last):
             ...
-            ValueError: must be a perfect square.
+            ValueError: element is not a square
         """
-        try:
-            return self.nth_root(2, extend=extend, all=all)
-        except ValueError:
+        if not self.is_square():
+            if extend:
+                from sage.categories.finite_fields import _sqrt_in_extension
+                return _sqrt_in_extension(self, all, name)
+            if all:
+                return []
             raise ValueError("must be a perfect square.")
+        return self.nth_root(2, extend=False, all=all)
 
-    def sqrt(self, extend=False, all=False):
-        """
-        See :meth:`square_root`.
-
-        EXAMPLES::
-
-            sage: k.<a> = GF(3^17)
-            sage: (a^3 - a - 1).sqrt()
-            a^16 + 2*a^15 + a^13 + 2*a^12 + a^10 + 2*a^9 + 2*a^8 + a^7 + a^6 + 2*a^5 + a^4 + 2*a^2 + 2*a + 2
-        """
-        return self.square_root(extend=extend, all=all)
+    square_root = sqrt
 
     def nth_root(self, n, extend=False, all=False, algorithm=None, cunningham=False):
         r"""

--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -1097,17 +1097,17 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
         Check the common finite-field square-root interface
         (:issue:`40796`)::
 
-            sage: q = a^2
+            sage: q = a**2
             sage: for method in (q.sqrt, q.square_root):
             ....:     for algorithm in (None, 'tonelli', 'cipolla'):
             ....:         roots = method(extend=False, all=True,
             ....:                        algorithm=algorithm, name='w')
             ....:         assert isinstance(roots, list) and len(roots) == 2
-            ....:         assert all(r.parent() is K and r^2 == q for r in roots)
-            ....:     assert method(algorithm='backend-default')^2 == q
+            ....:         assert all(r.parent() is K and r**2 == q for r in roots)
+            ....:     assert method(algorithm='backend-default')**2 == q
             sage: for method in (a.sqrt, a.square_root):
             ....:     root = method(extend=True, name='w')
-            ....:     assert root^2 == a
+            ....:     assert root**2 == a
         """
         cdef Cache_givaro cache = <Cache_givaro>self._cache
         cdef FiniteField_givaroElement root
@@ -1123,7 +1123,9 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
         else:
             if extend:
                 from sage.categories.finite_fields import _sqrt_in_extension
-                return _sqrt_in_extension(self, all, name, algorithm)
+                return _sqrt_in_extension(
+                    self, all_roots=all, name=name, algorithm=algorithm
+                )
             if all:
                 return []
             raise ValueError("element is not a square")

--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -1077,7 +1077,7 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
             sage: k(3).sqrt(extend=False)
             Traceback (most recent call last):
             ...
-            ValueError: must be a perfect square
+            ValueError: element is not a square
 
         TESTS::
 
@@ -1123,10 +1123,10 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
         else:
             if extend:
                 from sage.categories.finite_fields import _sqrt_in_extension
-                return _sqrt_in_extension(self, all, name)
+                return _sqrt_in_extension(self, all, name, algorithm)
             if all:
                 return []
-            raise ValueError("must be a perfect square")
+            raise ValueError("element is not a square")
 
         if all:
             if (cache.objectptr.characteristic() == 2

--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -1036,27 +1036,26 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
             return True
         return self.element % 2 == 0
 
-    def sqrt(FiniteField_givaroElement self, extend=False, all=False):
+    def sqrt(FiniteField_givaroElement self, *, extend=True, all=False,
+             algorithm=None, name=None):
         """
-        Return a square root of this finite field element in its
-        parent, if there is one.  Otherwise, raise a :exc:`ValueError`.
+        Return a square root of this finite field element, extending its
+        parent when necessary and requested.
 
         INPUT:
 
         - ``extend`` -- boolean (default: ``True``); if ``True``, return a
-          square root in an extension ring, if necessary. Otherwise,
-          raise a :exc:`ValueError` if the root is not in the base ring.
-
-          .. WARNING::
-
-              this option is not implemented!
+          square root in an extension ring when necessary
 
         - ``all`` -- boolean (default: ``False``); if ``True``, return all
-          square roots of ``self``, instead of just one
+          square roots of ``self``
 
-        .. WARNING::
+        - ``algorithm`` -- optional algorithm hint (default: ``None``);
+          accepted for the common finite-field interface; Givaro always uses
+          its backend default
 
-            The ``extend`` option is not implemented (yet).
+        - ``name`` -- string (default: ``None``); name of the generator when
+          a quadratic extension is created
 
         ALGORITHM:
 
@@ -1075,7 +1074,7 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
             sage: k(4).sqrt()
             2
             sage: k.<a> = GF(7^3)
-            sage: k(3).sqrt()
+            sage: k(3).sqrt(extend=False)
             Traceback (most recent call last):
             ...
             ValueError: must be a perfect square
@@ -1094,23 +1093,49 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
             sage: K.<a> = FiniteField(9)
             sage: a.sqrt(extend = False, all = True)
             []
+
+        Check the common finite-field square-root interface
+        (:issue:`40796`)::
+
+            sage: q = a^2
+            sage: for method in (q.sqrt, q.square_root):
+            ....:     for algorithm in (None, 'tonelli', 'cipolla'):
+            ....:         roots = method(extend=False, all=True,
+            ....:                        algorithm=algorithm, name='w')
+            ....:         assert isinstance(roots, list) and len(roots) == 2
+            ....:         assert all(r.parent() is K and r^2 == q for r in roots)
+            ....:     assert method(algorithm='backend-default')^2 == q
+            sage: for method in (a.sqrt, a.square_root):
+            ....:     root = method(name='w')
+            ....:     assert root^2 == a
         """
-        if all:
-            if self.is_square():
-                a = self.sqrt()
-                return [a, -a] if -a != a else [a]
-            return []
         cdef Cache_givaro cache = <Cache_givaro>self._cache
+        cdef FiniteField_givaroElement root
         if self.element == cache.objectptr.one:
-            return make_FiniteField_givaroElement(cache, cache.objectptr.one)
+            root = make_FiniteField_givaroElement(cache, cache.objectptr.one)
         elif self.element % 2 == 0:
-            return make_FiniteField_givaroElement(cache, self.element // 2)
+            root = make_FiniteField_givaroElement(cache, self.element // 2)
         elif cache.objectptr.characteristic() == 2:
-            return make_FiniteField_givaroElement(cache, (cache.objectptr.cardinality() - 1 + self.element) / 2)
-        elif extend:
-            raise NotImplementedError  # TODO: use RingExtension or GF(p^(2*e))
+            root = make_FiniteField_givaroElement(
+                cache,
+                (cache.objectptr.cardinality() - 1 + self.element) // 2,
+            )
         else:
+            if extend:
+                from sage.categories.finite_fields import _sqrt_in_extension
+                return _sqrt_in_extension(self, all, name)
+            if all:
+                return []
             raise ValueError("must be a perfect square")
+
+        if all:
+            if (cache.objectptr.characteristic() == 2
+                    or self.element == cache.objectptr.zero):
+                return [root]
+            return [root, -root]
+        return root
+
+    square_root = sqrt
 
     cpdef _add_(self, right):
         """

--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -1036,7 +1036,7 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
             return True
         return self.element % 2 == 0
 
-    def sqrt(FiniteField_givaroElement self, *, extend=True, all=False,
+    def sqrt(FiniteField_givaroElement self, *, extend=False, all=False,
              algorithm=None, name=None):
         """
         Return a square root of this finite field element, extending its
@@ -1044,7 +1044,7 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
 
         INPUT:
 
-        - ``extend`` -- boolean (default: ``True``); if ``True``, return a
+        - ``extend`` -- boolean (default: ``False``); if ``True``, return a
           square root in an extension ring when necessary
 
         - ``all`` -- boolean (default: ``False``); if ``True``, return all
@@ -1074,7 +1074,7 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
             sage: k(4).sqrt()
             2
             sage: k.<a> = GF(7^3)
-            sage: k(3).sqrt(extend=False)
+            sage: k(3).sqrt()
             Traceback (most recent call last):
             ...
             ValueError: element is not a square
@@ -1106,7 +1106,7 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
             ....:         assert all(r.parent() is K and r^2 == q for r in roots)
             ....:     assert method(algorithm='backend-default')^2 == q
             sage: for method in (a.sqrt, a.square_root):
-            ....:     root = method(name='w')
+            ....:     root = method(extend=True, name='w')
             ....:     assert root^2 == a
         """
         cdef Cache_givaro cache = <Cache_givaro>self._cache

--- a/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
+++ b/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
@@ -662,24 +662,26 @@ cdef class FiniteField_ntl_gf2eElement(FinitePolyExtElement):
             sage: GF(2^16,'a')(1).sqrt()
             1
 
+        TESTS:
+
         Check the common finite-field square-root interface
         (:issue:`40796`)::
 
-            sage: q = a^2
+            sage: q = a**2
             sage: for method in (q.sqrt, q.square_root):
             ....:     for algorithm in (None, 'tonelli', 'cipolla'):
             ....:         roots = method(extend=True, all=True,
             ....:                        algorithm=algorithm, name='w')
             ....:         assert isinstance(roots, list) and len(roots) == 1
-            ....:         assert roots[0].parent() is k and roots[0]^2 == q
-            ....:     assert method(algorithm='backend-default')^2 == q
+            ....:         assert roots[0].parent() is k and roots[0]**2 == q
+            ....:     assert method(algorithm='backend-default')**2 == q
 
         The NTL context is restored when calls from different fields are
         interleaved::
 
             sage: K.<b> = GF(2^17)
             sage: values = (a, b, k.zero(), K.one(), a + 1, b + 1)
-            sage: all(value.sqrt()^2 == value for value in values)
+            sage: all(value.sqrt()**2 == value for value in values)
             True
         """
         cdef FiniteField_ntl_gf2eElement a = self._new()

--- a/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
+++ b/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
@@ -638,9 +638,14 @@ cdef class FiniteField_ntl_gf2eElement(FinitePolyExtElement):
         """
         return True
 
-    def sqrt(FiniteField_ntl_gf2eElement self, all=False, extend=False):
+    def sqrt(FiniteField_ntl_gf2eElement self, *, extend=True, all=False,
+             algorithm=None, name=None):
         """
         Return a square root of this finite field element in its parent.
+
+        The common finite-field keywords ``extend``, ``all``, ``algorithm``,
+        and ``name`` are accepted.  NTL uses its characteristic-two backend
+        algorithm regardless of the supported algorithm hint.
 
         EXAMPLES::
 
@@ -656,13 +661,37 @@ cdef class FiniteField_ntl_gf2eElement(FinitePolyExtElement):
 
             sage: GF(2^16,'a')(1).sqrt()
             1
+
+        Check the common finite-field square-root interface
+        (:issue:`40796`)::
+
+            sage: q = a^2
+            sage: for method in (q.sqrt, q.square_root):
+            ....:     for algorithm in (None, 'tonelli', 'cipolla'):
+            ....:         roots = method(extend=True, all=True,
+            ....:                        algorithm=algorithm, name='w')
+            ....:         assert isinstance(roots, list) and len(roots) == 1
+            ....:         assert roots[0].parent() is k and roots[0]^2 == q
+            ....:     assert method(algorithm='backend-default')^2 == q
+
+        The NTL context is restored when calls from different fields are
+        interleaved::
+
+            sage: K.<b> = GF(2^17)
+            sage: values = (a, b, k.zero(), K.one(), a + 1, b + 1)
+            sage: all(value.sqrt()^2 == value for value in values)
+            True
         """
-        # this really should be handled special, its gf2 linear after
-        # all
-        a = self ** (self._cache._order // 2)
+        cdef FiniteField_ntl_gf2eElement a = self._new()
+        cdef long i
+        a.x = self.x
+        for i in range(GF2E_degree() - 1):
+            GF2E_sqr(a.x, a.x)
         if all:
             return [a]
         return a
+
+    square_root = sqrt
 
     cpdef _add_(self, right):
         """

--- a/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
+++ b/src/sage/rings/finite_rings/element_ntl_gf2e.pyx
@@ -638,7 +638,7 @@ cdef class FiniteField_ntl_gf2eElement(FinitePolyExtElement):
         """
         return True
 
-    def sqrt(FiniteField_ntl_gf2eElement self, *, extend=True, all=False,
+    def sqrt(FiniteField_ntl_gf2eElement self, *, extend=False, all=False,
              algorithm=None, name=None):
         """
         Return a square root of this finite field element in its parent.

--- a/src/sage/rings/finite_rings/element_pari_ffelt.pyx
+++ b/src/sage/rings/finite_rings/element_pari_ffelt.pyx
@@ -1026,13 +1026,13 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
         sig_off()
         return bool(i)
 
-    def sqrt(self, *, extend=True, all=False, algorithm=None, name=None):
+    def sqrt(self, *, extend=False, all=False, algorithm=None, name=None):
         """
         Return a square root of ``self``, if it exists.
 
         INPUT:
 
-        - ``extend`` -- boolean (default: ``True``); if ``True``, return a
+        - ``extend`` -- boolean (default: ``False``); if ``True``, return a
           square root in an extension field when necessary
 
         - ``all`` -- boolean (default: ``False``)
@@ -1068,7 +1068,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
             [2, 5]
 
             sage: K = FiniteField(7^3, 'alpha', implementation='pari_ffelt')
-            sage: K(3).sqrt(extend=False)
+            sage: K(3).sqrt()
             Traceback (most recent call last):
             ...
             ValueError: element is not a square
@@ -1092,7 +1092,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
             ....:     assert method(algorithm='backend-default')^2 == q
             sage: nonsquare = K.quadratic_nonresidue()
             sage: for method in (nonsquare.sqrt, nonsquare.square_root):
-            ....:     root = method(name='w')
+            ....:     root = method(extend=True, name='w')
             ....:     assert root^2 == nonsquare
         """
         cdef GEN s

--- a/src/sage/rings/finite_rings/element_pari_ffelt.pyx
+++ b/src/sage/rings/finite_rings/element_pari_ffelt.pyx
@@ -1026,19 +1026,23 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
         sig_off()
         return bool(i)
 
-    def sqrt(self, extend=False, all=False):
+    def sqrt(self, *, extend=True, all=False, algorithm=None, name=None):
         """
         Return a square root of ``self``, if it exists.
 
         INPUT:
 
-        - ``extend`` -- boolean (default: ``False``)
-
-           .. WARNING::
-
-               This option is not implemented.
+        - ``extend`` -- boolean (default: ``True``); if ``True``, return a
+          square root in an extension field when necessary
 
         - ``all`` -- boolean (default: ``False``)
+
+        - ``algorithm`` -- optional algorithm hint (default: ``None``);
+          accepted for the common finite-field interface; PARI always uses
+          its backend default
+
+        - ``name`` -- string (default: ``None``); name of the generator when
+          a quadratic extension is created
 
         OUTPUT:
 
@@ -1050,10 +1054,6 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
         extension field if necessary.  If ``extend`` is ``False``, a
         :exc:`ValueError` is raised if the element is not a square in the
         base field.
-
-        .. WARNING::
-
-           The ``extend`` option is not implemented (yet).
 
         EXAMPLES::
 
@@ -1068,19 +1068,33 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
             [2, 5]
 
             sage: K = FiniteField(7^3, 'alpha', implementation='pari_ffelt')
-            sage: K(3).sqrt()
+            sage: K(3).sqrt(extend=False)
             Traceback (most recent call last):
             ...
             ValueError: element is not a square
-            sage: K(3).sqrt(all=True)
+            sage: K(3).sqrt(extend=False, all=True)
             []
 
             sage: K.<a> = GF(3^17, implementation='pari_ffelt')
             sage: (a^3 - a - 1).sqrt()
             a^16 + 2*a^15 + a^13 + 2*a^12 + a^10 + 2*a^9 + 2*a^8 + a^7 + a^6 + 2*a^5 + a^4 + 2*a^2 + 2*a + 2
+
+        Check the common finite-field square-root interface
+        (:issue:`40796`)::
+
+            sage: q = a^2
+            sage: for method in (q.sqrt, q.square_root):
+            ....:     for algorithm in (None, 'tonelli', 'cipolla'):
+            ....:         roots = method(extend=True, all=True,
+            ....:                        algorithm=algorithm, name='w')
+            ....:         assert isinstance(roots, list) and len(roots) == 2
+            ....:         assert all(r.parent() is K and r^2 == q for r in roots)
+            ....:     assert method(algorithm='backend-default')^2 == q
+            sage: nonsquare = K.quadratic_nonresidue()
+            sage: for method in (nonsquare.sqrt, nonsquare.square_root):
+            ....:     root = method(name='w')
+            ....:     assert root^2 == nonsquare
         """
-        if extend:
-            raise NotImplementedError
         cdef GEN s
         cdef FiniteFieldElement_pari_ffelt x, mx
         sig_on()
@@ -1098,10 +1112,15 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
                 return [x, mx]
         else:
             sig_off()
+            if extend:
+                from sage.categories.finite_fields import _sqrt_in_extension
+                return _sqrt_in_extension(self, all, name)
             if all:
                 return []
             else:
                 raise ValueError("element is not a square")
+
+    square_root = sqrt
 
     def log(self, base, order=None, *, check=False):
         """

--- a/src/sage/rings/finite_rings/element_pari_ffelt.pyx
+++ b/src/sage/rings/finite_rings/element_pari_ffelt.pyx
@@ -1114,7 +1114,7 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
             sig_off()
             if extend:
                 from sage.categories.finite_fields import _sqrt_in_extension
-                return _sqrt_in_extension(self, all, name)
+                return _sqrt_in_extension(self, all, name, algorithm)
             if all:
                 return []
             else:

--- a/src/sage/rings/finite_rings/element_pari_ffelt.pyx
+++ b/src/sage/rings/finite_rings/element_pari_ffelt.pyx
@@ -1079,21 +1079,23 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
             sage: (a^3 - a - 1).sqrt()
             a^16 + 2*a^15 + a^13 + 2*a^12 + a^10 + 2*a^9 + 2*a^8 + a^7 + a^6 + 2*a^5 + a^4 + 2*a^2 + 2*a + 2
 
+        TESTS:
+
         Check the common finite-field square-root interface
         (:issue:`40796`)::
 
-            sage: q = a^2
+            sage: q = a**2
             sage: for method in (q.sqrt, q.square_root):
             ....:     for algorithm in (None, 'tonelli', 'cipolla'):
             ....:         roots = method(extend=True, all=True,
             ....:                        algorithm=algorithm, name='w')
             ....:         assert isinstance(roots, list) and len(roots) == 2
-            ....:         assert all(r.parent() is K and r^2 == q for r in roots)
-            ....:     assert method(algorithm='backend-default')^2 == q
+            ....:         assert all(r.parent() is K and r**2 == q for r in roots)
+            ....:     assert method(algorithm='backend-default')**2 == q
             sage: nonsquare = K.quadratic_nonresidue()
             sage: for method in (nonsquare.sqrt, nonsquare.square_root):
             ....:     root = method(extend=True, name='w')
-            ....:     assert root^2 == nonsquare
+            ....:     assert root**2 == nonsquare
         """
         cdef GEN s
         cdef FiniteFieldElement_pari_ffelt x, mx
@@ -1114,7 +1116,9 @@ cdef class FiniteFieldElement_pari_ffelt(FinitePolyExtElement):
             sig_off()
             if extend:
                 from sage.categories.finite_fields import _sqrt_in_extension
-                return _sqrt_in_extension(self, all, name, algorithm)
+                return _sqrt_in_extension(
+                    self, all_roots=all, name=name, algorithm=algorithm
+                )
             if all:
                 return []
             else:

--- a/src/sage/rings/finite_rings/integer_mod.pyx
+++ b/src/sage/rings/finite_rings/integer_mod.pyx
@@ -1114,6 +1114,10 @@ cdef class IntegerMod_abstract(FiniteRingElement):
         # We need to factor the modulus.  We do it here instead of
         # letting PARI do it, so that we can cache the factorisation.
         factorization = self._parent.factored_order()
+        # A single factor of exponent one means that the modulus is prime.
+        # The zero/one guards above cover characteristic two, and otherwise
+        # the Jacobi symbol just computed is the Legendre symbol.  Since it
+        # was not -1, the element is therefore a square.
         if len(factorization) == 1 and factorization[0][1] == 1:
             return 1
         return lift.__pari__().Zn_issquare(factorization)
@@ -1244,6 +1248,8 @@ cdef class IntegerMod_abstract(FiniteRingElement):
             sage: [x for x in R if x^2==17]
             [23, 41, 87, 105]
 
+        TESTS:
+
         Check the common finite-ring square-root interface on the GMP
         implementation (:issue:`40796`)::
 
@@ -1254,13 +1260,13 @@ cdef class IntegerMod_abstract(FiniteRingElement):
             ....:         roots = method(extend=False, all=True,
             ....:                        algorithm=algorithm, name='w')
             ....:         assert isinstance(roots, list) and len(roots) == 2
-            ....:         assert all(r.parent() is K and r^2 == q for r in roots)
-            ....:     assert method(algorithm='backend-default')^2 == q
+            ....:         assert all(r.parent() is K and r**2 == q for r in roots)
+            ....:     assert method(algorithm='backend-default')**2 == q
             sage: nonsquare = K.quadratic_nonresidue()
             sage: for method in (nonsquare.sqrt, nonsquare.square_root):
             ....:     roots = method(extend=True, all=True, name='w')
             ....:     assert len(roots) == 2
-            ....:     assert all(root^2 == nonsquare for root in roots)
+            ....:     assert all(root**2 == nonsquare for root in roots)
         """
         if self.is_one():
             if all:
@@ -1271,7 +1277,9 @@ cdef class IntegerMod_abstract(FiniteRingElement):
             if extend:
                 if self._parent.is_field():
                     from sage.categories.finite_fields import _sqrt_in_extension
-                    return _sqrt_in_extension(self, all, name, algorithm)
+                    return _sqrt_in_extension(
+                        self, all_roots=all, name=name, algorithm=algorithm
+                    )
                 y = name if name is not None else 'sqrt_ext'
                 R = self.parent()['x']
                 modulus = R.gen()**2 - R(self)
@@ -2934,6 +2942,10 @@ cdef class IntegerMod_int(IntegerMod_abstract):
         # We need to factor the modulus.  We do it here instead of
         # letting PARI do it, so that we can cache the factorisation.
         factorization = self._parent.factored_order()
+        # A single factor of exponent one means that the modulus is prime.
+        # The zero/one guards above cover characteristic two, and otherwise
+        # the Jacobi symbol just computed is the Legendre symbol.  Since it
+        # was not -1, the element is therefore a square.
         if len(factorization) == 1 and factorization[0][1] == 1:
             return 1
         return lift.__pari__().Zn_issquare(factorization)
@@ -3044,6 +3056,8 @@ cdef class IntegerMod_int(IntegerMod_abstract):
             sage: [x for x in R if x^2==17]
             [23, 41, 87, 105]
 
+        TESTS:
+
         Check the common finite-ring square-root interface on the native
         implementation (:issue:`40796`)::
 
@@ -3054,15 +3068,15 @@ cdef class IntegerMod_int(IntegerMod_abstract):
             ....:         roots = method(extend=False, all=True,
             ....:                        algorithm=algorithm, name='w')
             ....:         assert isinstance(roots, list) and len(roots) == 4
-            ....:         assert all(r.parent() is K and r^2 == q for r in roots)
-            ....:     assert method(algorithm='backend-default')^2 == q
+            ....:         assert all(r.parent() is K and r**2 == q for r in roots)
+            ....:     assert method(algorithm='backend-default')**2 == q
             sage: nonsquare = GF(7)(3)
             sage: for method in (nonsquare.sqrt, nonsquare.square_root):
             ....:     root = method(extend=True, name='w')
-            ....:     assert root^2 == nonsquare
+            ....:     assert root**2 == nonsquare
             ....:     roots = method(extend=True, all=True, name='w')
             ....:     assert len(roots) == 2
-            ....:     assert all(r^2 == nonsquare for r in roots)
+            ....:     assert all(r**2 == nonsquare for r in roots)
             sage: for method in (Zmod(15)(2).sqrt, Zmod(15)(2).square_root):
             ....:     try:
             ....:         method(extend=True, all=True, name='w')

--- a/src/sage/rings/finite_rings/integer_mod.pyx
+++ b/src/sage/rings/finite_rings/integer_mod.pyx
@@ -1194,11 +1194,11 @@ cdef class IntegerMod_abstract(FiniteRingElement):
             ...
             ValueError: element is not a square
             sage: y = x.sqrt(extend=True); y
-            sqrt_ext
+            sqrt359
             sage: y.parent()
-            Univariate Quotient Polynomial Ring in sqrt_ext over
+            Univariate Quotient Polynomial Ring in sqrt359 over
              Ring of integers modulo 360 with modulus x^2 + 1
-            sage: y^2
+            sage: y**2
             359
 
         We compute all square roots in several cases::
@@ -1280,7 +1280,10 @@ cdef class IntegerMod_abstract(FiniteRingElement):
                     return _sqrt_in_extension(
                         self, all_roots=all, name=name, algorithm=algorithm
                     )
-                y = name if name is not None else 'sqrt_ext'
+                # Keep the traditional element-dependent name for extensions
+                # of nonfields.  Finite fields use the shared ``sqrt_ext``
+                # parent in ``_sqrt_in_extension`` instead.
+                y = name if name is not None else 'sqrt%s' % self
                 R = self.parent()['x']
                 modulus = R.gen()**2 - R(self)
                 Q = R.quotient(modulus, names=(y,))
@@ -3009,11 +3012,11 @@ cdef class IntegerMod_int(IntegerMod_abstract):
             ...
             ValueError: element is not a square
             sage: y = x.sqrt(extend=True); y
-            sqrt_ext
+            sqrt359
             sage: y.parent()
-            Univariate Quotient Polynomial Ring in sqrt_ext
+            Univariate Quotient Polynomial Ring in sqrt359
              over Ring of integers modulo 360 with modulus x^2 + 1
-            sage: y^2
+            sage: y**2
             359
 
         We compute all square roots in several cases::

--- a/src/sage/rings/finite_rings/integer_mod.pyx
+++ b/src/sage/rings/finite_rings/integer_mod.pyx
@@ -1171,12 +1171,16 @@ cdef class IntegerMod_abstract(FiniteRingElement):
             sage: Mod(1/25, next_prime(2^90)).sqrt()^(-2)
             25
 
-        Error message as requested in :issue:`38802`::
+        All roots in the quadratic extension are computed without enumerating
+        that extension (:issue:`38802`)::
 
-            sage: sqrt(Mod(2, 101010), extend=True, all=True)
-            Traceback (most recent call last):
-            ...
-            NotImplementedError: Finding all square roots in extensions is not implemented; try extend=False to find only roots in the base ring Zmod(n).
+            sage: roots = sqrt(Mod(2, 101010), extend=True, all=True)
+            sage: len(roots)
+            128
+            sage: len(set(roots)) == len(roots)
+            True
+            sage: all(root**2 == 2 for root in roots)
+            True
 
         Using the suggested ``extend=False`` works and returns an empty list
         as expected::
@@ -1289,7 +1293,7 @@ cdef class IntegerMod_abstract(FiniteRingElement):
                 Q = R.quotient(modulus, names=(y,))
                 z = Q.gen()
                 if all:
-                    raise NotImplementedError("Finding all square roots in extensions is not implemented; try extend=False to find only roots in the base ring Zmod(n).")
+                    return _square_roots_in_quadratic_extension(self, Q)
                 return z
             if all:
                 return []
@@ -3081,13 +3085,10 @@ cdef class IntegerMod_int(IntegerMod_abstract):
             ....:     assert len(roots) == 2
             ....:     assert all(r**2 == nonsquare for r in roots)
             sage: for method in (Zmod(15)(2).sqrt, Zmod(15)(2).square_root):
-            ....:     try:
-            ....:         method(extend=True, all=True, name='w')
-            ....:     except NotImplementedError as error:
-            ....:         assert str(error).startswith(
-            ....:             "Finding all square roots in extensions")
-            ....:     else:
-            ....:         raise AssertionError("all extension roots were incomplete")
+            ....:     roots = method(extend=True, all=True, name='w')
+            ....:     assert len(roots) == 4
+            ....:     assert len(set(roots)) == len(roots)
+            ....:     assert all(root**2 == 2 for root in roots)
 
         TESTS:
 
@@ -3989,6 +3990,148 @@ cdef int jacobi_int64(int_fast64_t a, int_fast64_t m) except -2:
 ########################
 # Square root functions
 ########################
+
+def _square_roots_in_quadratic_extension(IntegerMod_abstract a, quotient):
+    r"""
+    Return all square roots of ``a`` in its quadratic quotient extension.
+
+    The input ``quotient`` must be
+    `(\ZZ/n\ZZ)[z]/(z^2-a)`.  Every element of this ring is uniquely of the
+    form `u + vz`, and it squares to ``a`` precisely when
+
+    .. MATH::
+
+        2uv = 0, \qquad u^2 + av^2 = a \pmod n.
+
+    The equations are solved modulo every prime-power factor of `n`.  Starting
+    with all solutions modulo `p`, each lift from `p^k` to `p^{k+1}` is a
+    two-variable linear system over `\GF{p}`.  The local answers are then
+    combined by the Chinese remainder theorem.
+
+    EXAMPLES::
+
+        sage: from sage.rings.finite_rings.integer_mod import _square_roots_in_quadratic_extension
+        sage: R = Zmod(8)
+        sage: P.<x> = R[]
+        sage: Q.<z> = P.quotient(x^2 - 2)
+        sage: roots = _square_roots_in_quadratic_extension(R(2), Q)
+        sage: len(roots), len(set(roots))
+        (8, 8)
+        sage: set(roots) == {root for root in Q if root^2 == 2}
+        True
+    """
+    value = a.lift()
+
+    def linear_solutions(a11, a12, a21, a22, b1, b2, p):
+        """
+        Solve a two-by-two linear system modulo the prime ``p``.
+        """
+        a11 = Integer(a11) % p
+        a12 = Integer(a12) % p
+        a21 = Integer(a21) % p
+        a22 = Integer(a22) % p
+        b1 = Integer(b1) % p
+        b2 = Integer(b2) % p
+
+        determinant = (a11 * a22 - a12 * a21) % p
+        if determinant:
+            inverse = determinant.inverse_mod(p)
+            return [((b1 * a22 - a12 * b2) * inverse % p,
+                     (a11 * b2 - b1 * a21) * inverse % p)]
+
+        if a11 or a12:
+            ax, ay, b = a11, a12, b1
+            cx, cy, d = a21, a22, b2
+        elif a21 or a22:
+            ax, ay, b = a21, a22, b2
+            cx, cy, d = a11, a12, b1
+        else:
+            if b1 or b2:
+                return []
+            return [(s, t) for s in range(p) for t in range(p)]
+
+        if ax:
+            inverse = ax.inverse_mod(p)
+            x0 = b * inverse % p
+            if cx * x0 % p != d:
+                return []
+            kernel_x = -ay * inverse % p
+            return [((x0 + kernel_x * t) % p, t) for t in range(p)]
+
+        inverse = ay.inverse_mod(p)
+        y0 = b * inverse % p
+        if cy * y0 % p != d:
+            return []
+        return [(s, y0) for s in range(p)]
+
+    def roots_mod_prime_power(p, exponent):
+        """
+        Return coefficient pairs for roots modulo ``p^exponent``.
+        """
+        residue_mod_p = value % p
+        if p == 2:
+            solutions = [
+                (u, v) for u in range(2) for v in range(2)
+                if (u * u + residue_mod_p * v * v - residue_mod_p) % 2 == 0
+            ]
+        elif not residue_mod_p:
+            solutions = [(0, v) for v in range(p)]
+        else:
+            solutions = [(0, 1), (0, p - 1)]
+            if residue_mod_p.jacobi(p) == 1:
+                root = square_root_mod_prime(
+                    Mod(residue_mod_p, p), p
+                ).lift()
+                solutions.extend([(root, 0), ((-root) % p, 0)])
+
+        modulus = p
+        for _ in range(1, exponent):
+            lifted_solutions = []
+            for u, v in solutions:
+                # Linearize (2*u*v, u^2 + a*v^2 - a) after replacing
+                # (u, v) by (u, v) + modulus*(du, dv).  All quadratic
+                # correction terms vanish modulo modulus*p.
+                first_error = 2 * u * v // modulus
+                second_error = (
+                    u * u + value * v * v - value
+                ) // modulus
+                corrections = linear_solutions(
+                    2 * v, 2 * u,
+                    2 * u, 2 * residue_mod_p * v,
+                    -first_error, -second_error, p,
+                )
+                lifted_solutions.extend(
+                    (u + modulus * du, v + modulus * dv)
+                    for du, dv in corrections
+                )
+            solutions = lifted_solutions
+            modulus *= p
+        return solutions
+
+    factorization = list(a.parent().factored_order())
+    moduli = [p**exponent for p, exponent in factorization]
+    local_roots = [roots_mod_prime_power(p, exponent)
+                   for p, exponent in factorization]
+
+    if len(local_roots) == 1:
+        coefficient_pairs = local_roots[0]
+    else:
+        from itertools import product
+        from sage.arith.misc import CRT_basis
+
+        basis = CRT_basis(moduli)
+        modulus = a.modulus()
+        coefficient_pairs = []
+        for local_choice in product(*local_roots):
+            constant = sum(b * root[0]
+                           for b, root in zip(basis, local_choice)) % modulus
+            linear = sum(b * root[1]
+                         for b, root in zip(basis, local_choice)) % modulus
+            coefficient_pairs.append((constant, linear))
+
+    return [quotient([constant, linear])
+            for constant, linear in coefficient_pairs]
+
 
 def square_root_mod_prime_power(IntegerMod_abstract a, p, e):
     r"""

--- a/src/sage/rings/finite_rings/integer_mod.pyx
+++ b/src/sage/rings/finite_rings/integer_mod.pyx
@@ -1161,7 +1161,7 @@ cdef class IntegerMod_abstract(FiniteRingElement):
             sage: mod(15, 389).sqrt(extend=False)
             Traceback (most recent call last):
             ...
-            ValueError: self must be a square
+            ValueError: element is not a square
             sage: Mod(1/9, next_prime(2^40)).sqrt()^(-2)
             9
             sage: Mod(1/25, next_prime(2^90)).sqrt()^(-2)
@@ -1188,11 +1188,11 @@ cdef class IntegerMod_abstract(FiniteRingElement):
             sage: x.sqrt(extend=False)
             Traceback (most recent call last):
             ...
-            ValueError: self must be a square
+            ValueError: element is not a square
             sage: y = x.sqrt(); y
-            sqrt359
+            sqrt_ext
             sage: y.parent()
-            Univariate Quotient Polynomial Ring in sqrt359 over
+            Univariate Quotient Polynomial Ring in sqrt_ext over
              Ring of integers modulo 360 with modulus x^2 + 1
             sage: y^2
             359
@@ -1269,24 +1269,20 @@ cdef class IntegerMod_abstract(FiniteRingElement):
 
         if not self.is_square_c():
             if extend:
-                y = name if name is not None else 'sqrt%s' % self
+                if self._parent.is_field():
+                    from sage.categories.finite_fields import _sqrt_in_extension
+                    return _sqrt_in_extension(self, all, name, algorithm)
+                y = name if name is not None else 'sqrt_ext'
                 R = self.parent()['x']
                 modulus = R.gen()**2 - R(self)
-                if self._parent.is_field():
-                    from sage.rings.finite_rings.finite_field_constructor import FiniteField
-                    Q = FiniteField(self._modulus.sageInteger**2, y, modulus)
-                else:
-                    R = self.parent()['x']
-                    Q = R.quotient(modulus, names=(y,))
+                Q = R.quotient(modulus, names=(y,))
                 z = Q.gen()
                 if all:
-                    if self._parent.is_field():
-                        return [z, -z] if z != -z else [z]
                     raise NotImplementedError("Finding all square roots in extensions is not implemented; try extend=False to find only roots in the base ring Zmod(n).")
                 return z
             if all:
                 return []
-            raise ValueError("self must be a square")
+            raise ValueError("element is not a square")
 
         F = self._parent.factored_order()
         cdef long e, exp, val
@@ -2985,7 +2981,7 @@ cdef class IntegerMod_int(IntegerMod_abstract):
             sage: mod(15, 389).sqrt(extend=False)
             Traceback (most recent call last):
             ...
-            ValueError: self must be a square
+            ValueError: element is not a square
             sage: Mod(1/9, next_prime(2^40)).sqrt()^(-2)
             9
             sage: Mod(1/25, next_prime(2^90)).sqrt()^(-2)
@@ -2999,11 +2995,11 @@ cdef class IntegerMod_int(IntegerMod_abstract):
             sage: x.sqrt(extend=False)
             Traceback (most recent call last):
             ...
-            ValueError: self must be a square
+            ValueError: element is not a square
             sage: y = x.sqrt(); y
-            sqrt359
+            sqrt_ext
             sage: y.parent()
-            Univariate Quotient Polynomial Ring in sqrt359
+            Univariate Quotient Polynomial Ring in sqrt_ext
              over Ring of integers modulo 360 with modulus x^2 + 1
             sage: y^2
             359
@@ -3102,7 +3098,7 @@ cdef class IntegerMod_int(IntegerMod_abstract):
             if not extend:
                 if all:
                     return []
-                raise ValueError("self must be a square")
+                raise ValueError("element is not a square")
         # Now we use a heuristic to guess whether or not it will
         # be faster to just brute-force search for squares in a c loop...
         # TODO: more tuning?
@@ -3118,7 +3114,7 @@ cdef class IntegerMod_int(IntegerMod_abstract):
             if not extend:
                 if all:
                     return []
-                raise ValueError("self must be a square")
+                raise ValueError("element is not a square")
         # Either it failed but extend was True, or the generic algorithm is better
         return IntegerMod_abstract.sqrt(self, extend=extend, all=all,
                                         algorithm=algorithm, name=name)
@@ -4030,7 +4026,7 @@ def square_root_mod_prime_power(IntegerMod_abstract a, p, e):
     # strip off even powers of p
     cdef int i, val = a.lift().valuation(p)
     if val % 2 == 1:
-        raise ValueError("self must be a square")
+        raise ValueError("element is not a square")
     if val > 0:
         unit = a._parent(a.lift() // p**val)
     else:
@@ -4041,7 +4037,7 @@ def square_root_mod_prime_power(IntegerMod_abstract a, p, e):
     if p == 2:
         # squares in Z/2^e are of the form 4^n*(1+8*m)
         if unit.lift() % 8 != 1:
-            raise ValueError("self must be a square")
+            raise ValueError("element is not a square")
 
         u = unit.lift()
         x = next(i for i in range(1,8,2) if i*i & 31 == u & 31)

--- a/src/sage/rings/finite_rings/integer_mod.pyx
+++ b/src/sage/rings/finite_rings/integer_mod.pyx
@@ -1057,6 +1057,17 @@ cdef class IntegerMod_abstract(FiniteRingElement):
             sage: Mod(1/25, 2^40).is_square()                                           # needs sage.libs.pari
             True
 
+            sage: for n in (2, 3, 5, 7, 8, 9, 11, 15):
+            ....:     R = Zmod(n)
+            ....:     squares = {x*x for x in R}
+            ....:     assert all(a.is_square() == (a in squares) for a in R)
+            sage: p = next_prime(2^40)
+            sage: R = Zmod(p)
+            sage: values = [R(i) for i in range(40)]
+            sage: all(a.is_square() == (a == 0 or a^((p - 1)//2) == 1)
+            ....:     for a in values)
+            True
+
             sage: for p,q,r in cartesian_product_iterator([[3,5],[11,13],[17,19]]):  # long time, needs sage.libs.pari
             ....:     for ep,eq,er in cartesian_product_iterator([[0,1,2,3],[0,1,2,3],[0,1,2,3]]):
             ....:         for e2 in [0, 1, 2, 3, 4]:
@@ -1102,9 +1113,12 @@ cdef class IntegerMod_abstract(FiniteRingElement):
             return 0
         # We need to factor the modulus.  We do it here instead of
         # letting PARI do it, so that we can cache the factorisation.
-        return lift.__pari__().Zn_issquare(self._parent.factored_order())
+        factorization = self._parent.factored_order()
+        if len(factorization) == 1 and factorization[0][1] == 1:
+            return 1
+        return lift.__pari__().Zn_issquare(factorization)
 
-    def sqrt(self, extend=True, all=False):
+    def sqrt(self, *, extend=True, all=False, algorithm=None, name=None):
         r"""
         Return square root or square roots of ``self`` modulo `n`.
 
@@ -1115,7 +1129,14 @@ cdef class IntegerMod_abstract(FiniteRingElement):
           :exc:`ValueError` if the square root is not in the base ring.
 
         - ``all`` -- boolean (default: ``False``); if ``True``, return {all}
-          square roots of self, instead of just one
+          square roots of self
+
+        - ``algorithm`` -- optional algorithm hint (default: ``None``);
+          accepted for the common finite-ring interface; the modular backend
+          always uses its own default
+
+        - ``name`` -- string (default: ``None``); name of the generator when
+          an extension is created
 
         ALGORITHM: Calculates the square roots mod `p` for each of
         the primes `p` dividing the order of the ring, then lifts
@@ -1222,6 +1243,24 @@ cdef class IntegerMod_abstract(FiniteRingElement):
             [23, 41, 87, 105]
             sage: [x for x in R if x^2==17]
             [23, 41, 87, 105]
+
+        Check the common finite-ring square-root interface on the GMP
+        implementation (:issue:`40796`)::
+
+            sage: K = GF(next_prime(2^40))
+            sage: q = K(4)
+            sage: for method in (q.sqrt, q.square_root):
+            ....:     for algorithm in (None, 'tonelli', 'cipolla'):
+            ....:         roots = method(extend=False, all=True,
+            ....:                        algorithm=algorithm, name='w')
+            ....:         assert isinstance(roots, list) and len(roots) == 2
+            ....:         assert all(r.parent() is K and r^2 == q for r in roots)
+            ....:     assert method(algorithm='backend-default')^2 == q
+            sage: nonsquare = K.quadratic_nonresidue()
+            sage: for method in (nonsquare.sqrt, nonsquare.square_root):
+            ....:     roots = method(extend=True, all=True, name='w')
+            ....:     assert len(roots) == 2
+            ....:     assert all(root^2 == nonsquare for root in roots)
         """
         if self.is_one():
             if all:
@@ -1230,7 +1269,7 @@ cdef class IntegerMod_abstract(FiniteRingElement):
 
         if not self.is_square_c():
             if extend:
-                y = 'sqrt%s' % self
+                y = name if name is not None else 'sqrt%s' % self
                 R = self.parent()['x']
                 modulus = R.gen()**2 - R(self)
                 if self._parent.is_field():
@@ -1241,7 +1280,8 @@ cdef class IntegerMod_abstract(FiniteRingElement):
                     Q = R.quotient(modulus, names=(y,))
                 z = Q.gen()
                 if all:
-                    # TODO
+                    if self._parent.is_field():
+                        return [z, -z] if z != -z else [z]
                     raise NotImplementedError("Finding all square roots in extensions is not implemented; try extend=False to find only roots in the base ring Zmod(n).")
                 return z
             if all:
@@ -2897,22 +2937,30 @@ cdef class IntegerMod_int(IntegerMod_abstract):
             return 0
         # We need to factor the modulus.  We do it here instead of
         # letting PARI do it, so that we can cache the factorisation.
-        return lift.__pari__().Zn_issquare(self._parent.factored_order())
+        factorization = self._parent.factored_order()
+        if len(factorization) == 1 and factorization[0][1] == 1:
+            return 1
+        return lift.__pari__().Zn_issquare(factorization)
 
-    def sqrt(self, extend=True, all=False):
+    def sqrt(self, *, extend=True, all=False, algorithm=None, name=None):
         r"""
         Return square root or square roots of ``self`` modulo `n`.
 
         INPUT:
 
-        - ``extend`` -- boolean (default: ``True``);
-          if ``True``, return a square root in an extension ring,
-          if necessary. Otherwise, raise a :exc:`ValueError` if the
-          square root is not in the base ring.
+        - ``extend`` -- boolean (default: ``True``); if ``True``, return a
+          square root in an extension ring, if necessary. Otherwise, raise a
+          :exc:`ValueError` if the square root is not in the base ring.
 
-        - ``all`` -- boolean (default: ``False``); if
-          ``True``, return {all} square roots of self, instead of
-          just one.
+        - ``all`` -- boolean (default: ``False``); if ``True``, return {all}
+          square roots of self.
+
+        - ``algorithm`` -- optional algorithm hint (default: ``None``);
+          accepted for the common finite-ring interface; the modular backend
+          always uses its own default
+
+        - ``name`` -- string (default: ``None``); name of the generator when
+          an extension is created
 
         ALGORITHM: Calculates the square roots mod `p` for each of
         the primes `p` dividing the order of the ring, then lifts
@@ -3000,6 +3048,34 @@ cdef class IntegerMod_int(IntegerMod_abstract):
             sage: [x for x in R if x^2==17]
             [23, 41, 87, 105]
 
+        Check the common finite-ring square-root interface on the native
+        implementation (:issue:`40796`)::
+
+            sage: K = Zmod(15)
+            sage: q = K(4)
+            sage: for method in (q.sqrt, q.square_root):
+            ....:     for algorithm in (None, 'tonelli', 'cipolla'):
+            ....:         roots = method(extend=False, all=True,
+            ....:                        algorithm=algorithm, name='w')
+            ....:         assert isinstance(roots, list) and len(roots) == 4
+            ....:         assert all(r.parent() is K and r^2 == q for r in roots)
+            ....:     assert method(algorithm='backend-default')^2 == q
+            sage: nonsquare = GF(7)(3)
+            sage: for method in (nonsquare.sqrt, nonsquare.square_root):
+            ....:     root = method(name='w')
+            ....:     assert root^2 == nonsquare
+            ....:     roots = method(extend=True, all=True, name='w')
+            ....:     assert len(roots) == 2
+            ....:     assert all(r^2 == nonsquare for r in roots)
+            sage: for method in (Zmod(15)(2).sqrt, Zmod(15)(2).square_root):
+            ....:     try:
+            ....:         method(extend=True, all=True, name='w')
+            ....:     except NotImplementedError as error:
+            ....:         assert str(error).startswith(
+            ....:             "Finding all square roots in extensions")
+            ....:     else:
+            ....:         raise AssertionError("all extension roots were incomplete")
+
         TESTS:
 
         Check for :issue:`30797`::
@@ -3032,7 +3108,10 @@ cdef class IntegerMod_int(IntegerMod_abstract):
         # TODO: more tuning?
         elif n <= 100 or n / (1 << len(moduli)) < 5000:
             if all:
-                return [self._new_c(i) for i from 0 <= i < n if (i*i) % n == self.ivalue]
+                roots = [self._new_c(i) for i from 0 <= i < n
+                         if (i*i) % n == self.ivalue]
+                if roots or not extend:
+                    return roots
             for i from 0 <= i <= n/2:
                 if (i*i) % n == self.ivalue:
                     return self._new_c(i)
@@ -3041,7 +3120,10 @@ cdef class IntegerMod_int(IntegerMod_abstract):
                     return []
                 raise ValueError("self must be a square")
         # Either it failed but extend was True, or the generic algorithm is better
-        return IntegerMod_abstract.sqrt(self, extend=extend, all=all)
+        return IntegerMod_abstract.sqrt(self, extend=extend, all=all,
+                                        algorithm=algorithm, name=name)
+
+    square_root = sqrt
 
     def _balanced_abs(self):
         r"""

--- a/src/sage/rings/finite_rings/integer_mod.pyx
+++ b/src/sage/rings/finite_rings/integer_mod.pyx
@@ -1118,13 +1118,13 @@ cdef class IntegerMod_abstract(FiniteRingElement):
             return 1
         return lift.__pari__().Zn_issquare(factorization)
 
-    def sqrt(self, *, extend=True, all=False, algorithm=None, name=None):
+    def sqrt(self, *, extend=False, all=False, algorithm=None, name=None):
         r"""
         Return square root or square roots of ``self`` modulo `n`.
 
         INPUT:
 
-        - ``extend`` -- boolean (default: ``True``); if ``True``, return a
+        - ``extend`` -- boolean (default: ``False``); if ``True``, return a
           square root in an extension ring, if necessary. Otherwise, raise a
           :exc:`ValueError` if the square root is not in the base ring.
 
@@ -1169,7 +1169,7 @@ cdef class IntegerMod_abstract(FiniteRingElement):
 
         Error message as requested in :issue:`38802`::
 
-            sage: sqrt(Mod(2, 101010), all=True)
+            sage: sqrt(Mod(2, 101010), extend=True, all=True)
             Traceback (most recent call last):
             ...
             NotImplementedError: Finding all square roots in extensions is not implemented; try extend=False to find only roots in the base ring Zmod(n).
@@ -1189,7 +1189,7 @@ cdef class IntegerMod_abstract(FiniteRingElement):
             Traceback (most recent call last):
             ...
             ValueError: element is not a square
-            sage: y = x.sqrt(); y
+            sage: y = x.sqrt(extend=True); y
             sqrt_ext
             sage: y.parent()
             Univariate Quotient Polynomial Ring in sqrt_ext over
@@ -2938,13 +2938,13 @@ cdef class IntegerMod_int(IntegerMod_abstract):
             return 1
         return lift.__pari__().Zn_issquare(factorization)
 
-    def sqrt(self, *, extend=True, all=False, algorithm=None, name=None):
+    def sqrt(self, *, extend=False, all=False, algorithm=None, name=None):
         r"""
         Return square root or square roots of ``self`` modulo `n`.
 
         INPUT:
 
-        - ``extend`` -- boolean (default: ``True``); if ``True``, return a
+        - ``extend`` -- boolean (default: ``False``); if ``True``, return a
           square root in an extension ring, if necessary. Otherwise, raise a
           :exc:`ValueError` if the square root is not in the base ring.
 
@@ -2996,7 +2996,7 @@ cdef class IntegerMod_int(IntegerMod_abstract):
             Traceback (most recent call last):
             ...
             ValueError: element is not a square
-            sage: y = x.sqrt(); y
+            sage: y = x.sqrt(extend=True); y
             sqrt_ext
             sage: y.parent()
             Univariate Quotient Polynomial Ring in sqrt_ext
@@ -3058,7 +3058,7 @@ cdef class IntegerMod_int(IntegerMod_abstract):
             ....:     assert method(algorithm='backend-default')^2 == q
             sage: nonsquare = GF(7)(3)
             sage: for method in (nonsquare.sqrt, nonsquare.square_root):
-            ....:     root = method(name='w')
+            ....:     root = method(extend=True, name='w')
             ....:     assert root^2 == nonsquare
             ....:     roots = method(extend=True, all=True, name='w')
             ....:     assert len(roots) == 2

--- a/src/sage/rings/finite_rings/integer_mod_ring.py
+++ b/src/sage/rings/finite_rings/integer_mod_ring.py
@@ -673,6 +673,7 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
         if it is found that the ring is in fact a field::
 
             sage: R = IntegerModRing(127)
+            sage: q = R(4)
             sage: R.category()
             Join of Category of finite commutative rings
                 and Category of subquotients of monoids
@@ -684,6 +685,12 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
             Join of Category of finite enumerated fields
                 and Category of subquotients of monoids
                 and Category of quotients of semigroups
+            sage: for method in (q.sqrt, q.square_root):
+            ....:     for algorithm in (None, 'tonelli', 'cipolla'):
+            ....:         roots = method(extend=False, all=True,
+            ....:                        algorithm=algorithm, name='w')
+            ....:         assert isinstance(roots, list) and len(roots) == 2
+            ....:         assert all(r.parent() is R and r^2 == q for r in roots)
 
         It is possible to mistakenly put `\ZZ/n\ZZ` into the category of fields.
         In this case, :meth:`is_field` will return ``True`` without performing a

--- a/src/sage/rings/finite_rings/integer_mod_ring.py
+++ b/src/sage/rings/finite_rings/integer_mod_ring.py
@@ -685,12 +685,17 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
             Join of Category of finite enumerated fields
                 and Category of subquotients of monoids
                 and Category of quotients of semigroups
+
+        TESTS::
+
             sage: for method in (q.sqrt, q.square_root):
             ....:     for algorithm in (None, 'tonelli', 'cipolla'):
             ....:         roots = method(extend=False, all=True,
             ....:                        algorithm=algorithm, name='w')
             ....:         assert isinstance(roots, list) and len(roots) == 2
-            ....:         assert all(r.parent() is R and r^2 == q for r in roots)
+            ....:         assert all(r.parent() is R and r**2 == q for r in roots)
+
+        EXAMPLES:
 
         It is possible to mistakenly put `\ZZ/n\ZZ` into the category of fields.
         In this case, :meth:`is_field` will return ``True`` without performing a

--- a/src/sage/rings/polynomial/polynomial_quotient_ring.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring.py
@@ -1156,16 +1156,30 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
 
             sage: R.<x> = GF(3)[]
             sage: A.<a> = R.quotient((x + 1)^2 * (x^2 + 1))
-            sage: moduli, components, basis = A._sqrt_primary_decomposition()
+            sage: data = A._sqrt_primary_decomposition()
+            sage: moduli, components, evaluations, basis = data
             sage: list(moduli)
             [x^2 + 2*x + 1, x^2 + 1]
             sage: [component.cardinality() for component in components]
             [9, 9]
+            sage: list(evaluations)
+            [None, None]
             sage: all(b % m == (i == j)
             ....:     for i, b in enumerate(basis)
             ....:     for j, m in enumerate(moduli))
             True
             sage: R.quotient((x + 1)^3)._sqrt_primary_decomposition() is None
+            True
+
+        Linear components are represented directly by the base field, which
+        avoids constructing degree-one quotient parents::
+
+            sage: B = R.quotient((x - 1) * (x + 1))
+            sage: data = B._sqrt_primary_decomposition()
+            sage: _, components, evaluations, _ = data
+            sage: all(component is R.base_ring() for component in components)
+            True
+            sage: set(evaluations) == {R.base_ring()(1), R.base_ring()(2)}
             True
 
         Quotients over non-fields retain the generic enumeration fallback::
@@ -1189,11 +1203,18 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
 
         polynomial_ring = self.polynomial_ring()
         name = self.variable_name()
-        components = tuple(PolynomialQuotientRing(polynomial_ring, modulus,
-                                                   name)
-                           for modulus in moduli)
+        base_ring = self.base_ring()
+        components = tuple(
+            base_ring if modulus.degree() == 1 else
+            PolynomialQuotientRing(polynomial_ring, modulus, name)
+            for modulus in moduli
+        )
+        evaluations = tuple(
+            -modulus[0] / modulus[1] if modulus.degree() == 1 else None
+            for modulus in moduli
+        )
         basis = tuple(CRT_basis(list(moduli)))
-        return moduli, components, basis
+        return moduli, components, evaluations, basis
 
     def ngens(self):
         """

--- a/src/sage/rings/polynomial/polynomial_quotient_ring.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring.py
@@ -2436,7 +2436,7 @@ class PolynomialQuotientRing_field(PolynomialQuotientRing_domain, Field):
             ....:         roots = method(extend=False, all=True,
             ....:                        algorithm=algorithm, name='w')
             ....:         assert isinstance(roots, list) and len(roots) == 2
-            ....:         assert all(r.parent() is S and r^2 == q for r in roots)
+            ....:         assert all(r.parent() is S and r**2 == q for r in roots)
             sage: S.category().is_subcategory(FiniteFields())
             True
         """

--- a/src/sage/rings/polynomial/polynomial_quotient_ring.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring.py
@@ -38,7 +38,7 @@ TESTS::
 
 
 import sage.rings.rational_field
-from sage.arith.misc import crt
+from sage.arith.misc import CRT_basis, crt
 from sage.categories.commutative_algebras import CommutativeAlgebras
 from sage.categories.commutative_rings import CommutativeRings
 from sage.categories.fields import Fields
@@ -1137,6 +1137,63 @@ class PolynomialQuotientRing_generic(QuotientRing_generic):
             x^2 + 1
         """
         return self.__polynomial
+
+    @cached_method
+    def _sqrt_primary_decomposition(self):
+        r"""
+        Return primary components used to compute square roots, if useful.
+
+        This private decomposition is available for a univariate polynomial
+        quotient over a finite field when its modulus has at least two
+        distinct irreducible factors.  Each primary factor is kept intact, so
+        the resulting moduli are pairwise coprime and their quotient rings can
+        be recombined by the Chinese remainder theorem.
+
+        A single primary component is not useful here and returns ``None``;
+        this also prevents recursive decomposition of that component.
+
+        EXAMPLES::
+
+            sage: R.<x> = GF(3)[]
+            sage: A.<a> = R.quotient((x + 1)^2 * (x^2 + 1))
+            sage: moduli, components, basis = A._sqrt_primary_decomposition()
+            sage: list(moduli)
+            [x^2 + 2*x + 1, x^2 + 1]
+            sage: [component.cardinality() for component in components]
+            [9, 9]
+            sage: all(b % m == (i == j)
+            ....:     for i, b in enumerate(basis)
+            ....:     for j, m in enumerate(moduli))
+            True
+            sage: R.quotient((x + 1)^3)._sqrt_primary_decomposition() is None
+            True
+
+        Quotients over non-fields retain the generic enumeration fallback::
+
+            sage: S.<y> = Zmod(4)[]
+            sage: S.quotient((y + 1) * (y^2 + y + 1))._sqrt_primary_decomposition() is None
+            True
+        """
+        from sage.categories.finite_fields import FiniteFields
+        if self.base_ring() not in FiniteFields():
+            return None
+
+        try:
+            factorization = self.modulus().factor()
+        except NotImplementedError:
+            return None
+        moduli = tuple(factor**exponent
+                       for factor, exponent in factorization)
+        if len(moduli) < 2:
+            return None
+
+        polynomial_ring = self.polynomial_ring()
+        name = self.variable_name()
+        components = tuple(PolynomialQuotientRing(polynomial_ring, modulus,
+                                                   name)
+                           for modulus in moduli)
+        basis = tuple(CRT_basis(list(moduli)))
+        return moduli, components, basis
 
     def ngens(self):
         """
@@ -2370,13 +2427,17 @@ class PolynomialQuotientRing_field(PolynomialQuotientRing_domain, Field):
         The category is set correctly on initialization and member methods are
         inherited correctly::
 
-            sage: R.<x> = GF(103)[]
-            sage: f = R.irreducible_element(3, algorithm="random")
-            sage: S = R.quo(f)
+            sage: R.<x> = GF(5)[]
+            sage: S.<a> = R.quo(x^2 + 2)
+            sage: q = S(4)
+            sage: for method in (q.sqrt, q.square_root):
+            ....:     for algorithm in (None, 'tonelli', 'cipolla',
+            ....:                       'backend-default'):
+            ....:         roots = method(extend=False, all=True,
+            ....:                        algorithm=algorithm, name='w')
+            ....:         assert isinstance(roots, list) and len(roots) == 2
+            ....:         assert all(r.parent() is S and r^2 == q for r in roots)
             sage: S.category().is_subcategory(FiniteFields())
-            True
-            sage: a = S.random_element()^2
-            sage: (a.sqrt())^2 == a
             True
         """
         category = CommutativeAlgebras(ring.base_ring().category()).Quotients() & Fields()

--- a/src/sage/rings/polynomial/polynomial_quotient_ring_element.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring_element.py
@@ -634,7 +634,7 @@ class PolynomialQuotientRingElement(polynomial_singular_interface.Polynomial_sin
             ....:                      algorithm='backend-default')
             sage: len(roots), len(set(roots))
             (4, 4)
-            sage: all(root^2 == 1 for root in roots)
+            sage: all(root**2 == 1 for root in roots)
             True
             sage: root = A.one()._sqrt_finite_decomposition(
             ....:     all=False, algorithm='backend-default')
@@ -649,7 +649,7 @@ class PolynomialQuotientRingElement(polynomial_singular_interface.Polynomial_sin
             sage: B.cardinality()
             1061520150601
             sage: roots = B.one().sqrt(extend=False, all=True)
-            sage: len(roots), all(root^2 == 1 for root in roots)
+            sage: len(roots), all(root**2 == 1 for root in roots)
             (64, True)
 
         If any component has no root, no CRT combinations are constructed::
@@ -658,6 +658,8 @@ class PolynomialQuotientRingElement(polynomial_singular_interface.Polynomial_sin
             sage: C.<c> = T.quotient((z - 1) * (z + 1))
             sage: C(z + 2).sqrt(extend=False, all=True)
             []
+
+        TESTS:
 
         Neither the one-root nor the all-roots path enumerates the full
         quotient when a decomposition is available::

--- a/src/sage/rings/polynomial/polynomial_quotient_ring_element.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring_element.py
@@ -681,11 +681,14 @@ class PolynomialQuotientRingElement(polynomial_singular_interface.Polynomial_sin
         if decomposition is None:
             return NotImplemented
 
-        _, components, basis = decomposition
+        _, components, evaluations, basis = decomposition
         lift = self.lift()
         roots_by_component = []
-        for component in components:
-            value = component(lift)
+        for component, evaluation in zip(components, evaluations):
+            if evaluation is None:
+                value = component(lift)
+            else:
+                value = lift(evaluation)
             if all:
                 roots = value.sqrt(extend=False, all=True,
                                    algorithm=algorithm)
@@ -703,11 +706,16 @@ class PolynomialQuotientRingElement(polynomial_singular_interface.Polynomial_sin
                 roots_by_component.append((root,))
 
         from itertools import product
-        zero = parent.polynomial_ring().zero()
+        polynomial_ring = parent.polynomial_ring()
+        zero = polynomial_ring.zero()
         def combine(roots):
-            return parent(sum((root.lift() * multiplier
-                               for root, multiplier in zip(roots, basis)),
-                              zero))
+            return parent(sum(
+                ((root.lift() if evaluation is None else
+                  polynomial_ring(root)) * multiplier
+                 for root, evaluation, multiplier in
+                 zip(roots, evaluations, basis)),
+                zero,
+            ))
 
         if not all:
             return combine(tuple(roots[0] for roots in roots_by_component))

--- a/src/sage/rings/polynomial/polynomial_quotient_ring_element.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring_element.py
@@ -616,13 +616,15 @@ class PolynomialQuotientRingElement(polynomial_singular_interface.Polynomial_sin
         """
         return self._polynomial
 
-    def _sqrt_all_finite_decomposition(self, algorithm=None):
+    def _sqrt_finite_decomposition(self, *, all, algorithm=None):
         r"""
-        Return all square roots using primary decomposition, if available.
+        Return square roots using primary decomposition, if available.
 
         This is an internal fast path for finite polynomial quotient rings.
-        It returns ``None`` when the parent has no useful decomposition, so
-        the generic finite-ring implementation can fall back to enumeration.
+        It returns ``NotImplemented`` when the parent has no useful
+        decomposition, so the generic finite-ring implementation can fall
+        back to enumeration.  With ``all=False``, ``None`` means that the
+        decomposition proved that no root exists.
 
         EXAMPLES::
 
@@ -633,6 +635,10 @@ class PolynomialQuotientRingElement(polynomial_singular_interface.Polynomial_sin
             sage: len(roots), len(set(roots))
             (4, 4)
             sage: all(root^2 == 1 for root in roots)
+            True
+            sage: root = A.one()._sqrt_finite_decomposition(
+            ....:     all=False, algorithm='backend-default')
+            sage: root**2 == 1
             True
 
         The work depends on the primary components and the output, rather
@@ -652,27 +658,58 @@ class PolynomialQuotientRingElement(polynomial_singular_interface.Polynomial_sin
             sage: C.<c> = T.quotient((z - 1) * (z + 1))
             sage: C(z + 2).sqrt(extend=False, all=True)
             []
+
+        Neither the one-root nor the all-roots path enumerates the full
+        quotient when a decomposition is available::
+
+            sage: from unittest.mock import patch
+            sage: square = C((z + 2)**2)
+            sage: with patch.object(type(C), '__iter__',
+            ....:                   side_effect=AssertionError("full enumeration")):
+            ....:     assert square.sqrt(extend=False)**2 == square
+            sage: with patch.object(type(C), '__iter__',
+            ....:                   side_effect=AssertionError("full enumeration")):
+            ....:     C(z + 2).sqrt(extend=False)
+            Traceback (most recent call last):
+            ...
+            ValueError: element is not a square
         """
         parent = self.parent()
         decomposition = parent._sqrt_primary_decomposition()
         if decomposition is None:
-            return None
+            return NotImplemented
 
-        moduli, components, basis = decomposition
+        _, components, basis = decomposition
         lift = self.lift()
         roots_by_component = []
         for component in components:
-            roots = component(lift).sqrt(extend=False, all=True,
-                                         algorithm=algorithm)
-            if not roots:
-                return []
-            roots_by_component.append(roots)
+            value = component(lift)
+            if all:
+                roots = value.sqrt(extend=False, all=True,
+                                   algorithm=algorithm)
+                if not roots:
+                    return []
+                roots_by_component.append(roots)
+            else:
+                try:
+                    root = value.sqrt(extend=False, all=False,
+                                      algorithm=algorithm)
+                except ValueError as error:
+                    if str(error) != "element is not a square":
+                        raise
+                    return None
+                roots_by_component.append((root,))
 
         from itertools import product
         zero = parent.polynomial_ring().zero()
-        return [parent(sum((root.lift() * multiplier
-                           for root, multiplier in zip(roots, basis)), zero))
-                for roots in product(*roots_by_component)]
+        def combine(roots):
+            return parent(sum((root.lift() * multiplier
+                               for root, multiplier in zip(roots, basis)),
+                              zero))
+
+        if not all:
+            return combine(tuple(roots[0] for roots in roots_by_component))
+        return [combine(roots) for roots in product(*roots_by_component)]
 
     def __iter__(self):
         return iter(self.list())

--- a/src/sage/rings/polynomial/polynomial_quotient_ring_element.py
+++ b/src/sage/rings/polynomial/polynomial_quotient_ring_element.py
@@ -616,6 +616,64 @@ class PolynomialQuotientRingElement(polynomial_singular_interface.Polynomial_sin
         """
         return self._polynomial
 
+    def _sqrt_all_finite_decomposition(self, algorithm=None):
+        r"""
+        Return all square roots using primary decomposition, if available.
+
+        This is an internal fast path for finite polynomial quotient rings.
+        It returns ``None`` when the parent has no useful decomposition, so
+        the generic finite-ring implementation can fall back to enumeration.
+
+        EXAMPLES::
+
+            sage: R.<x> = GF(3)[]
+            sage: A.<a> = R.quotient((x + 1)^2 * (x^2 + 1))
+            sage: roots = A.one().sqrt(extend=False, all=True,
+            ....:                      algorithm='backend-default')
+            sage: len(roots), len(set(roots))
+            (4, 4)
+            sage: all(root^2 == 1 for root in roots)
+            True
+
+        The work depends on the primary components and the output, rather
+        than on the cardinality of their full Cartesian product::
+
+            sage: S.<y> = GF(101)[]
+            sage: B = S.quotient(prod(y - i for i in range(6)))
+            sage: B.cardinality()
+            1061520150601
+            sage: roots = B.one().sqrt(extend=False, all=True)
+            sage: len(roots), all(root^2 == 1 for root in roots)
+            (64, True)
+
+        If any component has no root, no CRT combinations are constructed::
+
+            sage: T.<z> = GF(5)[]
+            sage: C.<c> = T.quotient((z - 1) * (z + 1))
+            sage: C(z + 2).sqrt(extend=False, all=True)
+            []
+        """
+        parent = self.parent()
+        decomposition = parent._sqrt_primary_decomposition()
+        if decomposition is None:
+            return None
+
+        moduli, components, basis = decomposition
+        lift = self.lift()
+        roots_by_component = []
+        for component in components:
+            roots = component(lift).sqrt(extend=False, all=True,
+                                         algorithm=algorithm)
+            if not roots:
+                return []
+            roots_by_component.append(roots)
+
+        from itertools import product
+        zero = parent.polynomial_ring().zero()
+        return [parent(sum((root.lift() * multiplier
+                           for root, multiplier in zip(roots, basis)), zero))
+                for roots in product(*roots_by_component)]
+
     def __iter__(self):
         return iter(self.list())
 

--- a/src/sage/rings/ring_extension.pyx
+++ b/src/sage/rings/ring_extension.pyx
@@ -476,18 +476,30 @@ class RingExtensionFactory(UniqueFactory):
             sage: key, extra_args = RingExtension.create_key_and_extra_args(QQ, ZZ)
             sage: RingExtension.create_object((8,9,0), key, **extra_args)
             Rational Field over its base
+
+        Existing constructor-specific names are not overwritten::
+
+            sage: E = RingExtension(QQ, QQ, gens=(QQ.one(),), names=('a',))
         """
         defining_morphism = key[0]
         constructors = extra_args['constructors']
         if len(constructors) == 0:
             raise NotImplementedError("no constructor available for this extension")
+        extension = None
         for constructor, kwargs in constructors[:-1]:
             try:
-                return constructor(defining_morphism, **kwargs)
+                extension = constructor(defining_morphism, **kwargs)
             except (NotImplementedError, ValueError, TypeError):
                 pass
-        constructor, kwargs = constructors[-1]
-        return constructor(defining_morphism, **kwargs)
+            else:
+                break
+        if extension is None:
+            constructor, kwargs = constructors[-1]
+            extension = constructor(defining_morphism, **kwargs)
+        names = key[2]
+        if names is not None and extension._names is None:
+            extension._assign_names(names, normalize=False)
+        return extension
 
 
 RingExtension = RingExtensionFactory("sage.rings.ring_extension.RingExtension")

--- a/src/sage/rings/ring_extension.pyx
+++ b/src/sage/rings/ring_extension.pyx
@@ -480,6 +480,23 @@ class RingExtensionFactory(UniqueFactory):
         Existing constructor-specific names are not overwritten::
 
             sage: E = RingExtension(QQ, QQ, gens=(QQ.one(),), names=('a',))
+            sage: E.variable_names()
+            (None,)
+
+        A generic fallback does not accept ``names`` in its constructor, but
+        the names stored in the factory key are restored afterwards::
+
+            sage: from sage.rings.ring_extension import RingExtension_generic
+            sage: K.<z> = GF(5^2)
+            sage: key, extra = RingExtension.create_key_and_extra_args(
+            ....:     K, GF(5), names=('w',),
+            ....:     constructors=[(RingExtension_generic,
+            ....:                    {'is_backend_exposed': True})])
+            sage: Q = RingExtension.create_object((8, 9, 0), key, **extra)
+            sage: Q.variable_names()
+            ('w',)
+            sage: Q(Q.backend().gen()).parent() is Q
+            True
         """
         defining_morphism = key[0]
         constructors = extra_args['constructors']
@@ -497,6 +514,9 @@ class RingExtensionFactory(UniqueFactory):
             constructor, kwargs = constructors[-1]
             extension = constructor(defining_morphism, **kwargs)
         names = key[2]
+        # A generic fallback cannot receive ``names`` in its constructor.
+        # Restore the names from the factory key, but leave names chosen by a
+        # more specialized constructor untouched.
         if names is not None and extension._names is None:
             extension._assign_names(names, normalize=False)
         return extension

--- a/src/sage/rings/ring_extension_element.pyx
+++ b/src/sage/rings/ring_extension_element.pyx
@@ -6,6 +6,8 @@ AUTHOR:
 - Xavier Caruso (2019)
 """
 
+from functools import lru_cache
+
 # ###########################################################################
 #    Copyright (C) 2019 Xavier Caruso <xavier.caruso@normalesup.org>
 #
@@ -23,7 +25,6 @@ from sage.cpython.getattr cimport AttributeErrorMessage
 from sage.cpython.getattr import dir_with_other_class
 from sage.misc.latex import latex
 
-from sage.structure.category_object import normalize_names
 from sage.structure.element cimport CommutativeAlgebraElement
 from sage.structure.parent cimport Parent
 from sage.rings.integer_ring import ZZ
@@ -34,6 +35,47 @@ from sage.rings.ring_extension cimport RingExtension_generic, RingExtensionWithG
 from sage.rings.ring_extension_morphism cimport MapRelativeRingToFreeModule, are_equal_morphisms
 from sage.rings.ring_extension_conversion cimport backend_parent, backend_element
 from sage.rings.ring_extension_conversion cimport to_backend, from_backend
+
+
+def _inspect_keyword_parameters(method):
+    r"""
+    Return the keyword parameters accepted by ``method``.
+
+    Positional-only parameters must not be forwarded as keywords::
+
+        sage: from sage.rings.ring_extension_element import _inspect_keyword_parameters
+        sage: def f(algorithm, /, *, name=None): pass
+        sage: _inspect_keyword_parameters(f)
+        (False, frozenset({'name'}))
+    """
+    from inspect import Parameter, signature
+
+    try:
+        parameters = signature(method).parameters
+    except (TypeError, ValueError):
+        return False, frozenset()
+    return (any(parameter.kind == Parameter.VAR_KEYWORD
+                for parameter in parameters.values()),
+            frozenset(name for name, parameter in parameters.items()
+                      if parameter.kind in (Parameter.POSITIONAL_OR_KEYWORD,
+                                            Parameter.KEYWORD_ONLY)))
+
+
+@lru_cache(maxsize=256)
+def _cached_keyword_parameters(function):
+    r"""Return cached keyword parameters for a stable function object."""
+    return _inspect_keyword_parameters(function)
+
+
+def _keyword_parameters(method):
+    r"""Return keyword parameters, caching bound methods by function."""
+    function = getattr(method, '__func__', None)
+    if function is None:
+        return _inspect_keyword_parameters(method)
+    try:
+        return _cached_keyword_parameters(function)
+    except TypeError:
+        return _inspect_keyword_parameters(method)
 
 
 # Classes
@@ -628,22 +670,24 @@ cdef class RingExtensionElement(CommutativeAlgebraElement):
             return is_sq, sq
         return is_sq
 
-    def sqrt(self, extend=True, all=False, name=None):
+    def sqrt(self, *, extend=True, all=False, algorithm=None, name=None):
         r"""
         Return a square root or all square roots of this element.
 
         INPUT:
 
-        - ``extend`` -- boolean (default: ``True``); if ``True``,
-          return a square root in an extension ring, if necessary.
-          Otherwise, raise a :exc:`ValueError` if the root is not in
-          the ring.
+        - ``extend`` -- boolean (default: ``True``); if ``True``, return a
+          square root in an extension ring, if necessary. Otherwise, raise a
+          :exc:`ValueError` if the root is not in the ring.
 
-        - ``all`` -- boolean (default: ``False``); if ``True``,
-          return all square roots of this element, instead of just one
+        - ``all`` -- boolean (default: ``False``); if ``True``, return all
+          square roots of this element, instead of just one.
 
         - ``name`` -- required when ``extend=True`` and ``self`` is not a
           square; this will be the name of the generator extension
+
+        - ``algorithm`` -- optional square-root algorithm hint forwarded to
+          the backend
 
         .. NOTE::
 
@@ -657,9 +701,68 @@ cdef class RingExtensionElement(CommutativeAlgebraElement):
             2 + 3*a + a^2
             sage: b.sqrt(all=True)
             [2 + 3*a + a^2, 3 + 2*a - a^2]
+
+            sage: for method in (b.sqrt, b.square_root):
+            ....:     roots = method(extend=False, all=True,
+            ....:                    algorithm='cipolla')
+            ....:     assert len(roots) == 2
+            ....:     assert all(r.parent() is K and r^2 == b for r in roots)
+
+        A nonsquare has no roots in the unextended ring::
+
+            sage: a.sqrt(extend=False, all=True)
+            []
+            sage: a.square_root(extend=False, all=True)
+            []
+
+        Both method names wrap roots from a backend quadratic extension::
+
+            sage: for method in (a.sqrt, a.square_root):
+            ....:     root = method(name='w', algorithm='cipolla')
+            ....:     assert root^2 == a
+            ....:     assert root.parent().variable_names() == ('w',)
+            ....:     roots = method(extend=True, all=True, name='w',
+            ....:                    algorithm='cipolla')
+            ....:     assert len(roots) == 2
+            ....:     assert all(r^2 == a for r in roots)
+
+        Names are part of the reconstructed parent's factory data::
+
+            sage: P = a.sqrt(name='wfresh').parent()
+            sage: factory, version, key, extra = P._factory_data
+            sage: Q = factory.create_object(version, key, **extra)
+            sage: Q.variable_names()
+            ('wfresh',)
+
+        Backends without an algorithm keyword ignore unsupported hints::
+
+            sage: Z = QQ.over()
+            sage: Z(4).sqrt(name='s'), Z(4).square_root(name='s')
+            (2, 2)
+            sage: Z(4).sqrt(algorithm='backend-default')^2
+            4
+            sage: Z(4).square_root(extend=False, all=True)
+            [2, -2]
         """
-        sq = self._backend.sqrt(extend=extend, all=all)
+        options = {'extend': extend, 'all': all}
+        method = self._backend.sqrt
+        if algorithm is not None or name is not None:
+            accepts_all, parameters = _keyword_parameters(method)
+            if (algorithm is not None
+                    and (accepts_all or 'algorithm' in parameters)):
+                options['algorithm'] = algorithm
+            if name is not None and (accepts_all or 'name' in parameters):
+                options['name'] = name
+        sq = method(**options)
+        return self._wrap_sqrt_output(sq, all, name)
+
+    square_root = sqrt
+
+    def _wrap_sqrt_output(self, sq, all, name):
+        r"""Wrap backend square roots as elements of a ring extension."""
         if all:
+            if not sq:
+                return []
             gen = sq[0]
         else:
             gen = sq
@@ -669,14 +772,18 @@ cdef class RingExtensionElement(CommutativeAlgebraElement):
             from sage.rings.ring_extension import RingExtension
             if name is None:
                 raise ValueError("you must specify a variable name")
+            from sage.structure.category_object import normalize_names
             names = normalize_names(1, name)
-            constructor = (RingExtensionWithGen,
-                           {'gen': gen, 'name': names[0], 'is_backend_exposed': False})
-            parent = RingExtension(backend_parent, parent, (gen,), names, constructors=[constructor])
+            constructors = [
+                (RingExtensionWithGen,
+                 {'gen': gen, 'names': names, 'is_backend_exposed': True}),
+                (RingExtension_generic, {'is_backend_exposed': True}),
+            ]
+            parent = RingExtension(backend_parent, parent, gens=(gen,),
+                                   names=names, constructors=constructors)
         if all:
             return [ parent(s) for s in sq ]
         return parent(sq)
-
 
 # Fraction fields
 #################

--- a/src/sage/rings/ring_extension_element.pyx
+++ b/src/sage/rings/ring_extension_element.pyx
@@ -735,11 +735,13 @@ cdef class RingExtensionElement(CommutativeAlgebraElement):
             sage: b.sqrt(all=True)
             [2 + 3*a + a^2, 3 + 2*a - a^2]
 
+        TESTS::
+
             sage: for method in (b.sqrt, b.square_root):
             ....:     roots = method(extend=False, all=True,
             ....:                    algorithm='cipolla')
             ....:     assert len(roots) == 2
-            ....:     assert all(r.parent() is K and r^2 == b for r in roots)
+            ....:     assert all(r.parent() is K and r**2 == b for r in roots)
 
         A nonsquare has no roots in the unextended ring::
 
@@ -757,12 +759,12 @@ cdef class RingExtensionElement(CommutativeAlgebraElement):
             sage: for method in (a.sqrt, a.square_root):
             ....:     root = method(extend=True, name='w',
             ....:                   algorithm='cipolla')
-            ....:     assert root^2 == a
+            ....:     assert root**2 == a
             ....:     assert root.parent().variable_names() == ('w',)
             ....:     roots = method(extend=True, all=True, name='w',
             ....:                    algorithm='cipolla')
             ....:     assert len(roots) == 2
-            ....:     assert all(r^2 == a for r in roots)
+            ....:     assert all(r**2 == a for r in roots)
 
         Different nonsquares use the same wrapped finite-field parent::
 
@@ -787,6 +789,8 @@ cdef class RingExtensionElement(CommutativeAlgebraElement):
             sage: W = L.over()
             sage: u = L.quadratic_nonresidue()
             sage: r = W(u).sqrt(extend=True, name='w')
+            sage: r.parent()
+            Finite Field in w of size 5^4 over its base
             sage: rr = loads(dumps(r))
             sage: rr**2 == rr.parent()(W(u))
             True
@@ -804,7 +808,7 @@ cdef class RingExtensionElement(CommutativeAlgebraElement):
             sage: Z = QQ.over()
             sage: Z(4).sqrt(name='s'), Z(4).square_root(name='s')
             (2, 2)
-            sage: Z(4).sqrt(algorithm='backend-default')^2
+            sage: Z(4).sqrt(algorithm='backend-default')**2
             4
             sage: Z(4).square_root(extend=False, all=True)
             [2, -2]
@@ -826,11 +830,11 @@ cdef class RingExtensionElement(CommutativeAlgebraElement):
                 if name is not None and (accepts_all or 'name' in parameters):
                     options['name'] = name
         sq = method(**options)
-        return self._wrap_sqrt_output(sq, all, name)
+        return self._wrap_sqrt_output(sq, all_roots=all, name=name)
 
     square_root = sqrt
 
-    def _wrap_sqrt_output(self, sq, all, name):
+    def _wrap_sqrt_output(self, sq, *, all_roots, name):
         r"""
         Wrap backend square roots as elements of a ring extension.
 
@@ -838,14 +842,14 @@ cdef class RingExtensionElement(CommutativeAlgebraElement):
 
             sage: K = GF(5).over()
             sage: q = K(4)
-            sage: roots = q._wrap_sqrt_output([GF(5)(2), GF(5)(3)],
-            ....:                             True, None)
+            sage: roots = q._wrap_sqrt_output(
+            ....:     [GF(5)(2), GF(5)(3)], all_roots=True, name=None)
             sage: roots == [K(2), K(3)] and all(root**2 == q for root in roots)
             True
-            sage: q._wrap_sqrt_output([], True, None)
+            sage: q._wrap_sqrt_output([], all_roots=True, name=None)
             []
         """
-        if all:
+        if all_roots:
             if not sq:
                 return []
             gen = sq[0]
@@ -864,6 +868,10 @@ cdef class RingExtensionElement(CommutativeAlgebraElement):
                 extension_gen = backend_parent.gen()
             else:
                 extension_gen = gen
+            # ``RingExtensionWithGen`` can reject a backend/base pair and
+            # fall through to ``RingExtension_generic``.  The generic class
+            # has no relative presentation to print, so expose its backend;
+            # the requested name remains part of the factory key.
             constructors = [
                 (RingExtensionWithGen,
                  {'gen': extension_gen, 'names': names,
@@ -873,7 +881,7 @@ cdef class RingExtensionElement(CommutativeAlgebraElement):
             parent = RingExtension(backend_parent, parent,
                                    gens=(extension_gen,),
                                    names=names, constructors=constructors)
-        if all:
+        if all_roots:
             return [ parent(s) for s in sq ]
         return parent(sq)
 

--- a/src/sage/rings/ring_extension_element.pyx
+++ b/src/sage/rings/ring_extension_element.pyx
@@ -37,7 +37,7 @@ from sage.rings.ring_extension_conversion cimport backend_parent, backend_elemen
 from sage.rings.ring_extension_conversion cimport to_backend, from_backend
 
 
-def _inspect_keyword_parameters(method):
+def _inspect_keyword_parameters(method, skip_first=False):
     r"""
     Return the keyword parameters accepted by ``method``.
 
@@ -53,22 +53,55 @@ def _inspect_keyword_parameters(method):
     try:
         parameters = signature(method).parameters
     except (TypeError, ValueError):
-        return False, frozenset()
+        return None
+    parameters = tuple(parameters.items())
+    if skip_first and parameters:
+        parameters = parameters[1:]
     return (any(parameter.kind == Parameter.VAR_KEYWORD
-                for parameter in parameters.values()),
-            frozenset(name for name, parameter in parameters.items()
+                for _, parameter in parameters),
+            frozenset(name for name, parameter in parameters
                       if parameter.kind in (Parameter.POSITIONAL_OR_KEYWORD,
                                             Parameter.KEYWORD_ONLY)))
 
 
 @lru_cache(maxsize=256)
 def _cached_keyword_parameters(function):
-    r"""Return cached keyword parameters for a stable function object."""
-    return _inspect_keyword_parameters(function)
+    r"""
+    Return cached keyword parameters for a stable function object.
+
+    The first parameter of an unbound function is supplied by its bound
+    instance and is therefore not a forwarded keyword::
+
+        sage: from sage.rings.ring_extension_element import _cached_keyword_parameters
+        sage: class C:
+        ....:     def f(instance, *, name=None): pass
+        sage: _cached_keyword_parameters(C.f)
+        (False, frozenset({'name'}))
+    """
+    return _inspect_keyword_parameters(function, skip_first=True)
 
 
 def _keyword_parameters(method):
-    r"""Return keyword parameters, caching bound methods by function."""
+    r"""
+    Return keyword parameters, caching bound methods by function.
+
+    EXAMPLES::
+
+        sage: from sage.rings.ring_extension_element import _keyword_parameters
+        sage: class C:
+        ....:     def f(self, *, algorithm=None): pass
+        sage: _keyword_parameters(C().f)
+        (False, frozenset({'algorithm'}))
+
+    A callable whose signature cannot be inspected is reported explicitly,
+    so callers do not silently discard requested keywords::
+
+        sage: class D:
+        ....:     def f(self): pass
+        sage: D.f.__signature__ = 'invalid'
+        sage: _keyword_parameters(D().f) is None
+        True
+    """
     function = getattr(method, '__func__', None)
     if function is None:
         return _inspect_keyword_parameters(method)
@@ -726,6 +759,33 @@ cdef class RingExtensionElement(CommutativeAlgebraElement):
             ....:     assert len(roots) == 2
             ....:     assert all(r^2 == a for r in roots)
 
+        Different nonsquares use the same wrapped finite-field parent::
+
+            sage: F = GF(7**3, 'a')
+            sage: E = F.over()
+            sage: r = E(F(3)).sqrt(name='w')
+            sage: s = E(F(5)).sqrt(name='w')
+            sage: r.parent() is s.parent()
+            True
+            sage: (r + s).parent() is r.parent()
+            True
+            sage: r**2 == E(F(3)) and s**2 == E(F(5))
+            True
+            sage: rr, ss = loads(dumps((r, s)))
+            sage: rr.parent() is ss.parent() and (rr + ss).parent() is rr.parent()
+            True
+
+        The defining morphism of a polynomial quotient field is pickleable::
+
+            sage: R.<x> = GF(5)[]
+            sage: L.<b> = R.quotient(x**2 + 2)
+            sage: W = L.over()
+            sage: u = L.quadratic_nonresidue()
+            sage: r = W(u).sqrt(name='w')
+            sage: rr = loads(dumps(r))
+            sage: rr**2 == rr.parent()(W(u))
+            True
+
         Names are part of the reconstructed parent's factory data::
 
             sage: P = a.sqrt(name='wfresh').parent()
@@ -747,19 +807,39 @@ cdef class RingExtensionElement(CommutativeAlgebraElement):
         options = {'extend': extend, 'all': all}
         method = self._backend.sqrt
         if algorithm is not None or name is not None:
-            accepts_all, parameters = _keyword_parameters(method)
-            if (algorithm is not None
-                    and (accepts_all or 'algorithm' in parameters)):
-                options['algorithm'] = algorithm
-            if name is not None and (accepts_all or 'name' in parameters):
-                options['name'] = name
+            keyword_parameters = _keyword_parameters(method)
+            if keyword_parameters is None:
+                if algorithm is not None:
+                    options['algorithm'] = algorithm
+                if name is not None:
+                    options['name'] = name
+            else:
+                accepts_all, parameters = keyword_parameters
+                if (algorithm is not None
+                        and (accepts_all or 'algorithm' in parameters)):
+                    options['algorithm'] = algorithm
+                if name is not None and (accepts_all or 'name' in parameters):
+                    options['name'] = name
         sq = method(**options)
         return self._wrap_sqrt_output(sq, all, name)
 
     square_root = sqrt
 
     def _wrap_sqrt_output(self, sq, all, name):
-        r"""Wrap backend square roots as elements of a ring extension."""
+        r"""
+        Wrap backend square roots as elements of a ring extension.
+
+        EXAMPLES::
+
+            sage: K = GF(5).over()
+            sage: q = K(4)
+            sage: roots = q._wrap_sqrt_output([GF(5)(2), GF(5)(3)],
+            ....:                             True, None)
+            sage: roots == [K(2), K(3)] and all(root**2 == q for root in roots)
+            True
+            sage: q._wrap_sqrt_output([], True, None)
+            []
+        """
         if all:
             if not sq:
                 return []
@@ -774,12 +854,19 @@ cdef class RingExtensionElement(CommutativeAlgebraElement):
                 raise ValueError("you must specify a variable name")
             from sage.structure.category_object import normalize_names
             names = normalize_names(1, name)
+            from sage.categories.finite_fields import FiniteFields
+            if backend_parent in FiniteFields():
+                extension_gen = backend_parent.gen()
+            else:
+                extension_gen = gen
             constructors = [
                 (RingExtensionWithGen,
-                 {'gen': gen, 'names': names, 'is_backend_exposed': True}),
+                 {'gen': extension_gen, 'names': names,
+                  'is_backend_exposed': True}),
                 (RingExtension_generic, {'is_backend_exposed': True}),
             ]
-            parent = RingExtension(backend_parent, parent, gens=(gen,),
+            parent = RingExtension(backend_parent, parent,
+                                   gens=(extension_gen,),
                                    names=names, constructors=constructors)
         if all:
             return [ parent(s) for s in sq ]

--- a/src/sage/rings/ring_extension_element.pyx
+++ b/src/sage/rings/ring_extension_element.pyx
@@ -703,13 +703,13 @@ cdef class RingExtensionElement(CommutativeAlgebraElement):
             return is_sq, sq
         return is_sq
 
-    def sqrt(self, *, extend=True, all=False, algorithm=None, name=None):
+    def sqrt(self, *, extend=False, all=False, algorithm=None, name=None):
         r"""
         Return a square root or all square roots of this element.
 
         INPUT:
 
-        - ``extend`` -- boolean (default: ``True``); if ``True``, return a
+        - ``extend`` -- boolean (default: ``False``); if ``True``, return a
           square root in an extension ring, if necessary. Otherwise, raise a
           :exc:`ValueError` if the root is not in the ring.
 
@@ -743,15 +743,20 @@ cdef class RingExtensionElement(CommutativeAlgebraElement):
 
         A nonsquare has no roots in the unextended ring::
 
-            sage: a.sqrt(extend=False, all=True)
+            sage: a.sqrt(all=True)
             []
-            sage: a.square_root(extend=False, all=True)
+            sage: a.square_root(all=True)
             []
+            sage: a.sqrt()
+            Traceback (most recent call last):
+            ...
+            ValueError: element is not a square
 
         Both method names wrap roots from a backend quadratic extension::
 
             sage: for method in (a.sqrt, a.square_root):
-            ....:     root = method(name='w', algorithm='cipolla')
+            ....:     root = method(extend=True, name='w',
+            ....:                   algorithm='cipolla')
             ....:     assert root^2 == a
             ....:     assert root.parent().variable_names() == ('w',)
             ....:     roots = method(extend=True, all=True, name='w',
@@ -763,8 +768,8 @@ cdef class RingExtensionElement(CommutativeAlgebraElement):
 
             sage: F = GF(7**3, 'a')
             sage: E = F.over()
-            sage: r = E(F(3)).sqrt(name='w')
-            sage: s = E(F(5)).sqrt(name='w')
+            sage: r = E(F(3)).sqrt(extend=True, name='w')
+            sage: s = E(F(5)).sqrt(extend=True, name='w')
             sage: r.parent() is s.parent()
             True
             sage: (r + s).parent() is r.parent()
@@ -781,14 +786,14 @@ cdef class RingExtensionElement(CommutativeAlgebraElement):
             sage: L.<b> = R.quotient(x**2 + 2)
             sage: W = L.over()
             sage: u = L.quadratic_nonresidue()
-            sage: r = W(u).sqrt(name='w')
+            sage: r = W(u).sqrt(extend=True, name='w')
             sage: rr = loads(dumps(r))
             sage: rr**2 == rr.parent()(W(u))
             True
 
         Names are part of the reconstructed parent's factory data::
 
-            sage: P = a.sqrt(name='wfresh').parent()
+            sage: P = a.sqrt(extend=True, name='wfresh').parent()
             sage: factory, version, key, extra = P._factory_data
             sage: Q = factory.create_object(version, key, **extra)
             sage: Q.variable_names()

--- a/src/sage/schemes/elliptic_curves/isogeny_small_degree.py
+++ b/src/sage/schemes/elliptic_curves/isogeny_small_degree.py
@@ -1131,6 +1131,16 @@ def isogenies_7_0(E, minimal_models=True):
           from Elliptic Curve defined by y^2 = x^3 + 1 over Finite Field of size 101
             to Elliptic Curve defined by y^2 = x^3 + 55*x + 100 over Finite Field of size 101]
 
+    Finite fields implemented as polynomial quotients support the common
+    square-root keywords used here (:issue:`40796`)::
+
+        sage: R.<x> = GF(5)[]
+        sage: K.<a> = R.quotient(x^2 + 2)
+        sage: E = EllipticCurve(K, [0, 0, 0, 0, 1])
+        sage: isogenies = isogenies_7_0(E)
+        sage: len(isogenies), {phi.degree() for phi in isogenies}
+        (8, {7})
+
     Examples over a number field::
 
         sage: from sage.schemes.elliptic_curves.isogeny_small_degree import isogenies_7_0

--- a/src/sage/schemes/hyperelliptic_curves/hyperelliptic_generic.py
+++ b/src/sage/schemes/hyperelliptic_curves/hyperelliptic_generic.py
@@ -797,6 +797,22 @@ class HyperellipticCurve_generic(WeightedProjectiveCurve):
             sage: H = HyperellipticCurve(f, h)
             sage: H.lift_x(z4^3 + z4^2 + z4, all=True)
             [(z4^3 + z4^2 + z4 : z4^2 + z4 + 1 : 1), (z4^3 + z4^2 + z4 : z4^3 : 1)]
+
+        Check that finite fields implemented by polynomial quotients accept
+        the common square-root keywords (:issue:`40796`)::
+
+            sage: F = GF(5)
+            sage: R.<t> = F[]
+            sage: K.<a> = R.quotient(t^2 + 2)
+            sage: S.<x> = K[]
+            sage: H = HyperellipticCurve(x^5 + x + 1)
+            sage: H.lift_x(K(0), all=True)
+            [(0 : 1 : 1), (0 : 4 : 1)]
+            sage: H = HyperellipticCurve(x^5 + x + 1, S(1))
+            sage: H.lift_x(K(0), all=True)
+            [(0 : 2 : 1)]
+            sage: HyperellipticCurve(x^6 + 1).roots_at_infinity()
+            [1, 4]
         """
         from sage.structure.element import get_coercion_model
 


### PR DESCRIPTION
Closes #40796.

## What changed

- Give finite-ring and finite-field `sqrt` / `square_root` implementations the common keyword-only signature
  `(*, extend=False, all=False, algorithm=None, name=None)`.
- Make both names true aliases at every concrete dispatch layer, including IntegerMod, Givaro, NTL, PARI, polynomial-quotient finite fields, generic finite commutative rings, Cartesian products, and ring extensions. Defining the alias at each override prevents an inherited `square_root` from bypassing an optimized `sqrt`.
- Preserve the safe default: a nonsquare `x.sqrt()` raises `ValueError`; constructing a quadratic extension requires explicit `x.sqrt(extend=True)`. This avoids silently changing exception-driven control flow.
- Treat `algorithm` as a backend hint. Unsupported hints fall back to that backend's default.
- Return a `list` consistently for `all=True`, handle zero without duplicate roots, preserve roots in their original parent, and use the common error `ValueError: element is not a square`.
- Make generic finite-ring decompositions work for both scalar and `all=True` calls:
  - Cartesian products compute roots componentwise and stop as soon as one component has no root.
  - finite-field polynomial quotients split into primary components and recombine one or all roots with cached CRT bases;
  - linear primary components are evaluated directly in the base field instead of constructing dynamic degree-one quotient parents;
  - parents without a structural decomposition use a real iterator only when one is implemented.
- Return extension roots in a reusable genuine quadratic `FiniteField` whenever the source can be embedded in one. Different nonsquares share a parent and can be combined; the default extension name is the fixed PARI-safe name `sqrt_ext`.
- Cache the extension root of one fixed nonsquare. For built-in fields whose quadratic extension is not Givaro, any later nonsquare `a` is handled as `a/n` (a square in the source field) times the cached root of `n`. Givaro keeps its faster direct extension-field square root.
- Rebuild polynomial-quotient-field embeddings from generator images, so `RingExtension` parents retain a pickleable defining morphism.
- Preserve names stored in a `RingExtension` factory key when construction falls back to `RingExtension_generic`, without overwriting names chosen by specialized constructors.
- Fix the generic finite-field Cipolla path (zero handling, parent preservation, and final validation) and use standard Tonelli-Shanks with an explicit root-or-`None` internal contract.
- Use NTL native repeated squaring for characteristic-two square roots and add safe prime-modulus `IntegerMod.is_square()` fast paths.
- Avoid an extra `is_square()` exponentiation in the `FinitePolyExtElement` fallback and distinguish a genuine no-root result from unrelated backend `ValueError`s.
- Make `RingExtension` keyword introspection tri-state: known unsupported hints can fall back, while an uninspectable callable receives explicitly supplied keywords instead of silently losing them.
- Make private extension/wrapping helpers keyword-only and name their cardinality flag `all_roots`, avoiding positional booleans and shadowing Python's `all` builtin.
- Cover the downstream hyperelliptic and small-degree-isogeny failures that exposed the inconsistent interfaces.
- Show the selected root rather than hiding it behind a square check: the Givaro example now documents `F(2).square_root() == 3`. Root selection itself is not part of the API contract.

This intentionally removes the historical backend-specific positional optional arguments. It also standardizes the safer `extend=False` default and the `all=True` container to `list`.

## Root cause

Finite rings shared category-level square-root methods, but concrete backends exposed different parameters, orders, defaults, aliases, and return containers. Some concrete methods rejected category-supported keywords, while inherited aliases could bypass optimized overrides. Generic quotient-field elements consequently failed in consumers that correctly passed `extend=False`.

The generic finite-ring fallback initially put structural optimizations only under `all=True`; scalar calls still enumerated the full parent. The first review benchmark consequently found the paradoxical result that asking for one root could be thousands of times slower than asking for all roots. Extension parents were also built from each individual radicand, so roots of different nonsquares landed in incompatible polynomial-quotient parents.

## Performance

### Method

- Existing concrete-backend measurements compare against `c9c8381962ad` (`10.10.beta8`) using 11 paired AB/BA rounds.
- The review-regression suites compare `0ba8b73b536` with final commit `32f7f7243b6`. They use independent editable installations, CPU 2 affinity, `PYTHONHASHSEED=0`, AB/BA repeated three times (six samples per revision), and report median +/- MAD.
- Every timed worker validates roots, exceptions, parent type, and (where applicable) common-parent identity outside the timed region.
- Final raw JSON SHA-256 values are:
  - scalar/all-roots PQR: `7d9ea14b18ef84dbc644a5f9f551b3e825862944c941127eeac5407c1bdc6c89`;
  - worst-case nonsquare PQR: `5d9c37ee805b49b6502b7e0c1f8c0a25676879828459deee14839650938941a5`;
  - proper extensions: `545e423662eab68e9232d9e348c02c55982da4568900a59ad0c70b51bd5402bc`.

### Polynomial-quotient decompositions: regressions removed

The first version paid for constructing one dynamic degree-one quotient parent per linear factor. The final version represents such a component by the base field and evaluates there directly. It also defers integral-domain category queries until they are needed.

| Case | Phase | Before median +/- MAD | Final median +/- MAD | Result |
|---|---:|---:|---:|---:|
| easy square, scalar | cold | 945.630 us +/- 56.413 us | 656.372 us +/- 66.300 us | 1.44x faster |
| easy square, scalar | hot | 615.079 us +/- 5.040 us | 8.406 us +/- 0.224 us | 73.2x faster |
| nonsquare, scalar | cold | 6.432 s +/- 37.548 ms | 514.247 us +/- 30.032 us | 12,509x faster |
| nonsquare, scalar | hot | 6.536 s +/- 95.512 ms | 10.392 us +/- 0.204 us | 629,001x faster |
| square, `all=True` | hot | 164.267 us +/- 2.427 us | 34.617 us +/- 0.179 us | 4.75x faster |
| nonsquare, `all=True` | hot | 23.772 us +/- 0.815 us | 1.977 us +/- 0.034 us | 12.0x faster |

Thus the previously reported 4.2 ms cold regression and 7--17 us `all=True` hot regressions are gone; all measured PQR cases are now faster than the comparison revision.

### Cartesian decompositions

These paths were already improved before the final remediation and were unchanged by it.

| Case | Phase | Before | This PR | Result |
|---|---:|---:|---:|---:|
| square, scalar | hot | 13.748 ms | 4.966 us | 2,769x faster |
| nonsquare, scalar | hot | 58.455 ms | 4.535 us | 12,891x faster |
| `Zmod(256) x GF(1009) x GF(1013)` nonsquare | cold | >15 s (timeout) | 578.589 us | >25,925x faster |
| same large product | hot | not run | 3.786 us | n/a |
| same large product, `all=True` | hot | 15.824 us | 14.913 us | 1.06x faster |

### Proper shared extension parents

These measurements use explicit `extend=True`.

| Case | Phase | Before median +/- MAD | Final median +/- MAD | Result |
|---|---:|---:|---:|---:|
| one nonsquare | cold | 17.723 ms +/- 0.683 ms | 27.792 ms +/- 0.708 ms | +10.1 ms once |
| one nonsquare | hot | 24.110 us +/- 0.219 us | 1.027 us +/- 0.023 us | 23.5x faster |
| two different nonsquares | cold | 17.621 ms +/- 0.129 ms | 27.074 ms +/- 0.454 ms | +9.45 ms once |
| two different nonsquares | hot | 51.063 us +/- 0.899 us | 16.315 us +/- 0.045 us | 3.13x faster |

The old result parents are polynomial quotient rings tied to each radicand (`proper finite field = false`, `common parent = false`). The final results are a genuine common `FiniteField` (`proper = true`, `common = true`) with a multiplicative generator. The remaining cold difference is the one-time construction of `GF(q^2)` and its source embedding; removing it would reintroduce the incompatible low-quality parents. The cached fixed-nonsquare root eliminates the former hot regression.

### Existing finite-field backends

| Case | Baseline | This PR | Result |
|---|---:|---:|---:|
| Givaro `sqrt()` | 59.818 ns | 65.292 ns | +5.47 ns / 1.089x |
| Givaro `sqrt(all=True)` | 336.881 ns | 150.081 ns | 2.25x faster |
| IntegerMod_int `sqrt()` | 558.902 ns | 560.695 ns | unchanged |
| GMP IntegerMod `sqrt()` | 7.916 us | 7.221 us | 1.10x faster |
| generic finite-field category `sqrt()` | 1.849 ms | 0.378 ms | 4.89x faster |
| PARI `sqrt()` | ratio 1.000 | ratio 0.994 | unchanged |

The NTL characteristic-two path is faster by 2.07x (degree 16), 5.55x (64), 9.58x (127), 7.96x (256), and 4.34x (512).

The only remaining measured no-argument regression is Givaro's fixed keyword-only call parsing, +5.47 ns. A same-build `% 2`/`// 2` versus bit-operation experiment produced 89.83 versus 89.65 ns, below the run MAD, so that speculative change was reverted. Eliminating this cost would require giving up the uniform public signature; the materially used `all=True` path is 2.25x faster.

The directly invoked `FinitePolyExtElement` fallback and `RingExtension` option-dispatch paths remain neutral within about 2--3%.

## Validation

- 4,727 long doctests across the 14 affected and downstream modules.
- 3,835 long doctests for the complete `src/sage/rings/finite_rings` directory.
- 100% Sage doctest coverage for the modified category and RingExtension helper methods (`finite_fields.py`, `commutative_rings.py`, `ring_extension.pyx`, and `ring_extension_element.pyx`).
- Exhaustive post-optimization checks for small mixed linear/primary polynomial quotients, plus prime, Givaro, PARI, NTL, and polynomial-quotient extension paths.
- Fresh-process pickle/unpickle checks for polynomial-quotient-field `RingExtension` parents, roots, defining morphisms, shared-parent identity, and arithmetic.
- Hyperelliptic `lift_x`, roots at infinity, and `isogenies_7_0` regression cases.
- `ruff check src/sage/categories/finite_fields.py`, Sage coverage checks, and `git diff --check`.

Representative commands:

```text
./sage -t --long -p 4 src/sage/rings/finite_rings
./sage -t --long -p 4 \
    src/sage/categories/commutative_rings.py \
    src/sage/categories/finite_fields.py \
    src/sage/rings/finite_rings/element_base.pyx \
    src/sage/rings/finite_rings/element_givaro.pyx \
    src/sage/rings/finite_rings/element_ntl_gf2e.pyx \
    src/sage/rings/finite_rings/element_pari_ffelt.pyx \
    src/sage/rings/finite_rings/integer_mod.pyx \
    src/sage/rings/finite_rings/integer_mod_ring.py \
    src/sage/rings/polynomial/polynomial_quotient_ring.py \
    src/sage/rings/polynomial/polynomial_quotient_ring_element.py \
    src/sage/rings/ring_extension.pyx \
    src/sage/rings/ring_extension_element.pyx \
    src/sage/schemes/elliptic_curves/isogeny_small_degree.py \
    src/sage/schemes/hyperelliptic_curves/hyperelliptic_generic.py
```

## Notes

- `all=True` does not promise root ordering; decomposition paths may return a different valid order from full-parent enumeration.
- A single primary polynomial-quotient component, or a finite non-domain without a safe decomposition interface, retains the correct enumeration fallback.
- Named absolute finite-field extensions register the source embedding at runtime. Bare roots and their common parent pickle correctly, but a fresh process does not reconstruct an arbitrary source-to-extension coercion; this is an existing limitation of `FiniteField.extension(..., map=True)`. `RingExtension` wrappers store a pickleable defining morphism and preserve their base coercion across a fresh-process round trip.
