### PR TITLE
gh-41911: reuse cached group-order factorizations in nth_root

### DIFF
--- a/src/sage/rings/finite_rings/element_base.pyx
+++ b/src/sage/rings/finite_rings/element_base.pyx
@@ -55,19 +55,59 @@ cdef class FiniteRingElement(CommutativeRingElement):
         Test very large modulus (assumed impossible to factor in reasonable time)::
 
             sage: p = 2^1024 + 643
-            sage: a = GF(p, proof=False)(3)**(29*283*3539)
+            sage: K = GF(p, proof=False)
+            sage: K.factored_unit_order.is_in_cache()
+            False
+            sage: a = K(3)**(29*283*3539)
             sage: r = a._nth_root_common(29*283*3539*12345, False, "Johnston", False)
             sage: r**(29*283*3539*12345) == a
+            True
+            sage: K.factored_unit_order.is_in_cache()
+            False
+
+        A cached factorization of the unit group order avoids factoring ``n``.
+        Here ``n`` is a product of two primes of about 192 bits each::
+
+            sage: from sage.structure.factorization import Factorization
+            sage: r = 3138550867693340381917894711603833208051177722232017256453
+            sage: s = 12554203470773361527671578846415332832204710888928069025857
+            sage: q = 70*r*s + 1
+            sage: K = GF(q, proof=False)
+            sage: F = Factorization([(2, 1), (5, 1), (7, 1), (r, 1), (s, 1)])
+            sage: K.factored_unit_order.set_cache((F,))
+            sage: n = 2*r*s
+            sage: a = K(3)^n
+            sage: from unittest.mock import patch
+            sage: with patch('sage.rings.factorint_pari.factor_using_pari',  # needs sage.libs.pari
+            ....:            side_effect=AssertionError("unexpected factorization")):
+            ....:     root = a.nth_root(n)
+            sage: root^n == a  # needs sage.libs.pari
+            True
+            sage: with patch('sage.arith.misc.primitive_root',
+            ....:            side_effect=AssertionError("unexpected factorization")):
+            ....:     one = K.one().nth_root(n)
+            sage: one == 1
+            True
+            sage: K.factored_unit_order.clear_cache()
+
+        Requesting all roots of one retains the full root set::
+
+            sage: roots = GF(31).one().nth_root(12, all=True)
+            sage: len(roots) == len(set(roots)) == 6
+            True
+            sage: all(root^12 == 1 for root in roots)
             True
         """
         K = self.parent()
         q = K.order()
         gcd = n.gcd(q-1)
         if self.is_one():
+            if not all:
+                return self
             if gcd == 1:
-                return [self] if all else self
+                return [self]
             nthroot = K.zeta(gcd)
-            return [nthroot**a for a in range(gcd)] if all else nthroot
+            return [nthroot**a for a in range(gcd)]
         if gcd == q-1:
             if all:
                 return []
@@ -86,6 +126,20 @@ cdef class FiniteRingElement(CommutativeRingElement):
         if cunningham:
             from sage.rings.factorint import factor_cunningham
             F = factor_cunningham(n)
+        elif n.nbits() < 40:
+            # Integer.factor() has a dedicated fast path in this range; it is
+            # cheaper than scanning a potentially long cached factorization.
+            F = n.factor()
+        elif K.factored_unit_order.is_in_cache():
+            known_factorization, = K.factored_unit_order()
+            F = []
+            remaining = n
+            for p, _ in known_factorization:
+                v, remaining = remaining.val_unit(p)
+                if v:
+                    F.append((p, v))
+                if remaining == 1:
+                    break
         else:
             F = n.factor()
         from sage.groups.generic import discrete_log
@@ -913,6 +967,20 @@ cdef class FinitePolyExtElement(FiniteRingElement):
           only currently supported option.  For IntegerMod elements, the problem
           is reduced to the prime modulus case using CRT and `p`-adic logs,
           and then this algorithm used.
+
+        If a complete prime factorization of the multiplicative group order
+        `q-1` is already known, it can be installed in the parent cache with
+        :meth:`~sage.misc.cachefunc.CachedFunction.set_cache`.  For sufficiently
+        large ``n``, this can avoid factoring the part that divides `q-1`.
+        The cache value is trusted and is not validated::
+
+            sage: from sage.structure.factorization import Factorization
+            sage: K = GF(31)
+            sage: K.factored_unit_order.set_cache(
+            ....:     (Factorization([(2, 1), (3, 1), (5, 1)]),))
+            sage: K(25).nth_root(5)
+            5
+            sage: K.factored_unit_order.clear_cache()
 
         OUTPUT:
 

--- a/src/sage/rings/finite_rings/element_base.pyx
+++ b/src/sage/rings/finite_rings/element_base.pyx
@@ -83,31 +83,16 @@ cdef class FiniteRingElement(CommutativeRingElement):
             ....:     root = a.nth_root(n)
             sage: root^n == a  # needs sage.libs.pari
             True
-            sage: with patch('sage.arith.misc.primitive_root',
-            ....:            side_effect=AssertionError("unexpected factorization")):
-            ....:     one = K.one().nth_root(n)
-            sage: one == 1
-            True
             sage: K.factored_unit_order.clear_cache()
-
-        Requesting all roots of one retains the full root set::
-
-            sage: roots = GF(31).one().nth_root(12, all=True)
-            sage: len(roots) == len(set(roots)) == 6
-            True
-            sage: all(root^12 == 1 for root in roots)
-            True
         """
         K = self.parent()
         q = K.order()
         gcd = n.gcd(q-1)
         if self.is_one():
