### PR TITLE
Annotate return types of PowerSeriesRing, LaurentPolynomialRing and QuotientRing (follow-up to #42670)

### DIFF
--- a/src/sage/rings/polynomial/laurent_polynomial_ring.py
+++ b/src/sage/rings/polynomial/laurent_polynomial_ring.py
@@ -52,7 +52,11 @@ from sage.structure.element import parent
 _cache = {}
 
 
-def LaurentPolynomialRing(base_ring, *args, **kwds):
+# The return annotation is only there for the typing info: it exists so that
+# static type checkers can infer the return type of
+# ``LaurentPolynomialRing``.  ``LaurentPolynomialRing_generic`` is the common
+# base of the univariate and multivariate implementations.
+def LaurentPolynomialRing(base_ring, *args, **kwds) -> LaurentPolynomialRing_generic:
     r"""
     Return the globally unique univariate or multivariate Laurent polynomial
     ring with given properties and variable name or names.
@@ -207,6 +211,16 @@ def LaurentPolynomialRing(base_ring, *args, **kwds):
            Defining w0, w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13, w14
            sage: (w0 + 2*w8 + w13)^2                                                    # needs sage.modules
            w0^2 + 4*w0*w8 + 4*w8^2 + 2*w0*w13 + 4*w8*w13 + w13^2
+
+    TESTS:
+
+    The return annotation matches the runtime type for the common cases::
+
+        sage: from sage.rings.polynomial.laurent_polynomial_ring_base import LaurentPolynomialRing_generic
+        sage: isinstance(LaurentPolynomialRing(ZZ, 'x'), LaurentPolynomialRing_generic)
+        True
+        sage: isinstance(LaurentPolynomialRing(ZZ, 2, 'x,y'), LaurentPolynomialRing_generic)
+        True
     """
     from sage.rings.polynomial.polynomial_ring import PolynomialRing_generic
     from sage.rings.polynomial.multi_polynomial_ring_base import MPolynomialRing_base

--- a/src/sage/rings/polynomial/laurent_polynomial_ring.py
+++ b/src/sage/rings/polynomial/laurent_polynomial_ring.py
@@ -52,10 +52,6 @@ from sage.structure.element import parent
 _cache = {}
 
 
-# The return annotation is only there for the typing info: it exists so that
-# static type checkers can infer the return type of
-# ``LaurentPolynomialRing``.  ``LaurentPolynomialRing_generic`` is the common
-# base of the univariate and multivariate implementations.
 def LaurentPolynomialRing(base_ring, *args, **kwds) -> LaurentPolynomialRing_generic:
     r"""
     Return the globally unique univariate or multivariate Laurent polynomial
@@ -220,6 +216,9 @@ def LaurentPolynomialRing(base_ring, *args, **kwds) -> LaurentPolynomialRing_gen
         sage: isinstance(LaurentPolynomialRing(ZZ, 'x'), LaurentPolynomialRing_generic)
         True
         sage: isinstance(LaurentPolynomialRing(ZZ, 2, 'x,y'), LaurentPolynomialRing_generic)
+        True
+        sage: import typing
+        sage: typing.get_type_hints(LaurentPolynomialRing)['return'] is LaurentPolynomialRing_generic
         True
     """
     from sage.rings.polynomial.polynomial_ring import PolynomialRing_generic

--- a/src/sage/rings/power_series_ring.py
+++ b/src/sage/rings/power_series_ring.py
@@ -132,8 +132,6 @@ TESTS::
     True
     sage: TestSuite(M).run()
 """
-from __future__ import annotations
-
 from sage.categories import commutative_rings
 from sage.misc import latex
 from sage.interfaces.abc import MagmaElement
@@ -177,14 +175,9 @@ except ImportError:
 lazy_import('sage.rings.lazy_series_ring', 'LazyPowerSeriesRing')
 
 
-# The return annotation is only there for the typing info: it exists so that
-# static type checkers can infer the return type of ``PowerSeriesRing``.
-# ``PowerSeriesRing_generic`` is the common base of the univariate
-# (``PowerSeriesRing_domain`` / ``PowerSeriesRing_over_field``) and the
-# multivariate (``MPowerSeriesRing_generic``) implementations.
 def PowerSeriesRing(base_ring, name=None, arg2=None, names=None,
                     sparse=False, default_prec=None, order='negdeglex',
-                    num_gens=None, implementation=None) -> PowerSeriesRing_generic:
+                    num_gens=None, implementation=None) -> 'PowerSeriesRing_generic':
     r"""
     Create a univariate or multivariate power series ring over a given
     (commutative) base ring.
@@ -368,7 +361,12 @@ def PowerSeriesRing(base_ring, name=None, arg2=None, names=None,
         True
         sage: isinstance(PowerSeriesRing(QQ, 'x'), PowerSeriesRing_generic)
         True
-        sage: isinstance(PowerSeriesRing(ZZ, 2, 'x,y'), PowerSeriesRing_generic)
+        sage: isinstance(PowerSeriesRing(ZZ, 'x,y'), PowerSeriesRing_generic)
+        True
+        sage: isinstance(PowerSeriesRing(GF(5), 'x', sparse=True), PowerSeriesRing_generic)
+        True
+        sage: import typing
+        sage: typing.get_type_hints(PowerSeriesRing)['return'] is PowerSeriesRing_generic
         True
     """
     # multivariate case:

--- a/src/sage/rings/power_series_ring.py
+++ b/src/sage/rings/power_series_ring.py
@@ -132,6 +132,7 @@ TESTS::
     True
     sage: TestSuite(M).run()
 """
+from __future__ import annotations
 
 from sage.categories import commutative_rings
 from sage.misc import latex

--- a/src/sage/rings/power_series_ring.py
+++ b/src/sage/rings/power_series_ring.py
@@ -176,9 +176,14 @@ except ImportError:
 lazy_import('sage.rings.lazy_series_ring', 'LazyPowerSeriesRing')
 
 
+# The return annotation is only there for the typing info: it exists so that
+# static type checkers can infer the return type of ``PowerSeriesRing``.
+# ``PowerSeriesRing_generic`` is the common base of the univariate
+# (``PowerSeriesRing_domain`` / ``PowerSeriesRing_over_field``) and the
+# multivariate (``MPowerSeriesRing_generic``) implementations.
 def PowerSeriesRing(base_ring, name=None, arg2=None, names=None,
                     sparse=False, default_prec=None, order='negdeglex',
-                    num_gens=None, implementation=None):
+                    num_gens=None, implementation=None) -> PowerSeriesRing_generic:
     r"""
     Create a univariate or multivariate power series ring over a given
     (commutative) base ring.
@@ -352,6 +357,18 @@ def PowerSeriesRing(base_ring, name=None, arg2=None, names=None,
     .. SEEALSO::
 
         * :func:`sage.misc.defaults.set_series_precision`
+
+    TESTS:
+
+    The return annotation matches the runtime type for the common cases::
+
+        sage: from sage.rings.power_series_ring import PowerSeriesRing_generic
+        sage: isinstance(PowerSeriesRing(ZZ, 'x'), PowerSeriesRing_generic)
+        True
+        sage: isinstance(PowerSeriesRing(QQ, 'x'), PowerSeriesRing_generic)
+        True
+        sage: isinstance(PowerSeriesRing(ZZ, 2, 'x,y'), PowerSeriesRing_generic)
+        True
     """
     # multivariate case:
     # examples for first case:

--- a/src/sage/rings/quotient_ring.py
+++ b/src/sage/rings/quotient_ring.py
@@ -286,6 +286,7 @@ def QuotientRing(R, I, names=None, **kwds) -> Parent:
     The return annotation matches the runtime type for generic, principal,
     noncommutative and unchanged quotient rings::
 
+        sage: from sage.structure.parent import Parent
         sage: isinstance(QuotientRing(ZZ, 2*ZZ), Parent)
         True
         sage: R = QQ['x']

--- a/src/sage/rings/quotient_ring.py
+++ b/src/sage/rings/quotient_ring.py
@@ -108,8 +108,6 @@ easily::
 # (at your option) any later version.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
-from __future__ import annotations
-
 import sage.interfaces.abc
 from sage.misc import latex
 import sage.structure.parent_gens
@@ -130,11 +128,7 @@ _CommRings = CommutativeRings()
 MPolynomialIdeal_quotient = None
 
 
-# The return annotation is only there for the typing info: it exists so that
-# static type checkers can infer the return type of ``QuotientRing``.
-# ``QuotientRing_generic`` is the common base of the generic quotient ring and
-# the polynomial quotient ring implementations.
-def QuotientRing(R, I, names=None, **kwds) -> QuotientRing_generic:
+def QuotientRing(R, I, names=None, **kwds) -> Parent:
     r"""
     Create a quotient ring of the ring `R` by the twosided ideal `I`.
 
@@ -289,12 +283,26 @@ def QuotientRing(R, I, names=None, **kwds) -> QuotientRing_generic:
 
     TESTS:
 
-    The return annotation matches the runtime type for the common cases::
+    The return annotation matches the runtime type for generic, principal,
+    noncommutative and unchanged quotient rings::
 
-        sage: from sage.rings.quotient_ring import QuotientRing_generic
-        sage: isinstance(QuotientRing(ZZ, 2*ZZ), QuotientRing_generic)
+        sage: isinstance(QuotientRing(ZZ, 2*ZZ), Parent)
         True
-        sage: isinstance(QuotientRing(QQ['x'], QQ['x'].gen()**2), QuotientRing_generic)
+        sage: R = QQ['x']
+        sage: isinstance(QuotientRing(R, R.ideal(R.gen()**2)), Parent)
+        True
+        sage: F.<x,y> = FreeAlgebra(QQ, 2)
+        sage: I = F * [x*y, y*x] * F
+        sage: isinstance(QuotientRing(F, I), Parent)
+        True
+        sage: R = QQ['x']
+        sage: QuotientRing(R, R.zero_ideal()) is R
+        True
+
+    The annotation resolves to the common parent base::
+
+        sage: import typing
+        sage: typing.get_type_hints(QuotientRing)['return'] is Parent
         True
     """
     # 1. Not all rings inherit from the base class of rings.

--- a/src/sage/rings/quotient_ring.py
+++ b/src/sage/rings/quotient_ring.py
@@ -108,6 +108,8 @@ easily::
 # (at your option) any later version.
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
+from __future__ import annotations
+
 import sage.interfaces.abc
 from sage.misc import latex
 import sage.structure.parent_gens

--- a/src/sage/rings/quotient_ring.py
+++ b/src/sage/rings/quotient_ring.py
@@ -128,7 +128,11 @@ _CommRings = CommutativeRings()
 MPolynomialIdeal_quotient = None
 
 
-def QuotientRing(R, I, names=None, **kwds):
+# The return annotation is only there for the typing info: it exists so that
+# static type checkers can infer the return type of ``QuotientRing``.
+# ``QuotientRing_generic`` is the common base of the generic quotient ring and
+# the polynomial quotient ring implementations.
+def QuotientRing(R, I, names=None, **kwds) -> QuotientRing_generic:
     r"""
     Create a quotient ring of the ring `R` by the twosided ideal `I`.
 
@@ -279,6 +283,16 @@ def QuotientRing(R, I, names=None, **kwds):
         True
         sage: I = R.ideal(0)
         sage: R is R.quotient(I)
+        True
+
+    TESTS:
+
+    The return annotation matches the runtime type for the common cases::
+
+        sage: from sage.rings.quotient_ring import QuotientRing_generic
+        sage: isinstance(QuotientRing(ZZ, 2*ZZ), QuotientRing_generic)
+        True
+        sage: isinstance(QuotientRing(QQ['x'], QQ['x'].gen()**2), QuotientRing_generic)
         True
     """
     # 1. Not all rings inherit from the base class of rings.


### PR DESCRIPTION
Follow-up to #42670: this PR annotates three constructor functions whose return types static type checkers cannot infer.

- `PowerSeriesRing` returns `PowerSeriesRing_generic`, the common base of its univariate and multivariate implementations.
- `LaurentPolynomialRing` returns `LaurentPolynomialRing_generic`, the common base of its univariate and multivariate implementations.
- `QuotientRing` returns `Parent`: unlike the narrower generic quotient class, this accurately covers all supported branches, including ordinary and principal quotients, noncommutative quotients, Boolean-polynomial implementations, integer quotients and the zero-ideal path that returns the original parent.

Forward references are quoted locally where the implementation class is defined later in the module, avoiding import-time `NameError` without changing annotation evaluation semantics for unrelated functions.

Regression doctests cover representative runtime branches and `typing.get_type_hints` resolution.  No runtime behavior changes; these are annotations only.
