### PR TITLE
build: Remove nonexistent Arch Linux package

### DIFF
--- a/build/pkgs/_prereq/distros/arch.txt
+++ b/build/pkgs/_prereq/distros/arch.txt
@@ -22,4 +22,3 @@ patch
 pkgconf
 zlib
 boost
-libboost-devel


### PR DESCRIPTION
Fixes #42637.

The Arch Linux prerequisite list includes `libboost-devel`, which is not an Arch Linux package. The valid `boost` package is already included in the list and provides the development headers.

This removes only the invalid `libboost-devel` entry. The Conda package references remain unchanged.

### Testing

Not run (package-list-only change).
