### PR TITLE
gh-38543: Respect parent inner product in default vector norm

### DIFF
--- a/src/sage/misc/functional.py
+++ b/src/sage/misc/functional.py
@@ -1291,9 +1291,9 @@ def norm(x):
     r"""
     Return the norm of ``x``.
 
-    For matrices and vectors, this returns the L2-norm. The L2-norm of a
-    vector `\textbf{v} = (v_1, v_2, \dots, v_n)`, also called the Euclidean
-    norm, is defined as
+    For matrices, this returns the L2-norm.  For vectors whose parent uses
+    the standard dot product, this returns the Euclidean norm.  The Euclidean
+    norm of a vector `\textbf{v} = (v_1, v_2, \dots, v_n)` is defined as
 
     .. MATH::
 
@@ -1303,7 +1303,9 @@ def norm(x):
 
     where `|v_i|` is the complex modulus of `v_i`. The Euclidean norm is often
     used for determining the distance between two points in two- or
-    three-dimensional space.
+    three-dimensional space.  If the parent of a vector defines a nonstandard
+    inner product, this instead returns the square root of the inner product
+    of the vector with itself.
 
     For complex numbers, the function returns the field norm. If
     `c = a + bi` is a complex number, then the norm of `c` is defined as the
@@ -1361,6 +1363,16 @@ def norm(x):
         sage: v = vector([a, b, c, d])
         sage: norm(v)
         sqrt(a^2 + b^2 + c^2 + d^2)
+
+    A nonstandard inner product defined by the parent determines the default
+    norm.  The coordinate 2-norm remains available as ``v.norm(2)``::
+
+        sage: V = VectorSpace(QQ, 2, inner_product_matrix=[[9, 0], [0, 1]])
+        sage: v = V([1, 0])
+        sage: norm(v)
+        3
+        sage: v.norm(2)
+        1
 
     The norm of matrices::
 

--- a/src/sage/modules/free_module_element.pyx
+++ b/src/sage/modules/free_module_element.pyx
@@ -1747,17 +1747,20 @@ cdef class FreeModuleElement(Vector):   # abstract base class
         """
         return sum([x**2 for x in self.list()]).sqrt()
 
-    def norm(self, p=__two__):
+    def norm(self, p=None):
         r"""
-        Return the `p`-norm of ``self``.
+        Return the default norm or the `p`-norm of ``self``.
 
         INPUT:
 
-        - ``p`` -- (default: 2) ``p`` can be a real number greater than 1,
-          infinity (``oo`` or ``Infinity``), or a symbolic expression:
+        - ``p`` -- (default: ``None``) if ``None``, use the norm induced by
+          a nonstandard inner product defined by the parent, or the usual
+          Euclidean norm otherwise; explicitly specified values can be real
+          numbers greater than or equal to 1, infinity (``oo`` or
+          ``Infinity``), or symbolic expressions:
 
           - `p=1`: the taxicab (Manhattan) norm
-          - `p=2`: the usual Euclidean norm (the default)
+          - `p=2`: the usual Euclidean norm
           - `p=\infty`: the maximum entry (in absolute value)
 
         .. NOTE::
@@ -1770,12 +1773,40 @@ cdef class FreeModuleElement(Vector):   # abstract base class
             sage: v.norm(5)                                                             # needs sage.symbolic
             276^(1/5)
 
-        The default is the usual Euclidean norm.  ::
+        When the parent uses the standard dot product, the default is the
+        usual Euclidean norm.  ::
 
             sage: v.norm()                                                              # needs sage.symbolic
             sqrt(14)
             sage: v.norm(2)                                                             # needs sage.symbolic
             sqrt(14)
+
+        If the parent defines a nonstandard inner product, the default is
+        induced by that inner product.  An explicitly requested 2-norm is
+        still the Euclidean norm of the coordinates (see :issue:`38543`)::
+
+            sage: from sage.modules.free_quadratic_module_integer_symmetric import IntegralLattice
+            sage: L = IntegralLattice(matrix([[1000, 0], [0, 1]]))
+            sage: w = L.0
+            sage: w.norm()                                                              # needs sage.symbolic
+            10*sqrt(10)
+            sage: w.norm(2)
+            1
+            sage: w.norm()^2 - w.inner_product(w)                                      # needs sage.symbolic
+            0
+
+        Inner product matrices in Sage need not be positive definite.  In
+        that case, the default value need not be a norm in the mathematical
+        sense; for example, a nonzero vector may have default norm zero::
+
+            sage: U = IntegralLattice(matrix([[0, 1], [1, 0]]))
+            sage: u = U.0
+            sage: bool(u)
+            True
+            sage: u.norm()
+            0
+            sage: U([1, -1]).norm()                                                    # needs sage.symbolic
+            sqrt(-2)
 
         The infinity norm is the maximum size (in absolute value)
         of the entries.  ::
@@ -1836,6 +1867,11 @@ cdef class FreeModuleElement(Vector):   # abstract base class
             sage: v.norm(int(2))                                                        # needs sage.symbolic
             sqrt(5)
         """
+        if p is None:
+            if not self.parent()._inner_product_is_dot_product():
+                return self.inner_product(self)**(__one__/__two__)
+            p = __two__
+
         abs_self = [abs(x) for x in self]
         if p == Infinity:
             return max(abs_self)
