### PR TITLE
implement partial derivatives for multisort species

### DIFF
--- a/src/sage/rings/species.py
+++ b/src/sage/rings/species.py
@@ -1826,7 +1826,7 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                         atoms[B] += e * f
             return M(atoms, check=False)
 
-        def derivative(self):
+        def derivative(self, variable=None):
             r"""
             Return the derivative of ``self``.
 
@@ -1834,7 +1834,9 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
             Section 2.6 in [BLL1998]_.
 
             Note that the result is a polynomial species rather than
-            a molecular species.
+            a molecular species. When the parent is unisort, ``variable`` may
+            be omitted. For a multisort parent, ``variable`` must be a sort
+            generator of the parent.
 
             EXAMPLES::
 
@@ -1849,20 +1851,74 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                 sage: (X*E2).derivative().is_molecular()
                 False
 
+            Partial derivatives of multisort species are obtained by specifying
+            a sort generator::
+
+                sage: M = MolecularSpecies("X, Y")
+                sage: X = M(SymmetricGroup(1), {0: [1]})
+                sage: Y = M(SymmetricGroup(1), {1: [1]})
+                sage: G = PermutationGroup([[(1,2), (3,4)]])
+                sage: F = M(G, {0: [1,2], 1: [3,4]})
+                sage: F
+                E_2(X*Y)
+                sage: F.derivative(X)
+                X*Y^2
+                sage: F.derivative(Y)
+                X^2*Y
+                sage: X.derivative(Y)
+                0
+
             TESTS::
 
+                sage: F.derivative()
+                Traceback (most recent call last):
+                ...
+                ValueError: the derivative variable must be specified for multisort species
+                sage: F.derivative(X*Y)
+                Traceback (most recent call last):
+                ...
+                ValueError: the derivative variable must be a sort generator of the parent
                 sage: M = MolecularSpecies("X")
                 sage: [sum(1 for m in M.subset(n) if m.derivative().is_molecular()) for n in range(1, 7)]
                 [1, 1, 2, 5, 5, 16]
                 sage: oeis(_) # optional - internet
                 0: A002106: Number of transitive permutation groups of degree n.
             """
+            M = self.parent()
+            if variable is None:
+                if M._arity != 1:
+                    raise ValueError("the derivative variable must be specified for multisort species")
+                sort = 0
+            else:
+                variables = tuple( M(SymmetricGroup(1), {i: [1]}) for i in range(M._arity))
+                if parent(variable) is not M or variable not in variables:
+                    raise ValueError("the derivative variable must be a sort generator of the parent")
+                sort = variables.index(variable)
+            return self._derivative_with_respect_to_sort(sort)
+
+        def _derivative_with_respect_to_sort(self, sort):
+            r"""
+            Return the derivative with respect to the sort indexed by ``sort``.
+
+            This method assumes that ``sort`` is a valid zero-based sort index.
+
+            TESTS::
+
+                sage: from sage.rings.species import MolecularSpecies
+                sage: M = MolecularSpecies("X, Y")
+                sage: G = PermutationGroup([[(1,2), (3,4)]])
+                sage: F = M(G, {0: [1,2], 1: [3,4]})
+                sage: F._derivative_with_respect_to_sort(0)
+                X*Y^2
+                sage: F._derivative_with_respect_to_sort(1)
+                X^2*Y
+            """
             def delete_point_from_permutation(g, r, m):
                 r"""
-                Delete the fixed point `r` from a permutation of `\{1,\dots, m\}`.
+                Delete the fixed point `r` from a permutation of `\{1,\dots,m\}`.
 
-                The permutation `g` is assumed to fix `r`. The remaining points are
-                relabelled increasingly in `{1,\dots, m - 1}`.
+                The permutation `g` is assumed to fix `r`. The remaining points are 
+                relabelled increasingly in `\{1,\dots,m-1\}`.
                 """
                 relabel = {i: i if i < r else i - 1 for i in range(1, m + 1) if i != r}
                 cycles = []
