### PR TITLE
Use expanduser for the DOT_SAGE default

### DIFF
--- a/src/sage/env.py
+++ b/src/sage/env.py
@@ -175,11 +175,7 @@ SAGE_DOC_SERVER_URL = var("SAGE_DOC_SERVER_URL")
 SAGE_DOC_LOCAL_PORT = var("SAGE_DOC_LOCAL_PORT", "0")
 
 # ~/.sage
-if sys.platform == 'win32':
-    home_dir = os.environ.get("USERPROFILE")
-else:  # Unix-like systems (Linux, macOS, etc.)
-    home_dir = os.environ.get("HOME")
-DOT_SAGE = var("DOT_SAGE", join(home_dir, ".sage"))
+DOT_SAGE = var("DOT_SAGE", os.path.expanduser("~/.sage"))
 SAGE_STARTUP_FILE = var("SAGE_STARTUP_FILE", join(DOT_SAGE, "init.sage"))
 
 # for sage_setup.setenv


### PR DESCRIPTION
Fixes #42002.

Use `os.path.expanduser("~/.sage")` as the default for `DOT_SAGE`.

On POSIX, when `HOME` is unset, `expanduser` can obtain the account home from the password database. An explicit non-empty `DOT_SAGE` still takes precedence through `var`.

This intentionally does not add a temporary-directory fallback, special handling for `HOME=""`, launcher changes, or a `platformdirs` migration.