### PR TITLE
Implement the second MRRW asymptotic bound

### DIFF
--- a/src/doc/en/reference/references/index.rst
+++ b/src/doc/en/reference/references/index.rst
@@ -5531,6 +5531,12 @@ REFERENCES:
              Volume 34, Issue 3, May 1983, Pages 340--359.
              :doi:`10.1016/0097-3165(83)90068-7`
 
+.. [MRRW1977] \R. J. McEliece, \E. R. Rodemich, \H. Rumsey, Jr.,
+              \L. R. Welch, *New Upper Bounds on the Rate of a Code via the
+              Delsarte-MacWilliams Inequalities*, IEEE Transactions on
+              Information Theory **23** (1977), no. 2, 157--166.
+              :doi:`10.1109/TIT.1977.1055688`
+
 .. [MR2016] \B. Malmskog, C. Rasmussen, *Picard curves over Q
             with good reduction away from 3*. LMS Journal of Computation and
             Mathematics 19 (2016), no. 2, 382-408.

--- a/src/sage/coding/bounds_catalog.py
+++ b/src/sage/coding/bounds_catalog.py
@@ -27,7 +27,8 @@ _lazy_import("sage.coding.code_bounds", ["codesize_upper_bound",
             "singleton_bound_asymp",
             "plotkin_bound_asymp",
             "elias_bound_asymp",
-            "mrrw1_bound_asymp"])
+            "mrrw1_bound_asymp",
+            "mrrw2_bound_asymp"])
 
 _lazy_import("sage.coding.delsarte_bounds",
             ["krawtchouk",

--- a/src/sage/coding/code_bounds.py
+++ b/src/sage/coding/code_bounds.py
@@ -163,7 +163,7 @@ PROBLEM: In this module we shall typically either (a) seek bounds on `k`, given
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from math import log1p
+from math import exp, log1p
 
 from sage.misc.lazy_import import lazy_import
 from sage.rings.real_double import RDF
@@ -797,15 +797,23 @@ def mrrw2_bound_asymp(delta, q):
 
         sage: codes.bounds.mrrw2_bound_asymp(0, 2)
         1.0
+        sage: codes.bounds.mrrw2_bound_asymp(2^-60, 2)
+        1.0
         sage: codes.bounds.mrrw2_bound_asymp(1/2, 2)
         0.0
 
     Values below the upper endpoint retain their numerical accuracy::
 
-        sage: codes.bounds.mrrw2_bound_asymp(RDF('0.499999994'), 2)  # abs tol 1e-27    # needs scipy
+        sage: # needs scipy
+        sage: codes.bounds.mrrw2_bound_asymp(RDF('0.499999994'), 2)  # abs tol 1e-27
         2.018429124836941e-15
-        sage: codes.bounds.mrrw2_bound_asymp(1/2 - 2^-100, 2)  # abs tol 1e-70          # needs scipy
+        sage: codes.bounds.mrrw2_bound_asymp(1/2 - 2^-100, 2)  # abs tol 1e-70
         1.2535809688529749e-58
+        sage: codes.bounds.mrrw2_bound_asymp(1/2 - 2^-538, 2) > 0
+        True
+        sage: all(codes.bounds.mrrw2_bound_asymp(1/2 - 2^-n, 2) > 0
+        ....:     for n in range(539, 543))
+        True
 
     The second bound is only known for binary codes::
 
@@ -841,17 +849,31 @@ def mrrw2_bound_asymp(delta, q):
     if twice_delta == 1:
         return RDF(0)
     upper = RDF(1 - twice_delta)
+    if upper == 1:
+        return RDF(1)
     log_two = RDF.log2()
+    smallest_normal = RDF(2)**-1022
 
     def binary_entropy(p):
         if p == 0:
             return RDF(0)
         return RDF((-p*log(p) + (p - 1)*log1p(-p)) / log_two)
 
-    def g(x):
+    def binary_entropy_from_log_p(log_p):
+        # H_2(p) = p*(1 - log(p))/log(2) + O(p^2), and the error is below
+        # the range of RDF here.
+        log_entropy = log_p + log(1 - log_p) - log(log_two)
+        return RDF(exp(log_entropy))
+
+    def g(x, log_x=None):
         x = RDF(x)
         s = sqrt(1 - x)
-        return binary_entropy(x / (2 * (1 + s)))
+        p = x / (2 * (1 + s))
+        if p < smallest_normal and (x != 0 or log_x is not None):
+            if log_x is None:
+                log_x = log(x)
+            return binary_entropy_from_log_p(log_x - 2*log_two)
+        return binary_entropy(p)
 
     def one_minus_g(y):
         y = RDF(y)
@@ -876,5 +898,5 @@ def mrrw2_bound_asymp(delta, q):
                              options={'xatol': 1e-12})
     if not result.success:
         raise RuntimeError("unable to minimize the second MRRW bound")
-    upper_value = g(upper**2)
+    upper_value = g(upper**2, 2*log(upper))
     return RDF(min(objective(0), result.fun, upper_value))

--- a/src/sage/coding/code_bounds.py
+++ b/src/sage/coding/code_bounds.py
@@ -783,12 +783,22 @@ def mrrw2_bound_asymp(delta, q):
         sage: codes.bounds.mrrw2_bound_asymp(1/10, 2)  # abs tol 1e-12                  # needs scipy
         0.692740743078879
 
+    At ``delta=0.3``, the right endpoint supplies the minimum::
+
+        sage: codes.bounds.mrrw2_bound_asymp(RDF('0.3'), 2)  # abs tol 1e-12             # needs scipy
+        0.2502249116110706
+
     At the endpoints the asymptotic bound is one and zero, respectively::
 
         sage: codes.bounds.mrrw2_bound_asymp(0, 2)
         1.0
         sage: codes.bounds.mrrw2_bound_asymp(1/2, 2)
         0.0
+
+    Values below the upper endpoint remain positive::
+
+        sage: codes.bounds.mrrw2_bound_asymp(RDF('0.499999994'), 2) > 0                 # needs scipy
+        True
 
     The second bound is only known for binary codes::
 
@@ -821,10 +831,14 @@ def mrrw2_bound_asymp(delta, q):
         return RDF(0)
 
     def g(x):
-        return RDF(entropy((1 - sqrt(1 - x)) / 2, 2))
+        x = RDF(x)
+        s = sqrt(1 - x)
+        return RDF(entropy(x / (2 * (1 + s)), 2))
 
     def objective(u):
-        return 1 + g(u**2) - g(u**2 + 2*delta*u + 2*delta)
+        a = u**2
+        b = a + 2*delta*u + 2*delta
+        return g(a) + (1 - g(b))
 
     from scipy.optimize import minimize_scalar
     upper = 1 - 2*delta
@@ -832,6 +846,5 @@ def mrrw2_bound_asymp(delta, q):
                              options={'xatol': 1e-12})
     if not result.success:
         raise RuntimeError("unable to minimize the second MRRW bound")