-            if not all:
-                return self
             if gcd == 1:
-                return [self]
+                return [self] if all else self
             nthroot = K.zeta(gcd)
-            return [nthroot**a for a in range(gcd)]
+            return [nthroot**a for a in range(gcd)] if all else nthroot
         if gcd == q-1:
             if all:
                 return []

--- a/src/sage/rings/finite_rings/integer_mod.pyx
+++ b/src/sage/rings/finite_rings/integer_mod.pyx
@@ -1361,6 +1361,20 @@ cdef class IntegerMod_abstract(FiniteRingElement):
           need to install an optional package to use this method, this can be
           done with the following command line: ``sage -i cunningham_tables``.
 
+        For a prime modulus, a known complete prime factorization of the
+        multiplicative group order can be installed in the parent cache.  For
+        sufficiently large ``n``, this can avoid factoring the part that
+        divides the group order.  The cache value is trusted and is not
+        validated::
+
+            sage: from sage.structure.factorization import Factorization
+            sage: R = IntegerModRing(11)
+            sage: R.factored_unit_order.set_cache(
+            ....:     [Factorization([(2, 1), (5, 1)])])
+            sage: R(9).nth_root(2)
+            3
+            sage: R.factored_unit_order.clear_cache()
+
         OUTPUT:
 
         If ``self`` has an `n`-th root, returns one (if ``all`` is ``False``) or a
@@ -1471,6 +1485,28 @@ cdef class IntegerMod_abstract(FiniteRingElement):
             sage: a = Mod(9,11)
             sage: a.nth_root(2, False, True, 'Johnston', cunningham=True)   # optional - cunningham_tables
             [3, 8]
+
+        A cached factorization avoids factoring a large ``n`` for a prime
+        modulus::
+
+            sage: from sage.structure.factorization import Factorization
+            sage: from unittest.mock import patch
+            sage: r = ZZ(34359738421)
+            sage: s = ZZ(68719476767)
+            sage: p = ZZ(174727560214515900603119)  # p = 74*r*s + 1 is prime
+            sage: n = r*s
+            sage: R = Zmod(p)
+            sage: R.factored_order.set_cache(Factorization([(p, 1)]))
+            sage: R.factored_unit_order.set_cache(
+            ....:     [Factorization([(2, 1), (37, 1), (r, 1), (s, 1)])])
+            sage: y = R(3)^n
+            sage: with patch('sage.rings.factorint_pari.factor_using_pari',  # needs sage.libs.pari
+            ....:            side_effect=AssertionError("unexpected factorization")):
+            ....:     root = y.nth_root(n)
+            sage: root^n == y  # needs sage.libs.pari
+            True
+            sage: R.factored_unit_order.clear_cache()
+            sage: R.factored_order.clear_cache()
 
         ALGORITHM:
 

--- a/src/sage/rings/finite_rings/integer_mod_ring.py
+++ b/src/sage/rings/finite_rings/integer_mod_ring.py
@@ -971,17 +971,33 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
         """
         return factor(self.__order, int_=(self.__order < 2**31))
 
+    @cached_method
     def factored_unit_order(self):
         r"""
         Return a list of :class:`Factorization` objects, each the factorization
         of the order of the units in a `\ZZ / p^n \ZZ` component of this group
         (using the Chinese Remainder Theorem).
 
