### PR TITLE
gh-38543: Fix norm() of IntegralLattice vectors to respect inner prod…

### DIFF
--- a/src/sage/modules/free_module_element.pyx
+++ b/src/sage/modules/free_module_element.pyx
@@ -1835,12 +1835,35 @@ cdef class FreeModuleElement(Vector):   # abstract base class
             sage: v = vector(QQ, [1,2])
             sage: v.norm(int(2))                                                        # needs sage.symbolic
             sqrt(5)
+
+        For vectors in an :class:`~sage.modules.free_quadratic_module_integer_symmetric.FreeQuadraticModule_integer_symmetric`
+        (e.g. an :func:`~sage.modules.free_quadratic_module_integer_symmetric.IntegralLattice`),
+        the 2-norm uses the lattice inner product, so ``norm()^2 == inner_product(v, v)``
+        (see :issue:`38543`)::
+
+            sage: from sage.modules.free_quadratic_module_integer_symmetric import IntegralLattice
+            sage: L = IntegralLattice(matrix([[1000, 0], [0, 1]]))
+            sage: v = L.0
+            sage: v.inner_product(v)
+            1000
+            sage: v.norm()^2
+            1000
+            sage: v.norm()^2 == v.inner_product(v)
+            True
         """
         abs_self = [abs(x) for x in self]
         if p == Infinity:
             return max(abs_self)
         if p < 1:
             raise ValueError("%s is not greater than or equal to 1" % p)
+
+        if p == 2:
+            # For IntegralLattice vectors, use the lattice inner product so that
+            # norm()^2 == inner_product(self, self). See :issue:`38543`.
+            from sage.modules.free_quadratic_module_integer_symmetric import (
+                FreeQuadraticModule_integer_symmetric)
+            if isinstance(self.parent(), FreeQuadraticModule_integer_symmetric):
+                return self.inner_product(self).sqrt()
 
         s = sum(a ** p for a in abs_self)
         return s**(__one__/p)

--- a/src/sage/modules/free_quadratic_module_integer_symmetric.py
+++ b/src/sage/modules/free_quadratic_module_integer_symmetric.py
@@ -643,6 +643,65 @@ class FreeQuadraticModule_integer_symmetric(FreeQuadraticModule_submodule_with_b
         [0 1]
         [1 0]
     """
+    class Element(FreeQuadraticModule_submodule_with_basis_pid.Element):
+        r"""
+        An element of an integral lattice (i.e. a vector in a
+        :class:`FreeQuadraticModule_integer_symmetric`).
+        """
+
+        def norm(self, p=2):
+            r"""
+            Return the `p`-norm of ``self``.
+
+            For `p = 2`, the norm is computed using the inner product matrix
+            of the parent lattice, so that ``norm()^2 == inner_product(self,
+            self)`` consistently (see :issue:`38543`).
+
+            For all other values of `p`, the standard `\ell^p` norm is used.
+
+            INPUT:
+
+            - ``p`` -- (default: 2) the norm parameter, as in
+              :meth:`~sage.modules.free_module_element.FreeModuleElement.norm`
+
+            EXAMPLES:
+
+            The 2-norm of a lattice vector respects the lattice inner product
+            matrix, so ``norm()^2 == inner_product(v, v)``::
+
+                sage: L = IntegralLattice(matrix([[1000, 0], [0, 1]]))
+                sage: v = L.0
+                sage: v.inner_product(v)
+                1000
+                sage: v.norm()^2
+                1000
+                sage: v.norm()^2 == v.inner_product(v)
+                True
+
+            The standard `\ell^1` norm is still the sum of absolute values::
+
+                sage: L = IntegralLattice(matrix([[2, 0], [0, 3]]))
+                sage: v = L([1, 2])
+                sage: v.norm(1)
+                3
+
+            TESTS:
+
+            Regression test for :issue:`38543`: before the fix, ``norm()^2``
+            used the plain Euclidean norm and disagreed with
+            ``inner_product(v, v)``::
+
+                sage: L = IntegralLattice(matrix([[1000, 0], [0, 1]]))
+                sage: v = L.0
+                sage: v.norm()^2 == v.inner_product(v)
+                True
+                sage: v.norm()^2
+                1000
+            """
+            if p == 2:
+                return self.inner_product(self).sqrt()
+            return super().norm(p)
+
     def __init__(self, ambient, basis, inner_product_matrix,
                  check=True, already_echelonized=False):
         r"""


### PR DESCRIPTION
The `.norm()` method on free module vectors was always computing the standard
Euclidean norm, even when the parent module had a non-trivial inner product
matrix. This caused a confusing inconsistency for `IntegralLattice` vectors
where `.norm()` and `.inner_product()` gave contradictory results.

### What problem does this solve?

```python
sage: L = IntegralLattice(matrix([[1000, 0], [0, 1]]))
sage: v = L.0
sage: v.norm()^2        # returned 1  ← WRONG (plain Euclidean dot product)
sage: v.inner_product(v)  # returned 1000 ← CORRECT (uses inner product matrix)