### PR TITLE
Raise minimum GCC version to 10.3

### DIFF
--- a/build/pkgs/gcc/SPKG.rst
+++ b/build/pkgs/gcc/SPKG.rst
@@ -28,11 +28,11 @@ Vendor and versions of the C and C++ compilers should match.
 
 Users of older Linux distributions should upgrade their systems before
 attempting to install Sage from source.  In particular, users on
-``ubuntu`` should use ``ubuntu-noble`` (24.04) or a newer release.
+``ubuntu`` should use ``ubuntu-jammy`` (22.04) or a newer release.
 
 The minimum supported GCC version is 10.3.  The following example uses
 matching version ``15`` C, C++, and Fortran compilers.  On
-``ubuntu-noble``, these packages are available from
+``ubuntu-jammy``, these packages are available from
 ``ppa:ubuntu-toolchain-r/test``:
 
 .. code-block:: bash

--- a/build/pkgs/gcc/SPKG.rst
+++ b/build/pkgs/gcc/SPKG.rst
@@ -26,24 +26,26 @@ need to run::
 
 Vendor and versions of the C and C++ compilers should match.
 
-Users of older Linux distributions (in particular, ``ubuntu-xenial``
-or older, ``debian-buster`` or older, ``linuxmint-18`` or older)
-should upgrade their systems before attempting to install Sage from
-source.  Users of ``ubuntu-bionic``, ``linuxmint-19.x``, and
-``opensuse-15.x`` can install a versioned ``gcc`` system package
-and then use::
+Users of older Linux distributions should upgrade their systems before
+attempting to install Sage from source.  In particular, users on
+``ubuntu`` should use ``ubuntu-noble`` (24.04) or a newer release.
 
-    $ ./configure CC=gcc-8 CXX=g++-8 FC=gfortran-8
+The minimum supported GCC version is 10.3.  The following example uses
+matching version ``15`` C, C++, and Fortran compilers.  On
+``ubuntu-noble``, these packages are available from
+``ppa:ubuntu-toolchain-r/test``:
 
-or similar. Users on ``ubuntu`` can also install a modern compiler
-toolchain `using the ubuntu-toolchain-r ppa
-<https://askubuntu.com/questions/1140183/install-gcc-9-on-ubuntu-18-04/1149383#1149383>`_.
-On ``ubuntu-trusty``, also the package ``binutils-2.26`` is required;
-after installing it, make it available using ``export
-PATH="/usr/lib/binutils-2.26/bin:$PATH"``.  Instead of upgrading their
-distribution, users of ``centos-7`` can install a modern compiler
-toolchain `using Redhat's devtoolset
-<https://stackoverflow.com/a/67212990/557937>`_.
+.. code-block:: bash
+
+    $ sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+    $ sudo apt-get update
+    $ sudo apt-get install gcc-15 g++-15 gfortran-15
+
+If these packages are already available from the standard repositories
+of your release, omit the ``add-apt-repository`` command.  After
+installation, select the compilers explicitly when configuring Sage::
+
+    $ ./configure CC=gcc-15 CXX=g++-15 FC=gfortran-15
 
 This package uses the non-standard default
 ``configure --with-system-gcc=force``, giving an error at ``configure``

