### PR TITLE
Optimize symmetric function powers and LLT transitions

### DIFF
--- a/src/sage/combinat/ribbon_tableau.py
+++ b/src/sage/combinat/ribbon_tableau.py
@@ -16,6 +16,7 @@ Ribbon tableaux
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 import functools
+from itertools import combinations
 
 from sage.categories.finite_enumerated_sets import FiniteEnumeratedSets
 from sage.categories.sets_cat import Sets
@@ -34,8 +35,6 @@ from sage.rings.integer_ring import ZZ
 from sage.structure.element import parent
 from sage.structure.parent import Parent
 from sage.structure.unique_representation import UniqueRepresentation
-
-from . import permutation
 
 
 class RibbonTableau(SkewTableau):
@@ -739,13 +738,19 @@ def graph_implementation_rec(skp, weight, length, function):
     """
     TESTS::
 
-        sage: from sage.combinat.ribbon_tableau import graph_implementation_rec, list_rec
+        sage: from sage.combinat.ribbon_tableau import count_rec, graph_implementation_rec, list_rec
         sage: graph_implementation_rec(SkewPartition([[1], []]), [1], 1, list_rec)
         [[[], [[1]]]]
         sage: graph_implementation_rec(SkewPartition([[2, 1], []]), [1, 2], 1, list_rec)
         [[[], [[2], [1, 2]]]]
         sage: graph_implementation_rec(SkewPartition([[], []]), [0], 1, list_rec)
         [[[], []]]
+
+    A zero ribbon length is not valid for :class:`RibbonTableaux`, but keep
+    the historical result for direct calls to this function::
+
+        sage: graph_implementation_rec(SkewPartition([[2, 1], []]), [1], 0, count_rec)
+        [1]
     """
     if sum(weight) == 0:
         weight = []
@@ -756,15 +761,23 @@ def graph_implementation_rec(skp, weight, length, function):
     outer_len = len(outer)
 
     # Some tests in order to know if the shape and the weight are compatible.
-    if weight and weight[-1] <= len(partp):
-        perms = permutation.Permutations([0] * (len(partp) - weight[-1]) + [length] * (weight[-1])).list()
-    else:
+    if not weight or weight[-1] > ell:
         return function([], [], skp, weight, length)
 
     selection = []
 
-    for j in range(len(perms)):
-        retire = [(val + ell - (i + 1) - perms[j][i]) for i, val in enumerate(partp)]
+    if length:
+        zero_position_sets = combinations(range(ell), ell - weight[-1])
+    else:
+        zero_position_sets = [range(ell)]
+
+    # This is the lexicographic order used by the former multiset
+    # ``Permutations(...).list()`` implementation.
+    for zero_positions in zero_position_sets:
+        perm = [length] * ell
+        for i in zero_positions:
+            perm[i] = 0
+        retire = [(val + ell - (i + 1) - perm[i]) for i, val in enumerate(partp)]
         retire.sort(reverse=True)
         retire = [val - ell + (i + 1) for i, val in enumerate(retire)]
 
@@ -779,7 +792,7 @@ def graph_implementation_rec(skp, weight, length, function):
                         append = False
                         break
                 if append:
-                    selection.append([retire, perms[j]])
+                    selection.append([retire, perm])
 
     # selection contains the list of current nodes
 