-    # At the upper endpoint the expression is the first MRRW bound.
-    upper_value = mrrw1_bound_asymp(delta, 2)
+    upper_value = g(upper**2)
     return RDF(min(objective(0), result.fun, upper_value))

--- a/src/sage/coding/code_bounds.py
+++ b/src/sage/coding/code_bounds.py
@@ -163,16 +163,21 @@ PROBLEM: In this module we shall typically either (a) seek bounds on `k`, given
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
-from sage.arith.misc import binomial, is_prime_power
-from sage.features.gap import GapPackage
-from sage.misc.functional import sqrt, log
+from math import log1p
+
 from sage.misc.lazy_import import lazy_import
-from sage.rings.integer_ring import ZZ
-from sage.rings.rational_field import QQ
 from sage.rings.real_double import RDF
 
-from .delsarte_bounds import (delsarte_bound_hamming_space,
-                              delsarte_bound_additive_hamming_space)
+from sage.arith.misc import binomial, is_prime_power
+from sage.features.gap import GapPackage
+from sage.misc.functional import log, sqrt
+from sage.rings.integer_ring import ZZ
+from sage.rings.rational_field import QQ
+
+from .delsarte_bounds import (
+    delsarte_bound_additive_hamming_space,
+    delsarte_bound_hamming_space,
+)
 
 lazy_import('sage.libs.gap.libgap', 'libgap')
 
@@ -795,10 +800,12 @@ def mrrw2_bound_asymp(delta, q):
         sage: codes.bounds.mrrw2_bound_asymp(1/2, 2)
         0.0
 
-    Values below the upper endpoint remain positive::
+    Values below the upper endpoint retain their numerical accuracy::
 
-        sage: codes.bounds.mrrw2_bound_asymp(RDF('0.499999994'), 2) > 0                 # needs scipy
-        True
+        sage: codes.bounds.mrrw2_bound_asymp(RDF('0.499999994'), 2)  # abs tol 1e-27    # needs scipy
+        2.018429124836941e-15
+        sage: codes.bounds.mrrw2_bound_asymp(1/2 - 2^-100, 2)  # abs tol 1e-70          # needs scipy
+        1.2535809688529749e-58
 
     The second bound is only known for binary codes::
 
