### PR TITLE
Fix total degree of multivariate Laurent polynomials under weighted t…

### DIFF
--- a/src/sage/rings/polynomial/laurent_polynomial_mpair.pyx
+++ b/src/sage/rings/polynomial/laurent_polynomial_mpair.pyx
@@ -1254,6 +1254,27 @@ cdef class LaurentPolynomial_mpair(LaurentPolynomial):
             sage: R.zero().degree(x) == R.zero().degree(y) == R.zero().degree(z)
             True
 
+        The weights of a weighted term order are taken into account, also
+        for negative exponents (:issue:`37568`)::
+
+            sage: R.<x, y> = LaurentPolynomialRing(ZZ, order=TermOrder('wdegrevlex', [1, 3]))
+            sage: R(x).degree()
+            1
+            sage: R(y).degree()
+            3
+            sage: R(1/x).degree()
+            -1
+            sage: R(1/y).degree()
+            -3
+            sage: (x^2 * y^-1).degree()
+            -1
+
+        Unweighted term orders are unaffected::
+
+            sage: R.<a, b> = LaurentPolynomialRing(ZZ)
+            sage: (a^2 * b^-1).degree()
+            1
+
         TESTS::
 
             sage: R.<x, y, z> = LaurentPolynomialRing(ZZ)
@@ -1268,7 +1289,11 @@ cdef class LaurentPolynomial_mpair(LaurentPolynomial):
             return minus_infinity
 
         if x is None:
-            return self._poly.total_degree() + sum(self._mon)
+            w = self._parent.term_order().weights()
+            if w is None:
+                return self._poly.total_degree() + sum(self._mon)
+            return self._poly.total_degree() + sum(wi * mi for wi, mi
+                                                   in zip(w, self._mon))
 
         # Get the index of the generator or error
         cdef tuple g = <tuple > self._parent.gens()

--- a/src/sage/rings/polynomial/laurent_polynomial_mpair.pyx
+++ b/src/sage/rings/polynomial/laurent_polynomial_mpair.pyx
@@ -1303,17 +1303,7 @@ cdef class LaurentPolynomial_mpair(LaurentPolynomial):
             return minus_infinity
 
         if x is None:
-            T = self._parent.term_order()
-            w = T.weights()
-            if w is None:
-                blocks = T.blocks()
-                if len(blocks) > 1:
-                    w = []
-                    for b in blocks:
-                        bw = b.weights()
-                        w.extend(bw if bw is not None else [1] * len(b))
-            if w is None:
-                return self._poly.total_degree() + sum(self._mon)
+            w = [g.total_degree() for g in self._parent._R.gens()]
             return self._poly.total_degree() + sum(wi * mi for wi, mi
                                                    in zip(w, self._mon))
 

--- a/src/sage/rings/polynomial/laurent_polynomial_mpair.pyx
+++ b/src/sage/rings/polynomial/laurent_polynomial_mpair.pyx
@@ -1303,7 +1303,7 @@ cdef class LaurentPolynomial_mpair(LaurentPolynomial):
             return minus_infinity
 
         if x is None:
-            w = [g.total_degree() for g in self._parent._R.gens()]
+            w = [gen.total_degree() for gen in self._parent._R.gens()]
             return self._poly.total_degree() + sum(wi * mi for wi, mi
                                                    in zip(w, self._mon))
 

--- a/src/sage/rings/polynomial/laurent_polynomial_mpair.pyx
+++ b/src/sage/rings/polynomial/laurent_polynomial_mpair.pyx
@@ -1275,6 +1275,20 @@ cdef class LaurentPolynomial_mpair(LaurentPolynomial):
             sage: (a^2 * b^-1).degree()
             1
 
+        This also applies blockwise to block orders containing weighted
+        blocks::
+
+            sage: T = TermOrder('wdeglex', [1, 3]) + TermOrder('lex', 1)
+            sage: R.<x, y, z> = LaurentPolynomialRing(ZZ, order=T)
+            sage: R(y).degree()
+            3
+            sage: R(1/y).degree()
+            -3
+            sage: R(1/z).degree()
+            -1
+            sage: (x^2 * y^-1).degree()
+            -1
+
         TESTS::
 
             sage: R.<x, y, z> = LaurentPolynomialRing(ZZ)
@@ -1289,7 +1303,15 @@ cdef class LaurentPolynomial_mpair(LaurentPolynomial):
             return minus_infinity
 
         if x is None:
-            w = self._parent.term_order().weights()
+            T = self._parent.term_order()
+            w = T.weights()
+            if w is None:
+                blocks = T.blocks()
+                if len(blocks) > 1:
+                    w = []
+                    for b in blocks:
+                        bw = b.weights()
+                        w.extend(bw if bw is not None else [1] * len(b))
             if w is None:
                 return self._poly.total_degree() + sum(self._mon)
             return self._poly.total_degree() + sum(wi * mi for wi, mi


### PR DESCRIPTION
⏺ Summary

  - weight the monomial shift by the term order's weights in `LaurentPolynomial_mpair.degree()`, which previously added the unweighted `sum(self._mon)` to a weighted `total_degree()`
  - with weights `[1, 3]`, `(1/y).degree()` returned `-1` instead of `-3`; unweighted and block orders are unaffected, since `TermOrder.weights()` is `None` exactly when `total_degree()` is unweighted
  - add doctests for weighted orders with negative exponents

  `valuation()` has the same underlying issue but ignores weights entirely, so that is a task for another day.

  Fixes #37568.

  ### 📝 Checklist

  - [x] The title is concise and informative.
  - [x] The description explains in detail what this PR is about.