### PR TITLE
fix compilation issue with buckygen

### DIFF
--- a/build/pkgs/buckygen/spkg-install.in
+++ b/build/pkgs/buckygen/spkg-install.in
@@ -6,6 +6,8 @@ fi
 
 cd src
 
+export CFLAGS="$CFLAGS -std=gnu17"
+
 $MAKE
 if [ $? -ne 0 ]; then
     echo >&2 "Error building buckygen."


### PR DESCRIPTION
this PR fixes the following compilation issue with optional package buckygen (at least on macOS)
```
[buckygen-1.1] No spkg-legacy-uninstall script; nothing to do
[buckygen-1.1] [spkg-install] rm -f buckygen
[buckygen-1.1] [spkg-install] gcc -std=gnu23 -g -O2 -O3 buckygen.c -o buckygen
[buckygen-1.1] [spkg-install] In file included from buckygen.c:280:
[buckygen-1.1] [spkg-install] ./splay.c:260:14: error: too many arguments to function call, expected 0, have 2
[buckygen-1.1] [spkg-install]   260 |             PRESENT(p);
[buckygen-1.1] [spkg-install]       |             ~~~~~~~~^~
[buckygen-1.1] [spkg-install] buckygen.c:274:34: note: expanded from macro 'PRESENT'
[buckygen-1.1] [spkg-install]   274 | #define PRESENT(p) old_splaynode(p, is_new_node)
[buckygen-1.1] [spkg-install]       |                    ~~~~~~~~~~~~~ ^~~~~~~~~~~~~~
[buckygen-1.1] [spkg-install] buckygen.c:278:6: note: 'old_splaynode' declared here
[buckygen-1.1] [spkg-install]   278 | void old_splaynode();
[buckygen-1.1] [spkg-install]       |      ^
[buckygen-1.1] [spkg-install] In file included from buckygen.c:280:
[buckygen-1.1] [spkg-install] ./splay.c:283:17: error: too many arguments to function call, expected 0, have 5
[buckygen-1.1] [spkg-install]   283 |     NOT_PRESENT(new_node);
[buckygen-1.1] [spkg-install]       |     ~~~~~~~~~~~~^~~~~~~~~
[buckygen-1.1] [spkg-install] buckygen.c:271:38: note: expanded from macro 'NOT_PRESENT'
[buckygen-1.1] [spkg-install]   271 | #define NOT_PRESENT(p) new_splaynode(p, canong, codelength, type, is_new_node)
[buckygen-1.1] [spkg-install]       |                        ~~~~~~~~~~~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[buckygen-1.1] [spkg-install] buckygen.c:277:6: note: 'new_splaynode' declared here
[buckygen-1.1] [spkg-install]   277 | void new_splaynode();
[buckygen-1.1] [spkg-install]       |      ^
[buckygen-1.1] [spkg-install] buckygen.c:901:6: error: conflicting types for 'new_splaynode'
[buckygen-1.1] [spkg-install]   901 | void new_splaynode(SPLAYNODE *el, unsigned char *canong, int codelength, int type, int *is_new_node)
[buckygen-1.1] [spkg-install]       |      ^
[buckygen-1.1] [spkg-install] buckygen.c:277:6: note: previous declaration is here
[buckygen-1.1] [spkg-install]   277 | void new_splaynode();
[buckygen-1.1] [spkg-install]       |      ^
[buckygen-1.1] [spkg-install] buckygen.c:915:6: error: conflicting types for 'old_splaynode'
[buckygen-1.1] [spkg-install]   915 | void old_splaynode(SPLAYNODE *el, int *is_new_node)
[buckygen-1.1] [spkg-install]       |      ^
[buckygen-1.1] [spkg-install] buckygen.c:278:6: note: previous declaration is here
[buckygen-1.1] [spkg-install]   278 | void old_splaynode();
[buckygen-1.1] [spkg-install]       |      ^
[buckygen-1.1] [spkg-install] 4 errors generated.
[buckygen-1.1] [spkg-install] make[5]: *** [buckygen] Error 1
[buckygen-1.1] [spkg-install] Error building buckygen.
[buckygen-1.1] ************************************************************************
[buckygen-1.1] Error installing package buckygen-1.1
[buckygen-1.1] ************************************************************************
```

This is the same fix as in https://github.com/passagemath/passagemath/issues/2427



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