+        The result is cached.  In particular, known complete prime
+        factorizations can be installed with
+        :meth:`~sage.misc.cachefunc.CachedFunction.set_cache`.  Cache values
+        are trusted and are not validated.
+
         EXAMPLES::
 
             sage: R = Integers(8*9*25*17*29)
             sage: R.factored_unit_order()
             [2^2, 2 * 3, 2^2 * 5, 2^4, 2^2 * 7]
+
+        The cache has the same list-of-factorizations format::
+
+            sage: from sage.structure.factorization import Factorization
+            sage: R = Integers(11)
+            sage: R.factored_unit_order.set_cache(
+            ....:     [Factorization([(2, 1), (5, 1)])])
+            sage: R.factored_unit_order()
+            [2 * 5]
+            sage: R.factored_unit_order.clear_cache()
         """
         ans = []
         from sage.structure.factorization import Factorization


### PR DESCRIPTION
Fixes #41911.

## What changed

- Cache `IntegerModRing.factored_unit_order()` so callers can install a known complete prime factorization with `set_cache()`.
- Reuse a cached factorization of the multiplicative group order in `nth_root()` instead of factoring the reduced exponent again.
- Extract only the needed prime valuations with `val_unit()` and stop once the remaining cofactor is 1.
- Keep the existing Cunningham path first, and factor exponents below 40 bits directly because Sage already has a faster small-integer path there.
- Document the trusted cache format and add hard finite-field and prime-modulus regressions that fail if PARI factorization is attempted.

## Why

`_nth_root_common()` reduces the requested exponent to `gcd(n, q - 1)`, but previously always factored that integer from scratch. This can dominate the entire root computation even when the caller already knows a complete factorization of `q - 1`.

The cache is explicitly trusted and is not validated, matching the existing `CachedMethod` contract. Small reduced exponents continue to use `Integer.factor()` so scanning a long cached factorization cannot regress inexpensive calls.

The existing deterministic root selection and `all=True` ordering for roots of `1` are preserved for compatibility with downstream p-adic and arithmetic-dynamics code.

## Performance

Measured on Sage 10.10.beta8 / Python 3.12, Linux x86_64 (WSL2), Intel Core i7-14650HX. Each process was pinned to one CPU with `taskset -c 2`. The table reports the median of 9 repeats; small cases used 6,000 calls per repeat and the 72-bit cases used 60 calls per repeat. The baseline is an unmodified `develop` binary at `c9c8381962a` from the same checkout.

| Case | `develop` | This PR | Change |
|---|---:|---:|---:|
| `GF(65537)`, cached, `n = 256` | 57.08 us | 56.44 us | -1.1% |
| `Zmod(65537)`, cached, `n = 256` | 60.09 us | 57.53 us | -4.3% |
| `GF(p)`, cached 72-bit semiprime exponent | 517.31 us | 11.51 us | 44.9x faster |
| `Zmod(p)`, cached 72-bit semiprime exponent | 503.31 us | 10.59 us | 47.5x faster |
| cached 386-bit semiprime exponent | >15 s (timeout) | 0.398 ms | timeout eliminated |

The uncached 72-bit paths remained stable: 504.89 us to 498.17 us for `GF(p)` and 508.30 us to 502.90 us for `Zmod(p)`. Interleaved-process measurements of the small cases varied by less than 5%; within the final binary, cached versus uncached `n = 256` differed by less than 1%.

The 72-bit case uses

```python
r = ZZ(34359738421)
s = ZZ(68719476767)
p = ZZ(174727560214515900603119)  # p - 1 = 2 * 37 * r * s
n = r * s
F = Factorization([(2, 1), (37, 1), (r, 1), (s, 1)])
```

The larger regression uses two primes of about 192 bits each and a 386-bit reduced exponent; its full constants and a guard against unexpected PARI factorization are included in the doctest.

## Validation

- `./sage -t --long src/sage/rings/finite_rings/element_base.pyx src/sage/rings/finite_rings/integer_mod.pyx src/sage/rings/finite_rings/integer_mod_ring.py` -- 1,341 tests passed.
- The same three files with `--hide=sage.libs.pari` -- 1,274 tests passed.
- The three modules that exposed the root-selection compatibility issue (`projective_ds.py`, `padic_generic.py`, and `padic_generic_element.pyx`) passed 2,677 tests with the exact CI random seed.
- A `GF(2^80)` extension-field smoke test with `factor_using_pari` patched to fail passed using the installed cache.
- `git diff --check` passed.