@@ -817,31 +824,54 @@ def mrrw2_bound_asymp(delta, q):
         Traceback (most recent call last):
         ...
         ValueError: the relative minimum distance must be between 0 and 1/2
+        sage: codes.bounds.mrrw2_bound_asymp(1/2 + 2^-100, 2)
+        Traceback (most recent call last):
+        ...
+        ValueError: the relative minimum distance must be between 0 and 1/2
     """
     if q != 2:
         raise NotImplementedError("the second MRRW bound is only implemented "
                                   "for binary codes")
-    delta = RDF(delta)
-    if delta < 0 or delta > 0.5:
+    twice_delta = 2*delta
+    if twice_delta < 0 or twice_delta > 1:
         raise ValueError("the relative minimum distance must be between 0 "
                          "and 1/2")
-    if delta == 0:
+    if twice_delta == 0:
         return RDF(1)
-    if delta == 0.5:
+    if twice_delta == 1:
         return RDF(0)
+    upper = RDF(1 - twice_delta)
+    log_two = RDF.log2()
+
+    def binary_entropy(p):
+        if p == 0:
+            return RDF(0)
+        return RDF((-p*log(p) + (p - 1)*log1p(-p)) / log_two)
 
     def g(x):
         x = RDF(x)
         s = sqrt(1 - x)
-        return RDF(entropy(x / (2 * (1 + s)), 2))
+        return binary_entropy(x / (2 * (1 + s)))
+
+    def one_minus_g(y):
+        y = RDF(y)
+        if y == 0:
+            return RDF(0)
+        if y == 1:
+            return RDF(1)
+        t = sqrt(y)
+        if y < 0.5:
+            value = log1p(-y) + t*(log1p(t) - log1p(-t))
+        else:
+            value = (1 - t)*log1p(-t) + (1 + t)*log1p(t)
+        return RDF(value / (2*log_two))
 
     def objective(u):
         a = u**2
-        b = a + 2*delta*u + 2*delta
-        return g(a) + (1 - g(b))
+        y = (1 + u) * (upper - u)
+        return g(a) + one_minus_g(y)
 
     from scipy.optimize import minimize_scalar
-    upper = 1 - 2*delta
     result = minimize_scalar(objective, bounds=(0, upper), method='bounded',
                              options={'xatol': 1e-12})
     if not result.success:

--- a/src/sage/coding/code_bounds.py
+++ b/src/sage/coding/code_bounds.py
@@ -18,6 +18,8 @@ AUTHORS:
 
 - Dima Pasechnik (2012-10): added LP bounds.
 
+- Devansh Sehgal (2026-08-07): implemented the second MRRW asymptotic bound.
+
 Let `F` be a finite set of size `q`.
 A subset `C` of `V=F^n` is called a code of length `n`.
 Often one considers the case where `F` is a finite field,
@@ -136,6 +138,10 @@ This module implements:
 - ``mrrw1_bound_asymp(delta,q)``, "first" asymptotic
   McEliese-Rumsey-Rodemich-Welsh bound for the information rate.
 
+- ``mrrw2_bound_asymp(delta,q)``, "second" asymptotic
+  McEliece-Rodemich-Rumsey-Welch bound for the information rate of binary
+  codes.
+
 -  Delsarte (a.k.a. Linear Programming (LP)) upper bounds.
 
 PROBLEM: In this module we shall typically either (a) seek bounds on `k`, given
@@ -146,8 +152,6 @@ PROBLEM: In this module we shall typically either (a) seek bounds on `k`, given
 
     - Johnson bounds for binary codes.
 
-    - mrrw2_bound_asymp(delta,q), "second" asymptotic
-      McEliese-Rumsey-Rodemich-Welsh bound for the information rate.
 """
 
 # ****************************************************************************