@@ -1875,18 +1931,19 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                 return tuple(cycles)
 
             M = self.parent()
-            if M._arity != 1:
-                raise NotImplementedError("derivative is not yet implemented for multisort species")
             P = PolynomialSpecies(ZZ, M._indices._names)
             m = sum(self.grade())
-            if m == 0:
+            if self.grade()[sort] == 0:
                 return P.zero()
             if m == 1:
                 return P.one()
-            H, _ = self.permutation_group()
+
+            H, dompart = self.permutation_group()
             ans = P.zero()
             for orbit in H.orbits():
                 r = min(orbit)
+                if r not in dompart[sort]:
+                    continue
                 H_r = libgap.Stabilizer(H.gap(), r)
                 gens = []
                 for g in H_r.GeneratorsOfGroup().sage():
@@ -1894,7 +1951,11 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                     if cycles:
                         gens.append(cycles)
                 H_r_star = PermutationGroup(gens, domain=range(1, m))
-                ans += P(M(H_r_star))
+
+                new_dompart = { i: [ point if point < r else point - 1 for point in block if point != r ]
+                    for i, block in enumerate(dompart)
+                }
+                ans += P(M(H_r_star, new_dompart, check=False))
             return ans
 
         def structures(self, *labels):

--- a/src/sage/rings/species.py
+++ b/src/sage/rings/species.py
@@ -1894,30 +1894,7 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                 sage: oeis(_) # optional - internet
                 0: A002106: Number of transitive permutation groups of degree n.
             """
-            M = self.parent()
-            variables = tuple(M(SymmetricGroup(1), {i: [1]}) for i in range(M._arity))
-            sorts = []
-            for variable in derivative_parse(args):
-                if variable is None:
-                    if M._arity != 1:
-                        raise ValueError(
-                            "the derivative variable must be specified for multisort species"
-                            )
-                    sort = 0
-                else:
-                    if parent(variable) is not M or variable not in variables:
-                        raise ValueError(
-                            "the derivative variable must be a sort generator of the parent"
-                            )
-                    sort = variables.index(variable)
-                sorts.append(sort)
-
-            result = self
-            for sort in sorts:
-                current_parent = result.parent()
-                current_variable = current_parent(SymmetricGroup(1), {sort: [1]})
-                result = result._derivative(current_variable)
-            return result
+            return multi_derivative(self, args)
 
         def _derivative(self, variable=None):
             r"""
@@ -1932,20 +1909,14 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                 2*X
             """
             M = self.parent()
-            variables = tuple(
-                M(SymmetricGroup(1), {i: [1]}) for i in range(M._arity)
-            )
             if variable is None:
                 if M._arity != 1:
-                    raise ValueError(
-                        "the derivative variable must be specified for multisort species"
-                    )
+                    raise ValueError("the derivative variable must be specified for multisort species")
                 sort = 0
             else:
+                variables = tuple(M(_SymmetricGroup(1), {i: [1]}) for i in range(M._arity))
                 if parent(variable) is not M or variable not in variables:
-                    raise ValueError(
-                        "the derivative variable must be a sort generator of the parent"
-                    )
+                    raise ValueError("the derivative variable must be a sort generator of the parent")
                 sort = variables.index(variable)
             return self._derivative_with_respect_to_sort(sort)
 
@@ -1992,7 +1963,7 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                 return P.one()
 
             H, dompart = self.permutation_group()
-            ans = P.zero()
+            result = P.zero()
             for orbit in H.orbits():
                 r = min(orbit)
                 if r not in dompart[sort]:
@@ -2005,11 +1976,11 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                         gens.append(cycles)
                 H_r_star = PermutationGroup(gens, domain=range(1, m))
 
-                new_dompart = { i: [ point if point < r else point - 1 for point in block if point != r ]
-                    for i, block in enumerate(dompart)
-                }
-                ans += P(M(H_r_star, new_dompart, check=False))
-            return ans
+                new_dompart = {i: [point if point < r else point - 1
+                                   for point in block if point != r]
+                               for i, block in enumerate(dompart)}
+                result += P(M(H_r_star, new_dompart, check=False))
+            return result
 
         def structures(self, *labels):
             r"""
