### PR TITLE
Mark arith_int and arith_llong as final

### DIFF
--- a/src/sage/rings/fast_arith.pxd
+++ b/src/sage/rings/fast_arith.pxd
@@ -1,5 +1,9 @@
+cimport cython
+
+
 cpdef prime_range(start, stop=*, algorithm=*, bint py_ints=*)
 
+@cython.final
 cdef class arith_int:
     cdef int abs_int(self, int x) except -1
     cdef int sign_int(self, int n) except -2
@@ -8,6 +12,7 @@ cdef class arith_int:
     cdef int c_inverse_mod_int(self, int a, int m) except -1
     cdef int c_rational_recon_int(self, int a, int m, int* n, int* d) except -1
 
+@cython.final
 cdef class arith_llong:
     cdef long long abs_longlong(self, long long x) except -1
     cdef long long sign_longlong(self, long long n) except -2

--- a/src/sage/rings/fast_arith.pxd
+++ b/src/sage/rings/fast_arith.pxd
@@ -3,6 +3,8 @@ cimport cython
 
 cpdef prime_range(start, stop=*, algorithm=*, bint py_ints=*)
 
+# Declaring these helper classes final avoids vtable lookups in generated code;
+# it is a performance optimization, not an object-oriented design decision.
 @cython.final
 cdef class arith_int:
     cdef int abs_int(self, int x) except -1

--- a/src/sage/rings/fast_arith.pyi
+++ b/src/sage/rings/fast_arith.pyi
@@ -1,7 +1,9 @@
+from typing import final
 
 def prime_range(start: int, stop: int | None = None, algorithm: str | None = None, py_ints: bool = False) -> list[int]:
     ...
 
+@final
 class arith_int:
     def abs_int(self, x: int) -> int:
         ...
@@ -33,6 +35,7 @@ class arith_int:
     def rational_recon_int(self, a: int, m: int) -> tuple[int, int]:
         ...
 
+@final
 class arith_llong:
     def abs_longlong(self, x: int) -> int:
         ...

--- a/src/sage/rings/fast_arith.pyx
+++ b/src/sage/rings/fast_arith.pyx
@@ -1,6 +1,20 @@
 # sage.doctest: needs sage.libs.pari
 """
 Basic arithmetic with C integers
+
+TESTS:
+
+The integer arithmetic helper classes cannot be subclassed::
+
+    sage: from sage.rings.fast_arith import arith_int, arith_llong
+    sage: type("arith_int_subclass", (arith_int,), {})
+    Traceback (most recent call last):
+    ...
+    TypeError: type 'sage.rings.fast_arith.arith_int' is not an acceptable base type
+    sage: type("arith_llong_subclass", (arith_llong,), {})
+    Traceback (most recent call last):
+    ...
+    TypeError: type 'sage.rings.fast_arith.arith_llong' is not an acceptable base type
 """
 
 # ****************************************************************************
@@ -516,7 +530,7 @@ cdef class arith_llong:
         y = v2
         if v1 < 0:
             y = -1*y
-        if x <= bnd and self.gcd_longlong(x, y) == 1:
+        if x <= bnd and self.c_gcd_longlong(x, y) == 1:
             n[0] = y
             d[0] = x
             return 0
@@ -528,6 +542,12 @@ cdef class arith_llong:
     def rational_recon_longlong(self, long long a, long long m):
         """
         Rational reconstruction of a modulo m.
+
+        EXAMPLES::
+
+            sage: from sage.rings.fast_arith import arith_llong
+            sage: arith_llong().rational_recon_longlong(1234567, 2147483629)
+            (-23606, 22613)
         """
         cdef long long n, d
         self.c_rational_recon_longlong(a, m, &n, &d)


### PR DESCRIPTION
## Summary

- mark `arith_int` and `arith_llong` as `cython.final`
- reflect the final classes in the Python type stub
- call `c_gcd_longlong` directly during long-long rational reconstruction
- add regression coverage for subclass rejection and rational reconstruction

## Rationale

These stateless arithmetic helper classes have no subclasses or extension hooks in Sage. Marking them final lets Cython avoid vtable dispatch for calls within `fast_arith`.

`c_rational_recon_longlong` previously called the Python-visible `gcd_longlong` wrapper. Calling its C implementation directly avoids Python method lookup and integer boxing on that path.

## Performance

On an Intel Core i7-14650HX with Python 3.12.13 and Cython 3.2.4, a controlled 21-round microbenchmark measured:

- Python API `rational_recon_longlong`: 161.53 ns/op to 144.70 ns/op (10.4% faster)
- Cython hot loop: about 62.2 ns/op to 36.2 ns/op (about 41.8% faster)

The benchmark pinned execution to one CPU and was independently repeated. The current Sage extension matched the optimized benchmark variant within 0.1 ns/op.

## Validation

- full Ninja build of the affected extension and its Cython dependents
- `python -m sage.doctest --random-seed 40714 src/sage/rings/fast_arith.pyx` (25 tests passed)
- runtime arithmetic and subclass-rejection smoke tests
- `ruff check src/sage/rings/fast_arith.pyi`
- `git diff --check`

Closes #40714
