### PR TITLE
Multisort lazy species derivatives

### DIFF
--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -1729,9 +1729,18 @@ class Stream_uninitialized(Stream):
             Currently, the first invocation is via
             :meth:`_good_cache` in :meth:`__getitem__`.
 
-        EXAMPLES::
+        EXAMPLES:
 
-            sage: from sage.data_structures.stream import Stream_uninitialized, Stream_exact, Stream_cauchy_mul, Stream_add, Stream_sub
+        A cache-less shifted stream does not hide the cached stream on which it depends::
+
+            sage: from sage.data_structures.stream import Stream_uninitialized, Stream_exact, Stream_cauchy_mul, Stream_add, Stream_sub, Stream_map_coefficients, Stream_shift
+            sage: C = Stream_uninitialized(0)
+            sage: M = Stream_map_coefficients(C, lambda c: c, True)
+            sage: S = Stream_shift(M, -1)
+            sage: C.define(S)
+            sage: C._input_streams == [C, M]
+            True
+
             sage: terms_of_degree = lambda n, R: [R.one()]
             sage: x = Stream_exact([1], order=1)
             sage: C = Stream_uninitialized(1)
@@ -1745,12 +1754,16 @@ class Stream_uninitialized(Stream):
              <sage.data_structures.stream.Stream_cauchy_mul object at 0x...>]
         """
         known = [self]
+        visited = [self]
         todo = [self]
         while todo:
             x = todo.pop()
             for y in x.input_streams():
-                if hasattr(y, "_cache") and not any(y is z for z in known):
-                    todo.append(y)
+                if any(y is z for z in visited):
+                    continue
+                visited.append(y)
+                todo.append(y)
+                if hasattr(y, "_cache"):
                     known.append(y)
         return known
 
@@ -4556,6 +4569,20 @@ class Stream_shift(Stream):
         self._series = series
         self._shift = shift
         super().__init__(series._true_order)
+
+    def input_streams(self):
+        r"""
+        Return the input stream of ``self``.
+
+        EXAMPLES::
+
+            sage: from sage.data_structures.stream import Stream_function, Stream_shift
+            sage: f = Stream_function(lambda n: n, True, 0)
+            sage: s = Stream_shift(f, -1)
+            sage: s.input_streams()[0] is f
+            True
+        """
+        return [self._series]
 
     @lazy_attribute
     def _approximate_order(self):

--- a/src/sage/rings/lazy_species.py
+++ b/src/sage/rings/lazy_species.py
@@ -79,7 +79,9 @@ from sage.rings.species import (_label_sets,
 from sage.data_structures.stream import (Stream_zero,
                                          Stream_exact,
                                          Stream_truncated,
-                                         Stream_function)
+                                         Stream_function,
+                                         Stream_map_coefficients,
+                                         Stream_shift)
 from sage.categories.tensor import tensor
 from sage.combinat.integer_vector import IntegerVectors
 from sage.combinat.subset import subsets
@@ -1953,19 +1955,29 @@ class DerivativeSpeciesElement(LazyCombinatorialSpeciesElement):
             sage: D[3] == (2*X*E2 + X^3)[3]
             True
             sage: TestSuite(D).run(skip=['_test_category', '_test_pickling'])
+
+        A derivative of an undefined species retains the dependency on its
+        coefficient stream::
+
+            sage: A = L.undefined()
+            sage: dA = A.derivative()
+            sage: M = dA._coeff_stream.input_streams()[0]
+            sage: M.input_streams()[0] is A._coeff_stream
+            True
         """
         if F.parent()._arity != 1:
             raise NotImplementedError("derivative is not yet implemented for multisort species")
 
         self._F = F
 
