### PR TITLE
Fix local_height_arch weighting real places as complex at prec=53

### DIFF
--- a/src/sage/rings/number_field/number_field_element.pyx
+++ b/src/sage/rings/number_field/number_field_element.pyx
@@ -4018,6 +4018,20 @@ cdef class NumberFieldElement(NumberFieldElement_base):
              0.02240347229957875780769746914391,
              0.780028961749618,
              1.16048938497298]
+
+        The weighting is by the local degree, so it must not be applied at a
+        real place.  With ``prec=53`` the places map into ``RDF`` and ``CDF``
+        rather than into ``RealField`` and ``ComplexField``, which used to
+        make the real places be weighted as if they were complex
+        (:issue:`31185`)::
+
+            sage: K.<s> = QuadraticField(2)
+            sage: s.local_height_arch(1, weighted=True)
+            0.3465735902799726547086160607291
+            sage: s.local_height_arch(1, weighted=True, prec=53)
+            0.3465735902799727
+            sage: s.global_height(prec=53)
+            0.346573590279973
         """
         K = self.number_field()
         emb = K.places(prec=prec)[i]
@@ -4026,7 +4040,8 @@ cdef class NumberFieldElement(NumberFieldElement_base):
         if a <= Kv.one():
             return Kv.zero()
         ht = a.log()
-        if weighted and not isinstance(Kv, sage.rings.abc.RealField):
+        if weighted and not isinstance(Kv, (sage.rings.abc.RealField,
+                                            sage.rings.abc.RealDoubleField)):
             ht*=2
         return ht
 


### PR DESCRIPTION
  Summary

  - `local_height_arch` tested for a real place with `isinstance(Kv, sage.rings.abc.RealField)`, but `places(prec=53)` maps into `RDF`/`CDF`, and `RDF` is not a `sage.rings.abc.RealField`; real places were therefore given the complex local
  degree 2
  - this made `global_height_arch` and `global_height` wrong at `prec=53`: `QuadraticField(2).gen().global_height(prec=53)` returned `0.693147180559945` instead of `0.346573590279973`
  - add `sage.rings.abc.RealDoubleField` to the check, matching the idiom already used in `NumberField_generic.hilbert_symbol`

  Fixes #31185.

  ### 📝 Checklist

  - [x] The title is concise and informative.
  - [x] The description explains in detail what this PR is about.