### PR TITLE
Fix Pynac ownership bugs and compiler warnings

### DIFF
--- a/src/sage/symbolic/expression.pyx
+++ b/src/sage/symbolic/expression.pyx
@@ -4828,6 +4828,32 @@ cdef class Expression(Expression_abc):
             sage: series_with_variable_coefficients.diff(x).coefficients(x)[:4]
             [[1, 0], [2, 1], [3, 2], [4, 3]]
 
+        A coefficient with a pole can contribute below the order of the
+        remainder, even when its stored power reaches that order::
+
+            sage: f = y + x*y^2/2 + x^2
+            sage: f.series(x, 2).subs(y=-1/x).diff(x)
+            (1/2/x^2) + Order(x)
+            sage: f = y + (x-1)*y^2/2 + (x-1)^2
+            sage: f.series(x==1, 2).subs(y=-1/(x-1)).diff(x)
+            (1/2/(x - 1)^2) + Order(x - 1)
+
+        Differentiating logarithmic coefficients also retains these terms::
+
+            sage: s = (log(x)/(1-x)).series(x, 4).diff(x).series(x, 3)
+            sage: (s.truncate() - (1/x + log(x) + 1
+            ....:      + (2*log(x) + 1)*x + (3*log(x) + 1)*x^2)).expand()
+            0
+
+        Coefficients need not themselves have Laurent series expansions::
+
+            sage: s = (y*x + x^2).series(x, 2).subs(y=sin(1/x))
+            sage: (s.diff(x).series(x, 1).truncate() - (x*sin(1/x)).diff(x)).expand()
+            0
+            sage: s = (y*x + x^2).series(x, 2).subs(y=sqrt(x))
+            sage: (s.diff(x).series(x, 1).truncate() - (x*sqrt(x)).diff(x)).simplify_full()
+            0
+
         Try different algorithms::
 
             sage: ((1 - x)^-x).series(x, 8, algorithm="maxima")

--- a/src/sage/symbolic/expression.pyx
+++ b/src/sage/symbolic/expression.pyx
@@ -1,11 +1,3 @@
-# distutils: sources = sage/symbolic/ginac/add.cpp sage/symbolic/ginac/archive.cpp sage/symbolic/ginac/assume.cpp sage/symbolic/ginac/basic.cpp sage/symbolic/ginac/cmatcher.cpp sage/symbolic/ginac/constant.cpp sage/symbolic/ginac/context.cpp sage/symbolic/ginac/ex.cpp sage/symbolic/ginac/expair.cpp sage/symbolic/ginac/expairseq.cpp sage/symbolic/ginac/exprseq.cpp sage/symbolic/ginac/fderivative.cpp sage/symbolic/ginac/function.cpp sage/symbolic/ginac/function_info.cpp sage/symbolic/ginac/infinity.cpp sage/symbolic/ginac/infoflagbase.cpp sage/symbolic/ginac/inifcns.cpp sage/symbolic/ginac/inifcns_comb.cpp sage/symbolic/ginac/inifcns_gamma.cpp sage/symbolic/ginac/inifcns_hyperb.cpp sage/symbolic/ginac/inifcns_hyperg.cpp sage/symbolic/ginac/inifcns_nstdsums.cpp sage/symbolic/ginac/inifcns_orthopoly.cpp sage/symbolic/ginac/inifcns_trans.cpp sage/symbolic/ginac/inifcns_trig.cpp sage/symbolic/ginac/inifcns_zeta.cpp sage/symbolic/ginac/lst.cpp sage/symbolic/ginac/matrix.cpp sage/symbolic/ginac/mpoly-ginac.cpp sage/symbolic/ginac/mpoly-singular.cpp sage/symbolic/ginac/mpoly.cpp sage/symbolic/ginac/mul.cpp sage/symbolic/ginac/normal.cpp sage/symbolic/ginac/numeric.cpp sage/symbolic/ginac/operators.cpp sage/symbolic/ginac/order.cpp sage/symbolic/ginac/power.cpp sage/symbolic/ginac/print.cpp sage/symbolic/ginac/pseries.cpp sage/symbolic/ginac/py_funcs.cpp sage/symbolic/ginac/registrar.cpp sage/symbolic/ginac/relational.cpp sage/symbolic/ginac/remember.cpp sage/symbolic/ginac/sum.cpp sage/symbolic/ginac/symbol.cpp sage/symbolic/ginac/templates.cpp sage/symbolic/ginac/upoly-ginac.cpp sage/symbolic/ginac/useries.cpp sage/symbolic/ginac/utils.cpp sage/symbolic/ginac/wildcard.cpp
-# distutils: language = c++
-# distutils: libraries = flint gmp SINGULAR_LIBRARIES
-# distutils: extra_compile_args = -std=c++11 SINGULAR_CFLAGS
-# distutils: depends = ginac/add.h ginac/archive.h ginac/assertion.h ginac/assume.h ginac/basic.h ginac/class_info.h ginac/cmatcher.h ginac/compiler.h ginac/constant.h ginac/container.h ginac/context.h ginac/ex.h ginac/ex_utils.h ginac/expair.h ginac/expairseq.h ginac/exprseq.h ginac/extern_templates.h ginac/fderivative.h ginac/flags.h ginac/function.h ginac/ginac.h ginac/infinity.h ginac/infoflagbase.h ginac/inifcns.h ginac/lst.h ginac/matrix.h ginac/mpoly.h ginac/mul.h ginac/normal.h ginac/numeric.h ginac/operators.h ginac/order.h ginac/optional.hpp ginac/power.h ginac/print.h ginac/pseries.h ginac/ptr.h ginac/py_funcs.h ginac/pynac-config.h ginac/registrar.h ginac/relational.h ginac/remember.h ginac/sum.h ginac/symbol.h ginac/templates.h ginac/tostring.h ginac/upoly.h ginac/useries-flint.h ginac/useries.h ginac/utils.h ginac/wildcard.h
-# distutils: include_dirs = SINGULAR_INCDIR
-# pynac/basic.h includes
-#   factory/factory.h    so this ^ is needed to find it
 """
 Symbolic Expressions
 
@@ -674,6 +666,20 @@ cdef class Expression(Expression_abc):
             Traceback (most recent call last):
             ...
             TypeError: Python infinity cannot have complex phase.
+
+        An unarchived Python object is released with its symbolic wrapper::
+
+            sage: import gc, weakref
+            sage: wrapped = SR._force_pyobject({1, 2}, force=True)
+            sage: restored = loads(dumps(wrapped))
+            sage: restored_object = restored.pyobject()
+            sage: restored_object is wrapped.pyobject()
+            False
+            sage: reference = weakref.ref(restored_object)
+            sage: del restored_object, restored
+            sage: _ = gc.collect()
+            sage: reference() is None
+            True
         """
         if is_a_constant(self._gobj):
             from sage.symbolic.constants import constants_name_table
@@ -2010,6 +2016,14 @@ cdef class Expression(Expression_abc):
 
             sage: t = SR(matrix(2,2,range(4)))
             sage: hash(t)
+            Traceback (most recent call last):
+            ...
+            RuntimeError: Python object not hashable
+
+        Copying an expression must preserve that state::
+
+            sage: wrapped = SR._force_pyobject([], force=True)
+            sage: hash(wrapped + 0)
             Traceback (most recent call last):
             ...
             RuntimeError: Python object not hashable
@@ -4804,6 +4818,15 @@ cdef class Expression(Expression_abc):
 
             sage: ((1 - x)^-x).series(x, 8)
             1 + 1*x^2 + 1/2*x^3 + 5/6*x^4 + 3/4*x^5 + 33/40*x^6 + 5/6*x^7 + Order(x^8)
+
+        Differentiation also applies the product rule when a series
+        coefficient starts depending on the expansion variable after a
+        substitution::
+
+            sage: x, y = var('x y')
+            sage: series_with_variable_coefficients = (y/(1-x)).series(x, 5).subs(y=x)
+            sage: series_with_variable_coefficients.diff(x).coefficients(x)[:4]
+            [[1, 0], [2, 1], [3, 2], [4, 3]]
 
         Try different algorithms::
 
@@ -14003,7 +14026,7 @@ cdef unsigned sage_domain_to_ginac_domain(object domain) except? 3474701533:
     else:
         raise ValueError(repr(domain)+": domain must be one of 'complex', 'real', 'positive' or 'integer'")
 
-cdef void send_sage_domain_to_maxima(Expression v, object domain) except +:
+cdef void send_sage_domain_to_maxima(Expression v, object domain) except *:
     from sage.symbolic.assumptions import assume
     # convert the domain argument to something easy to parse
     if domain is RR or domain == 'real':

--- a/src/sage/symbolic/ginac/basic.cpp
+++ b/src/sage/symbolic/ginac/basic.cpp
@@ -413,11 +413,13 @@ ex basic::collect(const ex & s, bool distributed) const
 
 	} else {
 		// Only one object specified
-                expairvec vec;
-                ex(*this).coefficients(s, vec);
-		for (const auto& term : vec)
-			x += term.first * power(s, term.second);
-                return x;
+		expairvec vec;
+		ex(*this).coefficients(s, vec);
+		exvector terms;
+		terms.reserve(vec.size());
+		for (const auto & term : vec)
+			terms.push_back(term.first * power(s, term.second));
+		return add(terms);
 	}
 	
 	// correct for lost fractional arguments and return

--- a/src/sage/symbolic/ginac/constant.cpp
+++ b/src/sage/symbolic/ginac/constant.cpp
@@ -222,8 +222,8 @@ int constant::compare_same_type(const basic & other) const
 
 	if (serial == o.serial)
 		return 0;
-	
-		return serial < o.serial ? -1 : 1;
+
+	return serial < o.serial ? -1 : 1;
 }
 
 bool constant::is_equal_same_type(const basic & other) const

--- a/src/sage/symbolic/ginac/ex.cpp
+++ b/src/sage/symbolic/ginac/ex.cpp
@@ -138,22 +138,30 @@ bool ex::match(const ex & pattern, exvector& vec) const
         return ret;
 }
 