--- a/src/sage/combinat/sf/dual.py
+++ b/src/sage/combinat/sf/dual.py
@@ -555,6 +555,19 @@ class SymmetricFunctionAlgebra_dual(classical.SymmetricFunctionAlgebra_classical
         d_product = left.dual() * right.dual()
         return eclass(self, dual=d_product)
 
+    def _power(self, x, n):
+        r"""
+        Return ``x`` to the power ``n`` by converting to the dual basis once.
+
+        TESTS::
+
+            sage: D = SymmetricFunctions(ZZ).witt().dual_basis()
+            sage: f = D[2] + D[1, 1]
+            sage: f^3 == f._pow_naive(3)
+            True
+        """
+        return self._power_via(x, n, self._dual_basis)
+
     class Element(classical.SymmetricFunctionAlgebra_classical.Element):
         """
         An element in the dual basis.

--- a/src/sage/combinat/sf/hall_littlewood.py
+++ b/src/sage/combinat/sf/hall_littlewood.py
@@ -546,6 +546,21 @@ class HallLittlewood_generic(sfa.SymmetricFunctionAlgebra_generic):
         """
         return self(self._s(left) * self._s(right))
 
+    def _power(self, x, n):
+        r"""
+        Return ``x`` to the power ``n`` by converting to the Schur basis once.
+
+        TESTS::
+
+            sage: Sym = SymmetricFunctions(QQ)
+            sage: for B in [Sym.hall_littlewood(t=2).P(),
+            ....:           Sym.hall_littlewood(t=2).Q(),
+            ....:           Sym.hall_littlewood(t=2).Qp()]:
+            ....:     f = B[2] + B[1, 1]
+            ....:     assert f^4 == f._pow_naive(4)
+        """
+        return self._power_via(x, n, self._s)
+
     def hall_littlewood_family(self):
         r"""
         The family of Hall-Littlewood bases associated to ``self``.

--- a/src/sage/combinat/sf/jack.py
+++ b/src/sage/combinat/sf/jack.py
@@ -731,6 +731,19 @@ class JackPolynomials_generic(sfa.SymmetricFunctionAlgebra_generic):
         """
         return self(self._P(left) * self._P(right))
 
+    def _power(self, x, n):
+        r"""
+        Return ``x`` to the power ``n`` by converting to the Jack `P` basis once.
+
+        TESTS::
+
+            sage: Jack = SymmetricFunctions(QQ).jack(t=2)
+            sage: for B in [Jack.J(), Jack.Q()]:
+            ....:     f = B[2] + B[1, 1]
+            ....:     assert f^4 == f._pow_naive(4)
+        """
+        return self._power_via(x, n, self._P)
+
     def jack_family(self):
         r"""
         Return the family of Jack bases associated to the basis ``self``.
@@ -969,6 +982,19 @@ class JackPolynomials_p(JackPolynomials_generic):
         """
         return self(self._m(left) * self._m(right))
 
+    def _power(self, x, n):
+        r"""
+        Return ``x`` to the power ``n`` by converting to monomials once.
+
+        TESTS::
+
+            sage: P = SymmetricFunctions(QQ).jack(t=2).P()
+            sage: f = P[2] + P[1, 1]
+            sage: f^4 == f._pow_naive(4)
+            True
+        """
+        return self._power_via(x, n, self._m)
+
     def scalar_jack_basis(self, part1, part2=None):
         r"""
         Return the scalar product of `P(part1)` and `P(part2)`.
@@ -1171,6 +1197,19 @@ class JackPolynomials_qp(JackPolynomials_generic):
         """
         return self(self._h(left) * self._h(right))
 
+    def _power(self, x, n):
+        r"""
+        Return ``x`` to the power ``n`` by converting to homogeneous functions once.
+
+        TESTS::
+
+            sage: Qp = SymmetricFunctions(QQ).jack(t=2).Qp()
+            sage: f = Qp[2] + Qp[1, 1]
+            sage: f^4 == f._pow_naive(4)
+            True
+        """
+        return self._power_via(x, n, self._h)
+
     def _h_cache(self, n):
         r"""
         Compute the change of basis between the Jack polynomials in the `Qp`
@@ -1365,6 +1404,19 @@ class SymmetricFunctionAlgebra_zonal(sfa.SymmetricFunctionAlgebra_generic):
             64/45*Z[2, 2] + 16/21*Z[3, 1] + Z[4]
         """
         return self(self._P(left) * self._P(right))
+
+    def _power(self, x, n):
+        r"""
+        Return ``x`` to the power ``n`` by converting to Jack `P` once.
+
+        TESTS::
+
+            sage: Z = SymmetricFunctions(QQ).zonal()
+            sage: f = Z[2] + Z[1, 1]
+            sage: f^4 == f._pow_naive(4)
+            True
+        """
+        return self._power_via(x, n, self._P)
 
     class Element(sfa.SymmetricFunctionAlgebra_generic.Element):
         def scalar_zonal(self, x):

--- a/src/sage/combinat/sf/llt.py
+++ b/src/sage/combinat/sf/llt.py
@@ -576,6 +576,19 @@ class LLT_generic(sfa.SymmetricFunctionAlgebra_generic):
         """
         return self(self._m(left) * self._m(right))
 
+    def _power(self, x, n):
+        r"""
+        Return ``x`` to the power ``n`` by converting to monomials once.
+
+        TESTS::
+
+            sage: LLT = SymmetricFunctions(QQ).llt(3, t=2)
+            sage: for B in [LLT.hspin(), LLT.hcospin()]:
+            ....:     f = B[2] + B[1, 1]
+            ....:     assert f^3 == f._pow_naive(3)
+        """
+        return self._power_via(x, n, self._m)
+
     def _m_cache(self, n):
         r"""
         Compute the change of basis from the monomial symmetric functions

--- a/src/sage/combinat/sf/macdonald.py
+++ b/src/sage/combinat/sf/macdonald.py
@@ -900,6 +900,19 @@ class MacdonaldPolynomials_generic(sfa.SymmetricFunctionAlgebra_generic):
         """
         return self(self._s(left) * self._s(right))
 
+    def _power(self, x, n):
+        r"""
+        Return ``x`` to the power ``n`` by converting to the Schur basis once.
+
+        TESTS::
+
+            sage: Mac = SymmetricFunctions(QQ).macdonald(q=2, t=3)
+            sage: for B in [Mac.P(), Mac.Q(), Mac.J(), Mac.H(), Mac.Ht()]:
+            ....:     f = B[2] + B[1, 1]
+            ....:     assert f^3 == f._pow_naive(3)
+        """
+        return self._power_via(x, n, self._s)
+
     def macdonald_family(self):
         r"""
         Return the family of Macdonald bases associated to the basis ``self``.
@@ -1716,6 +1729,30 @@ class MacdonaldPolynomials_s(MacdonaldPolynomials_generic):
         s_right = self._s._from_element(right)
         product = s_left * s_right
         return self._from_element(product)
+
+    def _power(self, x, n):
+        r"""
+        Return ``x`` to the power ``n`` using Schur structure constants.
+
+        The conversions here relabel coefficients with ``_from_element``;
+        they are deliberately not the parameter-dependent coercions between
+        the Macdonald `S` and Schur realizations.
+
+        TESTS::
+
+            sage: for q, t in [(1, 2), (2, 1), (1, 1)]:
+            ....:     S = SymmetricFunctions(QQ).macdonald(q=q, t=t).S()
+            ....:     f = S[2] + S[1, 1]
+            ....:     assert f^4 == f._pow_naive(4)
+        """
+        if n < 0:
+            return super()._power(x, n)
+        if n == 0:
+            return self.one()
+        if n == 1:
+            return x
+        y = self._s._from_element(x)
+        return self._from_element(self._s._power(y, n))
 
     def _to_s(self, part):
         r"""

--- a/src/sage/combinat/sf/monomial.py
+++ b/src/sage/combinat/sf/monomial.py
@@ -76,6 +76,24 @@ class SymmetricFunctionAlgebra_monomial(classical.SymmetricFunctionAlgebra_class
         """
         return self.realization_of().h()
 
+    def _power(self, x, n):
+        r"""
+        Return ``x`` to the power ``n`` by repeated multiplication.
+
+        For monomial symmetric functions this avoids the large intermediate
+        squares produced by binary exponentiation.
+
+        TESTS::
+
+            sage: m = SymmetricFunctions(QQ).m()
+            sage: f = m[2, 1] + m[3]
+            sage: all(f^n == f._pow_naive(n) for n in range(5))
+            True
+            sage: m.one()^(10^100) == m.one()
+            True
+        """
+        return self._power_naive(x, n)
+
     def product(self, left, right):
         """
         Return the product of ``left`` and ``right``.

--- a/src/sage/combinat/sf/orthogonal.py
+++ b/src/sage/combinat/sf/orthogonal.py
@@ -185,6 +185,19 @@ class SymmetricFunctionAlgebra_orthogonal(sfa.SymmetricFunctionAlgebra_generic):
                                   triangular='upper', unitriangular=True)
         Mi.register_as_coercion()
 
+    def _power(self, x, n):
+        r"""
+        Return ``x`` to the power ``n`` by converting to Schur functions once.
+
+        TESTS::
+
+            sage: o = SymmetricFunctions(QQ).o()
+            sage: f = o[2] + o[1, 1]
+            sage: f^4 == f._pow_naive(4)
+            True
+        """
+        return self._power_via(x, n, self._s)
+
     @cached_method
     def _o_to_s_on_basis(self, lam):
         r"""

--- a/src/sage/combinat/sf/orthotriang.py
+++ b/src/sage/combinat/sf/orthotriang.py
@@ -281,6 +281,23 @@ class SymmetricFunctionAlgebra_orthotriang(sfa.SymmetricFunctionAlgebra_generic)
         """
         return self(self._sf_base(left) * self._sf_base(right))
 
+    def _power(self, x, n):
+        r"""
+        Return ``x`` to the power ``n`` by converting to the base once.
+
+        TESTS::
+
+            sage: from sage.combinat.sf.sfa import zee
+            sage: from sage.combinat.sf.orthotriang import SymmetricFunctionAlgebra_orthotriang
+            sage: Sym = SymmetricFunctions(QQ)
+            sage: B = SymmetricFunctionAlgebra_orthotriang(
+            ....:     Sym, Sym.m(), zee, 'b', 'test basis')
+            sage: f = B[2] + B[1, 1]
+            sage: f^4 == f._pow_naive(4)
+            True
+        """
+        return self._power_via(x, n, self._sf_base)
+
 
 from sage.combinat.sf.sfa import SymmetricFunctionsFunctor
 

--- a/src/sage/combinat/sf/schur.py
+++ b/src/sage/combinat/sf/schur.py
@@ -243,56 +243,30 @@ class SymmetricFunctionAlgebra_schur(classical.SymmetricFunctionAlgebra_classica
         Bref = B._ref()
         return f"SymmetricFunctionAlgebraSchur({Bref})"
 
+    def _power(self, x, n):
+        r"""
+        Return ``x`` to the power ``n`` by repeated multiplication.
+
+        For Schur functions this avoids the large intermediate squares
+        produced by binary exponentiation.
+
+        EXAMPLES::
+
+            sage: s = SymmetricFunctions(QQ['x']).s()
+            sage: len(s([2,1])^8)  # long time
+            1485
+
+        TESTS::
+
+            sage: f = s[2, 1] + s[3]
+            sage: all(f^n == f._pow_naive(n) for n in range(5))
+            True
+            sage: (-s.one())^(10^100) == s.one()
+            True
+        """
+        return self._power_naive(x, n)
+
     class Element(classical.SymmetricFunctionAlgebra_classical.Element):
-        def __pow__(self, n):
-            """
-            Return the naive powering of an instance of ``self``.
-
-            INPUT:
-
-            - ``self`` -- an element of the Schur symmetric function basis
-            - ``n`` -- nonnegative integer
-
-            OUTPUT: the `n`-th power of an instance of ``self`` in the Schur basis
-
-            See ``Monoids.Element.__pow__`` and ``Monoids.Element._pow_naive``.
-
-            EXAMPLES::
-
-                sage: s = SymmetricFunctions(QQ['x']).s()
-                sage: len(s([2,1])^8) # long time (~ 4 s)
-                1485
-                sage: len(s([2,1])^9) # long time (~10 s)
-                2876
-
-            Binary exponentiation does not seem to bring any speedup for
-            Schur functions. This most likely is because of the
-            explosion of the number of terms.
-
-            #    sage: s = SymmetricFunctions(QQ).s(); y = s([1])
-            #    sage: n = 24
-            #    sage: %timeit y**n    # using binary exponentiation
-            #    10 loops, best of 3: 1.22 s per loop
-            #    sage: %timeit prod(y for i in range(n))
-            #    10 loops, best of 3: 1.06 s per loop
-
-            With polynomial coefficients, this is actually much *slower*
-            (although this should be profiled further; there seems to
-            be an unreasonable number of polynomial multiplication involved,
-            besides the fact that 1 * QQ['x'].one() currently involves a
-            polynomial multiplication)
-
-            #    sage: sage: s = SymmetricFunctions(QQ['x']).s()
-            #    sage: y = s([2,1])
-            #    sage: %timeit y**7
-            #    10 loops, best of 3: 18.9 s per loop
-            #    sage: %timeit y*y*y*y*y*y*y
-            #    10 loops, best of 3: 1.73 s per loop
-
-            Todo: do the same for the other non multiplicative bases?
-            """
-            return self._pow_naive(n)
-
         def omega(self):
             r"""
             Return the image of ``self`` under the omega automorphism.

--- a/src/sage/combinat/sf/sfa.py
+++ b/src/sage/combinat/sf/sfa.py
@@ -216,6 +216,7 @@ AUTHORS:
 from copy import copy
 from functools import reduce
 
+from sage.arith.power import generic_power
 from sage.categories.hopf_algebras import HopfAlgebras
 from sage.categories.hopf_algebras_with_basis import HopfAlgebrasWithBasis
 from sage.categories.principal_ideal_domains import PrincipalIdealDomains
@@ -1850,6 +1851,74 @@ class SymmetricFunctionAlgebra_generic(CombinatorialFreeModule):
                                          category=cat,
                                          bracket='', prefix=prefix)
 
