### PR TITLE
Fix RESetMapReduce termination request storm

### DIFF
--- a/src/sage/parallel/map_reduce.py
+++ b/src/sage/parallel/map_reduce.py
@@ -1592,6 +1592,33 @@ class RESetMapReduceWorker(mp.Process):
     def _thief(self):
         r"""
         Return the thief thread of this worker process.
+
+        TESTS:
+
+        When the last active steal request fails, signal termination before
+        waking the requester (:issue:`41115`)::
+
+            sage: from collections import deque
+            sage: from types import SimpleNamespace
+            sage: from sage.parallel.map_reduce import AbortError, RESetMapReduceWorker
+            sage: events = []
+            sage: def task_start():
+            ....:     events.append('start')
+            sage: def task_done():
+            ....:     events.append('done')
+            ....:     raise AbortError
+            sage: request = SimpleNamespace(get=lambda: 0)
+            sage: pipe = SimpleNamespace(send=lambda value: events.append('send'))
+            sage: target = SimpleNamespace(name='target', _write_task=pipe)
+            sage: aborted = SimpleNamespace(value=False)
+            sage: mapred = SimpleNamespace(_workers=[target],
+            ....:     _signal_task_start=task_start, _signal_task_done=task_done,
+            ....:     _aborted=aborted)
+            sage: worker = SimpleNamespace(_request=request, _mapred=mapred,
+            ....:     _todo=deque(), _stats=[0] * 4)
+            sage: RESetMapReduceWorker._thief(worker)
+            sage: events
+            ['start', 'done']
         """
         logger.debug("Thief started")
         reqs = 0
@@ -1606,9 +1633,12 @@ class RESetMapReduceWorker(mp.Process):
                 try:
                     work = self._todo.popleft()
                 except IndexError:
+                    # Signal completion before waking the requester.  Otherwise
+                    # it can immediately issue another request and prevent the
+                    # active-task counter from reaching zero.
+                    self._mapred._signal_task_done()
                     target._write_task.send(None)
                     logger.debug(f"Failed Steal {target.name}")
-                    self._mapred._signal_task_done()
                 else:
                     target._write_task.send(work)
                     logger.debug(f"Successful Steal {target.name}")


### PR DESCRIPTION
Fixes #41115.

## Problem

`RESetMapReduce` can take dramatically and unpredictably longer to terminate as the worker count grows.  In the report, `RESetMPExample(11)` was stable below roughly 100 processes but showed a heavy tail above that point; with 200 processes, the slowest run was about 68 times slower than the fastest.

The implementation of this protocol is unchanged between the Sage 10.6 and 10.7 tags, and the relevant ordering dates back to the original implementation.  This is therefore a latent scalability defect exposed by high process counts, rather than a code regression introduced in Sage 10.7.

## Root cause

Termination is detected by a shared active-task counter:

1. A worker whose local deque is empty enters `steal()` and calls `_signal_task_done()`, removing itself from the active count.
2. It sends a steal request to a randomly chosen worker and waits on its response pipe.
3. The victim's thief thread calls `_signal_task_start()` before checking its deque, so a request being serviced is temporarily represented in the active count.
4. If the victim has no work, the old failure path did this:

   ```python
   target._write_task.send(None)
   self._mapred._signal_task_done()
   ```

The response wakes the idle requester before the request being serviced is removed from the active count.  The requester can immediately enqueue another steal request; another thief thread can then increment the counter before the previous request decrements it.  With many idle workers continuously polling random victims, overlapping failed requests make the brief counter value of zero increasingly unlikely.

Consequently, termination depends on a scheduling coincidence in which all workers are idle and no failed request is being serviced.  The number of failed steals has a stochastic heavy tail, and the run time follows that tail.  The master process is only waiting for worker results at this stage, so assigning affinity to the master may change timing but does not address the distributed termination race.

## Fix

The failed-steal path now removes the request from the active count before waking the requester:

```python
self._mapred._signal_task_done()
target._write_task.send(None)
```

There are two cases:

- If other work or requests remain active, `_signal_task_done()` returns normally and the requester receives `None` exactly as before.
- If this is the last active request, `_signal_task_done()` reaches zero, calls `_shutdown()`, and raises `AbortError`.  `_shutdown()` already writes `AbortError` to every worker response pipe, so the blocked requester is released by the global shutdown message instead of being invited to issue another steal.

Successful steals and the explicit abort path are unchanged.  No new lock, queue, polling delay, or affinity policy is introduced.