--- a/build/pkgs/gcc/spkg-configure.m4
+++ b/build/pkgs/gcc/spkg-configure.m4
@@ -158,18 +158,22 @@ SAGE_SPKG_CONFIGURE_BASE([gcc], [
         AX_GXX_VERSION()
 
         if test $IS_REALLY_GCC = yes ; then
-            # Add the .0 because Debian/Ubuntu gives version numbers like
-            # 4.6 instead of 4.6.4 (Issue #18885)
-            AS_CASE(["$GXX_VERSION.0"],
-                [[[0-7]].*|8.[[0-3]].*], [
-                    # Install our own GCC if the system-provided one is older than gcc 8.4
+            GXX_FULL_VERSION="`$CXX -dumpfullversion -dumpversion 2>/dev/null`"
+            AS_IF([test -n "$GXX_FULL_VERSION"], [GXX_VERSION="$GXX_FULL_VERSION"])
+            GXX_MAJOR="`echo \"$GXX_VERSION\" | sed -e 's/\..*//'`"
+            GXX_MINOR="`echo \"$GXX_VERSION\" | sed -e 's/^[^.]*$/0/' -e 's/^[^.]*\\.//' -e 's/\..*//'`"
+
+            AS_IF([test "$GXX_MAJOR" -lt 10 -o "$GXX_MAJOR" = 10 -a "$GXX_MINOR" -lt 3], [
+                    # Install our own GCC if the system-provided one is older than gcc 10.3
                     SAGE_SHOULD_INSTALL_GCC([you have $CXX version $GXX_VERSION, which is quite old])
-                ],
-                [1[[7-9]].*], [
-                    # Install our own GCC if the system-provided one is newer than 16.x.
-                    # See https://github.com/sagemath/sage/issues/29456
-                    SAGE_SHOULD_INSTALL_GCC([$CXX is g++ version $GXX_VERSION, which is too recent for this version of Sage])
-                ])
+            ], [
+                AS_CASE(["$GXX_VERSION.0"],
+                    [1[[7-9]].*], [
+                        # Install our own GCC if the system-provided one is newer than 16.x.
+                        # See https://github.com/sagemath/sage/issues/29456
+                        SAGE_SHOULD_INSTALL_GCC([$CXX is g++ version $GXX_VERSION, which is too recent for this version of Sage])
+                    ])
+            ])
             fi
 
         # The following tests check that the version of the compilers

--- a/build/pkgs/gcc/spkg-configure.m4
+++ b/build/pkgs/gcc/spkg-configure.m4
@@ -159,19 +159,19 @@ SAGE_SPKG_CONFIGURE_BASE([gcc], [
 
         if test $IS_REALLY_GCC = yes ; then
             GXX_FULL_VERSION="`$CXX -dumpfullversion -dumpversion 2>/dev/null`"
-            AS_IF([test -n "$GXX_FULL_VERSION"], [GXX_VERSION="$GXX_FULL_VERSION"])
-            GXX_MAJOR="`echo \"$GXX_VERSION\" | sed -e 's/\..*//'`"
-            GXX_MINOR="`echo \"$GXX_VERSION\" | sed -e 's/^[^.]*$/0/' -e 's/^[^.]*\\.//' -e 's/\..*//'`"
+            AS_IF([test -z "$GXX_FULL_VERSION"], [GXX_FULL_VERSION="$GXX_VERSION"])
+            GXX_MAJOR="`echo \"$GXX_FULL_VERSION\" | sed -e 's/\..*//'`"
+            GXX_MINOR="`echo \"$GXX_FULL_VERSION\" | sed -e 's/^[^.]*$/0/' -e 's/^[^.]*\\.//' -e 's/\..*//'`"
 
             AS_IF([test "$GXX_MAJOR" -lt 10 -o "$GXX_MAJOR" = 10 -a "$GXX_MINOR" -lt 3], [
                     # Install our own GCC if the system-provided one is older than gcc 10.3
-                    SAGE_SHOULD_INSTALL_GCC([you have $CXX version $GXX_VERSION, which is quite old])
+                    SAGE_SHOULD_INSTALL_GCC([you have $CXX version $GXX_FULL_VERSION, which is quite old])
             ], [
-                AS_CASE(["$GXX_VERSION.0"],
+                AS_CASE(["$GXX_FULL_VERSION.0"],
                     [1[[7-9]].*], [
                         # Install our own GCC if the system-provided one is newer than 16.x.
                         # See https://github.com/sagemath/sage/issues/29456
-                        SAGE_SHOULD_INSTALL_GCC([$CXX is g++ version $GXX_VERSION, which is too recent for this version of Sage])
+                        SAGE_SHOULD_INSTALL_GCC([$CXX is g++ version $GXX_FULL_VERSION, which is too recent for this version of Sage])
                     ])
             ])
             fi

--- a/build/pkgs/gcc/spkg-configure.m4
+++ b/build/pkgs/gcc/spkg-configure.m4
@@ -158,22 +158,19 @@ SAGE_SPKG_CONFIGURE_BASE([gcc], [
         AX_GXX_VERSION()
 
         if test $IS_REALLY_GCC = yes ; then
-            GXX_FULL_VERSION="`$CXX -dumpfullversion -dumpversion 2>/dev/null`"
-            AS_IF([test -z "$GXX_FULL_VERSION"], [GXX_FULL_VERSION="$GXX_VERSION"])
-            GXX_MAJOR="`echo \"$GXX_FULL_VERSION\" | sed -e 's/\..*//'`"
-            GXX_MINOR="`echo \"$GXX_FULL_VERSION\" | sed -e 's/^[^.]*$/0/' -e 's/^[^.]*\\.//' -e 's/\..*//'`"
-
-            AS_IF([test "$GXX_MAJOR" -lt 10 -o "$GXX_MAJOR" = 10 -a "$GXX_MINOR" -lt 3], [
+            GXX_FULL_VERSION="`$CXX -dumpfullversion -dumpversion 2>/dev/null || $CXX -dumpversion`"
+            # Add the .0 because Debian/Ubuntu gives version numbers like
+            # 4.6 instead of 4.6.4 (Issue #18885)
+            AS_CASE(["$GXX_FULL_VERSION.0"],
+                [[[0-9]].*|10.[[0-2]].*], [
                     # Install our own GCC if the system-provided one is older than gcc 10.3
-                    SAGE_SHOULD_INSTALL_GCC([you have $CXX version $GXX_FULL_VERSION, which is quite old])
-            ], [
-                AS_CASE(["$GXX_FULL_VERSION.0"],
-                    [1[[7-9]].*], [
-                        # Install our own GCC if the system-provided one is newer than 16.x.
-                        # See https://github.com/sagemath/sage/issues/29456
-                        SAGE_SHOULD_INSTALL_GCC([$CXX is g++ version $GXX_FULL_VERSION, which is too recent for this version of Sage])
-                    ])
-            ])
+                    SAGE_SHOULD_INSTALL_GCC([you have $CXX version $GXX_VERSION, which is quite old])
+                ],
+                [1[[7-9]].*], [
+                    # Install our own GCC if the system-provided one is newer than 16.x.
+                    # See https://github.com/sagemath/sage/issues/29456
+                    SAGE_SHOULD_INSTALL_GCC([$CXX is g++ version $GXX_VERSION, which is too recent for this version of Sage])
+                ])
             fi
 
         # The following tests check that the version of the compilers

--- a/build/pkgs/gfortran/spkg-configure.m4
+++ b/build/pkgs/gfortran/spkg-configure.m4
@@ -77,22 +77,20 @@ SAGE_SPKG_CONFIGURE([gfortran], [
         AS_CASE(["$FC"],
             [*gfortran*], [
                 AC_MSG_CHECKING([the version of $FC])
-                GFORTRAN_VERSION="`$FC -dumpfullversion -dumpversion 2>/dev/null`"
-                AS_IF([test -z "$GFORTRAN_VERSION"], [GFORTRAN_VERSION="`$FC -dumpversion`"])
+                GFORTRAN_VERSION="`$FC -dumpfullversion -dumpversion 2>/dev/null || $FC -dumpversion`"
                 AC_MSG_RESULT([$GFORTRAN_VERSION])
-                GFORTRAN_MAJOR="`echo \"$GFORTRAN_VERSION\" | sed -e 's/\..*//'`"
-                GFORTRAN_MINOR="`echo \"$GFORTRAN_VERSION\" | sed -e 's/^[^.]*$/0/' -e 's/^[^.]*\\.//' -e 's/\..*//'`"
-                AS_IF([test "$GFORTRAN_MAJOR" -lt 10 -o "$GFORTRAN_MAJOR" = 10 -a "$GFORTRAN_MINOR" -lt 3], [
+                # Add the .0 because Debian/Ubuntu gives version numbers like
+                # 4.6 instead of 4.6.4 (Issue #18885)
+                AS_CASE(["$GFORTRAN_VERSION.0"],
+                    [[[0-9]].*|10.[[0-2]].*], [
                         # Install our own gfortran if the system-provided one is older than gcc-10.3.
                         SAGE_SHOULD_INSTALL_GFORTRAN([$FC is version $GFORTRAN_VERSION, which is quite old])
-                ], [
-                    AS_CASE(["$GFORTRAN_VERSION.0"],
-                        [1[[7-9]].*], [
+                    ],
+                    [1[[7-9]].*], [
                         # Install our own gfortran if the system-provided one is newer than 16.x.
                         # See https://github.com/sagemath/sage/issues/29456, https://github.com/sagemath/sage/issues/31838
                         SAGE_MUST_INSTALL_GFORTRAN([$FC is version $GFORTRAN_VERSION, which is too recent for this version of Sage])
                     ])
-                ])
             ])
     fi
 ])

--- a/build/pkgs/gfortran/spkg-configure.m4
+++ b/build/pkgs/gfortran/spkg-configure.m4
@@ -77,20 +77,22 @@ SAGE_SPKG_CONFIGURE([gfortran], [
         AS_CASE(["$FC"],
             [*gfortran*], [
                 AC_MSG_CHECKING([the version of $FC])
-                GFORTRAN_VERSION="`$FC -dumpversion`"
+                GFORTRAN_VERSION="`$FC -dumpfullversion -dumpversion 2>/dev/null`"
+                AS_IF([test -z "$GFORTRAN_VERSION"], [GFORTRAN_VERSION="`$FC -dumpversion`"])
                 AC_MSG_RESULT([$GFORTRAN_VERSION])
-                # Add the .0 because Debian/Ubuntu gives version numbers like
-                # 4.6 instead of 4.6.4 (Issue #18885)
-                AS_CASE(["$GFORTRAN_VERSION.0"],
-                    [[[0-3]].*|4.[[0-7]].*], [
-                        # Install our own gfortran if the system-provided one is older than gcc-4.8.
+                GFORTRAN_MAJOR="`echo \"$GFORTRAN_VERSION\" | sed -e 's/\..*//'`"
+                GFORTRAN_MINOR="`echo \"$GFORTRAN_VERSION\" | sed -e 's/^[^.]*$/0/' -e 's/^[^.]*\\.//' -e 's/\..*//'`"
+                AS_IF([test "$GFORTRAN_MAJOR" -lt 10 -o "$GFORTRAN_MAJOR" = 10 -a "$GFORTRAN_MINOR" -lt 3], [
+                        # Install our own gfortran if the system-provided one is older than gcc-10.3.
                         SAGE_SHOULD_INSTALL_GFORTRAN([$FC is version $GFORTRAN_VERSION, which is quite old])
-                    ],
-                    [1[[7-9]].*], [
+                ], [
+                    AS_CASE(["$GFORTRAN_VERSION.0"],
+                        [1[[7-9]].*], [
                         # Install our own gfortran if the system-provided one is newer than 16.x.
                         # See https://github.com/sagemath/sage/issues/29456, https://github.com/sagemath/sage/issues/31838
                         SAGE_MUST_INSTALL_GFORTRAN([$FC is version $GFORTRAN_VERSION, which is too recent for this version of Sage])
                     ])
+                ])
             ])
     fi
 ])


### PR DESCRIPTION
## Summary

- raise the minimum supported system GCC, G++, and GFortran version to 10.3
- use full GNU compiler version output so the 10.3 boundary is evaluated correctly
- update the compiler documentation to recommend Ubuntu 22.04 (Jammy) and use GCC 15 in the installation example

## Motivation

Current NumPy development requires GCC 10.3 or newer. Detecting older system compilers during configuration lets Sage select its bundled toolchain instead of failing later while building NumPy.

## User impact

System GNU compilers older than 10.3 now trigger installation of Sage's bundled compiler toolchain. GCC 10.3 remains accepted. The Ubuntu instructions now describe a current Jammy-based GCC 15 setup and retain the `ubuntu-toolchain-r/test` PPA for releases whose standard repositories do not provide those packages.

## Checks

- `git diff --check`
- boundary parsing: 10 and 10.2.1 rejected; 10.3.0 and 15.2.0 accepted
- local `g++-15` and `gfortran-15` full-version output verified as 15.2.0
