### PR TITLE
Fix dependency tracking for lazy derivative streams

### DIFF
--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -1729,9 +1729,18 @@ class Stream_uninitialized(Stream):
             Currently, the first invocation is via
             :meth:`_good_cache` in :meth:`__getitem__`.
 
-        EXAMPLES::
+        EXAMPLES:
 
-            sage: from sage.data_structures.stream import Stream_uninitialized, Stream_exact, Stream_cauchy_mul, Stream_add, Stream_sub
+        A cache-less shifted stream does not hide the cached stream on which it depends::
+
+            sage: from sage.data_structures.stream import Stream_uninitialized, Stream_exact, Stream_cauchy_mul, Stream_add, Stream_sub, Stream_map_coefficients, Stream_shift
+            sage: C = Stream_uninitialized(0)
+            sage: M = Stream_map_coefficients(C, lambda c: c, True)
+            sage: S = Stream_shift(M, -1)
+            sage: C.define(S)
+            sage: C._input_streams == [C, M]
+            True
+
             sage: terms_of_degree = lambda n, R: [R.one()]
             sage: x = Stream_exact([1], order=1)
             sage: C = Stream_uninitialized(1)
@@ -1745,12 +1754,16 @@ class Stream_uninitialized(Stream):
              <sage.data_structures.stream.Stream_cauchy_mul object at 0x...>]
         """
         known = [self]
+        visited = [self]
         todo = [self]
         while todo:
             x = todo.pop()
             for y in x.input_streams():
-                if hasattr(y, "_cache") and not any(y is z for z in known):
-                    todo.append(y)
+                if any(y is z for z in visited):
+                    continue
+                visited.append(y)
+                todo.append(y)
+                if hasattr(y, "_cache"):
                     known.append(y)
         return known
 
@@ -4556,6 +4569,20 @@ class Stream_shift(Stream):
         self._series = series
         self._shift = shift
         super().__init__(series._true_order)
+
+    def input_streams(self):
+        r"""
+        Return the input stream of ``self``.
+
+        EXAMPLES::
+
+            sage: from sage.data_structures.stream import Stream_function, Stream_shift
+            sage: f = Stream_function(lambda n: n, True, 0)
+            sage: s = Stream_shift(f, -1)
+            sage: s.input_streams()[0] is f
+            True
+        """
+        return [self._series]
 
     @lazy_attribute
     def _approximate_order(self):

--- a/src/sage/rings/lazy_species.py
+++ b/src/sage/rings/lazy_species.py
@@ -79,7 +79,9 @@ from sage.rings.species import (_label_sets,
 from sage.data_structures.stream import (Stream_zero,
                                          Stream_exact,
                                          Stream_truncated,
-                                         Stream_function)
+                                         Stream_function,
+                                         Stream_map_coefficients,
+                                         Stream_shift)
 from sage.categories.tensor import tensor
 from sage.combinat.integer_vector import IntegerVectors
 from sage.combinat.subset import subsets
@@ -1953,19 +1955,29 @@ class DerivativeSpeciesElement(LazyCombinatorialSpeciesElement):
             sage: D[3] == (2*X*E2 + X^3)[3]
             True
             sage: TestSuite(D).run(skip=['_test_category', '_test_pickling'])
+
+        A derivative of an undefined species retains the dependency on its
+        coefficient stream::
+
+            sage: A = L.undefined()
+            sage: dA = A.derivative()
+            sage: M = dA._coeff_stream.input_streams()[0]
+            sage: M.input_streams()[0] is A._coeff_stream
+            True
         """
         if F.parent()._arity != 1:
             raise NotImplementedError("derivative is not yet implemented for multisort species")
 
         self._F = F
 
-        coeff_stream = Stream_function(
-            lambda n: F[n + 1].derivative(),
-            F.parent()._sparse,
-            max(F._coeff_stream._approximate_order - 1, 0),
+        P = F.parent()
+        coeff_stream = Stream_map_coefficients(
+            F._coeff_stream,
+            lambda c: c.derivative(),
+            P._sparse,
         )
-        super().__init__(F.parent(), coeff_stream)
-
+        coeff_stream = Stream_shift(coeff_stream, -1)
+        super().__init__(P, coeff_stream)
     def generating_series(self):
         r"""
         Return the exponential generating series of ``self``.


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Current lazy derivative implementation works but does not expose dependency correctly to lazy streams. 

On current develop the following fails:

```
sage: p = SymmetricFunctions(QQ).p() 
sage: S = LazySymmetricFunctions(p) 
sage: A = S.undefined(1) 
sage: B = S.undefined(0) 
sage: dA = A.derivative_with_respect_to_p1() 
sage: S.define_implicitly([A, B], [A - p[1] - p[1]*A, B - dA]) 
sage: [B[n] for n in range(3)] 
[p[], 2*p[1], 3*p[1, 1]] 
sage: [dA[n] for n in range(3)]
```

The last line fails because the dependency of dA on A is not visible to the implicit solver.

This PR adds Stream_shifted_map_coefficients which is essentially Stream_map_coefficents with a shift parameter. It is then used in both derivative implementations to track stream dependencies and fix the error.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x ] The title is concise and informative.
- [x ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->