The added deterministic doctest models the final failed request: `_signal_task_done()` raises `AbortError`, and the test verifies that the normal `None` response is not sent first.

## Validation environment

- Base: `c9c8381962a` (Sage 10.10.beta8)
- Python 3.12.13
- Linux 6.18.33.2-microsoft-standard-WSL2
- Intel Core i7-14650HX, 24 logical CPUs
- `SAGE_NUM_THREADS=200` for the high-process tests; `proc_number(200)` returned 200

The host has only 24 logical CPUs, so 40--200 process runs are deliberately oversubscribed.  This stresses the protocol and scheduler but is not a substitute for final validation on the reporter's 384-core machine.  Absolute timings should not be compared across those machines; the run-to-run distribution and steal-request counts are the relevant local signals.

## Doctests

```text
python -m sage.doctest --force-lib src/sage/parallel/map_reduce.py
[298 tests, 5.67s wall]
All tests passed!
```

## Randomized same-host A/B benchmark

`RESetMPExample(10)`, 64 processes, 20 original-order and 20 patched-order runs.  The two variants were randomly interleaved with seed 41115.  The original behavior was restored only at runtime for the A/B comparison; all results matched the serial result.

| variant | time min / median / p95 / max (s) | failed steals min / median / p95 / max | correlation(time, failed steals) |
|---|---:|---:|---:|
| original order | 0.595 / 0.677 / 0.774 / 0.896 | 2,473 / 17,769 / 47,046 / 82,972 | 0.963 |
| patched order | 0.584 / 0.608 / 0.644 / 0.711 | 1,609 / 2,247 / 3,813 / 3,867 | -0.099 |

The original run time closely tracks the failed-request storm.  Reordering the two operations bounds the failed-request count in these runs and removes that relationship.

## Patched process-count matrix

`RESetMPExample(10)`, five runs at each process count.  Every result matched the serial result, and `multiprocessing.active_children()` was empty after every run.

| processes | time min / median / max (s) | failed steals median / max |
|---:|---:|---:|
| 40 | 0.549 / 0.583 / 0.602 | 1,246 / 2,208 |
| 80 | 0.615 / 0.640 / 0.643 | 3,230 / 3,988 |
| 100 | 0.637 / 0.665 / 0.692 | 4,124 / 6,172 |
| 120 | 0.678 / 0.705 / 0.743 | 3,990 / 6,481 |
| 160 | 0.776 / 0.800 / 0.840 | 6,383 / 8,297 |
| 200 | 0.903 / 0.921 / 1.000 | 8,716 / 9,814 |

## Original issue workload

`RESetMPExample(11)`, two runs at each process count.  Every result was checked against the exact polynomial `sum(i! * x^i, i=0..11)`.

| processes | run 1: seconds / failed steals | run 2: seconds / failed steals |
|---:|---:|---:|
| 40 | 4.983 / 2,010 | 4.979 / 1,993 |
| 80 | 5.123 / 2,967 | 5.668 / 2,474 |
| 100 | 5.146 / 3,429 | 5.410 / 3,774 |
| 120 | 5.330 / 4,961 | 5.186 / 4,113 |
| 160 | 5.345 / 8,197 | 5.645 / 5,314 |
| 200 | 5.439 / 6,404 | 5.358 / 7,589 |

To match the issue's seven-run `%timeit` sample at the worst reported process count, 200 processes were also run seven consecutive times:

| run | seconds | failed steals |
|---:|---:|---:|
| 1 | 6.178 | 13,139 |
| 2 | 5.697 | 12,150 |
| 3 | 5.627 | 8,652 |
| 4 | 5.610 | 6,363 |
| 5 | 5.539 | 11,389 |
| 6 | 5.678 | 8,783 |
| 7 | 5.675 | 9,254 |

Summary: mean 5.715 s, standard deviation 0.211 s, min 5.539 s, max 6.178 s, coefficient of variation 3.697%.  No heavy tail was observed.

## Boundary-path checks

- `reduce_locally=False`: two runs each at 2, 32, 100, and 200 processes; all exact results were correct and no child processes remained.
- Timeout/abort: three runs each at 2, 64, and 200 processes with a 0.02 s timeout; every run raised `AbortError` as expected and no child processes remained after cleanup.

Final confirmation should repeat the issue's benchmark on the original 384-core host, because that is the only way to reproduce its CPU and NUMA topology without oversubscription.