-        coeff_stream = Stream_function(
-            lambda n: F[n + 1].derivative(),
-            F.parent()._sparse,
-            max(F._coeff_stream._approximate_order - 1, 0),
+        P = F.parent()
+        coeff_stream = Stream_map_coefficients(
+            F._coeff_stream,
+            lambda c: c.derivative(),
+            P._sparse,
         )
-        super().__init__(F.parent(), coeff_stream)
-
+        coeff_stream = Stream_shift(coeff_stream, -1)
+        super().__init__(P, coeff_stream)
     def generating_series(self):
         r"""
         Return the exponential generating series of ``self``.

--- a/src/sage/rings/lazy_species.py
+++ b/src/sage/rings/lazy_species.py
@@ -96,6 +96,7 @@ from sage.groups.perm_gps.permgroup_named import (AlternatingGroup,
                                                   DihedralGroup,
                                                   SymmetricGroup)
 from sage.modules.free_module_element import vector
+from sage.misc.derivative import multi_derivative
 from sage.misc.inherit_comparison import InheritComparisonClasscallMetaclass
 from sage.structure.element import parent
 from sage.structure.unique_representation import UniqueRepresentation
@@ -1068,7 +1069,7 @@ class LazyCombinatorialSpeciesElement(LazyCompletionGradedAlgebraElement):
         """
         return HadamardProductSpeciesElement(self, other)
 
-    def derivative(self):
+    def derivative(self, *args):
         r"""
         Return the derivative species of ``self``.
 
@@ -1078,6 +1079,19 @@ class LazyCombinatorialSpeciesElement(LazyCompletionGradedAlgebraElement):
         unique bijection `U \sqcup \{*\} \to V \sqcup \{*\}` that agrees
         with `\sigma` on `U` and fixes `*`.
 
+        For a multisort species, the derivative with respect to sort `i`
+        is defined by
+
+        \frac{\partial}{\partial X_i} F[U_1, \ldots, U_k]
+        = F[U_1, \ldots, U_i \sqcup \{*\}, \ldots, U_k].
+
+        The arguments follow Sage's standard derivative syntax (see
+        :func:`sage.misc.derivative.derivative_parse`). The sort generator
+        may be omitted if the parent is unisort. It must be specified if
+        the parent is multisort.
+
+
+
         EXAMPLES::
 
             sage: L.<X> = LazyCombinatorialSpecies(QQ)
@@ -1086,8 +1100,54 @@ class LazyCombinatorialSpeciesElement(LazyCompletionGradedAlgebraElement):
             sage: Lin = 1 / (1 - X)
             sage: Lin.derivative()[4] == (Lin^2)[4]
             True
+
+        Partial derivatives of multisort lazy species are obtained by
+        specifying a sort generator::
+
+            sage: L.<X, Y> = LazyCombinatorialSpecies(QQ)
+            sage: F = X^2 * Y^2
+            sage: F.derivative(X, 2)[2]
+            2*Y^2
+            sage: F.derivative(X, Y)[2]
+            4*X*Y
+            sage: F.derivative([X, Y])[2]
+            4*X*Y
+            sage: F.derivative(0) is F
+            True
+            sage: X.derivative(Y)[0]
+            0
         """
-        return DerivativeSpeciesElement(self)
+        return multi_derivative(self, args)
+
+    def _derivative(self, variable=None):
+        r"""
+        Return the derivative of ``self`` with respect to one sort.
+
+        TESTS::
+
+            sage: L.<X, Y> = LazyCombinatorialSpecies(QQ)
+            sage: F = X^2 * Y^2
+            sage: F._derivative(X)[3]
+            2*X*Y^2
+        """
+        P = self.parent()
+        if variable is None:
+            if P._arity != 1:
+                raise ValueError(
+                    "the derivative variable must be specified for multisort species"
+                )
+            sort = 0
+        else:
+            variables = P._first_ngens(P._arity)
+            if (parent(variable) is not P
+                    or not isinstance(variable._coeff_stream, Stream_exact)
+                    or variable not in variables):
+                raise ValueError(
+                    "the derivative variable must be a sort generator of the parent"
+                )
+            sort = variables.index(variable)
+
+        return DerivativeSpeciesElement(self, sort)
 
 
 class LazyCombinatorialSpeciesElementGeneratingSeriesMixin:
@@ -1943,7 +2003,7 @@ class HadamardProductSpeciesElement(LazyCombinatorialSpeciesElement):
 
 
 class DerivativeSpeciesElement(LazyCombinatorialSpeciesElement):
-    def __init__(self, F):
+    def __init__(self, F, sort=0):
         r"""
         Initialize the derivative of ``F``.
 
@@ -1964,16 +2024,27 @@ class DerivativeSpeciesElement(LazyCombinatorialSpeciesElement):
             sage: M = dA._coeff_stream.input_streams()[0]
             sage: M.input_streams()[0] is A._coeff_stream
             True
+
+        Partial derivatives of undefined multisort species retain their
+        dependencies through nested shifted streams::
+
+            sage: L.<X, Y> = LazyCombinatorialSpecies(QQ)
+            sage: F = L.undefined(1)
+            sage: D = F.derivative(X)
+            sage: Dxy = F.derivative(X, Y)
+            sage: F.define(X + Y*F)
+            sage: [D[n] for n in range(3)]
+            [1, Y, Y^2]
+            sage: [Dxy[n] for n in range(3)]
+            [1, 2*Y, 3*Y^2]
         """
-        if F.parent()._arity != 1:
-            raise NotImplementedError("derivative is not yet implemented for multisort species")
-
         self._F = F
-
+        self._sort = sort
         P = F.parent()
+        sort_variable = P._laurent_poly_ring._first_ngens(P._arity)[sort]
         coeff_stream = Stream_map_coefficients(
             F._coeff_stream,
-            lambda c: c.derivative(),
+            lambda c: c._derivative(sort_variable),
             P._sparse,
         )
         coeff_stream = Stream_shift(coeff_stream, -1)
@@ -1993,7 +2064,8 @@ class DerivativeSpeciesElement(LazyCombinatorialSpeciesElement):
             sage: Lin.derivative().generating_series() - (Lin^2).generating_series()
             O(X^7)
         """
-        return self._F.generating_series().derivative()
+        f = self._F.generating_series()
+        return f.derivative(f.parent().gen(self._sort))
 
     def cycle_index_series(self):
         r"""
@@ -2006,6 +2078,8 @@ class DerivativeSpeciesElement(LazyCombinatorialSpeciesElement):
             sage: E.derivative().cycle_index_series() - E.cycle_index_series()
             O^6
         """
+        if self.parent()._arity != 1:
+            return super().cycle_index_series()
         return self._F.cycle_index_series().derivative_with_respect_to_p1()
 
 

--- a/src/sage/rings/lazy_species.py
+++ b/src/sage/rings/lazy_species.py
@@ -1082,15 +1082,14 @@ class LazyCombinatorialSpeciesElement(LazyCompletionGradedAlgebraElement):
         For a multisort species, the derivative with respect to sort `i`
         is defined by
 
-        \frac{\partial}{\partial X_i} F[U_1, \ldots, U_k]
-        = F[U_1, \ldots, U_i \sqcup \{*\}, \ldots, U_k].
+        .. MATH::
+
+            \frac{\partial}{\partial X_i} F[U_1, \ldots, U_k] = F[U_1, \ldots, U_i \sqcup \{*\}, \ldots, U_k].
 
         The arguments follow Sage's standard derivative syntax (see
         :func:`sage.misc.derivative.derivative_parse`). The sort generator
         may be omitted if the parent is unisort. It must be specified if
         the parent is multisort.
-
-
 
         EXAMPLES::
 
@@ -2049,6 +2048,7 @@ class DerivativeSpeciesElement(LazyCombinatorialSpeciesElement):
         )
         coeff_stream = Stream_shift(coeff_stream, -1)
         super().__init__(P, coeff_stream)
+
     def generating_series(self):
         r"""
         Return the exponential generating series of ``self``.

--- a/src/sage/rings/species.py
+++ b/src/sage/rings/species.py
@@ -1826,7 +1826,7 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                         atoms[B] += e * f
             return M(atoms, check=False)
 
-        def derivative(self):
+        def derivative(self, variable=None):
             r"""
             Return the derivative of ``self``.
 
@@ -1834,7 +1834,9 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
             Section 2.6 in [BLL1998]_.
 
             Note that the result is a polynomial species rather than
-            a molecular species.
+            a molecular species. When the parent is unisort, ``variable`` may
+            be omitted. For a multisort parent, ``variable`` must be a sort
+            generator of the parent.
 
             EXAMPLES::
 
@@ -1849,20 +1851,74 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                 sage: (X*E2).derivative().is_molecular()
                 False
 
+            Partial derivatives of multisort species are obtained by specifying
+            a sort generator::
+
+                sage: M = MolecularSpecies("X, Y")
+                sage: X = M(SymmetricGroup(1), {0: [1]})
+                sage: Y = M(SymmetricGroup(1), {1: [1]})
+                sage: G = PermutationGroup([[(1,2), (3,4)]])
+                sage: F = M(G, {0: [1,2], 1: [3,4]})
+                sage: F
+                E_2(X*Y)
+                sage: F.derivative(X)
+                X*Y^2
+                sage: F.derivative(Y)
+                X^2*Y
+                sage: X.derivative(Y)
+                0
+
             TESTS::
 
+                sage: F.derivative()
+                Traceback (most recent call last):
+                ...
+                ValueError: the derivative variable must be specified for multisort species
+                sage: F.derivative(X*Y)
+                Traceback (most recent call last):
+                ...
+                ValueError: the derivative variable must be a sort generator of the parent
                 sage: M = MolecularSpecies("X")
                 sage: [sum(1 for m in M.subset(n) if m.derivative().is_molecular()) for n in range(1, 7)]
                 [1, 1, 2, 5, 5, 16]
                 sage: oeis(_) # optional - internet
                 0: A002106: Number of transitive permutation groups of degree n.
             """
+            M = self.parent()
+            if variable is None:
+                if M._arity != 1:
+                    raise ValueError("the derivative variable must be specified for multisort species")
+                sort = 0
+            else:
+                variables = tuple( M(SymmetricGroup(1), {i: [1]}) for i in range(M._arity))
+                if parent(variable) is not M or variable not in variables:
+                    raise ValueError("the derivative variable must be a sort generator of the parent")
+                sort = variables.index(variable)
+            return self._derivative_with_respect_to_sort(sort)
+
+        def _derivative_with_respect_to_sort(self, sort):
+            r"""
+            Return the derivative with respect to the sort indexed by ``sort``.
+
+            This method assumes that ``sort`` is a valid zero-based sort index.
+
+            TESTS::
+
+                sage: from sage.rings.species import MolecularSpecies
+                sage: M = MolecularSpecies("X, Y")
+                sage: G = PermutationGroup([[(1,2), (3,4)]])
+                sage: F = M(G, {0: [1,2], 1: [3,4]})
+                sage: F._derivative_with_respect_to_sort(0)
+                X*Y^2
+                sage: F._derivative_with_respect_to_sort(1)
+                X^2*Y
+            """
             def delete_point_from_permutation(g, r, m):
                 r"""
-                Delete the fixed point `r` from a permutation of `\{1,\dots, m\}`.
+                Delete the fixed point `r` from a permutation of `\{1,\dots,m\}`.
 
-                The permutation `g` is assumed to fix `r`. The remaining points are
-                relabelled increasingly in `{1,\dots, m - 1}`.
+                The permutation `g` is assumed to fix `r`. The remaining points are 
+                relabelled increasingly in `\{1,\dots,m-1\}`.
                 """
                 relabel = {i: i if i < r else i - 1 for i in range(1, m + 1) if i != r}
                 cycles = []
@@ -1875,18 +1931,19 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                 return tuple(cycles)
 
             M = self.parent()
-            if M._arity != 1:
-                raise NotImplementedError("derivative is not yet implemented for multisort species")
             P = PolynomialSpecies(ZZ, M._indices._names)
             m = sum(self.grade())
-            if m == 0:
+            if self.grade()[sort] == 0:
                 return P.zero()
             if m == 1:
                 return P.one()
-            H, _ = self.permutation_group()
+
+            H, dompart = self.permutation_group()
             ans = P.zero()
             for orbit in H.orbits():
                 r = min(orbit)
+                if r not in dompart[sort]:
+                    continue
                 H_r = libgap.Stabilizer(H.gap(), r)
                 gens = []
                 for g in H_r.GeneratorsOfGroup().sage():
@@ -1894,7 +1951,11 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                     if cycles:
                         gens.append(cycles)
                 H_r_star = PermutationGroup(gens, domain=range(1, m))
-                ans += P(M(H_r_star))
+
+                new_dompart = { i: [ point if point < r else point - 1 for point in block if point != r ]
+                    for i, block in enumerate(dompart)
+                }
+                ans += P(M(H_r_star, new_dompart, check=False))
             return ans
 
         def structures(self, *labels):

--- a/src/sage/rings/species.py
+++ b/src/sage/rings/species.py
@@ -1894,30 +1894,7 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                 sage: oeis(_) # optional - internet
                 0: A002106: Number of transitive permutation groups of degree n.
             """
-            M = self.parent()
-            variables = tuple(M(SymmetricGroup(1), {i: [1]}) for i in range(M._arity))
-            sorts = []
-            for variable in derivative_parse(args):
-                if variable is None:
-                    if M._arity != 1:
-                        raise ValueError(
-                            "the derivative variable must be specified for multisort species"
-                            )
-                    sort = 0
-                else:
-                    if parent(variable) is not M or variable not in variables:
-                        raise ValueError(
-                            "the derivative variable must be a sort generator of the parent"
-                            )
-                    sort = variables.index(variable)
-                sorts.append(sort)
-
-            result = self
-            for sort in sorts:
-                current_parent = result.parent()
-                current_variable = current_parent(SymmetricGroup(1), {sort: [1]})
-                result = result._derivative(current_variable)
-            return result
+            return multi_derivative(self, args)
 
         def _derivative(self, variable=None):
             r"""
@@ -1932,20 +1909,14 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                 2*X
             """
             M = self.parent()
-            variables = tuple(
-                M(SymmetricGroup(1), {i: [1]}) for i in range(M._arity)
-            )
             if variable is None:
                 if M._arity != 1:
-                    raise ValueError(
-                        "the derivative variable must be specified for multisort species"
-                    )
+                    raise ValueError("the derivative variable must be specified for multisort species")
                 sort = 0
             else:
+                variables = tuple(M(_SymmetricGroup(1), {i: [1]}) for i in range(M._arity))
                 if parent(variable) is not M or variable not in variables:
-                    raise ValueError(
-                        "the derivative variable must be a sort generator of the parent"
-                    )
+                    raise ValueError("the derivative variable must be a sort generator of the parent")
                 sort = variables.index(variable)
             return self._derivative_with_respect_to_sort(sort)
 
@@ -1992,7 +1963,7 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                 return P.one()
 
             H, dompart = self.permutation_group()
-            ans = P.zero()
+            result = P.zero()
             for orbit in H.orbits():
                 r = min(orbit)
                 if r not in dompart[sort]:
@@ -2005,11 +1976,11 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                         gens.append(cycles)
                 H_r_star = PermutationGroup(gens, domain=range(1, m))
 
-                new_dompart = { i: [ point if point < r else point - 1 for point in block if point != r ]
-                    for i, block in enumerate(dompart)
-                }
-                ans += P(M(H_r_star, new_dompart, check=False))
-            return ans
+                new_dompart = {i: [point if point < r else point - 1
+                                   for point in block if point != r]
+                               for i, block in enumerate(dompart)}
+                result += P(M(H_r_star, new_dompart, check=False))
+            return result
 
         def structures(self, *labels):
             r"""
@@ -2278,12 +2249,16 @@ class PolynomialSpeciesElement(CombinatorialFreeModule.Element):
                 raise ValueError("the derivative variable must be specified for multisort species")
             sort = 0
         else:
-            variables = tuple(P(SymmetricGroup(1), {i: [1]}) for i in range(P._arity))
-            if parent(variable) is not P or variable not in variables:
+            if parent(variable) is not P:
+                variable = P(variable, check=True)
+            variables = P._first_ngens(P._arity)
+            try:
+                sort = variables.index(variable)
+            except ValueError:
                 raise ValueError("the derivative variable must be a sort generator of the parent")
-            sort = variables.index(variable)
-        return sum((c * P(M._derivative_with_respect_to_sort(sort)) for M, c in self.monomial_coefficients().items()),
-                    P.zero())
+        return sum((c * P(M._derivative_with_respect_to_sort(sort))
+                    for M, c in self.monomial_coefficients().items()),
+                   P.zero())
 
     def hadamard_product(self, other):
         r"""
@@ -2921,7 +2896,7 @@ class PolynomialSpecies(CombinatorialFreeModule):
 
         Atomic and molecular species are accepted as arguments::
 
-            sage: from sage.rings.species import AtomicSpecies, PolynomialSpecies
+            sage: from sage.rings.species import AtomicSpecies, MolecularSpecies
             sage: P = PolynomialSpecies(ZZ, "X, Y")
             sage: A = AtomicSpecies("X, Y")
             sage: P(A(SymmetricGroup(3), {1: [1,2,3]}))
@@ -2932,6 +2907,16 @@ class PolynomialSpecies(CombinatorialFreeModule):
             Traceback (most recent call last):
             ...
             ValueError: all keys of the dict {E_3: 1} must be Atomic species in X, Y
+
+            sage: M = MolecularSpecies("X, Y")
+            sage: P(M(SymmetricGroup(3), {1: [1,2,3]}))
+            E_3(Y)
+
+            sage: M = MolecularSpecies("X, Z")
+            sage: P(M(SymmetricGroup(3), {0: [1,2,3]}))
+            Traceback (most recent call last):
+            ...
+            ValueError: E_3(X) must be a Molecular species in X, Y
         """
         if parent(G) is self:
             # pi cannot be None because of framework
@@ -2941,6 +2926,8 @@ class PolynomialSpecies(CombinatorialFreeModule):
             G = self._indices({G: ZZ.one()})
 
         if isinstance(G, MolecularSpecies.Element):
+            if check and not G.parent() == self._indices:
+                raise ValueError(f"{G} must be a {self._indices}")
             return self._from_dict({G: self.base_ring().one()})
 
         if isinstance(G, dict):

--- a/src/sage/rings/species.py
+++ b/src/sage/rings/species.py
@@ -2159,7 +2159,7 @@ class PolynomialSpeciesElement(CombinatorialFreeModule.Element):
             result += c * result_m
         return result
 
-    def derivative(self):
+    def derivative(self, variable=None):
         r"""
         Return the derivative of ``self``.
 
@@ -2175,11 +2175,24 @@ class PolynomialSpeciesElement(CombinatorialFreeModule.Element):
             1 + 2*X*E_2
             sage: E2(E2).derivative()
             X*E_2
+            sage: P.<X, Y> = PolynomialSpecies(QQ)
+            sage: F = X^2 + 2*Y
+            sage: F.derivative(X)
+            2*X
+            sage: F.derivative(Y)
+            2
         """
         P = self.parent()
-        if P._arity != 1:
-            raise NotImplementedError("derivative is not yet implemented for multisort species")
-        return sum((c * P(M.derivative()) for M, c in self.monomial_coefficients().items()),
+        if variable is None:
+            if P._arity != 1:
+                raise ValueError("the derivative variable must be specified for multisort species")
+            sort = 0
+        else:
+            variables = tuple(P(SymmetricGroup(1), {i: [1]}) for i in range(P._arity))
+            if parent(variable) is not P or variable not in variables:
+                raise ValueError("the derivative variable must be a sort generator of the parent")
+            sort = variables.index(variable)
+        return sum((c * P(M._derivative_with_respect_to_sort(sort)) for M, c in self.monomial_coefficients().items()),
                     P.zero())
 
     def hadamard_product(self, other):

--- a/src/sage/rings/species.py
+++ b/src/sage/rings/species.py
@@ -53,6 +53,7 @@ from sage.groups.perm_gps.permgroup import PermutationGroup, PermutationGroup_ge
 from sage.groups.perm_gps.permgroup_named import SymmetricGroup
 from sage.libs.gap.libgap import libgap
 from sage.misc.cachefunc import cached_method, cached_function
+from sage.misc.derivative import derivative_parse, multi_derivative
 from sage.misc.fast_methods import WithEqualityById
 from sage.misc.inherit_comparison import InheritComparisonClasscallMetaclass
 from sage.misc.misc_c import prod
@@ -1826,7 +1827,7 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                         atoms[B] += e * f
             return M(atoms, check=False)
 
-        def derivative(self, variable=None):
+        def derivative(self, *args):
             r"""
             Return the derivative of ``self``.
 
@@ -1834,9 +1835,10 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
             Section 2.6 in [BLL1998]_.
 
             Note that the result is a polynomial species rather than
-            a molecular species. When the parent is unisort, ``variable`` may
-            be omitted. For a multisort parent, ``variable`` must be a sort
-            generator of the parent.
+            a molecular species. The arguments follow Sage's standard derivative
+            syntax (see :func:`sage.misc.derivative.derivative_parse`). The sort
+            generator may be omitted if the parent is unisort. It
+            must be specified if the parent is Multisort.
 
             EXAMPLES::
 
@@ -1867,6 +1869,14 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                 X^2*Y
                 sage: X.derivative(Y)
                 0
+                sage: F.derivative(X, 2)
+                Y^2
+                sage: F.derivative(X, Y)
+                2*X*Y
+                sage: F.derivative([X, Y])
+                2*X*Y
+                sage: F.derivative(0) == F
+                True
 
             TESTS::
 
@@ -1885,14 +1895,57 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                 0: A002106: Number of transitive permutation groups of degree n.
             """
             M = self.parent()
+            variables = tuple(M(SymmetricGroup(1), {i: [1]}) for i in range(M._arity))
+            sorts = []
+            for variable in derivative_parse(args):
+                if variable is None:
+                    if M._arity != 1:
+                        raise ValueError(
+                            "the derivative variable must be specified for multisort species"
+                            )
+                    sort = 0
+                else:
+                    if parent(variable) is not M or variable not in variables:
+                        raise ValueError(
+                            "the derivative variable must be a sort generator of the parent"
+                            )
+                    sort = variables.index(variable)
+                sorts.append(sort)
+
+            result = self
+            for sort in sorts:
+                current_parent = result.parent()
+                current_variable = current_parent(SymmetricGroup(1), {sort: [1]})
+                result = result._derivative(current_variable)
+            return result
+
+        def _derivative(self, variable=None):
+            r"""
+            Return the derivative of ``self`` with respect to one variable.
+
+            TESTS::
+
+                sage: from sage.rings.species import MolecularSpecies
+                sage: M = MolecularSpecies("X")
+                sage: X = M(SymmetricGroup(1))
+                sage: (X^2)._derivative(X)
+                2*X
+            """
+            M = self.parent()
+            variables = tuple(
+                M(SymmetricGroup(1), {i: [1]}) for i in range(M._arity)
+            )
             if variable is None:
                 if M._arity != 1:
-                    raise ValueError("the derivative variable must be specified for multisort species")
+                    raise ValueError(
+                        "the derivative variable must be specified for multisort species"
+                    )
                 sort = 0
             else:
-                variables = tuple( M(SymmetricGroup(1), {i: [1]}) for i in range(M._arity))
                 if parent(variable) is not M or variable not in variables:
-                    raise ValueError("the derivative variable must be a sort generator of the parent")
+                    raise ValueError(
+                        "the derivative variable must be a sort generator of the parent"
+                    )
                 sort = variables.index(variable)
             return self._derivative_with_respect_to_sort(sort)
 
@@ -2159,9 +2212,46 @@ class PolynomialSpeciesElement(CombinatorialFreeModule.Element):
             result += c * result_m
         return result
 
-    def derivative(self, variable=None):
+    def derivative(self, *args):
         r"""
         Return the derivative of ``self``.
+
+        TESTS::
+
+            sage: from sage.rings.species import PolynomialSpecies
+            sage: P = PolynomialSpecies(QQ, ["X"])
+            sage: X = P(SymmetricGroup(1))
+            sage: E2 = P(SymmetricGroup(2))
+            sage: (X^3).derivative()
+            3*X^2
+            sage: (E2^2 + X).derivative()
+            1 + 2*X*E_2
+            sage: E2(E2).derivative()
+            X*E_2
+            sage: (X^3).derivative(2)
+            6*X
+
+            sage: P.<X, Y> = PolynomialSpecies(QQ)
+            sage: F = X^2 + 2*Y
+            sage: F.derivative(X)
+            2*X
+            sage: F.derivative(Y)
+            2
+            sage: G = X^2*Y^2
+            sage: G.derivative(X, 2)
+            2*Y^2
+            sage: G.derivative(X, Y)
+            4*X*Y
+            sage: G.derivative([X, Y])
+            4*X*Y
+            sage: G.derivative(0) == G
+            True
+        """
+        return multi_derivative(self, args)
+
+    def _derivative(self, variable=None):
+        r"""
+        Return the derivative of ``self`` with respect to one variable.
 
         TESTS::
 

--- a/src/sage/rings/species.py
+++ b/src/sage/rings/species.py
@@ -1917,7 +1917,7 @@ class MolecularSpecies(IndexedFreeAbelianMonoid):
                 r"""
                 Delete the fixed point `r` from a permutation of `\{1,\dots,m\}`.
 
-                The permutation `g` is assumed to fix `r`. The remaining points are 
+                The permutation `g` is assumed to fix `r`. The remaining points are
                 relabelled increasingly in `\{1,\dots,m-1\}`.
                 """
                 relabel = {i: i if i < r else i - 1 for i in range(1, m + 1) if i != r}


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

This pr implements partial derivaties for multisort `LazyCombinatorialSpecies`.  When differentiating unisort species, the sort may or may not be specified. However, it must be specified for multisort species. `derivative` of lazy species also now supports sage's standard derivative syntax.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x ] The title is concise and informative.
- [x ] The description explains in detail what this PR is about.
- [ x] I have linked a relevant issue or discussion.
- [ x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

#42638 
#42653 

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