+static bool find_matches(const ex & expression, const ex & pattern, lst & found)
+{
+	if (expression.match(pattern)) {
+		found.append(expression);
+		return true;
+	}
+	bool any_found = false;
+	for (size_t i = 0; i < expression.nops(); ++i)
+		if (find_matches(expression.op(i), pattern, found))
+			any_found = true;
+	return any_found;
+}
+
 /** Find all occurrences of a pattern. The found matches are appended to
  *  the "found" list. If the expression itself matches the pattern, the
  *  children are not further examined. This function returns true when any
  *  matches were found. */
 bool ex::find(const ex & pattern, lst & found) const
 {
-	if (match(pattern)) {
-		found.append(*this);
+	const bool any_found = find_matches(*this, pattern, found);
+	if (any_found) {
 		found.sort();
 		found.unique();
-		return true;
 	}
-	bool any_found = false;
-	for (size_t i=0; i<nops(); i++)
-		if (op(i).find(pattern, found))
-			any_found = true;
 	return any_found;
 }
 
@@ -756,7 +764,7 @@ static bool _collect_powers(ex& e, ex& repl, bool& collected)
 ex ex::collect_powers() const
 {
         ex the_ex = *this;
-        bool b;
+        bool b = false;
         ex r;
         (void)_collect_powers(the_ex, r, b);
         return b? r:the_ex;

--- a/src/sage/symbolic/ginac/ex.h
+++ b/src/sage/symbolic/ginac/ex.h
@@ -30,6 +30,7 @@
 #include <iosfwd>
 #include <iterator>
 #include <functional>
+#include <memory>
 #include <stack>
 #include <unordered_set>
 
@@ -351,12 +352,18 @@ ex::ex(const std::string &s, const ex &l) : bp(construct_from_string_and_lst(s, 
 
 // Iterators
 
-class const_iterator : public std::iterator<std::random_access_iterator_tag, ex, ptrdiff_t, const ex *, const ex &> {
+class const_iterator {
 	friend class ex;
 	friend class const_preorder_iterator;
 	friend class const_postorder_iterator;
 
 public:
+	using iterator_category = std::random_access_iterator_tag;
+	using value_type = ex;
+	using difference_type = ptrdiff_t;
+	using pointer = const ex *;
+	using reference = const ex &;
+
 	const_iterator() throw() {}
 
 private:
@@ -497,8 +504,14 @@ struct _iter_rep {
 
 } // namespace internal
 
-class const_preorder_iterator : public std::iterator<std::forward_iterator_tag, ex, ptrdiff_t, const ex *, const ex &> {
+class const_preorder_iterator {
 public:
+	using iterator_category = std::forward_iterator_tag;
+	using value_type = ex;
+	using difference_type = ptrdiff_t;
+	using pointer = const ex *;
+	using reference = const ex &;
+
 	const_preorder_iterator() throw() {}
 
 	const_preorder_iterator(const ex &e, size_t n)
@@ -561,8 +574,14 @@ private:
 	}
 };
 
-class const_postorder_iterator : public std::iterator<std::forward_iterator_tag, ex, ptrdiff_t, const ex *, const ex &> {
+class const_postorder_iterator {
 public:
+	using iterator_category = std::forward_iterator_tag;
+	using value_type = ex;
+	using difference_type = ptrdiff_t;
+	using pointer = const ex *;
+	using reference = const ex &;
+
 	const_postorder_iterator() throw() {}
 
 	const_postorder_iterator(const ex &e, size_t n)

--- a/src/sage/symbolic/ginac/expairseq.cpp
+++ b/src/sage/symbolic/ginac/expairseq.cpp
@@ -359,8 +359,7 @@ epvector* conjugateepvector(const epvector& epv)
 ex expairseq::conjugate() const
 {
 	std::unique_ptr<epvector> newepv(conjugateepvector(seq));
-        // this is known to be numeric
-	const numeric& x = ex_to<numeric>(overall_coeff.conjugate());
+	const numeric x = overall_coeff.conj();
 	if (!newepv and overall_coeff.is_equal(x)) {
 		return *this;
 	}
@@ -972,8 +971,7 @@ void expairseq::make_flat(const exvector &v, bool do_hold)
 	// and their cumulative number of operands
 	int nexpairseqs = 0;
 	int noperands = 0;
-	bool do_idx_rename = false;
-	
+
 	if (!do_hold) {
                 for (const auto & elem : v) {
 			if (ex_to<basic>(elem).tinfo()==this->tinfo()) {
@@ -988,7 +986,7 @@ void expairseq::make_flat(const exvector &v, bool do_hold)
 	seq.reserve(v.size()+noperands-nexpairseqs);
 	
 	// copy elements and split off numerical part
-	make_flat_inserter mf(v, do_idx_rename);
+	make_flat_inserter mf(v, false);
         for (const auto & elem : v) {
 		if (ex_to<basic>(elem).tinfo()==this->tinfo() && !do_hold) {
 			ex newfactor = mf.handle_factor(elem, _ex1);
@@ -1009,7 +1007,7 @@ void expairseq::make_flat(const exvector &v, bool do_hold)
 
 /** Combine this expairseq with argument epvector.
  *  It cares for associativity as well as for special handling of numerics. */
-void expairseq::make_flat(const epvector &v, bool do_index_renaming)
+void expairseq::make_flat(const epvector &v, bool /*do_index_renaming*/)
 {
 	// count number of operands which are of same expairseq derived type
 	// and their cumulative number of operands

--- a/src/sage/symbolic/ginac/expairseq.h
+++ b/src/sage/symbolic/ginac/expairseq.h
@@ -187,9 +187,9 @@ protected:
 class make_flat_inserter
 {
 	public:
-		make_flat_inserter(const epvector &epv, bool b)
+		make_flat_inserter(const epvector & /*epv*/, bool /*b*/)
 		{}
-		make_flat_inserter(const exvector &v, bool b)
+		make_flat_inserter(const exvector & /*v*/, bool /*b*/)
                 {}
 		ex handle_factor(const ex &x, const ex &coeff)
 		{

--- a/src/sage/symbolic/ginac/exprseq.cpp
+++ b/src/sage/symbolic/ginac/exprseq.cpp
@@ -43,8 +43,8 @@ template <> bool exprseq::info(unsigned inf) const
 {
 	if (inf == info_flags::exprseq)
 		return true;
-	
-		return inherited::info(inf);
+
+	return inherited::info(inf);
 }
 
 template <>

--- a/src/sage/symbolic/ginac/function.cpp
+++ b/src/sage/symbolic/ginac/function.cpp
@@ -40,17 +40,52 @@
 #include "cmatcher.h"
 #include "wildcard.h"
 #include "expairseq.h"
+#include "pyobject_ptr.h"
 
 #include <iostream>
+#include <memory>
 #include <string>
 #include <stdexcept>
 #include <list>
 #include <limits>
+#include <type_traits>
 #ifdef DO_GINAC_ASSERT
 #  include <typeinfo>
 #endif
 
 namespace GiNaC {
+
+namespace {
+
+using internal::pyobject_ptr;
+
+// function_options predates type-safe callable wrappers and stores callbacks
+// with several signatures in a no-argument function-pointer field.  C++
+// guarantees that converting a function pointer to another function-pointer
+// type and back recovers the original value.  Keep that type-erasure boundary
+// here, and make every call site state the exact type it restores.
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
+template <typename To, typename From>
+To callback_cast(From callback) noexcept
+{
+	static_assert(std::is_pointer<To>::value,
+	              "callback destination must be a pointer");
+	static_assert(std::is_function<typename std::remove_pointer<To>::type>::value,
+	              "callback destination must be a function pointer");
+	static_assert(std::is_pointer<From>::value,
+	              "callback source must be a pointer");
+	static_assert(std::is_function<typename std::remove_pointer<From>::type>::value,
+	              "callback source must be a function pointer");
+	return reinterpret_cast<To>(callback);
+}
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+} // namespace
 
 //////////
 // helper class function_options
@@ -132,28 +167,28 @@ function_options & function_options::latex_name(std::string const & tn)
 function_options & function_options::eval_func(eval_funcp_1 e)
 {
 	test_and_set_nparams(1);
-	eval_f = eval_funcp(e);
+	eval_f = callback_cast<eval_funcp>(e);
         pynac_eval_f = eval_f;
 	return *this;
 }
 function_options & function_options::eval_func(eval_funcp_2 e)
 {
 	test_and_set_nparams(2);
-	eval_f = eval_funcp(e);
+	eval_f = callback_cast<eval_funcp>(e);
         pynac_eval_f = eval_f;
 	return *this;
 }
 function_options & function_options::eval_func(eval_funcp_3 e)
 {
 	test_and_set_nparams(3);
-	eval_f = eval_funcp(e);
+	eval_f = callback_cast<eval_funcp>(e);
         pynac_eval_f = eval_f;
 	return *this;
 }
 function_options & function_options::eval_func(eval_funcp_6 e)
 {
 	test_and_set_nparams(6);
-	eval_f = eval_funcp(e);
+	eval_f = callback_cast<eval_funcp>(e);
         pynac_eval_f = eval_f;
 	return *this;
 }
@@ -161,183 +196,183 @@ function_options & function_options::eval_func(eval_funcp_6 e)
 function_options & function_options::evalf_func(evalf_funcp_1 ef)
 {
 	test_and_set_nparams(1);
-	evalf_f = evalf_funcp(ef);
+	evalf_f = callback_cast<evalf_funcp>(ef);
 	return *this;
 }
 function_options & function_options::evalf_func(evalf_funcp_2 ef)
 {
 	test_and_set_nparams(2);
-	evalf_f = evalf_funcp(ef);
+	evalf_f = callback_cast<evalf_funcp>(ef);
 	return *this;
 }
 function_options & function_options::evalf_func(evalf_funcp_3 ef)
 {
 	test_and_set_nparams(3);
-	evalf_f = evalf_funcp(ef);
+	evalf_f = callback_cast<evalf_funcp>(ef);
 	return *this;
 }
 function_options & function_options::evalf_func(evalf_funcp_6 ef)
 {
 	test_and_set_nparams(6);
-	evalf_f = evalf_funcp(ef);
+	evalf_f = callback_cast<evalf_funcp>(ef);
 	return *this;
 }
 
 function_options & function_options::conjugate_func(conjugate_funcp_1 c)
 {
 	test_and_set_nparams(1);
-	conjugate_f = conjugate_funcp(c);
+	conjugate_f = callback_cast<conjugate_funcp>(c);
 	return *this;
 }
 function_options & function_options::conjugate_func(conjugate_funcp_2 c)
 {
 	test_and_set_nparams(2);
-	conjugate_f = conjugate_funcp(c);
+	conjugate_f = callback_cast<conjugate_funcp>(c);
 	return *this;
 }
 function_options & function_options::conjugate_func(conjugate_funcp_3 c)
 {
 	test_and_set_nparams(3);
-	conjugate_f = conjugate_funcp(c);
+	conjugate_f = callback_cast<conjugate_funcp>(c);
 	return *this;
 }
 
 function_options & function_options::real_part_func(real_part_funcp_1 c)
 {
 	test_and_set_nparams(1);
-	real_part_f = real_part_funcp(c);
+	real_part_f = callback_cast<real_part_funcp>(c);
 	return *this;
 }
 function_options & function_options::real_part_func(real_part_funcp_2 c)
 {
 	test_and_set_nparams(2);
-	real_part_f = real_part_funcp(c);
+	real_part_f = callback_cast<real_part_funcp>(c);
 	return *this;
 }
 function_options & function_options::real_part_func(real_part_funcp_3 c)
 {
 	test_and_set_nparams(3);
-	real_part_f = real_part_funcp(c);
+	real_part_f = callback_cast<real_part_funcp>(c);
 	return *this;
 }
 
 function_options & function_options::imag_part_func(imag_part_funcp_1 c)
 {
 	test_and_set_nparams(1);
-	imag_part_f = imag_part_funcp(c);
+	imag_part_f = callback_cast<imag_part_funcp>(c);
 	return *this;
 }
 function_options & function_options::imag_part_func(imag_part_funcp_2 c)
 {
 	test_and_set_nparams(2);
-	imag_part_f = imag_part_funcp(c);
+	imag_part_f = callback_cast<imag_part_funcp>(c);
 	return *this;
 }
 function_options & function_options::imag_part_func(imag_part_funcp_3 c)
 {
 	test_and_set_nparams(3);
-	imag_part_f = imag_part_funcp(c);
+	imag_part_f = callback_cast<imag_part_funcp>(c);
 	return *this;
 }
 
 function_options & function_options::derivative_func(derivative_funcp_1 d)
 {
 	test_and_set_nparams(1);
-	derivative_f = derivative_funcp(d);
+	derivative_f = callback_cast<derivative_funcp>(d);
 	return *this;
 }
 function_options & function_options::derivative_func(derivative_funcp_2 d)
 {
 	test_and_set_nparams(2);
-	derivative_f = derivative_funcp(d);
+	derivative_f = callback_cast<derivative_funcp>(d);
 	return *this;
 }
 function_options & function_options::derivative_func(derivative_funcp_3 d)
 {
 	test_and_set_nparams(3);
-	derivative_f = derivative_funcp(d);
+	derivative_f = callback_cast<derivative_funcp>(d);
 	return *this;
 }
 function_options & function_options::derivative_func(derivative_funcp_6 d)
 {
 	test_and_set_nparams(6);
-	derivative_f = derivative_funcp(d);
+	derivative_f = callback_cast<derivative_funcp>(d);
 	return *this;
 }
 
 function_options & function_options::expl_derivative_func(expl_derivative_funcp_1 d)
 {
 	test_and_set_nparams(1);
-	expl_derivative_f = expl_derivative_funcp(d);
+	expl_derivative_f = callback_cast<expl_derivative_funcp>(d);
 	return *this;
 }
 function_options & function_options::expl_derivative_func(expl_derivative_funcp_2 d)
 {
 	test_and_set_nparams(2);
-	expl_derivative_f = expl_derivative_funcp(d);
+	expl_derivative_f = callback_cast<expl_derivative_funcp>(d);
 	return *this;
 }
 function_options & function_options::expl_derivative_func(expl_derivative_funcp_3 d)
 {
 	test_and_set_nparams(3);
-	expl_derivative_f = expl_derivative_funcp(d);
+	expl_derivative_f = callback_cast<expl_derivative_funcp>(d);
 	return *this;
 }
 
 function_options & function_options::power_func(power_funcp_1 d)
 {
 	test_and_set_nparams(1);
-	power_f = power_funcp(d);
+	power_f = callback_cast<power_funcp>(d);
 	return *this;
 }
 function_options & function_options::power_func(power_funcp_2 d)
 {
 	test_and_set_nparams(2);
-	power_f = power_funcp(d);
+	power_f = callback_cast<power_funcp>(d);
 	return *this;
 }
 function_options & function_options::power_func(power_funcp_3 d)
 {
 	test_and_set_nparams(3);
-	power_f = power_funcp(d);
+	power_f = callback_cast<power_funcp>(d);
 	return *this;
 }
 
 function_options & function_options::series_func(series_funcp_1 s)
 {
 	test_and_set_nparams(1);
-	series_f = series_funcp(s);
+	series_f = callback_cast<series_funcp>(s);
 	return *this;
 }
 function_options & function_options::series_func(series_funcp_2 s)
 {
 	test_and_set_nparams(2);
-	series_f = series_funcp(s);
+	series_f = callback_cast<series_funcp>(s);
 	return *this;
 }
 function_options & function_options::series_func(series_funcp_3 s)
 {
 	test_and_set_nparams(3);
-	series_f = series_funcp(s);
+	series_f = callback_cast<series_funcp>(s);
 	return *this;
 }
 
 function_options & function_options::subs_func(subs_funcp_1 s)
 {
 	test_and_set_nparams(1);
-	subs_f = subs_funcp(s);
+	subs_f = callback_cast<subs_funcp>(s);
 	return *this;
 }
 function_options & function_options::subs_func(subs_funcp_2 s)
 {
 	test_and_set_nparams(2);
-	subs_f = subs_funcp(s);
+	subs_f = callback_cast<subs_funcp>(s);
 	return *this;
 }
 function_options & function_options::subs_func(subs_funcp_3 s)
 {
 	test_and_set_nparams(3);
-	subs_f = subs_funcp(s);
+	subs_f = callback_cast<subs_funcp>(s);
 	return *this;
 }
 
@@ -346,51 +381,51 @@ function_options & function_options::subs_func(subs_funcp_3 s)
 function_options& function_options::eval_func(eval_funcp_exvector e)
 {
 	eval_use_exvector_args = true;
-	eval_f = eval_funcp(e);
+	eval_f = callback_cast<eval_funcp>(e);
         pynac_eval_f = eval_f;
 	return *this;
 }
 function_options& function_options::evalf_func(evalf_funcp_exvector ef)
 {
 	evalf_use_exvector_args = true;
-	evalf_f = evalf_funcp(ef);
+	evalf_f = callback_cast<evalf_funcp>(ef);
 	return *this;
 }
 function_options& function_options::conjugate_func(conjugate_funcp_exvector c)
 {
 	conjugate_use_exvector_args = true;
-	conjugate_f = conjugate_funcp(c);
+	conjugate_f = callback_cast<conjugate_funcp>(c);
 	return *this;
 }
 function_options& function_options::real_part_func(real_part_funcp_exvector c)
 {
 	real_part_use_exvector_args = true;
-	real_part_f = real_part_funcp(c);
+	real_part_f = callback_cast<real_part_funcp>(c);
 	return *this;
 }
 function_options& function_options::imag_part_func(imag_part_funcp_exvector c)
 {
 	imag_part_use_exvector_args = true;
-	imag_part_f = imag_part_funcp(c);
+	imag_part_f = callback_cast<imag_part_funcp>(c);
 	return *this;
 }
 
 function_options& function_options::derivative_func(derivative_funcp_exvector d)
 {
 	derivative_use_exvector_args = true;
-	derivative_f = derivative_funcp(d);
+	derivative_f = callback_cast<derivative_funcp>(d);
 	return *this;
 }
 function_options& function_options::power_func(power_funcp_exvector d)
 {
 	power_use_exvector_args = true;
-	power_f = power_funcp(d);
+	power_f = callback_cast<power_funcp>(d);
 	return *this;
 }
 function_options& function_options::series_func(series_funcp_exvector s)
 {
 	series_use_exvector_args = true;
-	series_f = series_funcp(s);
+	series_f = callback_cast<series_funcp>(s);
 	return *this;
 }
 
@@ -398,7 +433,7 @@ function_options& function_options::derivative_func(
 		derivative_funcp_exvector_symbol d)
 {
 	derivative_use_exvector_args = true;
-	derivative_f = derivative_funcp(d);
+	derivative_f = callback_cast<derivative_funcp>(d);
 	return *this;
 }
 
@@ -645,14 +680,15 @@ function::function(const archive_node &n, lst &sym_lst) : inherited(n, sym_lst)
 		if (!n.find_string("pickle", s))
 			throw std::runtime_error("function::function archive error: cannot read pickled function");
 		// unpickle
-		PyObject* arg = Py_BuildValue("s#",s.c_str(), s.size());
-		PyObject* sfunc = py_funcs.py_loads(arg);
-		Py_DECREF(arg);
-		if (PyErr_Occurred() != nullptr) {
+		pyobject_ptr arg(Py_BuildValue("s#", s.c_str(), s.size()));
+		if (!arg)
+			throw std::runtime_error("function::function archive error: cannot create pickle argument");
+		pyobject_ptr sfunc(py_funcs.py_loads(arg.get()));
+		if (!sfunc || PyErr_Occurred() != nullptr) {
 		    throw(std::runtime_error("function::function archive error: caught exception in py_loads"));
 		}
 		// get the serial of the new SFunction
-		unsigned int ser = py_funcs.py_get_serial_from_sfunction(sfunc);
+		unsigned int ser = py_funcs.py_get_serial_from_sfunction(sfunc.get());
 		if (PyErr_Occurred() != nullptr) {
 		    throw(std::runtime_error("function::function archive error: cannot get serial from SFunction"));
 		}
@@ -706,18 +742,17 @@ void function::archive(archive_node &n) const
 	if (python_func != 0u) {
 		n.add_unsigned("python", python_func);
 		// find the corresponding SFunction object
-		PyObject* sfunc = py_funcs.py_get_sfunction_from_serial(serial);
-		if (PyErr_Occurred() != nullptr) {
+		pyobject_ptr sfunc(py_funcs.py_get_sfunction_from_serial(serial));
+		if (!sfunc || PyErr_Occurred() != nullptr) {
 		    throw(std::runtime_error("function::archive cannot get serial from SFunction"));
 		}
 		// call python to pickle it
-		std::string* pickled = py_funcs.py_dumps(sfunc);
-		if (PyErr_Occurred() != nullptr) {
+		std::unique_ptr<std::string> pickled(py_funcs.py_dumps(sfunc.get()));
+		if (!pickled || PyErr_Occurred() != nullptr) {
 		    throw(std::runtime_error("function::archive py_dumps raised exception"));
 		}
 		// store the pickle in the archive
 		n.add_string("pickle", *pickled);
-		delete pickled;
 	} else {
 		n.add_unsigned("python", 0);
 		n.add_string("name", registered_functions()[serial].name);
@@ -737,22 +772,24 @@ void function::print(const print_context & c, unsigned level) const
 	const print_context_class_info *pc_info = &c.get_class_info();
 	if (serial >= static_cast<unsigned>(py_funcs.py_get_ginac_serial())) {
 		//convert arguments to a PyTuple of Expressions
-		PyObject* args = py_funcs.exvector_to_PyTuple(seq);
+		pyobject_ptr args(py_funcs.exvector_to_PyTuple(seq));
+		if (!args)
+			throw std::runtime_error("function::print(): cannot convert arguments to Python");
 
-		std::string* sout;
+		std::unique_ptr<std::string> sout;
 		if (is_a<print_latex>(c)) {
-			sout = py_funcs.py_latex_function(serial, args);
-                        if (PyErr_Occurred() != nullptr) {
-                                throw(std::runtime_error("function::print(): python print function raised exception"));
-                        }
+			sout.reset(py_funcs.py_latex_function(serial, args.get()));
+				if (!sout || PyErr_Occurred() != nullptr) {
+					throw(std::runtime_error("function::print(): python print function raised exception"));
+				}
                         c.s << *sout;
                         c.s.flush();
 		}
 		else if (is_a<print_tree>(c)) {
-			sout = py_funcs.py_print_function(serial, args);
-                        if (PyErr_Occurred() != nullptr) {
-                                throw(std::runtime_error("function::print(): python print function raised exception"));
-                        }
+			sout.reset(py_funcs.py_print_function(serial, args.get()));
+				if (!sout || PyErr_Occurred() != nullptr) {
+					throw(std::runtime_error("function::print(): python print function raised exception"));
+				}
                         std::string fname = sout->substr(0, sout->find_first_of('('));
 			c.s << std::string(level, ' ') << class_name() << " "
 			    << fname << " @" << this << ", serial=" << serial
@@ -765,33 +802,36 @@ void function::print(const print_context & c, unsigned level) const
 			c.s << std::string(level + delta_indent, ' ') << "=====" << std::endl;
 		}
                 else {
-			sout = py_funcs.py_print_function(serial, args);
-                        if (PyErr_Occurred() != nullptr) {
-                                throw(std::runtime_error("function::print(): python print function raised exception"));
-                        }
+			sout.reset(py_funcs.py_print_function(serial, args.get()));
+				if (!sout || PyErr_Occurred() != nullptr) {
+					throw(std::runtime_error("function::print(): python print function raised exception"));
+				}
                         c.s << *sout;
                         c.s.flush();
 		}
 
-		delete sout;
-		Py_DECREF(args);
 	} else {
 
 		if (is_a<print_latex>(c)) {
-		        PyObject* sfunc = py_funcs.py_get_sfunction_from_serial(serial);
-                        if (PyObject_HasAttrString(sfunc, "_print_latex_")) {
-                                PyObject* args = py_funcs.exvector_to_PyTuple(seq);
-                                std::string* sout;
-                                sout = py_funcs.py_latex_function(serial, args);
-                                if (PyErr_Occurred() != nullptr) {
-                                        throw(std::runtime_error("function::print(): python print function raised exception"));
-                                }
-                                c.s << *sout;
-                                c.s.flush();
-                                delete sout;
-                                Py_DECREF(args);
-                                return;
-                        }
+		        pyobject_ptr sfunc(py_funcs.py_get_sfunction_from_serial(serial));
+			if (!sfunc)
+				throw std::runtime_error("function::print(): cannot get symbolic function");
+			const int has_print_latex = PyObject_HasAttrString(sfunc.get(), "_print_latex_");
+			if (has_print_latex < 0)
+				throw std::runtime_error("function::print(): cannot inspect symbolic function");
+			if (has_print_latex != 0) {
+				pyobject_ptr args(py_funcs.exvector_to_PyTuple(seq));
+				if (!args)
+					throw std::runtime_error("function::print(): cannot convert arguments to Python");
+				std::unique_ptr<std::string> sout(
+					py_funcs.py_latex_function(serial, args.get()));
+				if (!sout || PyErr_Occurred() != nullptr) {
+					throw(std::runtime_error("function::print(): python print function raised exception"));
+				}
+				c.s << *sout;
+				c.s.flush();
+				return;
+			}
 		}
 
                 const function_options &opt = registered_functions()[serial];
@@ -835,18 +875,18 @@ next_context:
 		// Method found, call it
 		current_serial = serial;
                 if (opt.print_use_exvector_args)
-                        (reinterpret_cast<print_funcp_exvector>(pdt[id]))(seq, c);
+                        callback_cast<print_funcp_exvector>(pdt[id])(seq, c);
                 else
                         switch (opt.nparams) {
                         // the following lines have been generated for max. 14 parameters
                         case 1:
-                                (reinterpret_cast<print_funcp_1>(pdt[id]))(seq[1 - 1], c);
+                                callback_cast<print_funcp_1>(pdt[id])(seq[1 - 1], c);
                                 break;
                         case 2:
-                                (reinterpret_cast<print_funcp_2>(pdt[id]))(seq[1 - 1], seq[2 - 1], c);
+                                callback_cast<print_funcp_2>(pdt[id])(seq[1 - 1], seq[2 - 1], c);
                                 break;
                         case 3:
-                                (reinterpret_cast<print_funcp_3>(pdt[id]))(seq[1 - 1], seq[2 - 1], seq[3 - 1], c);
+                                callback_cast<print_funcp_3>(pdt[id])(seq[1 - 1], seq[2 - 1], seq[3 - 1], c);
                                 break;
 
                         // end of generated lines
@@ -890,40 +930,40 @@ ex function::eval(int level) const
 	if (opt.pynac_eval_f == nullptr
             and (opt.python_func & function_options::eval_python_f) != 0u) {
 		// convert seq to a PyTuple of Expressions
-		PyObject* args = py_funcs.exvector_to_PyTuple(seq);
+		pyobject_ptr args(py_funcs.exvector_to_PyTuple(seq));
+		if (!args)
+			throw std::runtime_error("function::eval(): cannot convert arguments to Python");
 		// call opt.eval_f with this list
-		PyObject* pyresult = PyObject_CallMethod(reinterpret_cast<PyObject*>(eval_f),
-				const_cast<char*>("_eval_"), const_cast<char*>("O"), args);
-		Py_DECREF(args);
-		if (pyresult == nullptr) { 
+		pyobject_ptr pyresult(PyObject_CallMethod(reinterpret_cast<PyObject*>(eval_f),
+				const_cast<char*>("_eval_"), const_cast<char*>("O"), args.get()));
+		if (!pyresult) {
 			throw(std::runtime_error("function::eval(): python function raised exception"));
 		}
-		if ( pyresult == Py_None ) {
+		if (pyresult.get() == Py_None) {
 			return this->hold();
 		}
 		// convert output Expression to an ex
-		eval_result = py_funcs.pyExpression_to_ex(pyresult);
-		Py_DECREF(pyresult);
+		eval_result = py_funcs.pyExpression_to_ex(pyresult.get());
 		if (PyErr_Occurred() != nullptr) { 
 			throw(std::runtime_error("function::eval(): python function (Expression_to_ex) raised exception"));
 		}
 	}
 	else if (opt.eval_use_exvector_args)
-		eval_result = (reinterpret_cast<eval_funcp_exvector>(eval_f))(seq);
+		eval_result = callback_cast<eval_funcp_exvector>(eval_f)(seq);
 	else
 	switch (opt.nparams) {
 		// the following lines have been generated for max. 14 parameters
 	case 1:
-		eval_result = (reinterpret_cast<eval_funcp_1>(eval_f))(seq[1-1]);
+		eval_result = callback_cast<eval_funcp_1>(eval_f)(seq[1-1]);
 		break;
 	case 2:
-		eval_result = (reinterpret_cast<eval_funcp_2>(eval_f))(seq[1-1], seq[2-1]);
+		eval_result = callback_cast<eval_funcp_2>(eval_f)(seq[1-1], seq[2-1]);
 		break;
 	case 3:
-		eval_result = (reinterpret_cast<eval_funcp_3>(eval_f))(seq[1-1], seq[2-1], seq[3-1]);
+		eval_result = callback_cast<eval_funcp_3>(eval_f)(seq[1-1], seq[2-1], seq[3-1]);
 		break;
 	case 6:
-		eval_result = (reinterpret_cast<eval_funcp_6>(eval_f))(seq[1-1], seq[2-1], seq[3-1], seq[4-1], seq[5-1], seq[6-1]);
+		eval_result = callback_cast<eval_funcp_6>(eval_f)(seq[1-1], seq[2-1], seq[3-1], seq[4-1], seq[5-1], seq[6-1]);
 		break;
 
 		// end of generated lines
@@ -960,12 +1000,12 @@ ex function::evalf(int level, PyObject* kwds) const
                         try {
                                 return n.try_py_method(get_name());
                         }
-                        catch (std::logic_error) {
+                        catch (const std::logic_error&) {
                                 try {
                                         const numeric& nn = ex_to<numeric>(n.evalf()).try_py_method(get_name());
                                         return nn.to_dict_parent(kwds);
                                 }
-                                catch (std::logic_error) {}
+                                catch (const std::logic_error&) {}
                         }
                 }
 		return function(serial,eseq).hold();
@@ -973,35 +1013,37 @@ ex function::evalf(int level, PyObject* kwds) const
 	current_serial = serial;
 	if ((opt.python_func & function_options::evalf_python_f) != 0u) { 
 		// convert seq to a PyTuple of Expressions
-		PyObject* args = py_funcs.exvector_to_PyTuple(eseq);
+		pyobject_ptr args(py_funcs.exvector_to_PyTuple(eseq));
+		if (!args)
+			throw std::runtime_error("function::evalf(): cannot convert arguments to Python");
+		pyobject_ptr callback(PyObject_GetAttrString(
+			reinterpret_cast<PyObject*>(opt.evalf_f), "_evalf_"));
+		if (!callback)
+			throw std::runtime_error("function::evalf(): cannot get Python callback");
 		// call opt.evalf_f with this list
-		PyObject* pyresult = PyObject_Call(
-			PyObject_GetAttrString(reinterpret_cast<PyObject*>(opt.evalf_f),
-				"_evalf_"), args, kwds);
-		Py_DECREF(args);
-		if (pyresult == nullptr) { 
+		pyobject_ptr pyresult(PyObject_Call(callback.get(), args.get(), kwds));
+		if (!pyresult) {
 			throw(std::runtime_error("function::evalf(): python function raised exception"));
 		}
 		// convert output Expression to an ex
-		ex result = py_funcs.pyExpression_to_ex(pyresult);
-		Py_DECREF(pyresult);
+		ex result = py_funcs.pyExpression_to_ex(pyresult.get());
 		if (PyErr_Occurred() != nullptr) { 
 			throw(std::runtime_error("function::evalf(): python function (pyExpression_to_ex) raised exception"));
 		}
 		return result;
 	}
 	if (opt.evalf_use_exvector_args)
-		return (reinterpret_cast<evalf_funcp_exvector>(opt.evalf_f))(seq, kwds);
+		return callback_cast<evalf_funcp_exvector>(opt.evalf_f)(seq, kwds);
 	switch (opt.nparams) {
 		// the following lines have been generated for max. 14 parameters
 	case 1:
-		return (reinterpret_cast<evalf_funcp_1>(opt.evalf_f))(eseq[1-1], kwds);
+		return callback_cast<evalf_funcp_1>(opt.evalf_f)(eseq[1-1], kwds);
 	case 2:
-		return (reinterpret_cast<evalf_funcp_2>(opt.evalf_f))(eseq[1-1], eseq[2-1], kwds);
+		return callback_cast<evalf_funcp_2>(opt.evalf_f)(eseq[1-1], eseq[2-1], kwds);
 	case 3:
-		return (reinterpret_cast<evalf_funcp_3>(opt.evalf_f))(eseq[1-1], eseq[2-1], eseq[3-1], kwds);
+		return callback_cast<evalf_funcp_3>(opt.evalf_f)(eseq[1-1], eseq[2-1], eseq[3-1], kwds);
 	case 6:
-		return (reinterpret_cast<evalf_funcp_6>(opt.evalf_f))(eseq[1-1], eseq[2-1], eseq[3-1], eseq[4-1], eseq[5-1], eseq[6-1], kwds);
+		return callback_cast<evalf_funcp_6>(opt.evalf_f)(eseq[1-1], eseq[2-1], eseq[3-1], eseq[4-1], eseq[5-1], eseq[6-1], kwds);
 
 		// end of generated lines
 	}
@@ -1047,25 +1089,34 @@ ex function::series(const relational & r, int order, unsigned options) const
 	current_serial = serial;
 	if ((opt.python_func & function_options::series_python_f) != 0u) {
 		// convert seq to a PyTuple of Expressions
-		PyObject* args = py_funcs.exvector_to_PyTuple(seq);
+		pyobject_ptr args(py_funcs.exvector_to_PyTuple(seq));
+		if (!args)
+			throw std::runtime_error("function::series(): cannot convert arguments to Python");
 		// create a dictionary {'order': order, 'options':options}
-		PyObject* kwds = Py_BuildValue("{s:i,s:I}","order",order,"options",options);
+		pyobject_ptr kwds(Py_BuildValue("{s:i,s:I}",
+		                                  "order", order,
+		                                  "options", options));
+		if (!kwds)
+			throw std::runtime_error("function::series(): cannot create keyword arguments");
 		// add variable to expand for as a keyword argument
-		PyDict_SetItemString(kwds, "var", py_funcs.ex_to_pyExpression(r.lhs()));
+		pyobject_ptr var(py_funcs.ex_to_pyExpression(r.lhs()));
+		if (!var || PyDict_SetItemString(kwds.get(), "var", var.get()) < 0)
+			throw std::runtime_error("function::series(): cannot set expansion variable");
 		// add the point of expansion as a keyword argument
-		PyDict_SetItemString(kwds, "at", py_funcs.ex_to_pyExpression(r.rhs()));
+		pyobject_ptr at(py_funcs.ex_to_pyExpression(r.rhs()));
+		if (!at || PyDict_SetItemString(kwds.get(), "at", at.get()) < 0)
+			throw std::runtime_error("function::series(): cannot set expansion point");
+		pyobject_ptr callback(PyObject_GetAttrString(
+			reinterpret_cast<PyObject*>(opt.series_f), "_series_"));
+		if (!callback)
+			throw std::runtime_error("function::series(): cannot get Python callback");
 		// call opt.series_f with this list
-		PyObject* pyresult = PyObject_Call(
-			PyObject_GetAttrString(reinterpret_cast<PyObject*>(opt.series_f),
-				"_series_"), args, kwds);
-		Py_DECREF(args);
-		Py_DECREF(kwds);
-		if (pyresult == nullptr) { 
+		pyobject_ptr pyresult(PyObject_Call(callback.get(), args.get(), kwds.get()));
+		if (!pyresult) {
 			throw(std::runtime_error("function::series(): python function raised exception"));
 		}
 		// convert output Expression to an ex
-		ex result = py_funcs.pyExpression_to_ex(pyresult);
-		Py_DECREF(pyresult);
+		ex result = py_funcs.pyExpression_to_ex(pyresult.get());
 		if (PyErr_Occurred() != nullptr) { 
 			throw(std::runtime_error("function::series(): python function (pyExpression_to_ex) raised exception"));
 		}
@@ -1073,8 +1124,8 @@ ex function::series(const relational & r, int order, unsigned options) const
 	}
 	if (opt.series_use_exvector_args) {
 		try {
-			res = (reinterpret_cast<series_funcp_exvector>(opt.series_f))(seq, r, order, options);
-		} catch (do_taylor) {
+			res = callback_cast<series_funcp_exvector>(opt.series_f)(seq, r, order, options);
+		} catch (const do_taylor&) {
 			res = basic::series(r, order, options);
 		}
 		return res;
@@ -1083,22 +1134,22 @@ ex function::series(const relational & r, int order, unsigned options) const
 		// the following lines have been generated for max. 14 parameters
 	case 1:
 		try {
-			res = (reinterpret_cast<series_funcp_1>(opt.series_f))(seq[1-1],r,order,options);
-		} catch (do_taylor) {
+			res = callback_cast<series_funcp_1>(opt.series_f)(seq[1-1],r,order,options);
+		} catch (const do_taylor&) {
 			res = basic::series(r, order, options);
 		}
 		return res;
 	case 2:
 		try {
-			res = (reinterpret_cast<series_funcp_2>(opt.series_f))(seq[1-1], seq[2-1],r,order,options);
-		} catch (do_taylor) {
+			res = callback_cast<series_funcp_2>(opt.series_f)(seq[1-1], seq[2-1],r,order,options);
+		} catch (const do_taylor&) {
 			res = basic::series(r, order, options);
 		}
 		return res;
 	case 3:
 		try {
-			res = (reinterpret_cast<series_funcp_3>(opt.series_f))(seq[1-1], seq[2-1], seq[3-1],r,order,options);
-		} catch (do_taylor) {
+			res = callback_cast<series_funcp_3>(opt.series_f)(seq[1-1], seq[2-1], seq[3-1],r,order,options);
+		} catch (const do_taylor&) {
 			res = basic::series(r, order, options);
 		}
 		return res;
@@ -1117,18 +1168,18 @@ ex function::subs(const exmap & m, unsigned options) const
 
 	if ((opt.python_func & function_options::subs_python_f) != 0u) {
 		// convert seq to a PyTuple of Expressions
-		PyObject* args = py_funcs.subs_args_to_PyTuple(m, options, seq);
+		pyobject_ptr args(py_funcs.subs_args_to_PyTuple(m, options, seq));
+		if (!args)
+			throw std::runtime_error("function::subs(): cannot convert arguments to Python");
 		// call opt.subs_f with this list
-		PyObject* pyresult = PyObject_CallMethod(
+		pyobject_ptr pyresult(PyObject_CallMethod(
 				reinterpret_cast<PyObject*>(opt.subs_f),
-				const_cast<char*>("_subs_"), const_cast<char*>("O"), args);
-		Py_DECREF(args);
-		if (pyresult == nullptr) { 
+				const_cast<char*>("_subs_"), const_cast<char*>("O"), args.get()));
+		if (!pyresult) {
 			throw(std::runtime_error("function::subs(): python method (_subs_) raised exception"));
 		}
 		// convert output Expression to an ex
-		ex result = py_funcs.pyExpression_to_ex(pyresult);
-		Py_DECREF(pyresult);
+		ex result = py_funcs.pyExpression_to_ex(pyresult.get());
 		if (PyErr_Occurred() != nullptr) { 
 			throw(std::runtime_error("function::subs(): python function (pyExpression_to_ex) raised exception"));
 		}
@@ -1139,11 +1190,11 @@ ex function::subs(const exmap & m, unsigned options) const
 
 	switch (opt.nparams) {
 	case 1:
-		return (reinterpret_cast<subs_funcp_1>(opt.subs_f))(m, seq[1-1]);
+		return callback_cast<subs_funcp_1>(opt.subs_f)(m, seq[1-1]);
 	case 2:
-		return (reinterpret_cast<subs_funcp_2>(opt.subs_f))(m, seq[1-1], seq[2-1]);
+		return callback_cast<subs_funcp_2>(opt.subs_f)(m, seq[1-1], seq[2-1]);
 	case 3:
-		return (reinterpret_cast<subs_funcp_3>(opt.subs_f))(m, seq[1-1], seq[2-1], seq[3-1]);
+		return callback_cast<subs_funcp_3>(opt.subs_f)(m, seq[1-1], seq[2-1], seq[3-1]);
 
 		// end of generated lines
 	}
@@ -1162,35 +1213,35 @@ ex function::conjugate() const
 
 	if ((opt.python_func & function_options::conjugate_python_f) != 0u) {
 		// convert seq to a PyTuple of Expressions
-		PyObject* args = py_funcs.exvector_to_PyTuple(seq);
+		pyobject_ptr args(py_funcs.exvector_to_PyTuple(seq));
+		if (!args)
+			throw std::runtime_error("function::conjugate(): cannot convert arguments to Python");
 		// call opt.conjugate_f with this list
-		PyObject* pyresult = PyObject_CallMethod(
+		pyobject_ptr pyresult(PyObject_CallMethod(
 				reinterpret_cast<PyObject*>(opt.conjugate_f),
-				const_cast<char*>("_conjugate_"), const_cast<char*>("O"), args);
-		Py_DECREF(args);
-		if (pyresult == nullptr) { 
+				const_cast<char*>("_conjugate_"), const_cast<char*>("O"), args.get()));
+		if (!pyresult) {
 			throw(std::runtime_error("function::conjugate(): python function raised exception"));
 		}
 		// convert output Expression to an ex
-		ex result = py_funcs.pyExpression_to_ex(pyresult);
-		Py_DECREF(pyresult);
+		ex result = py_funcs.pyExpression_to_ex(pyresult.get());
 		if (PyErr_Occurred() != nullptr) { 
 			throw(std::runtime_error("function::conjugate(): python function (pyExpression_to_ex) raised exception"));
 		}
 		return result;
 	}
 	if (opt.conjugate_use_exvector_args) {
-		return (reinterpret_cast<conjugate_funcp_exvector>(opt.conjugate_f))(seq);
+		return callback_cast<conjugate_funcp_exvector>(opt.conjugate_f)(seq);
 	}
 
 	switch (opt.nparams) {
 		// the following lines have been generated for max. 14 parameters
 	case 1:
-		return (reinterpret_cast<conjugate_funcp_1>(opt.conjugate_f))(seq[1-1]);
+		return callback_cast<conjugate_funcp_1>(opt.conjugate_f)(seq[1-1]);
 	case 2:
-		return (reinterpret_cast<conjugate_funcp_2>(opt.conjugate_f))(seq[1-1], seq[2-1]);
+		return callback_cast<conjugate_funcp_2>(opt.conjugate_f)(seq[1-1], seq[2-1]);
 	case 3:
-		return (reinterpret_cast<conjugate_funcp_3>(opt.conjugate_f))(seq[1-1], seq[2-1], seq[3-1]);
+		return callback_cast<conjugate_funcp_3>(opt.conjugate_f)(seq[1-1], seq[2-1], seq[3-1]);
 
 		// end of generated lines
 	}
@@ -1208,33 +1259,33 @@ ex function::real_part() const
 
 	if ((opt.python_func & function_options::real_part_python_f) != 0u) {
 		// convert seq to a PyTuple of Expressions
-		PyObject* args = py_funcs.exvector_to_PyTuple(seq);
+		pyobject_ptr args(py_funcs.exvector_to_PyTuple(seq));
+		if (!args)
+			throw std::runtime_error("function::real_part(): cannot convert arguments to Python");
 		// call opt.real_part_f with this list
-		PyObject* pyresult = PyObject_CallMethod(reinterpret_cast<PyObject*>(opt.real_part_f),
-				const_cast<char*>("_real_part_"), const_cast<char*>("O"), args);
-		Py_DECREF(args);
-		if (pyresult == nullptr) { 
+		pyobject_ptr pyresult(PyObject_CallMethod(reinterpret_cast<PyObject*>(opt.real_part_f),
+				const_cast<char*>("_real_part_"), const_cast<char*>("O"), args.get()));
+		if (!pyresult) {
 			throw(std::runtime_error("function::real_part(): python function raised exception"));
 		}
 		// convert output Expression to an ex
-		ex result = py_funcs.pyExpression_to_ex(pyresult);
-		Py_DECREF(pyresult);
+		ex result = py_funcs.pyExpression_to_ex(pyresult.get());
 		if (PyErr_Occurred() != nullptr) { 
 			throw(std::runtime_error("function::real_part(): python function (pyExpression_to_ex) raised exception"));
 		}
 		return result;
 	}
 	if (opt.real_part_use_exvector_args)
-		return (reinterpret_cast<real_part_funcp_exvector>(opt.real_part_f))(seq);
+		return callback_cast<real_part_funcp_exvector>(opt.real_part_f)(seq);
 
 	switch (opt.nparams) {
 		// the following lines have been generated for max. 14 parameters
 	case 1:
-		return (reinterpret_cast<real_part_funcp_1>(opt.real_part_f))(seq[1-1]);
+		return callback_cast<real_part_funcp_1>(opt.real_part_f)(seq[1-1]);
 	case 2:
-		return (reinterpret_cast<real_part_funcp_2>(opt.real_part_f))(seq[1-1], seq[2-1]);
+		return callback_cast<real_part_funcp_2>(opt.real_part_f)(seq[1-1], seq[2-1]);
 	case 3:
-		return (reinterpret_cast<real_part_funcp_3>(opt.real_part_f))(seq[1-1], seq[2-1], seq[3-1]);
+		return callback_cast<real_part_funcp_3>(opt.real_part_f)(seq[1-1], seq[2-1], seq[3-1]);
 
 		// end of generated lines
 	}
@@ -1252,33 +1303,33 @@ ex function::imag_part() const
 
 	if ((opt.python_func & function_options::imag_part_python_f) != 0u) {
 		// convert seq to a PyTuple of Expressions
-		PyObject* args = py_funcs.exvector_to_PyTuple(seq);
+		pyobject_ptr args(py_funcs.exvector_to_PyTuple(seq));
+		if (!args)
+			throw std::runtime_error("function::imag_part(): cannot convert arguments to Python");
 		// call opt.imag_part_f with this list
-		PyObject* pyresult = PyObject_CallMethod(reinterpret_cast<PyObject*>(opt.imag_part_f),
-				const_cast<char*>("_imag_part_"), const_cast<char*>("O"), args);
-		Py_DECREF(args);
-		if (pyresult == nullptr) { 
+		pyobject_ptr pyresult(PyObject_CallMethod(reinterpret_cast<PyObject*>(opt.imag_part_f),
+				const_cast<char*>("_imag_part_"), const_cast<char*>("O"), args.get()));
+		if (!pyresult) {
 			throw(std::runtime_error("function::imag_part(): python function raised exception"));
 		}
 		// convert output Expression to an ex
-		ex result = py_funcs.pyExpression_to_ex(pyresult);
-		Py_DECREF(pyresult);
+		ex result = py_funcs.pyExpression_to_ex(pyresult.get());
 		if (PyErr_Occurred() != nullptr) { 
 			throw(std::runtime_error("function::imag_part(): python function (pyExpression_to_ex) raised exception"));
 		}
 		return result;
 	}
 	if (opt.imag_part_use_exvector_args)
-		return (reinterpret_cast<imag_part_funcp_exvector>(opt.imag_part_f))(seq);
+		return callback_cast<imag_part_funcp_exvector>(opt.imag_part_f)(seq);
 
 	switch (opt.nparams) {
 		// the following lines have been generated for max. 14 parameters
 	case 1:
-		return (reinterpret_cast<imag_part_funcp_1>(opt.imag_part_f))(seq[1-1]);
+		return callback_cast<imag_part_funcp_1>(opt.imag_part_f)(seq[1-1]);
 	case 2:
-		return (reinterpret_cast<imag_part_funcp_2>(opt.imag_part_f))(seq[1-1], seq[2-1]);
+		return callback_cast<imag_part_funcp_2>(opt.imag_part_f)(seq[1-1], seq[2-1]);
 	case 3:
-		return (reinterpret_cast<imag_part_funcp_3>(opt.imag_part_f))(seq[1-1], seq[2-1], seq[3-1]);
+		return callback_cast<imag_part_funcp_3>(opt.imag_part_f)(seq[1-1], seq[2-1], seq[3-1]);
 
 		// end of generated lines
 	}
@@ -1314,25 +1365,28 @@ ex function::derivative(const symbol & s) const
 
 		if ((opt.python_func & function_options::derivative_python_f) != 0u) {
 			// convert seq to a PyTuple of Expressions
-			PyObject* args = py_funcs.exvector_to_PyTuple(seq);
+			pyobject_ptr args(py_funcs.exvector_to_PyTuple(seq));
+			if (!args)
+				throw std::runtime_error("function::derivative(): cannot convert arguments to Python");
 			// create a dictionary {'diff_param': s}
-			PyObject* symb = py_funcs.ex_to_pyExpression(s);
-			PyObject* kwds = Py_BuildValue("{s:O}","diff_param",
-					symb);
+			pyobject_ptr symb(py_funcs.ex_to_pyExpression(s));
+			if (!symb)
+				throw std::runtime_error("function::derivative(): cannot convert differentiation variable to Python");
+			pyobject_ptr kwds(Py_BuildValue("{s:O}", "diff_param", symb.get()));
+			if (!kwds)
+				throw std::runtime_error("function::derivative(): cannot create keyword arguments");
+			pyobject_ptr callback(PyObject_GetAttrString(
+				reinterpret_cast<PyObject*>(opt.derivative_f), "_tderivative_"));
+			if (!callback)
+				throw std::runtime_error("function::derivative(): cannot get Python callback");
 			// call opt.derivative_f with this list
-			PyObject* pyresult = PyObject_Call(
-				PyObject_GetAttrString(
-					reinterpret_cast<PyObject*>(opt.derivative_f),
-					"_tderivative_"), args, kwds);
-			Py_DECREF(symb);
-			Py_DECREF(args);
-			Py_DECREF(kwds);
-			if (pyresult == nullptr) { 
+			pyobject_ptr pyresult(PyObject_Call(
+				callback.get(), args.get(), kwds.get()));
+			if (!pyresult) {
 				throw(std::runtime_error("function::derivative(): python function raised exception"));
 			}
 			// convert output Expression to an ex
-			result = py_funcs.pyExpression_to_ex(pyresult);
-			Py_DECREF(pyresult);
+			result = py_funcs.pyExpression_to_ex(pyresult.get());
 			if (PyErr_Occurred() != nullptr) { 
 				throw(std::runtime_error("function::derivative(): python function (pyExpression_to_ex) raised exception"));
 			}
@@ -1342,7 +1396,7 @@ ex function::derivative(const symbol & s) const
 		if (!opt.derivative_use_exvector_args)
 			throw(std::runtime_error("function::derivative(): cannot call C++ function without exvector args"));
 		
-		return (reinterpret_cast<derivative_funcp_exvector_symbol>(opt.derivative_f))(seq, s);
+		return callback_cast<derivative_funcp_exvector_symbol>(opt.derivative_f)(seq, s);
 
 	} 
         // Chain rule
@@ -1444,8 +1498,8 @@ tinfo_t function::return_type_tinfo() const
 		// argument. Thus, exp() of a matrix behaves like a matrix, etc.
 		if (seq.empty())
 			return this;
-		
-			return seq.begin()->return_type_tinfo();
+
+		return seq.begin()->return_type_tinfo();
 	
 }
 
@@ -1473,41 +1527,45 @@ ex function::pderivative(unsigned diff_param) const // partial differentiation
 	current_serial = serial;
 	if ((opt.python_func & function_options::derivative_python_f) != 0u) {
 		// convert seq to a PyTuple of Expressions
-		PyObject* args = py_funcs.exvector_to_PyTuple(seq);
+		pyobject_ptr args(py_funcs.exvector_to_PyTuple(seq));
+		if (!args)
+			throw std::runtime_error("function::pderivative(): cannot convert arguments to Python");
 		// create a dictionary {'diff_param': diff_param}
-		PyObject* kwds = Py_BuildValue("{s:I}","diff_param",diff_param);
+		pyobject_ptr kwds(Py_BuildValue("{s:I}", "diff_param", diff_param));
+		if (!kwds)
+			throw std::runtime_error("function::pderivative(): cannot create keyword arguments");
+		pyobject_ptr callback(PyObject_GetAttrString(
+			reinterpret_cast<PyObject*>(opt.derivative_f), "_derivative_"));
+		if (!callback)
+			throw std::runtime_error("function::pderivative(): cannot get Python callback");
 		// call opt.derivative_f with this list
-		PyObject* pyresult = PyObject_Call(
-			PyObject_GetAttrString(reinterpret_cast<PyObject*>(opt.derivative_f),
-				"_derivative_"), args, kwds);
-		Py_DECREF(args);
-		Py_DECREF(kwds);
-		if (pyresult == nullptr) { 
+		pyobject_ptr pyresult(PyObject_Call(
+			callback.get(), args.get(), kwds.get()));
+		if (!pyresult) {
 			throw(std::runtime_error("function::pderivative(): python function raised exception"));
 		}
-		if ( pyresult == Py_None ) {
+		if (pyresult.get() == Py_None) {
 			return fderivative(serial, diff_param, seq);
 		}
 		// convert output Expression to an ex
-		ex result = py_funcs.pyExpression_to_ex(pyresult);
-		Py_DECREF(pyresult);
+		ex result = py_funcs.pyExpression_to_ex(pyresult.get());
 		if (PyErr_Occurred() != nullptr) { 
 			throw(std::runtime_error("function::pderivative(): python function (pyExpression_to_ex) raised exception"));
 		}
 		return result;
 	}
 	if (opt.derivative_use_exvector_args)
-		return (reinterpret_cast<derivative_funcp_exvector>(opt.derivative_f))(seq, diff_param);
+		return callback_cast<derivative_funcp_exvector>(opt.derivative_f)(seq, diff_param);
 	switch (opt.nparams) {
 		// the following lines have been generated for max. 14 parameters
 	case 1:
-		return (reinterpret_cast<derivative_funcp_1>(opt.derivative_f))(seq[1-1],diff_param);
+		return callback_cast<derivative_funcp_1>(opt.derivative_f)(seq[1-1],diff_param);
 	case 2:
-		return (reinterpret_cast<derivative_funcp_2>(opt.derivative_f))(seq[1-1], seq[2-1],diff_param);
+		return callback_cast<derivative_funcp_2>(opt.derivative_f)(seq[1-1], seq[2-1],diff_param);
 	case 3:
-		return (reinterpret_cast<derivative_funcp_3>(opt.derivative_f))(seq[1-1], seq[2-1], seq[3-1],diff_param);
+		return callback_cast<derivative_funcp_3>(opt.derivative_f)(seq[1-1], seq[2-1], seq[3-1],diff_param);
 	case 6:
-		return (reinterpret_cast<derivative_funcp_6>(opt.derivative_f))(seq[1-1], seq[2-1], seq[3-1], seq[4-1], seq[5-1], seq[6-1], diff_param);
+		return callback_cast<derivative_funcp_6>(opt.derivative_f)(seq[1-1], seq[2-1], seq[3-1], seq[4-1], seq[5-1], seq[6-1], diff_param);
 
 		// end of generated lines
 	}
@@ -1523,15 +1581,15 @@ ex function::expl_derivative(const symbol & s) const // explicit differentiation
 		// Invoke the defined explicit derivative function.
 		current_serial = serial;
 		if (opt.expl_derivative_use_exvector_args)
-			return (reinterpret_cast<expl_derivative_funcp_exvector>(opt.expl_derivative_f))(seq, s);
+			return callback_cast<expl_derivative_funcp_exvector>(opt.expl_derivative_f)(seq, s);
 		switch (opt.nparams) {
 			// the following lines have been generated for max. 14 parameters
 			case 1:
-				return (reinterpret_cast<expl_derivative_funcp_1>(opt.expl_derivative_f))(seq[0], s);
+				return callback_cast<expl_derivative_funcp_1>(opt.expl_derivative_f)(seq[0], s);
 			case 2:
-				return (reinterpret_cast<expl_derivative_funcp_2>(opt.expl_derivative_f))(seq[0], seq[1], s);
+				return callback_cast<expl_derivative_funcp_2>(opt.expl_derivative_f)(seq[0], seq[1], s);
 			case 3:
-				return (reinterpret_cast<expl_derivative_funcp_3>(opt.expl_derivative_f))(seq[0], seq[1], seq[2], s);
+				return callback_cast<expl_derivative_funcp_3>(opt.expl_derivative_f)(seq[0], seq[1], seq[2], s);
 		}
 	}
 	// There is no fallback for explicit derivative.
@@ -1551,37 +1609,44 @@ ex function::power(const ex & power_param) const // power of function
 	current_serial = serial;
 	if ((opt.python_func & function_options::power_python_f) != 0u) {
 		// convert seq to a PyTuple of Expressions
-		PyObject* args = py_funcs.exvector_to_PyTuple(seq);
+		pyobject_ptr args(py_funcs.exvector_to_PyTuple(seq));
+		if (!args)
+			throw std::runtime_error("function::power(): cannot convert arguments to Python");
 		// create a dictionary {'power_param': power_param}
-		PyObject* kwds = PyDict_New();
-		PyDict_SetItemString(kwds, "power_param", py_funcs.ex_to_pyExpression(power_param));
+		pyobject_ptr kwds(PyDict_New());
+		if (!kwds)
+			throw std::runtime_error("function::power(): cannot create keyword arguments");
+		pyobject_ptr py_power_param(py_funcs.ex_to_pyExpression(power_param));
+		if (!py_power_param ||
+		    PyDict_SetItemString(kwds.get(), "power_param", py_power_param.get()) < 0)
+			throw std::runtime_error("function::power(): cannot set power parameter");
+		pyobject_ptr callback(PyObject_GetAttrString(
+			reinterpret_cast<PyObject*>(opt.power_f), "_power_"));
+		if (!callback)
+			throw std::runtime_error("function::power(): cannot get Python callback");
 		// call opt.power_f with this list
-		PyObject* pyresult = PyObject_Call(
-			PyObject_GetAttrString(reinterpret_cast<PyObject*>(opt.power_f),
-				"_power_"), args, kwds);
-		Py_DECREF(args);
-		Py_DECREF(kwds);
-		if (pyresult == nullptr) { 
+		pyobject_ptr pyresult(PyObject_Call(
+			callback.get(), args.get(), kwds.get()));
+		if (!pyresult) {
 			throw(std::runtime_error("function::power(): python function raised exception"));
 		}
 		// convert output Expression to an ex
-		ex result = py_funcs.pyExpression_to_ex(pyresult);
-		Py_DECREF(pyresult);
+		ex result = py_funcs.pyExpression_to_ex(pyresult.get());
 		if (PyErr_Occurred() != nullptr) { 
 			throw(std::runtime_error("function::power(): python function (pyExpression_to_ex) raised exception"));
 		}
 		return result;
 	}
 	if (opt.power_use_exvector_args)
-		return (reinterpret_cast<power_funcp_exvector>(opt.power_f))(seq,  power_param);
+		return callback_cast<power_funcp_exvector>(opt.power_f)(seq, power_param);
 	switch (opt.nparams) {
 		// the following lines have been generated for max. 14 parameters
 	case 1:
-		return (reinterpret_cast<power_funcp_1>(opt.power_f))(seq[1-1],power_param);
+		return callback_cast<power_funcp_1>(opt.power_f)(seq[1-1],power_param);
 	case 2:
-		return (reinterpret_cast<power_funcp_2>(opt.power_f))(seq[1-1], seq[2-1],power_param);
+		return callback_cast<power_funcp_2>(opt.power_f)(seq[1-1], seq[2-1],power_param);
 	case 3:
-		return (reinterpret_cast<power_funcp_3>(opt.power_f))(seq[1-1], seq[2-1], seq[3-1],power_param);
+		return callback_cast<power_funcp_3>(opt.power_f)(seq[1-1], seq[2-1], seq[3-1],power_param);
 
 		// end of generated lines
 	}
@@ -1770,4 +1835,3 @@ bool has_function(const ex& x,
 }
 
 } // namespace GiNaC
-

--- a/src/sage/symbolic/ginac/infoflagbase.h
+++ b/src/sage/symbolic/ginac/infoflagbase.h
@@ -17,7 +17,8 @@ namespace GiNaC {
 class infoflagbase {
 public:
 	infoflagbase();
-        infoflagbase(const infoflagbase& other) : bits(other.bits) {}
+        infoflagbase(const infoflagbase&) = default;
+        infoflagbase& operator=(const infoflagbase&) = default;
 
 	std::string to_string() const       { return bits.to_string(); }
 	bool get(unsigned flag) const;
@@ -46,4 +47,3 @@ private:
 } // namespace GiNaC
 
 #endif	/* INFOFLAGBASE_H */
-

--- a/src/sage/symbolic/ginac/inifcns.cpp
+++ b/src/sage/symbolic/ginac/inifcns.cpp
@@ -749,8 +749,9 @@ static ex Order_series(const ex & x, const relational & r, int order, unsigned o
 {
 	// Just wrap the function into a pseries object
 	epvector new_seq;
-	GINAC_ASSERT(is_a<symbol>(r.lhs()));
-	const symbol &s = ex_to<symbol>(r.lhs());
+	const ex lhs = r.lhs();
+	GINAC_ASSERT(is_a<symbol>(lhs));
+	const symbol &s = ex_to<symbol>(lhs);
         int ldeg = x.ldegree(s).to_int();
 	new_seq.emplace_back(Order(_ex1), numeric(std::min(ldeg, order)));
 	return pseries(r, new_seq);

--- a/src/sage/symbolic/ginac/inifcns_gamma.cpp
+++ b/src/sage/symbolic/ginac/inifcns_gamma.cpp
@@ -266,13 +266,12 @@ static ex beta_eval(const ex & x, const ex & y)
 			if (nx.is_negative()) {
 				if (nx<=-ny)
 					return pow(*_num_1_p, ny)*beta(1-x-y, y);
-                                throw (pole_error("beta_eval(): simple pole",1));
+				throw pole_error("beta_eval(): simple pole", 1);
 			}
 			if (ny.is_negative()) {
 				if (ny<=-nx)
 					return pow(*_num_1_p, nx)*beta(1-y-x, x);
-				
-					throw (pole_error("beta_eval(): simple pole",1));
+				throw pole_error("beta_eval(): simple pole", 1);
 			}
 			return gamma(x)*gamma(y)/gamma(x+y);
 		}
@@ -316,8 +315,9 @@ static ex beta_series(const ex & arg1,
 	// gamma series directly.
 	const ex arg1_pt = arg1.subs(rel, subs_options::no_pattern);
 	const ex arg2_pt = arg2.subs(rel, subs_options::no_pattern);
-	GINAC_ASSERT(is_a<symbol>(rel.lhs()));
-	const symbol &s = ex_to<symbol>(rel.lhs());
+	const ex lhs = rel.lhs();
+	GINAC_ASSERT(is_a<symbol>(lhs));
+	const symbol &s = ex_to<symbol>(lhs);
 	ex arg1_ser, arg2_ser, arg1arg2_ser;
 	if ((!arg1_pt.is_integer() || arg1_pt.info(info_flags::positive)) &&
 	    (!arg2_pt.is_integer() || arg2_pt.info(info_flags::positive)))

--- a/src/sage/symbolic/ginac/inifcns_hyperb.cpp
+++ b/src/sage/symbolic/ginac/inifcns_hyperb.cpp
@@ -911,7 +911,8 @@ static ex atanh_series(const ex &arg,
  		// method:
  		// This is the branch cut: assemble the primitive series manually and
  		// then add the corresponding complex step function.
- 		const symbol &s = ex_to<symbol>(rel.lhs());
+		const ex lhs = rel.lhs();
+		const symbol &s = ex_to<symbol>(lhs);
  		const ex &point = rel.rhs();
  		const symbol foo;
  		const ex replarg = series(atanh(arg), s==foo, order).subs(foo==point, subs_options::no_pattern);

--- a/src/sage/symbolic/ginac/inifcns_hyperg.cpp
+++ b/src/sage/symbolic/ginac/inifcns_hyperg.cpp
@@ -37,19 +37,25 @@
 #include "symbol.h"
 #include "pseries.h"
 #include "utils.h"
+#include "pyobject_ptr.h"
 
 #include <utility>
 #include <vector>
 #include <stdexcept>
 #include <sstream>
 #include <string>
-#include <memory>
 
 #if PY_MAJOR_VERSION > 2
 #define PyString_FromString PyUnicode_FromString
 #endif
 
 namespace GiNaC {
+
+namespace {
+
+using internal::pyobject_ptr;
+
+} // namespace
 
 inline void py_error(const char* errmsg) {
         throw std::runtime_error((PyErr_Occurred() != nullptr) ? errmsg:
@@ -63,31 +69,36 @@ ex _2F1(const ex& a, const ex& b, const ex& c, ex x)
         avec.push_back(a);
         avec.push_back(b);
         bvec.push_back(c);
-        PyObject *lista = py_funcs.exvector_to_PyTuple(avec);
-        PyObject *listb = py_funcs.exvector_to_PyTuple(bvec);
-        PyObject *z = py_funcs.ex_to_pyExpression(std::move(x));
+        pyobject_ptr lista(py_funcs.exvector_to_PyTuple(avec));
+        if (!lista)
+                py_error("Error converting hypergeometric numerator parameters");
+        pyobject_ptr listb(py_funcs.exvector_to_PyTuple(bvec));
+        if (!listb)
+                py_error("Error converting hypergeometric denominator parameters");
+        pyobject_ptr z(py_funcs.ex_to_pyExpression(std::move(x)));
+        if (!z)
+                py_error("Error converting hypergeometric argument");
 
-        PyObject* m = PyImport_ImportModule("sage.functions.hypergeometric");
-        if (m == nullptr)
+        pyobject_ptr m(PyImport_ImportModule("sage.functions.hypergeometric"));
+        if (!m)
                 py_error("Error importing hypergeometric");
-        PyObject* hypfunc = PyObject_GetAttrString(m, "hypergeometric");
-        if (hypfunc == nullptr)
+        pyobject_ptr hypfunc(PyObject_GetAttrString(m.get(), "hypergeometric"));
+        if (!hypfunc)
                 py_error("Error getting hypergeometric attribute");
 
-        PyObject* name = PyString_FromString(const_cast<char*>("__call__"));
-        PyObject* pyresult = PyObject_CallMethodObjArgs(hypfunc, name, lista, listb, z, NULL);
-        Py_DECREF(m);
-        Py_DECREF(name);
-        Py_DECREF(hypfunc);
-        if (pyresult == nullptr) {
+        pyobject_ptr name(PyString_FromString("__call__"));
+        if (!name)
+                py_error("Error creating hypergeometric method name");
+        pyobject_ptr pyresult(PyObject_CallMethodObjArgs(
+                hypfunc.get(), name.get(), lista.get(), listb.get(), z.get(), nullptr));
+        if (!pyresult) {
                 throw(std::runtime_error("numeric::hypergeometric_pFq(): python function hypergeometric::__call__ raised exception"));
         }
-        if ( pyresult == Py_None ) {
+        if (pyresult.get() == Py_None) {
                 throw(std::runtime_error("numeric::hypergeometric_pFq(): python function hypergeometric::__call__ returned None"));
         }
         // convert output Expression to an ex
-        ex eval_result = py_funcs.pyExpression_to_ex(pyresult);
-        Py_DECREF(pyresult);
+        ex eval_result = py_funcs.pyExpression_to_ex(pyresult.get());
         if (PyErr_Occurred() != nullptr) {
                 throw(std::runtime_error("numeric::hypergeometric_pFq(): python function (Expression_to_ex) raised exception"));
         }
@@ -99,7 +110,7 @@ ex _2F1(const ex& a, const ex& b, const ex& c, ex x)
 // Appell F1 function
 //////////
 
-static ex appellf1_evalf(const ex& a, const ex& b1, const ex& b2, const ex& c, const ex& x, const ex& y, PyObject* parent)
+static ex appellf1_evalf(const ex& a, const ex& b1, const ex& b2, const ex& c, const ex& x, const ex& y, PyObject*)
 {
 	/*if (is_exactly_a<numeric>(a) and is_exactly_a<numeric>(b1)
             and is_exactly_a<numeric>(b2) and is_exactly_a<numeric>(c)

--- a/src/sage/symbolic/ginac/inifcns_trans.cpp
+++ b/src/sage/symbolic/ginac/inifcns_trans.cpp
@@ -379,7 +379,7 @@ static ex log_series(const ex &arg,
 	// maybe substitution of rel into arg fails because of a pole
 	try {
 		arg_pt = arg.subs(rel, subs_options::no_pattern);
-	} catch (pole_error) {
+	} catch (const pole_error&) {
 		must_expand_arg = true;
 	}
 	// or we are at the branch point anyways
@@ -407,7 +407,8 @@ static ex log_series(const ex &arg,
 			++extra_ord;
 		} while (!argser.is_terminating() && argser.nops()==1);
 
-		const symbol &s = ex_to<symbol>(rel.lhs());
+		const ex lhs = rel.lhs();
+		const symbol &s = ex_to<symbol>(lhs);
 		const ex &point = rel.rhs();
 		const numeric &num = argser.ldegree(s);
                 long n = num.to_long();
@@ -450,7 +451,8 @@ static ex log_series(const ex &arg,
 		// method:
 		// This is the branch cut: assemble the primitive series manually and
 		// then add the corresponding complex step function.
-		const symbol &s = ex_to<symbol>(rel.lhs());
+		const ex lhs = rel.lhs();
+		const symbol &s = ex_to<symbol>(lhs);
 		const ex &point = rel.rhs();
 		const symbol foo;
 		const ex replarg = series(log(arg), s==foo, order).subs(foo==point, subs_options::no_pattern);
@@ -668,7 +670,8 @@ static ex Li2_series(const ex &x, const relational &rel, int order, unsigned opt
 			// method:
 			// This is the branch cut: assemble the primitive series manually
 			// and then add the corresponding complex step function.
-			const symbol &s = ex_to<symbol>(rel.lhs());
+			const ex lhs = rel.lhs();
+			const symbol &s = ex_to<symbol>(lhs);
 			const ex point = rel.rhs();
 			const symbol foo;
 			epvector seq;

--- a/src/sage/symbolic/ginac/inifcns_trig.cpp
+++ b/src/sage/symbolic/ginac/inifcns_trig.cpp
@@ -415,12 +415,13 @@ static ex cos_eval(const ex & x)
                         if (c.is_rational()) {
                                 numeric den = c.denom();
                                 numeric num = c.numer().mod(den * *_num2_p);
-                                if (num > den)
-                                        num = den * *_num2_p - num;
-                                if (num*(*_num2_p) > den)
-                                        return mul(_ex_1, cos_eval((den-num)*Pi/den));
-                                
-                                        return cos((num*Pi)/den).hold();
+	                                if (num > den) {
+	                                        num = den * *_num2_p - num;
+	                                }
+	                                if (num*(*_num2_p) > den)
+	                                        return mul(_ex_1, cos_eval((den-num)*Pi/den));
+
+	                                return cos((num*Pi)/den).hold();
                         }
                 }
 	}
@@ -959,10 +960,10 @@ static ex sec_eval(const ex & x)
                 return power(res, _ex_1);
         }
         // cos has reflected also the argument so take it
-        if (is_ex_the_function(res, cos))
-                return sec(res.op(0)).hold();
-        
-                return -sec((-res).op(0)).hold();
+	        if (is_ex_the_function(res, cos))
+	                return sec(res.op(0)).hold();
+
+	        return -sec((-res).op(0)).hold();
 }
 
 static ex sec_deriv(const ex & x, unsigned deriv_param)
@@ -1070,11 +1071,11 @@ static ex csc_eval(const ex & x)
 
         // Handle simplification via sin
         ex res = sin_eval(x);
-        if (not is_ex_the_function(res, sin) && not is_ex_the_function(_ex_1*res, sin)) {
-                if (res.is_zero())
-                        return UnsignedInfinity;
-                
-                        return power(res, _ex_1);
+	        if (not is_ex_the_function(res, sin) && not is_ex_the_function(_ex_1*res, sin)) {
+	                if (res.is_zero())
+	                        return UnsignedInfinity;
+
+	                return power(res, _ex_1);
         }
         // sin has reflected also the argument so take it
         if (is_ex_the_function(res, sin))
@@ -1377,7 +1378,8 @@ static ex atan_series(const ex &arg,
 		// method:
 		// This is the branch cut: assemble the primitive series manually and
 		// then add the corresponding complex step function.
-		const symbol &s = ex_to<symbol>(rel.lhs());
+		const ex lhs = rel.lhs();
+		const symbol &s = ex_to<symbol>(lhs);
 		const ex &point = rel.rhs();
 		const symbol foo;
 		const ex replarg = series(atan(arg), s==foo, order).subs(foo==point, subs_options::no_pattern);

--- a/src/sage/symbolic/ginac/matrix.cpp
+++ b/src/sage/symbolic/ginac/matrix.cpp
@@ -919,8 +919,8 @@ ex matrix::charpoly(const ex & lambda) const
 		}
 		if ((row%2) != 0u)
 			return -poly;
-		
-			return poly;
+
+		return poly;
 
 	} else {
 	

--- a/src/sage/symbolic/ginac/mpoly-singular.cpp
+++ b/src/sage/symbolic/ginac/mpoly-singular.cpp
@@ -20,10 +20,14 @@
 
 #include "pynac-config.h"
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-register"
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wdeprecated-register"
+#endif
 #include "factory/factory.h"
-#pragma clang diagnostic pop
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
 
 #include "upoly.h"
 #include "normal.h"
@@ -76,7 +80,7 @@ static CanonicalForm num2canonical(const numeric& n, ex_int_umap& map, exvector&
         try {
                 return n.to_canonical();
         }
-        catch (std::runtime_error) {
+        catch (const std::runtime_error&) {
                 if (not n.is_real()) {
                         numeric re = n.real();
                         numeric im = n.imag();
@@ -233,7 +237,7 @@ const CanonicalForm ex::to_canonical(ex_int_umap& amap,
                                 try {
                                         return ::power(var, n.to_long());
                                 }
-                                catch (std::runtime_error) {
+                                catch (const std::runtime_error&) {
                                         throw std::runtime_error("exponent too big");
                                 }
                         }
@@ -261,7 +265,7 @@ const CanonicalForm ex::to_canonical(ex_int_umap& amap,
                         try {
                                 return ::power(var, n.to_long());
                         }
-                        catch (std::runtime_error) {
+                        catch (const std::runtime_error&) {
                                 throw std::runtime_error("exponent too big");
                         }
                 }
@@ -672,4 +676,3 @@ ex resultantpoly(const ex & ee1, const ex & ee2, const ex & s)
 
 
 } // namespace GiNaC
-

--- a/src/sage/symbolic/ginac/mul.cpp
+++ b/src/sage/symbolic/ginac/mul.cpp
@@ -377,7 +377,7 @@ void mul::do_print_rat_func(const print_context & c, unsigned level,
 
 }
 
-void mul::do_print_python_repr(const print_python_repr & c, unsigned level) const
+void mul::do_print_python_repr(const print_python_repr & c, unsigned /*level*/) const
 {
 	c.s << class_name() << '(';
 	op(0).print(c);
@@ -793,7 +793,8 @@ ex mul::eval(int level) const
 
 ex mul::eval_exponentials() const
 {
-	ex exp_arg = _ex0;
+	exvector exp_args;
+	exp_args.reserve(seq.size());
 	numeric oc = *_num1_p;
 	epvector s;
 	s.reserve(seq.size());
@@ -804,9 +805,10 @@ ex mul::eval_exponentials() const
 		if (likely(not simplifyable_exp))
 			s.push_back(elem);
 		else
-			exp_arg += elem.rest.op(0) * num_coeff;
+			exp_args.push_back(elem.rest.op(0) * num_coeff);
 	}
 
+	const ex exp_arg = add(exp_args);
 	ex new_exp = exp(exp_arg);
 	if (is_exactly_a<numeric>(new_exp))
 		oc = oc.mul(ex_to<numeric>(new_exp));

--- a/src/sage/symbolic/ginac/normal.cpp
+++ b/src/sage/symbolic/ginac/normal.cpp
@@ -1056,8 +1056,8 @@ ex expairseq::to_polynomial(exmap & repl) const
 	ex oc = overall_coeff.to_polynomial(repl);
 	if (oc.info(info_flags::numeric))
 		return thisexpairseq(s, overall_coeff);
-	
-		s.emplace_back(oc, _ex1);
+
+	s.emplace_back(oc, _ex1);
 	return thisexpairseq(s, default_overall_coeff());
 }
 

--- a/src/sage/symbolic/ginac/numeric.cpp
+++ b/src/sage/symbolic/ginac/numeric.cpp
@@ -56,6 +56,7 @@
 #include "flint/fmpz_factor.h"
 
 #include <cmath>
+#include <cstring>
 #include <utility>
 
 #include "numeric.h"
@@ -67,12 +68,23 @@
 #include "archive.h"
 #include "tostring.h"
 #include "utils.h"
+#include "pyobject_ptr.h"
 #include "../../cpython/pycore_long.h"
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-register"
+#if defined(__clang__)
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wdeprecated-register"
+#endif
 #include "factory/factory.h"
-#pragma clang diagnostic pop
+#if defined(__clang__)
+# pragma clang diagnostic pop
+#endif
+
+namespace {
+
+using GiNaC::internal::pyobject_ptr;
+
+}
 
 //#define Logging_refctr
 #if defined(Logging_refctr)
@@ -257,38 +269,40 @@ PyObject* Integer(const long int& x) {
 int precision(const GiNaC::numeric& num, PyObject*& a_parent) {
         int prec = 0;
         PyObject* the_parent = a_parent;
+        pyobject_ptr owned_parent;
         if (a_parent == nullptr) {
-                PyObject* m = PyImport_ImportModule("sage.structure.element");
+                pyobject_ptr m(PyImport_ImportModule("sage.structure.element"));
                 if (m == nullptr)
                         py_error("Error importing element");
-                PyObject* f = PyObject_GetAttrString(m, "parent");
+                pyobject_ptr f(PyObject_GetAttrString(m.get(), "parent"));
                 if (f == nullptr)
                         py_error("Error getting parent attribute");
-                PyObject* obj = num.to_pyobject();
-                the_parent = PyObject_CallFunctionObjArgs(f, obj, NULL);
-                Py_DECREF(obj);
-                Py_DECREF(f);
-                Py_DECREF(m);
+                pyobject_ptr obj(num.to_pyobject());
+                owned_parent.reset(PyObject_CallFunctionObjArgs(f.get(), obj.get(), NULL));
+                if (owned_parent == nullptr)
+                        py_error("Error calling parent");
+                the_parent = owned_parent.get();
         }
         else if (PyDict_Check(a_parent)) {
-                PyObject* pkey = PyString_FromString(const_cast<char*>("parent"));
-                the_parent = PyDict_GetItem(a_parent, pkey);
-                Py_DECREF(pkey);
+                the_parent = PyDict_GetItemString(a_parent, "parent");
         }
-        PyObject *mprec = nullptr;
+        pyobject_ptr mprec;
         if (the_parent != nullptr)
-                mprec = PyObject_CallMethod(the_parent, const_cast<char*>("precision"), NULL);
+                mprec.reset(PyObject_CallMethod(the_parent, const_cast<char*>("precision"), NULL));
         if (mprec == nullptr) {
                 prec = 53;
                 PyErr_Clear();
         }
         else {
-                prec = PyLong_AsLong(mprec);
-                Py_DECREF(mprec);
+                prec = PyLong_AsLong(mprec.get());
         }
         if (a_parent == nullptr) {
-                a_parent = PyDict_New();
-                PyDict_SetItemString(a_parent, "parent", the_parent);
+                pyobject_ptr parent_dict(PyDict_New());
+                if (parent_dict == nullptr)
+                        py_error("Error creating parent dictionary");
+                if (PyDict_SetItemString(parent_dict.get(), "parent", the_parent) < 0)
+                        py_error("Error setting parent dictionary");
+                a_parent = parent_dict.release();
         }
         return prec;
 }
@@ -450,13 +464,14 @@ PyObject* common_parent(const numeric& x, const numeric& y)
 
 const numeric numeric::arbfunc_0arg(const char* name, PyObject* parent) const
 {
-        int prec = precision(*this, parent);
-        PyObject* field = CBF(prec+15);
-        PyObject* ret = CallBallMethod0Arg(field, name, *this);
-        Py_DECREF(field);
+        PyObject* evalf_parent = parent;
+        int prec = precision(*this, evalf_parent);
+        pyobject_ptr owned_parent(parent == nullptr ? evalf_parent : nullptr);
+        pyobject_ptr field(CBF(prec+15));
+        pyobject_ptr ret(CallBallMethod0Arg(field.get(), name, *this));
 
-        numeric rnum(ret);
-        return ex_to<numeric>(rnum.evalf(0, parent));
+        numeric rnum(ret.release());
+        return ex_to<numeric>(rnum.evalf(0, evalf_parent));
 }
 
 static PyObject* py_tuple_from_numvector(const std::vector<numeric>& vec)
@@ -506,37 +521,9 @@ std::ostream& operator<<(std::ostream& os, const numeric& s) {
 }
 
 const numeric& numeric::operator=(const numeric& x) {
-        switch (t) {
-        case LONG:
-                break;
-        case MPZ:
-                mpz_clear(v._bigint);
-                break;
-        case MPQ:
-                mpq_clear(v._bigrat);
-                break;
-        case PYOBJECT:
-                Py_DECREF(v._pyobject);
-                break;
-        }
-        t = x.t;
-        hash = x.hash;
-        switch (x.t) {
-        case LONG:
-                v._long = x.v._long;
-                break;
-        case MPZ:
-                mpz_init(v._bigint);
-                mpz_set(v._bigint, x.v._bigint);
-                break;
-        case MPQ:
-                mpq_init(v._bigrat);
-                mpq_set(v._bigrat, x.v._bigrat);
-                break;
-        case PYOBJECT:
-                v = x.v;
-                Py_INCREF(v._pyobject);
-                break;
+        if (this != &x) {
+                numeric copy(x);
+                swap(copy);
         }
         return *this;
 }
@@ -686,8 +673,14 @@ static long _mpq_pythonhash(mpq_t the_rat)
     mpq_set(rat, the_rat);
     long n = _mpz_pythonhash_raw(mpq_numref(rat));
     long d = _mpz_pythonhash_raw(mpq_denref(rat));
-    if (d != 1L)
-        n = n + (d-1) * 7461864723258187525;
+    unsigned long unsigned_hash = static_cast<unsigned long>(n);
+    if (d != 1L) {
+        constexpr unsigned long hash_multiplier =
+            static_cast<unsigned long>(7461864723258187525ULL);
+        unsigned_hash += (static_cast<unsigned long>(d) - 1UL)
+                         * hash_multiplier;
+    }
+    std::memcpy(&n, &unsigned_hash, sizeof(n));
     mpq_clear(rat);
     if (n == -1)
         return -2;
@@ -733,6 +726,7 @@ numeric::numeric() : basic(&numeric::tinfo_static), t(LONG), v(0) {
 numeric::numeric(const numeric& other) : basic(&numeric::tinfo_static) {
         t = other.t;
         hash = other.hash;
+        is_hashable = other.is_hashable;
         switch (t) {
         case LONG:
                 v._long = other.v._long;
@@ -933,7 +927,6 @@ inherited(n, sym_lst) {
                         PyErr_Clear();
                         is_hashable = false;
                 }
-                Py_INCREF(v._pyobject);
                 return;
         default:
                 stub("unarchiving numeric");
@@ -3526,11 +3519,11 @@ const numeric numeric::real() const {
                 try {
                         return try_py_method("real");
                 }
-                catch (std::logic_error) {}
+                catch (const std::logic_error&) {}
                 try {
                         return try_py_method("real_part");
                 }
-                catch (std::logic_error) {}
+                catch (const std::logic_error&) {}
                 return *this;
         }
         default:
@@ -3554,11 +3547,11 @@ const numeric numeric::imag() const {
                 try {
                         return try_py_method("imag");
                 }
-                catch (std::logic_error) {}
+                catch (const std::logic_error&) {}
                 try {
                         return try_py_method("imag_part");
                 }
-                catch (std::logic_error) {}
+                catch (const std::logic_error&) {}
                 return *_num0_p;
         }
         default:
@@ -3853,17 +3846,18 @@ const numeric numeric::acosh(PyObject* parent) const {
 }
 
 const numeric numeric::atanh(PyObject* parent) const {
-        int prec = precision(*this, parent);
-        PyObject* field = CBF(prec+15);
-        PyObject* ret = CallBallMethod0Arg(field, const_cast<char*>("arctanh"), *this);
-        Py_DECREF(field);
+        PyObject* evalf_parent = parent;
+        int prec = precision(*this, evalf_parent);
+        pyobject_ptr owned_parent(parent == nullptr ? evalf_parent : nullptr);
+        pyobject_ptr field(CBF(prec+15));
+        pyobject_ptr ret(CallBallMethod0Arg(field.get(), "arctanh", *this));
 
-        numeric rnum(ret);
+        numeric rnum(ret.release());
         if ((is_real() or imag().is_zero())
             and abs()<(*_num1_p))
-                return ex_to<numeric>(rnum.real().evalf(0, parent));
+                return ex_to<numeric>(rnum.real().evalf(0, evalf_parent));
         
-        return ex_to<numeric>(rnum.evalf(0, parent));
+        return ex_to<numeric>(rnum.evalf(0, evalf_parent));
 }
 
 const numeric numeric::Li2(const numeric &n, PyObject* parent) const {
@@ -3886,13 +3880,7 @@ const numeric numeric::Li2(const numeric &n, PyObject* parent) const {
 }
 
 const numeric numeric::lgamma(PyObject* parent) const {
-        int prec = precision(*this, parent);
-        PyObject* field = CBF(prec+15);
-        PyObject* ret = CallBallMethod0Arg(field, const_cast<char*>("log_gamma"), *this);
-        Py_DECREF(field);
-
-        numeric rnum(ret);
-        return ex_to<numeric>(rnum.evalf(0, parent));
+        return arbfunc_0arg("log_gamma", parent);
 }
 
 const numeric numeric::gamma(PyObject* parent) const {
@@ -4838,11 +4826,11 @@ const numeric Li2(const numeric &x, PyObject* parent) {
         try {
                 return x.try_py_method("dilog");
         }
-        catch (std::logic_error) {}
+        catch (const std::logic_error&) {}
         try {
                 return x.try_py_method("polylog", *_num2_p);
         }
-        catch (std::logic_error) {}
+        catch (const std::logic_error&) {}
 
         return x.Li2(*_num2_p, parent);
 }

--- a/src/sage/symbolic/ginac/numeric.cpp
+++ b/src/sage/symbolic/ginac/numeric.cpp
@@ -713,7 +713,7 @@ GINAC_IMPLEMENT_REGISTERED_CLASS_OPT(numeric, basic,
         print_func<print_python_repr>(&numeric::do_print_python_repr))
 
 
-numeric::numeric() : basic(&numeric::tinfo_static), t(LONG), v(0) {
+numeric::numeric() : basic(&numeric::tinfo_static), t(LONG), v(0), hash(0) {
         setflag(status_flags::evaluated | status_flags::expanded);
 }
 

--- a/src/sage/symbolic/ginac/power.cpp
+++ b/src/sage/symbolic/ginac/power.cpp
@@ -436,8 +436,8 @@ ex power::eval(int level) const
 		if (eexponent.is_positive()) {
 			if (basis_inf.is_unsigned_infinity())
 				return UnsignedInfinity;
-			
-				return mul(pow(basis_inf.get_direction(), eexponent), Infinity);
+
+			return mul(pow(basis_inf.get_direction(), eexponent), Infinity);
                 }
 		throw(std::domain_error("power::eval(): pow(Infinity, c)"
 					" for constant of undetermined sign is not defined."));
@@ -455,8 +455,8 @@ ex power::eval(int level) const
 		if (abs_base > _ex1) {
 			if (ebasis.is_positive())
 				return Infinity;
-			
-				return UnsignedInfinity;
+
+			return UnsignedInfinity;
                         }
 		if (abs_base < _ex1) return _ex0;
 		if (abs_base == _ex1)
@@ -895,8 +895,8 @@ int power::compare_same_type(const basic & other) const
 	int cmpval = basis.compare(o.basis);
 	if (cmpval != 0)
 		return cmpval;
-	
-		return exponent.compare(o.exponent);
+
+	return exponent.compare(o.exponent);
 }
 
 unsigned power::return_type() const
@@ -1008,24 +1008,27 @@ ex power::expand(unsigned options) const
 	
 	// (x+y)^n
 	if (is_exactly_a<add>(expanded_basis)) {
-                if (int_exponent == 1)
-                        return expanded_basis;
-                if ((options & expand_options::expand_only_numerators) == 0 and
-                        int_exponent == -1)
-                        return dynallocate<power>(expanded_basis, _ex_1).
-                             setflag(status_flags::expanded|status_flags::evaluated);
-                if ((options & expand_options::expand_only_numerators) != 0 and
-                        int_exponent < 0)
-                        return this->hold();
-                if (int_exponent >= 0 or
-                        (options & expand_options::expand_only_numerators) != 0)
-		        return expand_add(ex_to<add>(expanded_basis),
-                                        int_exponent, options);
-                
-                        return dynallocate<power>(expand_add(ex_to<add>(expanded_basis),
-                                        -int_exponent, options), _ex_1).
-                        setflag(status_flags::expanded|status_flags::evaluated);
-        }
+		if (int_exponent == 1) {
+			return expanded_basis;
+		}
+		if ((options & expand_options::expand_only_numerators) == 0 and
+		    int_exponent == -1) {
+			return dynallocate<power>(expanded_basis, _ex_1).
+			       setflag(status_flags::expanded|status_flags::evaluated);
+		}
+		if ((options & expand_options::expand_only_numerators) != 0 and
+		    int_exponent < 0) {
+			return this->hold();
+		}
+		if (int_exponent >= 0 or
+		    (options & expand_options::expand_only_numerators) != 0)
+			return expand_add(ex_to<add>(expanded_basis),
+			                  int_exponent, options);
+
+		return dynallocate<power>(expand_add(ex_to<add>(expanded_basis),
+		                          -int_exponent, options), _ex_1).
+		       setflag(status_flags::expanded|status_flags::evaluated);
+	}
 	
 	// (x*y)^n -> x^n * y^n
 	if (is_exactly_a<mul>(expanded_basis))
@@ -1034,8 +1037,8 @@ ex power::expand(unsigned options) const
 	// cannot expand further
 	if (are_ex_trivially_equal(basis,expanded_basis) && are_ex_trivially_equal(exponent,expanded_exponent))
 		return this->hold();
-	
-		return (new power(expanded_basis,expanded_exponent))->setflag(status_flags::dynallocated | (options == 0 ? status_flags::expanded : 0));
+
+	return (new power(expanded_basis,expanded_exponent))->setflag(status_flags::dynallocated | (options == 0 ? status_flags::expanded : 0));
 }
 
 //////////

--- a/src/sage/symbolic/ginac/pseries.cpp
+++ b/src/sage/symbolic/ginac/pseries.cpp
@@ -206,7 +206,7 @@ void pseries::do_print_tree(const print_tree & c, unsigned level) const
 	point.print(c, level + c.delta_indent);
 }
 
-void pseries::do_print_python_repr(const print_python_repr & c, unsigned level) const
+void pseries::do_print_python_repr(const print_python_repr & c, unsigned /*level*/) const
 {
 	c.s << class_name() << "(relational(";
 	var.print(c);
@@ -285,8 +285,7 @@ numeric pseries::degree(const ex &s) const
 		// Return last exponent
 		if (!seq.empty())
 			return ex_to<numeric>((seq.end()-1)->coeff).to_int();
-		
-			return 0;
+		return 0;
 	} else {
                 
 		if (seq.empty())
@@ -312,8 +311,7 @@ numeric pseries::ldegree(const ex &s) const
 		// Return first exponent
 		if (!seq.empty())
 			return ex_to<numeric>((seq.begin())->coeff);
-		
-			return 0;
+		return 0;
 	} else {
 		if (seq.empty())
 			return 0;
@@ -368,7 +366,7 @@ ex pseries::coeff(const ex &s, const ex & n) const
 }
 
 /** Does nothing. */
-ex pseries::collect(const ex &s, bool distributed) const
+ex pseries::collect(const ex & /*s*/, bool /*distributed*/) const
 {
 	return *this;
 }
@@ -489,49 +487,63 @@ ex pseries::expand(unsigned options) const
  *  @see ex::diff */
 ex pseries::derivative(const symbol & s) const
 {
-	epvector new_seq;
-
 	if (s == var) {
-		
-		// FIXME: coeff might depend on var
-                for (const auto & elem : seq) {
+		const relational expansion(var, point);
+		epvector coefficient_derivatives;
+		epvector power_derivatives;
+		coefficient_derivatives.reserve(seq.size());
+		power_derivatives.reserve(seq.size());
+		for (const auto & elem : seq) {
 			if (is_order_function(elem.rest)) {
-				new_seq.emplace_back(elem.rest, elem.coeff - 1);
+				power_derivatives.emplace_back(elem.rest, elem.coeff - 1);
 			} else {
-				const ex& c = elem.rest * elem.coeff;
-				if (!c.is_zero())
-					new_seq.emplace_back(c, elem.coeff - 1);
+				const ex coefficient_derivative = elem.rest.diff(s);
+				if (!coefficient_derivative.is_zero())
+					coefficient_derivatives.emplace_back(coefficient_derivative,
+					                                     elem.coeff);
+
+				const ex power_derivative = elem.rest * elem.coeff;
+				if (!power_derivative.is_zero())
+					power_derivatives.emplace_back(power_derivative,
+					                               elem.coeff - 1);
 			}
 		}
 
-	} else {
-
-                for (const auto & elem : seq) {
-			if (is_order_function(elem.rest)) {
-				new_seq.push_back(elem);
-			} else {
-				const ex& c = elem.rest.diff(s);
-				if (!c.is_zero())
-					new_seq.emplace_back(c, elem.coeff);
-			}
-		}
+		if (coefficient_derivatives.empty())
+			return pseries(expansion, std::move(power_derivatives));
+		if (power_derivatives.empty())
+			return pseries(expansion, std::move(coefficient_derivatives));
+		return pseries(expansion, std::move(power_derivatives)).add_series(
+			pseries(expansion, std::move(coefficient_derivatives)));
 	}
 
+	epvector new_seq;
+	new_seq.reserve(seq.size());
+	for (const auto & elem : seq) {
+		if (is_order_function(elem.rest)) {
+			new_seq.push_back(elem);
+		} else {
+			const ex coefficient_derivative = elem.rest.diff(s);
+			if (!coefficient_derivative.is_zero())
+				new_seq.emplace_back(coefficient_derivative, elem.coeff);
+		}
+	}
 	return pseries(relational(var,point), new_seq);
 }
 
 ex pseries::convert_to_poly(bool no_order) const
 {
-	ex e;
-        for (const auto & elem : seq) {
+	exvector terms;
+	terms.reserve(seq.size());
+	for (const auto & elem : seq) {
 		if (is_order_function(elem.rest)) {
 			if (!no_order)
-				e += Order(power(var - point, elem.coeff));
+				terms.push_back(Order(power(var - point, elem.coeff)));
 		}
-                else
-			e += elem.rest * power(var - point, elem.coeff);
+		else
+			terms.push_back(elem.rest * power(var - point, elem.coeff));
 	}
-	return e;
+	return add(terms);
 }
 
 bool pseries::is_terminating() const
@@ -560,10 +572,11 @@ ex pseries::exponop(size_t i) const
 
 /** Default implementation of ex::series(). This performs Taylor expansion.
  *  @see ex::series */
-ex basic::series(const relational & r, int order, unsigned options) const
+ex basic::series(const relational & r, int order, unsigned /*options*/) const
 {
 	epvector seq;
-	const symbol &s = ex_to<symbol>(r.lhs());
+	const ex lhs = r.lhs();
+	const symbol &s = ex_to<symbol>(lhs);
 
 	// default for order-values that make no sense for Taylor expansion
 	if ((order <= 0) && this->has(s)) {
@@ -602,7 +615,7 @@ ex basic::series(const relational & r, int order, unsigned options) const
 }
 
 
-ex numeric::series(const relational & r, int order, unsigned options) const
+ex numeric::series(const relational & r, int order, unsigned /*options*/) const
 {
 	epvector seq;
         if (not is_zero())
@@ -613,7 +626,7 @@ ex numeric::series(const relational & r, int order, unsigned options) const
 
 /** Implementation of ex::series() for symbols.
  *  @see ex::series */
-ex symbol::series(const relational & r, int order, unsigned options) const
+ex symbol::series(const relational & r, int order, unsigned /*options*/) const
 {
 	epvector seq;
 	const ex point = r.rhs();
@@ -855,7 +868,7 @@ ex mul::series(const relational & r, int order, unsigned options) const
 		bool flag_redo = false;
 		try {
 			real_ldegree = buf.expand().ldegree(sym-r.rhs()).to_int();
-		} catch (std::runtime_error) {}
+		} catch (const std::runtime_error &) {}
 
 		if (real_ldegree == 0) {
 			if ( factor < 0 ) {
@@ -1053,7 +1066,7 @@ ex power::series(const relational & r, int order, unsigned options) const
 		if (is_exactly_a<infinity>(basis_subs)) {
 			must_expand_basis = true;
 		}
-	} catch (pole_error) {
+	} catch (const pole_error &) {
 		must_expand_basis = true;
 	}
 
@@ -1063,7 +1076,7 @@ ex power::series(const relational & r, int order, unsigned options) const
 		if (is_exactly_a<infinity>(exponent_subs)) {
 			exponent_is_regular = false;
 		}
-	} catch (pole_error) {
+	} catch (const pole_error &) {
 		exponent_is_regular = false;
 	}
 
@@ -1133,7 +1146,7 @@ ex power::series(const relational & r, int order, unsigned options) const
 	ex result;
 	try {
 		result = ex_to<pseries>(e).power_const(numexp, order);
-	} catch (pole_error) {
+	} catch (const pole_error &) {
 		epvector ser;
 		ser.emplace_back(Order(_ex1), order);
 		result = pseries(r, ser);
@@ -1147,26 +1160,26 @@ ex power::series(const relational & r, int order, unsigned options) const
 ex pseries::series(const relational & r, int order, unsigned options) const
 {
 	const ex p = r.rhs();
-	GINAC_ASSERT(is_exactly_a<symbol>(r.lhs()));
-	const symbol &s = ex_to<symbol>(r.lhs());
-	
+	const ex lhs = r.lhs();
+	GINAC_ASSERT(is_exactly_a<symbol>(lhs));
+	const symbol &s = ex_to<symbol>(lhs);
+
 	if (var.is_equal(s) && point.is_equal(p)) {
 		if (order > degree(s))
 			return *this;
-		
-			epvector new_seq;
-                        for (const auto & elem : seq) {
-				int o = ex_to<numeric>(elem.coeff).to_int();
-				if (o >= order) {
-					new_seq.emplace_back(Order(_ex1), o);
-					break;
-				}
-				new_seq.push_back(elem);
+
+		epvector new_seq;
+		for (const auto & elem : seq) {
+			int o = ex_to<numeric>(elem.coeff).to_int();
+			if (o >= order) {
+				new_seq.emplace_back(Order(_ex1), o);
+				break;
 			}
-			return pseries(r, new_seq);
-		
-	} else
-		return convert_to_poly().series(r, order, options);
+			new_seq.push_back(elem);
+		}
+		return pseries(r, new_seq);
+	}
+	return convert_to_poly().series(r, order, options);
 }
 
 
@@ -1203,7 +1216,7 @@ ex ex::series(const ex & r, int order, unsigned options) const
                                                 order,
                                                 options);
                         }
-                        catch(flint_error) {
+                        catch(const flint_error &) {
                                 ;
                         }
                 }

--- a/src/sage/symbolic/ginac/pseries.cpp
+++ b/src/sage/symbolic/ginac/pseries.cpp
@@ -509,6 +509,25 @@ ex pseries::derivative(const symbol & s) const
 			}
 		}
 
+		// A coefficient derivative at the new Order exponent need not be
+		// negligible: its coefficient may have a pole.  Move that term down
+		// one power before add_series truncates, combining equal powers.
+		if (!is_terminating() && !coefficient_derivatives.empty()
+		    && coefficient_derivatives.back().coeff.is_equal(seq.back().coeff - 1)
+		    && !coefficient_derivatives.back().rest.is_polynomial(var)) {
+			expair tail = coefficient_derivatives.back();
+			coefficient_derivatives.pop_back();
+			tail.rest *= var - point;
+			tail.coeff -= 1;
+			if (!coefficient_derivatives.empty()
+			    && coefficient_derivatives.back().coeff.is_equal(tail.coeff)) {
+				tail.rest += coefficient_derivatives.back().rest;
+				coefficient_derivatives.pop_back();
+			}
+			if (!tail.rest.is_zero())
+				coefficient_derivatives.push_back(tail);
+		}
+
 		if (coefficient_derivatives.empty())
 			return pseries(expansion, std::move(power_derivatives));
 		if (power_derivatives.empty())

--- a/src/sage/symbolic/ginac/pyobject_ptr.h
+++ b/src/sage/symbolic/ginac/pyobject_ptr.h
@@ -1,0 +1,29 @@
+/** @file pyobject_ptr.h
+ *
+ *  Small RAII helper for owned Python references used by the Pynac bridge.
+ */
+
+#ifndef __GINAC_PYOBJECT_PTR_H__
+#define __GINAC_PYOBJECT_PTR_H__
+
+#include <Python.h>
+
+#include <memory>
+
+namespace GiNaC {
+namespace internal {
+
+struct pyobject_deleter
+{
+	void operator()(PyObject* object) const noexcept
+	{
+		Py_XDECREF(object);
+	}
+};
+
+using pyobject_ptr = std::unique_ptr<PyObject, pyobject_deleter>;
+
+} // namespace internal
+} // namespace GiNaC
+
+#endif // __GINAC_PYOBJECT_PTR_H__

--- a/src/sage/symbolic/ginac/relational.cpp
+++ b/src/sage/symbolic/ginac/relational.cpp
@@ -225,8 +225,8 @@ ex relational::map(map_function & f) const
 	if (!are_ex_trivially_equal(lh, mapped_lh)
 	 || !are_ex_trivially_equal(rh, mapped_rh))
 		return (new relational(mapped_lh, mapped_rh, o))->setflag(status_flags::dynallocated);
-	
-		return *this;
+
+	return *this;
 }
 
 ex relational::eval(int level) const
@@ -247,8 +247,8 @@ ex relational::subs(const exmap & m, unsigned options) const
 
 	if (!are_ex_trivially_equal(lh, subsed_lh) || !are_ex_trivially_equal(rh, subsed_rh))
 		return relational(subsed_lh, subsed_rh, o).subs_one_level(m, options);
-	
-		return subs_one_level(m, options);
+
+	return subs_one_level(m, options);
 }
 
 // protected
@@ -444,14 +444,16 @@ relational::result relational::decide() const
                 else {
                         inf = ex_to<infinity>(lh);
                 }
-                if (inf.is_unsigned_infinity() and o!=equal and o!=not_equal)
-                        return result::undecidable;
-                if (has_symbol(other))
-                        return result::notimplemented;
-                if (inf.compare_other_type(other, oper))
-                        return result::True;
-                
-                        return result::False;
+	                if (inf.is_unsigned_infinity() and o!=equal and o!=not_equal) {
+	                        return result::undecidable;
+	                }
+	                if (has_symbol(other)) {
+	                        return result::notimplemented;
+	                }
+	                if (inf.compare_other_type(other, oper))
+	                        return result::True;
+
+	                return result::False;
         }
 
 	const ex df = lh-rh;

--- a/src/sage/symbolic/ginac/remember.cpp
+++ b/src/sage/symbolic/ginac/remember.cpp
@@ -34,11 +34,9 @@ namespace GiNaC {
 //////////
 
 remember_table_entry::remember_table_entry(function const & f, ex  r)
-  : hashvalue(f.gethash()), seq(f.seq), result(std::move(r))
-{
-	++last_access = access_counter;
-	successful_hits = 0;
-}
+  : hashvalue(f.gethash()), seq(f.seq), result(std::move(r)),
+    last_access(++access_counter), successful_hits(0)
+{}
 
 bool remember_table_entry::is_equal(function const & f) const
 {
@@ -47,7 +45,7 @@ bool remember_table_entry::is_equal(function const & f) const
 	size_t num = seq.size();
 	for (size_t i=0; i<num; ++i)
 		if (!seq[i].is_equal(f.seq[i])) return false;
-	++last_access = access_counter;
+	last_access = ++access_counter;
 	++successful_hits;
 	return true;
 }

--- a/src/sage/symbolic/ginac/sum.cpp
+++ b/src/sage/symbolic/ginac/sum.cpp
@@ -562,7 +562,7 @@ ex gosper_sum_definite(ex f, ex s, ex a, ex b, int* success)
                         return res;
                 return t;
         }
-        catch (gosper_domain_error) {
+        catch (const gosper_domain_error&) {
                 *success = 0;
                 return _ex0;
         }
@@ -579,7 +579,7 @@ ex gosper_sum_indefinite(ex f, ex s, int* success)
                         return res;
                 return t;
         }
-        catch (gosper_domain_error) {
+        catch (const gosper_domain_error&) {
                 *success = 0;
                 return _ex0;
         }

--- a/src/sage/symbolic/ginac/upoly-ginac.cpp
+++ b/src/sage/symbolic/ginac/upoly-ginac.cpp
@@ -240,7 +240,7 @@ ex decomp_rational(const ex &a, const ex &x)
         try {
         	q = quo(numer, denom, x);
         }
-        catch (std::logic_error) {
+        catch (const std::logic_error&) {
 		return a;
         }
 	return q + rem(numer, denom, x) / denom;
@@ -536,7 +536,7 @@ ex parfrac(const ex & a, const ex & x)
         	// Convert N(x)/D(x) -> Q(x) + R(x)/D(x), so degree(R) < degree(D)
                 qr = quo_rem(numer, denom, x, true);
         }
-        catch (std::logic_error) {
+        catch (const std::logic_error&) {
                 return a;
         }
 	// Factorize denominator and compute cofactors

--- a/src/sage/symbolic/ginac/useries.cpp
+++ b/src/sage/symbolic/ginac/useries.cpp
@@ -322,10 +322,10 @@ bool useries_can_handle(const ex& the_ex, const symbol& s)
                         (void) nd.op(1).degree(s).to_long();
                         (void) nd.op(1).ldegree(s).to_long();
                 }
-                catch (conversion_error) {
+                catch (const conversion_error&) {
                         throw std::runtime_error("exponent too big");
                 }
-                catch (std::runtime_error) {}
+                catch (const std::runtime_error&) {}
         }
         return ok;
 }
@@ -406,7 +406,7 @@ ex useries(const ex& the_ex, const symbol& x, int order, unsigned options)
         try {
                 ldeg = low_series_degree(the_ex);
         }
-        catch (ldegree_error) {
+        catch (const ldegree_error&) {
                 may_extend = true;
         }
 

--- a/src/sage/symbolic/ginac/utils.cpp
+++ b/src/sage/symbolic/ginac/utils.cpp
@@ -56,8 +56,16 @@ unsigned log2(unsigned n)
  *  the static flyweights on the heap. */
 int library_init::count = 0;
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wuninitialized"
+// These objects deliberately reserve static storage and are reconstructed
+// with placement new by library_init.  Their self-initializers must not call
+// ex::ex(), which depends on the very flyweights being initialized here.
+#if defined(__clang__)
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wuninitialized"
+#elif defined(__GNUC__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wuninitialized"
+#endif
 // static numeric -120
 const numeric *_num_120_p;
 const ex _ex_120 = _ex_120;
@@ -294,7 +302,11 @@ const ex _ex120 = _ex120;
 // static numeric 144
 const numeric *_num144_p;
 const ex _ex144 = _ex144;
-#pragma clang diagnostic pop
+#if defined(__clang__)
+# pragma clang diagnostic pop
+#elif defined(__GNUC__)
+# pragma GCC diagnostic pop
+#endif
 
 /** Ctor of static initialization helpers.  The fist call to this is going
  *  to initialize the library, the others do nothing. */

--- a/src/sage/symbolic/meson.build
+++ b/src/sage/symbolic/meson.build
@@ -125,7 +125,6 @@ foreach name, pyx : extension_data_cpp
     subdir: 'sage/symbolic',
     install: true,
     override_options: ['cython_language=cpp'],
-    cpp_args: '-std=c++11',
     include_directories: [
       inc_cpython,
       inc_ext,

--- a/src/sage/symbolic/pynac.pxi
+++ b/src/sage/symbolic/pynac.pxi
@@ -548,7 +548,6 @@ cdef extern from "pynac_wrap.h":
         mpq_ptr py_mpq_from_rational(x)
 
         py_float(a, PyObject* kwds)
-        py_RDF_from_double(double x)
 
         py_factorial(x)
         py_doublefactorial(x)

--- a/src/sage/symbolic/pynac_impl.pxi
+++ b/src/sage/symbolic/pynac_impl.pxi
@@ -48,8 +48,6 @@ from sage.rings.integer_ring import ZZ
 from sage.rings.integer cimport Integer, smallInteger
 from sage.rings.rational cimport Rational
 from sage.rings.real_mpfr import RR, RealField
-from sage.rings.rational cimport rational_power_parts
-from sage.rings.real_double cimport RealDoubleElement
 from sage.rings.cc import CC
 from sage.structure.coerce cimport coercion_model
 from sage.structure.element cimport Element, parent
@@ -881,36 +879,8 @@ cdef int py_get_parent_char(o) except -1:
 
 
 #################################################################
-# power helpers
-#################################################################
-
-cdef py_rational_power_parts(base, exp):
-    if type(base) is not Rational:
-        base = Rational(base)
-    if type(exp) is not Rational:
-        exp = Rational(exp)
-    res= rational_power_parts(base, exp)
-    return res + (bool(res[0] == 1),)
-
-#################################################################
 # Binomial Coefficients
 #################################################################
-
-
-cdef py_binomial_int(int n, unsigned int k):
-    cdef bint sign
-    if n < 0:
-        n = -n + (k-1)
-        sign = k % 2
-    else:
-        sign = 0
-    cdef Integer ans = PY_NEW(Integer)
-    # Compute the binomial coefficient using GMP.
-    mpz_bin_uiui(ans.value, n, k)
-    # Return the answer or the negative of it (only if k is odd and n is negative).
-    if sign:
-        return -ans
-    return ans
 
 cdef py_binomial(n, k):
     # Keep track of the sign we should use.
@@ -1109,16 +1079,6 @@ def py_imag_for_doctests(x):
         1
     """
     return py_imag(x)
-
-
-#################################################################
-# Conjugate
-#################################################################
-cdef py_conjugate(x):
-    try:
-        return x.conjugate()
-    except AttributeError:
-        return x  # assume is real since it doesn't have an imag attribute.
 
 
 cdef bint py_is_rational(x) noexcept:
@@ -1428,11 +1388,6 @@ def py_float_for_doctests(n, kwds):
     """
     return py_float(n, <PyObject*>kwds)
 
-
-cdef py_RDF_from_double(double x):
-    cdef RealDoubleElement r = RealDoubleElement.__new__(RealDoubleElement)
-    r._value = x
-    return r
 
 #################################################################
 # SPECIAL FUNCTIONS
@@ -2041,10 +1996,6 @@ cdef py_sqrt(x):
         return math.sqrt(float(x))
 
 
-cdef py_abs(x):
-    return abs(x)
-
-
 cdef py_mod(x, n):
     """
     Return x mod n. Both x and n are assumed to be integers.
@@ -2108,28 +2059,6 @@ cdef py_smod(a, b):
 
 cdef py_irem(x, n):
     return Integer(x) % Integer(n)
-
-
-cdef py_iquo(x, n):
-    return Integer(x)//Integer(n)
-
-
-cdef py_iquo2(x, n):
-    x = Integer(x)
-    n = Integer(n)
-    try:
-        q = x//n
-        r = x - q*n
-        return q, r
-    except (TypeError, ValueError):
-        return 0, 0
-
-
-cdef int py_int_length(x) except -1:
-    # Size in binary notation.  For integers, this is the smallest n >= 0 such
-    # that -2^n <= x < 2^n. If x > 0, this is the unique n > 0 such that
-    # 2^(n-1) <= x < 2^n.  This returns 0 if x is not an integer.
-    return Integer(x).nbits()
 
 
 cdef py_li(x, n, parent):

--- a/src/sage/symbolic/series_impl.pxi
+++ b/src/sage/symbolic/series_impl.pxi
@@ -126,7 +126,7 @@ Check that :issue:`22733` is fixed::
 # ****************************************************************************
 
 
-cpdef bint _is_order(Expression expr):
+cpdef bint _is_order(Expression expr) except -1:
     """
     Return whether ``expr`` has the form ``Order(...)``.
 


### PR DESCRIPTION
This PR fixes incorrect symbolic series derivatives, Python reference leaks, and numeric/cache state bugs in Sage's Pynac bridge. It also updates the C++/Cython code to address compiler warnings. The concrete fixes and the maintenance changes are described separately below.

## Bugs fixed

### 1. Series differentiation omitted derivatives of variable-dependent coefficients

A series coefficient can depend on the expansion variable, for example after substitution. Previously, when differentiating with respect to the expansion variable, `pseries::derivative()` differentiated only the stored powers and omitted the derivatives of the coefficients. It now applies the full product rule.

The following regression example now includes the missing contributions:

```sage
sage: x, y = var('x y')
sage: s = (y/(1-x)).series(x, 5).subs(y=x)
sage: s.diff(x).coefficients(x)[:4]
[[1, 0], [2, 1], [3, 2], [4, 3]]
```

The implementation also preserves coefficient-derivative terms at the new `Order` boundary when their coefficients may contain poles. For example:

```sage
sage: f = y + x*y^2/2 + x^2
sage: f.series(x, 2).subs(y=-1/x).diff(x)
(1/2/x^2) + Order(x)
```

Before combining the product-rule contributions, a non-polynomial coefficient derivative at that boundary is moved down one stored power, with a compensating factor in its coefficient. Equal powers are merged. This retains the existing formal representation and supports logarithms, fractional powers, and essential singularities without requiring the coefficients to have Laurent expansions.

### 2. Unarchiving a wrapped Python object leaked a reference

The numeric archive constructor added an extra reference to the object returned by unpickling. Deleting the restored symbolic expression therefore did not release its wrapped object. The extra `Py_INCREF` is removed.

The added regression doctest checks the object's lifetime directly:

```sage
sage: import gc, weakref
sage: wrapped = SR._force_pyobject({1, 2}, force=True)
sage: restored = loads(dumps(wrapped))
sage: obj = restored.pyobject()
sage: reference = weakref.ref(obj)
sage: del obj, restored
sage: _ = gc.collect()
sage: reference() is None
True
```

Previously, the final check returned `False`.

### 3. Copying or assigning a numeric could lose its hashability state

The numeric copy constructor and assignment operator did not preserve `is_hashable`. A copy of an unhashable wrapped Python object could consequently be treated as hashable. Copies and assignments now preserve that state; the regression doctest requires:

```sage
sage: wrapped = SR._force_pyobject([], force=True)
sage: hash(wrapped + 0)
Traceback (most recent call last):
...
RuntimeError: Python object not hashable
```

### 4. Python callbacks and numeric evaluation leaked temporary references

Several callback paths did not release owned references, including bound callback methods, temporary keyword values, hypergeometric argument tuples, and symbolic function objects used in archiving. Manual cleanup could also be skipped on early returns or exceptions. Numeric evaluation additionally retained internally created parent objects/dictionaries.

A small internal `pyobject_ptr` RAII helper now manages these references in `function.cpp`, `numeric.cpp`, and `inifcns_hyperg.cpp`; owned strings use `std::unique_ptr`. The affected paths check allocation/callback failures and release resources during exception unwinding.

### 5. Internal numeric and remember-table defects

- **Unsafe numeric self-assignment:** the old assignment operator released its storage before reading the source, even when source and destination were the same object. A self-assignment guard and copy-and-swap avoid invalidating GMP/Python storage.
- **Uninitialized state:** initialize the default numeric's cached hash and the success flag used by `collect_powers()`.
- **Signed overflow in rational hashing:** perform the hash's wraparound arithmetic using unsigned values.
- **Incorrect LRU timestamps:** `++last_access = access_counter` incremented the wrong variable, read uninitialized state in the constructor, and never advanced the shared clock. New entries and cache hits now use `last_access = ++access_counter`, so eviction can distinguish recent accesses.

## Compiler-warning and maintenance changes

- Replace deprecated `std::iterator` inheritance with explicit iterator traits; centralize callback function-pointer casts; catch exceptions by reference; and correct misleading indentation, unused declarations, and compiler-specific diagnostic guards.
- Make temporary expression ownership explicit in conjugation and series code.
- Correct Cython exception specifications, remove unused Cython helpers and obsolete distutils metadata, and let the symbolic Meson build use the project's C++ standard.
- Construct sums in bulk in collection, exponential combination, and series conversion, and sort/deduplicate pattern matches once after traversal.