### PR TITLE
Fix Ninja jobserver warnings in doctests

### DIFF
--- a/.homebrew-build-env
+++ b/.homebrew-build-env
@@ -7,6 +7,12 @@ for l in bzip2 texinfo polymake; do
         PATH="$HOMEBREW/opt/$l/bin:$PATH"
     fi
 done
+# Homebrew installs GNU make as "gmake" to avoid shadowing the system make.
+# Use its "make" symlink as well: GNU make 4.4 and later use the FIFO
+# jobserver protocol supported by Ninja 1.13 and later.
+if [ -d "$HOMEBREW/opt/make/libexec/gnubin" ]; then
+    PATH="$HOMEBREW/opt/make/libexec/gnubin:$PATH"
+fi
 export PATH
 if [ -z "$PKG_CONFIG_PATH" ]; then
     PKG_CONFIG_PATH="$HOMEBREW/lib/pkgconfig"

--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,11 @@ TEST_OPTIONAL = sage,optional
 # Keep track of the top-level *test* Makefile target for logging.
 TEST_TARGET = $@
 
-TEST = ./sage -t --logfile=$(TEST_LOG) $(TEST_FLAGS) --optional=$(TEST_OPTIONAL) $(TEST_FILES)
+# In a non-verbose editable install, meson-python invokes Ninja on every
+# import, even when there is nothing to rebuild.  The check performed in
+# verbose mode captures the no-op Ninja output, preventing jobserver warnings
+# from leaking into the output of subprocess doctests (see issue #40869).
+TEST = MESONPY_EDITABLE_VERBOSE=1 ./sage -t --logfile=$(TEST_LOG) $(TEST_FLAGS) --optional=$(TEST_OPTIONAL) $(TEST_FILES)
 
 test-git-no-uncommitted-changes:
 	./tools/test-git-no-uncommitted-changes

--- a/build/pkgs/_prereq/SPKG.rst
+++ b/build/pkgs/_prereq/SPKG.rst
@@ -15,7 +15,8 @@ computer:
 - **C compiler** (**C/C++** - compiler required on macOS): a sufficently modern compiler.
   Ideally these can be directly used to build Sage. The options are essentially GNU gcc/g++ on Linux,
   and clang/clang++ on macOS (which conventionally misnames them gcc/g++), on BSDs, and also on Linux.
-- **make**: GNU make, version 3.80 or later. Version 3.82 or later is recommended.
+- **make**: GNU make, version 3.80 or later. Version 4.4 or later is recommended
+  so that Ninja can use its FIFO-based jobserver protocol.
 - **m4**: GNU m4 1.4.2 or later (non-GNU or older versions might also work).
 - **perl**: version 5.8.0 or later.
 - **ar** and **ranlib**: can be obtained as part of GNU binutils.

--- a/build/pkgs/_prereq/distros/homebrew.txt
+++ b/build/pkgs/_prereq/distros/homebrew.txt
@@ -8,5 +8,6 @@
 # Everything on a line after a # character is ignored.
 #
 pkgconf
+make
 zlib
 boost


### PR DESCRIPTION
## Summary

- prevent Ninja jobserver warnings from leaking into subprocess doctest output
- install and prefer Homebrew's GNU Make so macOS builds use the FIFO jobserver supported by Ninja
- recommend GNU Make 4.4 or later in the source prerequisites

## Root cause

This is a follow-up to #40869.

The GNU Make shipped by macOS uses the legacy pipe jobserver and exports it in
`MAKEFLAGS`.  Ninja 1.13 supports the POSIX jobserver only when GNU Make uses
the FIFO protocol introduced in GNU Make 4.4, so it emits
`Ignoring jobserver: Pipe-based protocol is not supported`.

In a non-verbose meson-python editable install, every new Python process runs
Ninja, even when the build tree is already clean.  Ninja's stdout is hidden,
but this warning is written to stderr and becomes part of the captured output
of subprocess doctests.

The test entry point now enables meson-python's editable verbose mode.  That
mode first performs a captured Ninja dry run and skips the real invocation
when there is no work.  Since `test` depends on `all`, this is the expected
state when doctests begin.  For real builds on Homebrew, GNU Make 4.4 or later
provides the compatible FIFO jobserver instead of merely hiding the warning.

## Validation

- reproduced the failure in `src/sage/repl/interpreter.py` with legacy
  `--jobserver-fds=3,4` flags: 1 failure out of 142 tests
- reran the same doctest with the patched test entry point: all 142 tests pass
- ran the patched test entry point under both pipe and FIFO jobserver styles
- ran a real Ninja build under GNU Make 4.4 FIFO mode and verified
  `Jobserver mode detected` followed by a successful build
- verified that `.homebrew-build-env` selects
  `opt/make/libexec/gnubin/make`
- ran `bash -n .homebrew-build-env` and `git diff --check`