+    def _power(self, x, n):
+        r"""
+        Return ``x`` to the power ``n``.
+
+        This is the default powering strategy for a basis of symmetric
+        functions.  Bases whose multiplication is computed in another basis
+        can override this method to avoid changing basis at every
+        multiplication.
+
+        TESTS::
+
+            sage: p = SymmetricFunctions(QQ).p()
+            sage: f = p[2] + p[1, 1]
+            sage: f^3 == f * f * f
+            True
+        """
+        return generic_power(x, n)
+
+    def _power_naive(self, x, n):
+        r"""
+        Return ``x`` to the power ``n`` by repeated multiplication.
+
+        Negative powers retain the standard inversion semantics.
+
+        Stop as soon as a product vanishes, which is important over base
+        rings with zero divisors::
+
+            sage: Sym = SymmetricFunctions(Zmod(4))
+            sage: (2*Sym.m()[1])^(10^100)
+            0
+            sage: (2*Sym.s()[1])^(10^100)
+            0
+        """
+        if n < 0:
+            return generic_power(x, n)
+        if n == 0:
+            return self.one()
+        if n == 1:
+            return x
+        # Avoid a linear loop for zero and scalar elements, in particular
+        # when the exponent does not fit in a machine integer.
+        if all(not part for part in x._monomial_coefficients):
+            return generic_power(x, n)
+        result = x
+        for _ in range(n - 1):
+            result *= x
+            if not result:
+                return result
+        return result
+
+    def _power_via(self, x, n, basis):
+        r"""
+        Return ``x`` to the power ``n`` by working in ``basis``.
+
+        The input and output are converted exactly once.  The powering
+        strategy of ``basis`` is used for the intermediate computation.
+        """
+        if n < 0:
+            return generic_power(x, n)
+        if n == 0:
+            return self.one()
+        if n == 1:
+            return x
+        if basis is self:
+            return generic_power(x, n)
+        y = basis(x)
+        return self(basis._power(y, n))
+
     _print_style = 'lex'
 
     # Todo: share this with ncsf and over algebras with basis indexed by word-like elements