@@ -2278,12 +2249,16 @@ class PolynomialSpeciesElement(CombinatorialFreeModule.Element):
                 raise ValueError("the derivative variable must be specified for multisort species")
             sort = 0
         else:
-            variables = tuple(P(SymmetricGroup(1), {i: [1]}) for i in range(P._arity))
-            if parent(variable) is not P or variable not in variables:
+            if parent(variable) is not P:
+                variable = P(variable, check=True)
+            variables = P._first_ngens(P._arity)
+            try:
+                sort = variables.index(variable)
+            except ValueError:
                 raise ValueError("the derivative variable must be a sort generator of the parent")
-            sort = variables.index(variable)
-        return sum((c * P(M._derivative_with_respect_to_sort(sort)) for M, c in self.monomial_coefficients().items()),
-                    P.zero())
+        return sum((c * P(M._derivative_with_respect_to_sort(sort))
+                    for M, c in self.monomial_coefficients().items()),
+                   P.zero())
 
     def hadamard_product(self, other):
         r"""
@@ -2921,7 +2896,7 @@ class PolynomialSpecies(CombinatorialFreeModule):
 
         Atomic and molecular species are accepted as arguments::
 
-            sage: from sage.rings.species import AtomicSpecies, PolynomialSpecies
+            sage: from sage.rings.species import AtomicSpecies, MolecularSpecies
             sage: P = PolynomialSpecies(ZZ, "X, Y")
             sage: A = AtomicSpecies("X, Y")
             sage: P(A(SymmetricGroup(3), {1: [1,2,3]}))
@@ -2932,6 +2907,16 @@ class PolynomialSpecies(CombinatorialFreeModule):
             Traceback (most recent call last):
             ...
             ValueError: all keys of the dict {E_3: 1} must be Atomic species in X, Y
+
+            sage: M = MolecularSpecies("X, Y")
+            sage: P(M(SymmetricGroup(3), {1: [1,2,3]}))
+            E_3(Y)
+
+            sage: M = MolecularSpecies("X, Z")
+            sage: P(M(SymmetricGroup(3), {0: [1,2,3]}))
+            Traceback (most recent call last):
+            ...
+            ValueError: E_3(X) must be a Molecular species in X, Y
         """
         if parent(G) is self:
             # pi cannot be None because of framework
@@ -2941,6 +2926,8 @@ class PolynomialSpecies(CombinatorialFreeModule):
             G = self._indices({G: ZZ.one()})
 
         if isinstance(G, MolecularSpecies.Element):
+            if check and not G.parent() == self._indices:
+                raise ValueError(f"{G} must be a {self._indices}")
             return self._from_dict({G: self.base_ring().one()})
 
         if isinstance(G, dict):

--- a/src/sage/rings/species.py
+++ b/src/sage/rings/species.py
@@ -2159,7 +2159,7 @@ class PolynomialSpeciesElement(CombinatorialFreeModule.Element):
             result += c * result_m
         return result
 
-    def derivative(self):
+    def derivative(self, variable=None):
         r"""
         Return the derivative of ``self``.
 
@@ -2175,11 +2175,24 @@ class PolynomialSpeciesElement(CombinatorialFreeModule.Element):
             1 + 2*X*E_2
             sage: E2(E2).derivative()
             X*E_2
+            sage: P.<X, Y> = PolynomialSpecies(QQ)
+            sage: F = X^2 + 2*Y
+            sage: F.derivative(X)
+            2*X
+            sage: F.derivative(Y)
+            2
         """
         P = self.parent()