@@ -738,3 +742,96 @@ def mrrw1_bound_asymp(delta, q):
         0.3545789026652697
     """
     return RDF(entropy((q-1-delta*(q-2)-2*sqrt((q-1)*delta*(1-delta)))/q, q))
+
+
+def mrrw2_bound_asymp(delta, q):
+    r"""
+    Return the second asymptotic McEliece-Rodemich-Rumsey-Welch bound.
+
+    This is an upper bound for the information rate of a binary code with
+    relative minimum distance ``delta``. It is defined by
+
+    .. MATH::
+
+        \min_{0 \leq u \leq 1 - 2\delta}
+        \left(1 + g(u^2) - g(u^2 + 2\delta u + 2\delta)\right),
+
+    where
+
+    .. MATH::
+
+        g(x) = H_2\left(\frac{1 - \sqrt{1-x}}{2}\right).
+
+    The returned :class:`~sage.rings.real_double.RealDoubleElement` is a
+    numerical approximation obtained with SciPy's bounded scalar minimizer
+    and an explicit comparison with both endpoints.
+
+    INPUT:
+
+    - ``delta`` -- real number in `[0, 1/2]`; the relative minimum distance
+
+    - ``q`` -- integer equal to `2`; the alphabet size
+
+    REFERENCES:
+
+    - [MRRW1977]_
+
+    EXAMPLES::
+
+        sage: codes.bounds.mrrw2_bound_asymp(1/5, 2)  # abs tol 1e-12                   # needs scipy
+        0.461359603763518
+        sage: codes.bounds.mrrw2_bound_asymp(1/10, 2)  # abs tol 1e-12                  # needs scipy
+        0.692740743078879
+
+    At the endpoints the asymptotic bound is one and zero, respectively::
+
+        sage: codes.bounds.mrrw2_bound_asymp(0, 2)
+        1.0
+        sage: codes.bounds.mrrw2_bound_asymp(1/2, 2)
+        0.0
+
+    The second bound is only known for binary codes::
+
+        sage: codes.bounds.mrrw2_bound_asymp(1/5, 3)
+        Traceback (most recent call last):
+        ...
+        NotImplementedError: the second MRRW bound is only implemented for binary codes
+
+    Relative minimum distances outside the binary range are rejected::
+
+        sage: codes.bounds.mrrw2_bound_asymp(-1/10, 2)
+        Traceback (most recent call last):
+        ...
+        ValueError: the relative minimum distance must be between 0 and 1/2
+        sage: codes.bounds.mrrw2_bound_asymp(3/5, 2)
+        Traceback (most recent call last):
+        ...
+        ValueError: the relative minimum distance must be between 0 and 1/2
+    """
+    if q != 2:
+        raise NotImplementedError("the second MRRW bound is only implemented "
+                                  "for binary codes")
+    delta = RDF(delta)
+    if delta < 0 or delta > 0.5:
+        raise ValueError("the relative minimum distance must be between 0 "
+                         "and 1/2")
+    if delta == 0:
+        return RDF(1)
+    if delta == 0.5:
+        return RDF(0)
+
+    def g(x):
+        return RDF(entropy((1 - sqrt(1 - x)) / 2, 2))
+
+    def objective(u):
+        return 1 + g(u**2) - g(u**2 + 2*delta*u + 2*delta)
+
+    from scipy.optimize import minimize_scalar
+    upper = 1 - 2*delta
+    result = minimize_scalar(objective, bounds=(0, upper), method='bounded',
+                             options={'xatol': 1e-12})
+    if not result.success:
+        raise RuntimeError("unable to minimize the second MRRW bound")
+    # At the upper endpoint the expression is the first MRRW bound.
+    upper_value = mrrw1_bound_asymp(delta, 2)
+    return RDF(min(objective(0), result.fun, upper_value))


### PR DESCRIPTION
This implements the existing `mrrw2_bound_asymp(delta, q)` TODO for the binary second McEliece–Rodemich–Rumsey–Welch asymptotic bound from equation (1.4) of the original 1977 paper.

The new public `codes.bounds.mrrw2_bound_asymp` function:

- evaluates the one-dimensional formula numerically with SciPy's bounded scalar minimizer and explicit endpoint comparison;
- uses cancellation-resistant forms for the entropy argument, objective, and right endpoint near `delta=1/2`;
- returns exact continuous endpoint values at `delta=0` and `delta=1/2`;
- rejects relative distances outside `[0, 1/2]`;
- raises `NotImplementedError` for unsupported nonbinary alphabets; and
- is exported from the coding-bounds catalog and documented with the original-paper reference.

The `delta=0.2` example agrees with Table I of the paper (`0.461359603763518` before rounding). Regression examples also cover a right-endpoint minimum at `delta=0.3` and ensure a valid distance just below `1/2` retains its tiny positive value.

Fixes #42639.

### Validation

- `code_bounds.py` doctests: 59/59
- `bounds_catalog.py` doctests: 1/1
- `sage -coverage`: 100% (20/20 functions)
- Locked CI Ruff 0.14.13, with and without preview: passed
- `git diff --check`: passed

The reference inventory and edited coding HTML were generated in the official Sage 10.9 image. A standalone full-manual run could not resolve the image's bibliography inventory (including baseline citations), so the draft-PR documentation workflow remains the full integration check.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains the problem and implementation.
- [x] Linked the design issue.
- [x] Added doctests covering the change.
- [x] Updated the public documentation and bibliography.

### :hourglass: Dependencies

None.