@@ -3135,6 +3204,36 @@ class SymmetricFunctionAlgebra_generic_Element(CombinatorialFreeModule.Element):
         m[1, 1, 1] + m[2, 1] + m[3]
         sage: m.set_print_style('lex')
     """
+    def _pow_int(self, n):
+        r"""
+        Return ``self`` to the integer power ``n``.
+
+        The parent selects the powering strategy so that bases implemented
+        through a change of basis can perform that change only once.
+
+        This also preserves the standard handling of negative powers and of
+        the three-argument form of :func:`pow`::
+
+            sage: s = SymmetricFunctions(QQ).s()
+            sage: (2*s.one())^(-2)
+            1/4*s[]
+            sage: s[1]^(-1)
+            Traceback (most recent call last):
+            ...
+            ValueError: cannot invert self (= s[1])
+            sage: pow(s[1], 2, 3)
+            Traceback (most recent call last):
+            ...
+            TypeError: the 3-argument version of pow() is not supported
+
+        Both Python and Sage integers use the same strategy::
+
+            sage: f = s[2] + s[1, 1]
+            sage: f^int(3) == f^Integer(3)
+            True
+        """
+        return self.parent()._power(self, n)
+
     def __truediv__(self, x):
         r"""
         Return the quotient of ``self`` by ``other``.

