### PR TITLE
 Implement is_S_integral for number field elements

### DIFF
--- a/src/sage/rings/number_field/number_field_element.pyx
+++ b/src/sage/rings/number_field/number_field_element.pyx
@@ -3710,6 +3710,53 @@ cdef class NumberFieldElement(NumberFieldElement_base):
         """
         return all(a in ZZ for a in self.absolute_minpoly())
 
+    def is_S_integral(self, S):
+        r"""
+        Return whether this number is `S`-integral, that is, integral
+        at every prime of the ring of integers not contained in ``S``.
+
+        INPUT:
+
+        - ``S`` -- list of prime ideals of the ring of integers of the
+          parent number field
+
+        EXAMPLES::
+
+            sage: x = polygen(ZZ, 'x')
+            sage: K.<a> = NumberField(x^2 - 5)
+            sage: S = K.primes_above(2)
+            sage: (a/2).is_integral()
+            False
+            sage: (a/2).is_S_integral(S)
+            True
+            sage: (K(1)/3).is_S_integral(S)
+            False
+
+        With ``S`` empty this is the same as :meth:`is_integral`::
+
+            sage: a.is_S_integral([])
+            True
+            sage: (a/2).is_S_integral([])
+            False
+
+        The zero element is `S`-integral for every ``S``::
+
+            sage: K(0).is_S_integral(S)
+            True
+
+        An example in a relative extension::
+
+            sage: K.<a, b> = NumberField([x^2 + 1, x^2 + 3])
+            sage: S = K.primes_above(2)
+            sage: ((a - b)/2).is_integral()
+            False
+            sage: ((a - b)/2).is_S_integral(S)
+            True
+        """
+        if self.is_zero():
+            return True
+        return self.parent().ideal(self).is_S_integral(S)
+
     def matrix(self, base=None):
         r"""
         If ``base`` is ``None``, return the matrix of right multiplication by the


### PR DESCRIPTION
Summary

  - add `is_S_integral` to `NumberFieldElement`, so `a.is_S_integral(S)` works directly instead of requiring `K.ideal(a).is_S_integral(S)`
  - the implementation in the issue used `self.number_field()`, which does not exist on elements; this uses `self.parent()`
  - zero is special-cased: `K.ideal(0)` is a `NumberFieldIdeal` rather than a fractional ideal and has no `is_S_integral`, so the naive delegation raises `AttributeError`
  - doctests cover `S` empty, the zero element, and a relative extension

  Fixes #40135.

  ### 📝 Checklist

  - [x] The title is concise and informative.
  - [x] The description explains in detail what this PR is about.


