### PR TITLE
Fix typo in class documentation for CrystalElementShiftedPrimedTableau

### DIFF
--- a/src/sage/combinat/shifted_primed_tableau.py
+++ b/src/sage/combinat/shifted_primed_tableau.py
@@ -842,7 +842,7 @@ class ShiftedPrimedTableau(ClonableArray,
 
 class CrystalElementShiftedPrimedTableau(ShiftedPrimedTableau):
     """
-    Class for elements of ``crystals.ShiftedPrimedTableau``.
+    Class for elements of ``crystals.ShiftedPrimedTableaux``.
     """
 
     def _to_matrix(self):


### PR DESCRIPTION
Perhaps a sphinx role could also be added, but I don't know the right syntax.  Note that `crystals.ShiftedPrimedTableaux` is just `ShiftedPrimedTableaux_shape`, the point of the doc is to make clear that it can be accessed via the crystals catalogue.