--- a/src/sage/combinat/sf/symplectic.py
+++ b/src/sage/combinat/sf/symplectic.py
@@ -193,6 +193,19 @@ class SymmetricFunctionAlgebra_symplectic(sfa.SymmetricFunctionAlgebra_generic):
                                   triangular='upper', unitriangular=True)
         Mi.register_as_coercion()
 
+    def _power(self, x, n):
+        r"""
+        Return ``x`` to the power ``n`` by converting to Schur functions once.
+
+        TESTS::
+
+            sage: sp = SymmetricFunctions(QQ).sp()
+            sage: f = sp[2] + sp[1, 1]
+            sage: f^4 == f._pow_naive(4)
+            True
+        """
+        return self._power_via(x, n, self._s)
+
     @cached_method
     def _sp_to_s_on_basis(self, lam):
         r"""


### PR DESCRIPTION
Fixes #41615.

This provides a basis-aware powering strategy for symmetric functions and removes a major allocation hotspot in the LLT transition code. It is an alternative implementation to #41623 that keeps the standard `Element.__pow__` dispatch instead of overriding `__pow__` in individual element classes.

## What changed

- `SymmetricFunctionAlgebra_generic_Element._pow_int` now delegates to a private strategy on its parent.
- The default strategy remains binary exponentiation, so multiplicative bases keep their existing behavior.
- Monomial and Schur functions use repeated multiplication, avoiding the large intermediate squares produced by binary exponentiation.
- Bases whose `product` already works through another realization convert once, compute the whole nonnegative power there, and convert back once:
  - Hall--Littlewood and ordinary Macdonald bases: Schur;
  - Jack `P` and LLT: monomial;
  - Jack `J`/`Q` and zonal: Jack `P`, whose own strategy continues to monomial;
  - Jack `Qp`: homogeneous, in the `Qp` subclass rather than a basis-name check;
  - symplectic, orthogonal, orthotriangular, and generic dual bases: their existing computation basis.
- Macdonald `S` has its own strategy using the same coefficient relabelling as its product. This is important at singular specializations such as `q = 1` or `t = 1`, where the actual Schur coercion can degenerate even though `S.product` remains valid.
- The old Schur `Element.__pow__` override is removed. This restores standard negative-power and three-argument `pow` behavior; for example `(2*s.one())^(-2)` is now `1/4*s[]`, while nonunits still fail to invert.
- Naive strategies keep O(1) paths for exponents 0 and 1, use binary powering for scalars, and stop once a product becomes zero over a ring with zero divisors.
- `graph_implementation_rec` now streams the binary ribbon choices with `itertools.combinations` instead of materializing all multiset permutations. The generated order is unchanged. A compatibility path retains the historical result for direct calls with invalid ribbon length zero.

## Why

Binary exponentiation is not uniformly optimal here. For monomial and Schur functions, squaring can create much larger intermediates than multiplying repeatedly by the sparse original factor. For bases implemented through an algebra isomorphism, the old path can also repeat basis transitions at each multiplication; converting once is algebraically equivalent and avoids those intermediate transitions.

The LLT transition builder additionally materialized every candidate multiset permutation. Streaming the same candidates removes a large transient allocation and was identified as the dominant LLT memory hotspot.

## Benchmarks

Each method was run in a separate fresh Sage process. Within a process only that same method was repeated, so the steady-state number warms only its own caches. Construction is outside the timer. `current` is `x**n` from this branch; `generic` is `sage.arith.power.generic_power(x, n)`, which models the previous category implementation. Results were compared outside the timed region; term counts and SHA-256 summaries match across methods.

| Input | current cold / self-warmed | generic cold / self-warmed | speedup cold / self-warmed |
|---|---:|---:|---:|
| `m[3,2,1]^6` over `QQ` | 7.116 / 7.045 s | 78.685 / 81.063 s | 11.06x / 11.51x |
| `s[2,1]^8` over `QQ` | 0.3006 / 0.3028 s | 10.0467 / 10.5949 s | 33.43x / 34.99x |
| Jack `J(t=2)`, sum of degree-3 basis elements, exponent 3 | 12.060 / 0.00972 s | 11.949 / 0.01248 s | 0.99x / 1.28x |
| Hall--Littlewood `Qp(t=2)`, sum of degree-4 basis elements, exponent 3 | 1.5665 / 0.02385 s | 1.5712 / 0.02818 s | 1.00x / 1.18x |
| Macdonald `P(q=2,t=3)`, sum of degree-3 basis elements, exponent 3 | 11.385 / 0.02076 s | 12.113 / 0.02412 s | 1.06x / 1.16x |
| LLT `HSp3[1,1]^4`, two fresh trials | 10.879--12.846 / 0.0655--0.0780 s | 10.809--12.301 / 0.0712--0.1091 s | 0.96--0.99x / 1.09--1.40x |

Cold parameter-family timings are dominated by building the transition cache for the final degree, so the one-conversion strategy is mainly a modest steady-state improvement in these small examples. In particular, LLT cold time is effectively unchanged; same-process cross-method benchmarks can make whichever method runs second appear hundreds of times faster because it inherits the first method's transition cache, so no such number is claimed here.

For the LLT allocation itself, generating the `binomial(20, 10) = 184756` candidates gives the same count and checksum while reducing process peak RSS from about 277 MiB to 217 MiB (the Sage baseline is about 217 MiB). In an end-to-end reconstructed old-vs-new `HSp3[1,1]^4` run, peak RSS was about 639 MiB vs 224 MiB; wall time varied, so this is presented as a memory result rather than a general speedup claim.

Reproduction pattern (save the worker below as `bench_power.py` and run each method in a new process):

```bash
DOT_SAGE=/tmp/sage-bench sage bench_power.py m current --steady-reps 1
DOT_SAGE=/tmp/sage-bench sage bench_power.py m generic --steady-reps 1
DOT_SAGE=/tmp/sage-bench sage bench_power.py jack current --steady-reps 3
DOT_SAGE=/tmp/sage-bench sage bench_power.py jack generic --steady-reps 3
```

The benchmark workers construct the requested basis and input, time either `x**n` or `generic_power(x, n)`, repeat only the same method for self-warmed measurements, and compare result length and a digest outside the timer.

<details>
<summary>Benchmark worker</summary>

```python
import argparse
import hashlib
import json
import resource
from time import perf_counter

from sage.all import Partitions, QQ, SymmetricFunctions
from sage.arith.power import generic_power


def make_case(name):
    if name == "llt":
        R = QQ["t"].fraction_field()
        B = SymmetricFunctions(R).llt(3).hspin()
        return B[1, 1], 4

    Sym = SymmetricFunctions(QQ)
    if name == "m":
        return Sym.m()[3, 2, 1], 6
    if name == "s":
        return Sym.s()[2, 1], 8
    if name == "jack":
        B, degree = Sym.jack(t=2).J(), 3
    elif name == "hl":
        B, degree = Sym.hall_littlewood(t=2).Qp(), 4
    elif name == "mac":
        B, degree = Sym.macdonald(q=2, t=3).P(), 3
    else:
        raise ValueError(name)
    return sum((B[p] for p in Partitions(degree)), B.zero()), 3


parser = argparse.ArgumentParser()
parser.add_argument("case", choices=["m", "s", "jack", "hl", "mac", "llt"])
parser.add_argument("method", choices=["current", "generic"])
parser.add_argument("--steady-reps", type=int, default=1)
args = parser.parse_args()
x, n = make_case(args.case)
power = (lambda: x**n) if args.method == "current" else (lambda: generic_power(x, n))

times = []
reference = None
for _ in range(1 + args.steady_reps):
    start = perf_counter()
    result = power()
    times.append(perf_counter() - start)
    if reference is None:
        reference = result
    else:
        assert result == reference

data = repr(sorted(result.monomial_coefficients(copy=False).items())).encode()
print(json.dumps({
    "case": args.case,
    "method": args.method,
    "cold_s": times[0],
    "steady_s": times[1:],
    "terms": len(result),
    "digest": hashlib.sha256(data).hexdigest()[:16],
    "maxrss_kib": resource.getrusage(resource.RUSAGE_SELF).ru_maxrss,
}, sort_keys=True))
```

</details>

## Validation

- Regular doctests for all 12 changed files: 3061 tests passed.
- Long doctests for all 12 changed files: 3099 tests passed.
- Ruff, both regular and preview configurations: passed.
- `git diff --check`: passed.
- Adversarial probes covered 25 bases; Python and Sage integers; exponents 0, 1, positive, negative, and huge; three-argument `pow`; pickle round trips; nilpotents over `Z/4Z`; `ZZ`, finite fields, polynomial and fraction fields; singular Macdonald specializations; dual and custom orthotriangular bases.
- LLT equivalence probes compared 8622 valid small shapes for the count/list callbacks and 2967 spin cases, including output and callback order.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

None.