-        if P._arity != 1:
-            raise NotImplementedError("derivative is not yet implemented for multisort species")
-        return sum((c * P(M.derivative()) for M, c in self.monomial_coefficients().items()),
+        if variable is None:
+            if P._arity != 1:
+                raise ValueError("the derivative variable must be specified for multisort species")
+            sort = 0
+        else:
+            variables = tuple(P(SymmetricGroup(1), {i: [1]}) for i in range(P._arity))
+            if parent(variable) is not P or variable not in variables:
+                raise ValueError("the derivative variable must be a sort generator of the parent")
+            sort = variables.index(variable)
+        return sum((c * P(M._derivative_with_respect_to_sort(sort)) for M, c in self.monomial_coefficients().items()),
                     P.zero())
 
     def hadamard_product(self, other):

--- a/src/sage/rings/species.py
+++ b/src/sage/rings/species.py
@@ -53,6 +53,7 @@ from sage.groups.perm_gps.permgroup import PermutationGroup, PermutationGroup_ge
 from sage.groups.perm_gps.permgroup_named import SymmetricGroup
 from sage.libs.gap.libgap import libgap
 from sage.misc.cachefunc import cached_method, cached_function
+from sage.misc.derivative import derivative_parse, multi_derivative
 from sage.misc.fast_methods import WithEqualityById
 from sage.misc.inherit_comparison import InheritComparisonClasscallMetaclass
 from sage.misc.misc_c import prod
@@ -1826,7 +1827,7 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                         atoms[B] += e * f
             return M(atoms, check=False)
 
-        def derivative(self, variable=None):
+        def derivative(self, *args):
             r"""
             Return the derivative of ``self``.
 
@@ -1834,9 +1835,10 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
             Section 2.6 in [BLL1998]_.
 
             Note that the result is a polynomial species rather than
-            a molecular species. When the parent is unisort, ``variable`` may
-            be omitted. For a multisort parent, ``variable`` must be a sort
-            generator of the parent.
+            a molecular species. The arguments follow Sage's standard derivative
+            syntax (see :func:`sage.misc.derivative.derivative_parse`). The sort
+            generator may be omitted if the parent is unisort. It
+            must be specified if the parent is Multisort.
 
             EXAMPLES::
 
@@ -1867,6 +1869,14 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                 X^2*Y
                 sage: X.derivative(Y)
                 0
+                sage: F.derivative(X, 2)
+                Y^2
+                sage: F.derivative(X, Y)
+                2*X*Y
+                sage: F.derivative([X, Y])
+                2*X*Y
+                sage: F.derivative(0) == F
+                True
 
             TESTS::
 
@@ -1885,14 +1895,57 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                 0: A002106: Number of transitive permutation groups of degree n.
             """
             M = self.parent()
+            variables = tuple(M(SymmetricGroup(1), {i: [1]}) for i in range(M._arity))
+            sorts = []
+            for variable in derivative_parse(args):
+                if variable is None:
+                    if M._arity != 1:
+                        raise ValueError(
+                            "the derivative variable must be specified for multisort species"
+                            )
+                    sort = 0
+                else:
+                    if parent(variable) is not M or variable not in variables:
+                        raise ValueError(
+                            "the derivative variable must be a sort generator of the parent"
+                            )
+                    sort = variables.index(variable)
+                sorts.append(sort)
+
+            result = self
+            for sort in sorts:
+                current_parent = result.parent()
+                current_variable = current_parent(SymmetricGroup(1), {sort: [1]})
+                result = result._derivative(current_variable)
+            return result
+
+        def _derivative(self, variable=None):
+            r"""
+            Return the derivative of ``self`` with respect to one variable.
+
+            TESTS::
+
+                sage: from sage.rings.species import MolecularSpecies
+                sage: M = MolecularSpecies("X")
+                sage: X = M(SymmetricGroup(1))
+                sage: (X^2)._derivative(X)
+                2*X
+            """
+            M = self.parent()
+            variables = tuple(
+                M(SymmetricGroup(1), {i: [1]}) for i in range(M._arity)
+            )
             if variable is None:
                 if M._arity != 1:
-                    raise ValueError("the derivative variable must be specified for multisort species")
+                    raise ValueError(
+                        "the derivative variable must be specified for multisort species"
+                    )
                 sort = 0
             else:
-                variables = tuple( M(SymmetricGroup(1), {i: [1]}) for i in range(M._arity))
                 if parent(variable) is not M or variable not in variables:
-                    raise ValueError("the derivative variable must be a sort generator of the parent")
+                    raise ValueError(
+                        "the derivative variable must be a sort generator of the parent"
+                    )
                 sort = variables.index(variable)
             return self._derivative_with_respect_to_sort(sort)
 
@@ -2159,9 +2212,46 @@ class PolynomialSpeciesElement(CombinatorialFreeModule.Element):
             result += c * result_m
         return result
 
-    def derivative(self, variable=None):
+    def derivative(self, *args):
         r"""
         Return the derivative of ``self``.
+
+        TESTS::
+
+            sage: from sage.rings.species import PolynomialSpecies
+            sage: P = PolynomialSpecies(QQ, ["X"])
+            sage: X = P(SymmetricGroup(1))
+            sage: E2 = P(SymmetricGroup(2))
+            sage: (X^3).derivative()
+            3*X^2
+            sage: (E2^2 + X).derivative()
+            1 + 2*X*E_2
+            sage: E2(E2).derivative()
+            X*E_2
+            sage: (X^3).derivative(2)
+            6*X
+
+            sage: P.<X, Y> = PolynomialSpecies(QQ)
+            sage: F = X^2 + 2*Y
+            sage: F.derivative(X)
+            2*X
+            sage: F.derivative(Y)
+            2
+            sage: G = X^2*Y^2
+            sage: G.derivative(X, 2)
+            2*Y^2
+            sage: G.derivative(X, Y)
+            4*X*Y
+            sage: G.derivative([X, Y])
+            4*X*Y
+            sage: G.derivative(0) == G
+            True
+        """
+        return multi_derivative(self, args)
+
+    def _derivative(self, variable=None):
+        r"""
+        Return the derivative of ``self`` with respect to one variable.
 
         TESTS::
 

--- a/src/sage/rings/species.py
+++ b/src/sage/rings/species.py
@@ -1917,7 +1917,7 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                 r"""
                 Delete the fixed point `r` from a permutation of `\{1,\dots,m\}`.
 
-                The permutation `g` is assumed to fix `r`. The remaining points are 
+                The permutation `g` is assumed to fix `r`. The remaining points are
                 relabelled increasingly in `\{1,\dots,m-1\}`.
                 """
                 relabel = {i: i if i < r else i - 1 for i in range(1, m + 1) if i != r}


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

This implements partial derivatives for multisort molecular species. For unisort species, sort may or may not be specified as in the current implementation.

```   
sage: from sage.rings.species import MolecularSpecies
sage: M = MolecularSpecies("X")
sage: X = M(SymmetricGroup(1))
sage: E2 = M(SymmetricGroup(2))
sage: F = X*E2
sage: F.derivative()
E_2 + X^2
sage: F.derivative(X)
E_2 + X^2
 ```
However, sort must be specified for multisort species.

```    
sage: from sage.rings.species import PolynomialSpecies
sage: P.<X, Y> = PolynomialSpecies(QQ)
sage: F = X^2 + 2*Y
sage: F.derivative(X)
2*X
sage: F.derivative(Y)
2
sage: F.derivative(X).derivative()
ValueError: the derivative variable must be specified for multisort species
sage: F.derivative(X).derivative(X)
2
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [x ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