@@ -2673,7 +2709,7 @@ cdef class FreeModuleElement(Vector):   # abstract base class
         The dot product of a vector with itself is the 2-norm, squared. ::
 
             sage: v = vector(QQ, [3, 4, 7])
-            sage: v.dot_product(v) - v.norm()^2                                         # needs sage.symbolic
+            sage: v.dot_product(v) - v.norm(2)^2                                        # needs sage.symbolic
             0
 
         TESTS:
@@ -3622,13 +3658,13 @@ cdef class FreeModuleElement(Vector):   # abstract base class
             True
 
         For vectors with complex entries, the Hermitian inner product
-        has a more natural relationship with the 2-norm (which is the
-        default for the :meth:`norm` method). The norm squared equals
-        the Hermitian inner product of the vector with itself.  ::
+        has a more natural relationship with the 2-norm. The 2-norm
+        squared equals the Hermitian inner product of the vector with
+        itself.  ::
 
             sage: # needs sage.rings.complex_double sage.symbolic
             sage: v = vector(CDF, [-0.66+0.47*I, -0.60+0.91*I, -0.62-0.87*I, 0.53+0.32*I])
-            sage: abs(v.norm()^2 - v.hermitian_inner_product(v)) < 1.0e-10
+            sage: abs(v.norm(2)^2 - v.hermitian_inner_product(v)) < 1.0e-10
             True
 
         TESTS:

--- a/src/sage/modules/vector_double_dense.pyx
+++ b/src/sage/modules/vector_double_dense.pyx
@@ -356,21 +356,26 @@ cdef class Vector_double_dense(Vector_numpy_dense):
         v = self._new(out)
         return v
 
-    def norm(self, p=2):
+    def norm(self, p=None):
         r"""
-        Return the norm (or related computations) of the vector.
+        Return the default norm or a related computation of the vector.
 
         INPUT:
 
-        - ``p`` -- (default: 2) controls which norm is computed,
-          allowable values are any real number and positive and
-          negative infinity.  See output discussion for specifics.
+        - ``p`` -- (default: ``None``) if ``None``, use the norm induced
+          by a nonstandard inner product defined by the parent, or the
+          usual Euclidean norm otherwise; explicitly specified values can
+          be any real number or positive or negative infinity.  See the
+          output discussion for specifics.
 
         OUTPUT:
 
-        Returned value is a double precision floating point value
-        in ``RDF`` (or an integer when ``p=0``).  The default value
-        of ``p = 2`` is the "usual" Euclidean norm.  For other values:
+        For an explicitly specified ``p``, the returned value is a double
+        precision floating point value in ``RDF`` (or an integer when
+        ``p=0``).  The value ``p = 2`` gives the "usual" Euclidean norm.
+        If ``p`` is ``None`` and the parent defines a nonstandard inner
+        product, the result is the square root of the inner product of the
+        vector with itself and may instead be in ``CDF``.  For other values:
 
         - ``p = Infinity`` or ``p = oo``: the maximum of the
           absolute values of the entries, where the absolute value
@@ -426,6 +431,17 @@ cdef class Vector_double_dense(Vector_numpy_dense):
             sage: w.norm(p=oo)
             13.0
 
+        If the parent defines a nonstandard inner product, it determines
+        the default.  An explicitly requested 2-norm is still the Euclidean
+        norm of the coordinates::
+
+            sage: V = VectorSpace(RDF, 2, inner_product_matrix=[[4, 0], [0, 1]])
+            sage: u = V([1, 0])
+            sage: u.norm()
+            2.0
+            sage: u.norm(p=2)
+            1.0
+
         Negative values of ``p`` are allowed and will
         provide the same computation as for positive values.
         A zero entry in the vector will raise a warning and return
@@ -457,6 +473,10 @@ cdef class Vector_double_dense(Vector_numpy_dense):
         """
         import sage.rings.infinity
         import sage.rings.integer
+        if p is None:
+            if not self.parent()._inner_product_is_dot_product():
+                return self.inner_product(self).sqrt()
+            p = 2
         if p == sage.rings.infinity.Infinity:
             p = numpy.inf
         elif p == -sage.rings.infinity.Infinity:


### PR DESCRIPTION
Fixes #38543.

Related PRs: #41603, #42644.

## Summary

- Make `v.norm()` use `sqrt(v.inner_product(v))` when the parent defines a nonstandard inner product.
- Keep explicitly requested p-norms unchanged, in particular making `v.norm(2)` the Euclidean norm of the coordinates.
- Apply the same default behavior to the optimized RDF/CDF vector implementation and to the top-level `norm(v)` helper.
- Document and test the behavior for standard, nonstandard, and indefinite inner products.

## Rationale

The previous default `p=2` conflated two different operations: the norm induced by the parent and the coordinate 2-norm. Following the review direction in #41603, this uses `p=None` to represent the parent-defined default while preserving the documented meaning of every explicit p-norm. This also avoids the regressions seen with the approach in #42644.

## Validation

- Rebuilt `free_module_element` and `vector_double_dense` from Cython through linking, with no compiler warnings.
- Ran 1,689 doctests across the three changed files.
- Ran 2,302 additional doctests covering free and quadratic modules plus RDF/CDF vector implementations.
- `git diff --check` passes.
