### PR TITLE
Fix plethysm over infinite polynomial rings

### DIFF
--- a/src/sage/combinat/sf/sfa.py
+++ b/src/sage/combinat/sf/sfa.py
@@ -3505,11 +3505,41 @@ class SymmetricFunctionAlgebra_generic_Element(CombinatorialFreeModule.Element):
             sage: s[2](5)
             15*B[] # B[]
 
-        .. TODO::
+        Infinite polynomial rings use generators that represent entire
+        variable families.  Only the finitely many variables occurring in
+        a coefficient need to be raised (:issue:`42687`)::
 
-            The implementation of plethysm in
-            :class:`sage.data_structures.stream.Stream_plethysm` seems
-            to be faster.  This should be investigated.
+            sage: R.<a> = InfinitePolynomialRing(QQ)
+            sage: p = SymmetricFunctions(R).p()
+            sage: s = SymmetricFunctions(QQ).s()
+            sage: (a[0] * p[2])(s[2])
+            a_0*s[2, 2] - a_0*s[3, 1] + a_0*s[4]
+            sage: p[2]((a[0] + a[7]) * p[1])
+            (a_7^2+a_0^2)*p[2]
+            sage: p[2].plethysm((a[0] + a[7]) * p[1], exclude=[a[7]])
+            (a_7+a_0^2)*p[2]
+            sage: p[2].plethysm((a[0] + a[7]) * p[1], exclude=iter([a[7]]))
+            (a_7+a_0^2)*p[2]
+
+        This also works for the sparse implementation::
+
+            sage: R.<a> = InfinitePolynomialRing(QQ, implementation='sparse')
+            sage: p = SymmetricFunctions(R).p()
+            sage: p[2]((a[0] + a[7]) * p[1])
+            (a_7^2+a_0^2)*p[2]
+
+        Tensor and infinite polynomial coefficients can be combined::
+
+            sage: X = tensor([p[1], p[[]]])
+            sage: p[2](a[0] * X)
+            a_0^2*p[2] # p[]
+
+        .. NOTE::
+
+            :class:`sage.data_structures.stream.Stream_plethysm` computes
+            homogeneous components on demand.  Using it here would require
+            converting both finite inputs to exact streams and recombining
+            all components, so this method keeps its direct implementation.
         """
         from sage.structure.element import parent as get_parent
         Px = get_parent(x)
@@ -3544,6 +3574,8 @@ class SymmetricFunctionAlgebra_generic_Element(CombinatorialFreeModule.Element):
 
         p = parent.realization_of().power()
 
+        if exclude is not None:
+            exclude = tuple(exclude)
         degree_one = _variables_recursive(R, include=include, exclude=exclude)
 
         if tensorflag:
@@ -3551,7 +3583,7 @@ class SymmetricFunctionAlgebra_generic_Element(CombinatorialFreeModule.Element):
             lincomb = Px.linear_combination
             elt = lincomb((prod((lincomb((tensor([p[r].plethysm(base(la))
                                                  for base, la in zip(tparents, trm)]),
-                                         _raise_variables(c, r, degree_one))
+                                         _raise_variables(c, r, degree_one, exclude))
                                         for trm, c in x)
                                 for r in mu), tensor([base.one() for base in tparents])),
                            d)
@@ -3568,7 +3600,8 @@ class SymmetricFunctionAlgebra_generic_Element(CombinatorialFreeModule.Element):
         p_x = p(x)
 
         def f(part):
-            return p.prod(pn_pleth(p_x.map_coefficients(lambda c: _raise_variables(c, i, degree_one)), i)
+            return p.prod(pn_pleth(p_x.map_coefficients(
+                lambda c: _raise_variables(c, i, degree_one, exclude)), i)
                           for i in part)
         ret = p._apply_module_morphism(p(self), f, codomain=p)
         if Px is R:
@@ -6854,7 +6887,7 @@ def _variables_recursive(R, include=None, exclude=None):
     return [g for g in degree_one if g != R.one()]
 
 
-def _raise_variables(c, n, variables):
+def _raise_variables(c, n, variables, exclude=None):
     r"""
     Replace the given variables in the ring element ``c`` with their
     ``n``-th power.
@@ -6863,7 +6896,10 @@ def _raise_variables(c, n, variables):
 
     - ``c`` -- an element of a ring
     - ``n`` -- the power to raise the given variables to
-    - ``variables`` -- the variables to raise
+    - ``variables`` -- the variables to raise; generators of infinite
+      polynomial rings stand for the corresponding variable families
+    - ``exclude`` -- (optional) variables to omit when expanding a family
+      generator
 
     EXAMPLES::
 
@@ -6872,7 +6908,31 @@ def _raise_variables(c, n, variables):
         sage: S.<t> = R[]
         sage: _raise_variables(2*a + 3*b*t, 2, [a, t])
         3*b*t^2 + 2*a^2
+
+    Generators of infinite polynomial rings are expanded to the finitely
+    many variables that occur in ``c``::
+
+        sage: A.<a> = InfinitePolynomialRing(QQ)
+        sage: _raise_variables(a[0] + a[3], 2, [a])
+        a_3^2 + a_0^2
+        sage: _raise_variables(a[0] + a[3], 2, [a], exclude=[a[3]])
+        a_3 + a_0^2
     """
+    from sage.rings.polynomial.infinite_polynomial_ring import InfinitePolynomialGen
+
+    family_generators = [g for g in variables
+                         if isinstance(g, InfinitePolynomialGen)]
+    if family_generators:
+        variables = [g for g in variables
+                     if not isinstance(g, InfinitePolynomialGen)]
+        if hasattr(c, 'variables'):
+            variables.extend(v for v in c.variables()
+                             if any(v.parent() is g._parent
+                                    and str(v).rsplit('_', 1)[0] == g._name
+                                    for g in family_generators))
+        if exclude is not None:
+            variables = [g for g in variables if g not in exclude]
+
     try:
         return c.subs(**{str(g): g ** n for g in variables})
     except AttributeError:

--- a/src/sage/combinat/sf/sfa.py
+++ b/src/sage/combinat/sf/sfa.py
@@ -3505,9 +3505,9 @@ class SymmetricFunctionAlgebra_generic_Element(CombinatorialFreeModule.Element):
             sage: s[2](5)
             15*B[] # B[]
 
-        Infinite polynomial rings use generators that represent entire
-        variable families.  Only the finitely many variables occurring in
-        a coefficient need to be raised (:issue:`42687`)::
+        For infinite polynomial rings, the variables are determined from
+        each coefficient, so only finitely many need to be raised
+        (:issue:`42687`)::
 
             sage: R.<a> = InfinitePolynomialRing(QQ)
             sage: p = SymmetricFunctions(R).p()
@@ -6844,7 +6844,8 @@ def _variables_recursive(R, include=None, exclude=None):
     If ``include`` is specified, only these variables are returned
     as elements of ``R``.  Otherwise, all variables in ``R``
     (recursively) with the exception of those in ``exclude`` are
-    returned.
+    returned.  For an infinite polynomial ring, return ``None`` so that
+    the variables can be determined from each coefficient instead.
 
     EXAMPLES::
 
@@ -6860,6 +6861,10 @@ def _variables_recursive(R, include=None, exclude=None):
         sage: _variables_recursive(S, include=[b])
         [b]
 
+        sage: A.<x> = InfinitePolynomialRing(QQ)
+        sage: _variables_recursive(A) is None
+        True
+
     TESTS::
 
         sage: _variables_recursive(R.fraction_field(), exclude=[b])
@@ -6874,6 +6879,9 @@ def _variables_recursive(R, include=None, exclude=None):
     if include is not None:
         degree_one = [R(g) for g in include]
     else:
+        from sage.rings.polynomial.infinite_polynomial_ring import InfinitePolynomialRing_sparse
+        if isinstance(R, InfinitePolynomialRing_sparse):
+            return None
         try:
             degree_one = [R(g) for g in R.variable_names_recursive()]
         except AttributeError:
@@ -6896,10 +6904,10 @@ def _raise_variables(c, n, variables, exclude=None):
 
     - ``c`` -- an element of a ring
     - ``n`` -- the power to raise the given variables to
-    - ``variables`` -- the variables to raise; generators of infinite
-      polynomial rings stand for the corresponding variable families
-    - ``exclude`` -- (optional) variables to omit when expanding a family
-      generator
+    - ``variables`` -- the variables to raise, or ``None`` to use the
+      variables occurring in ``c``
+    - ``exclude`` -- (optional) variables to omit when ``variables`` is
+      ``None``
 
     EXAMPLES::
 
@@ -6909,27 +6917,16 @@ def _raise_variables(c, n, variables, exclude=None):
         sage: _raise_variables(2*a + 3*b*t, 2, [a, t])
         3*b*t^2 + 2*a^2
 
-    Generators of infinite polynomial rings are expanded to the finitely
-    many variables that occur in ``c``::
+    The variables can be determined directly from ``c``::
 
         sage: A.<a> = InfinitePolynomialRing(QQ)
-        sage: _raise_variables(a[0] + a[3], 2, [a])
+        sage: _raise_variables(a[0] + a[3], 2, None)
         a_3^2 + a_0^2
-        sage: _raise_variables(a[0] + a[3], 2, [a], exclude=[a[3]])
+        sage: _raise_variables(a[0] + a[3], 2, None, exclude=[a[3]])
         a_3 + a_0^2
     """
-    from sage.rings.polynomial.infinite_polynomial_ring import InfinitePolynomialGen
-
-    family_generators = [g for g in variables
-                         if isinstance(g, InfinitePolynomialGen)]
-    if family_generators:
-        variables = [g for g in variables
-                     if not isinstance(g, InfinitePolynomialGen)]
-        if hasattr(c, 'variables'):
-            variables.extend(v for v in c.variables()
-                             if any(v.parent() is g._parent
-                                    and str(v).rsplit('_', 1)[0] == g._name
-                                    for g in family_generators))
+    if variables is None:
+        variables = c.variables() if hasattr(c, 'variables') else ()
         if exclude is not None:
             variables = [g for g in variables if g not in exclude]
 

--- a/src/sage/combinat/sf/sfa.py
+++ b/src/sage/combinat/sf/sfa.py
@@ -3339,9 +3339,21 @@ class SymmetricFunctionAlgebra_generic_Element(CombinatorialFreeModule.Element):
         `f \left[ g \right]` or by `f \circ g`. It is an algebra map
         in `f`, but not (generally) in `g`.
 
-        By default, the degree one elements are taken to be the
-        generators for the ``self``'s base ring. This setting can be
-        modified by specifying the ``include`` and ``exclude`` keywords.
+        By default, the degree one elements are taken to be the variables
+        returned by ``variable_names_recursive`` on the base ring of
+        ``self``.  If the base ring does not implement this method, there
+        are no default degree one elements.  This setting can be modified
+        by specifying the ``include`` and ``exclude`` keywords.
+
+        In particular, algebraic or symbolic elements are not inferred to
+        be degree one variables::
+
+            sage: p = SymmetricFunctions(QQbar).p()
+            sage: p[2](QQbar(sqrt(-1)))
+            I
+            sage: p = SymmetricFunctions(SR).p()
+            sage: p[2](SR("x") * p[2])
+            x*p[4]
 
         INPUT:
 
@@ -3505,8 +3517,8 @@ class SymmetricFunctionAlgebra_generic_Element(CombinatorialFreeModule.Element):
             sage: s[2](5)
             15*B[] # B[]
 
-        For infinite polynomial rings, the variables are determined from
-        each coefficient, so only finitely many need to be raised
+        Infinite polynomial rings do not have a finite collection of
+        variables and therefore have no default degree one elements
         (:issue:`42687`)::
 
             sage: R.<a> = InfinitePolynomialRing(QQ)
@@ -3515,31 +3527,22 @@ class SymmetricFunctionAlgebra_generic_Element(CombinatorialFreeModule.Element):
             sage: (a[0] * p[2])(s[2])
             a_0*s[2, 2] - a_0*s[3, 1] + a_0*s[4]
             sage: p[2]((a[0] + a[7]) * p[1])
+            (a_7+a_0)*p[2]
+            sage: p[2].plethysm((a[0] + a[7]) * p[1], include=[a[0], a[7]])
             (a_7^2+a_0^2)*p[2]
-            sage: p[2].plethysm((a[0] + a[7]) * p[1], exclude=[a[7]])
-            (a_7+a_0^2)*p[2]
-            sage: p[2].plethysm((a[0] + a[7]) * p[1], exclude=iter([a[7]]))
-            (a_7+a_0^2)*p[2]
 
         This also works for the sparse implementation::
 
             sage: R.<a> = InfinitePolynomialRing(QQ, implementation='sparse')
             sage: p = SymmetricFunctions(R).p()
-            sage: p[2]((a[0] + a[7]) * p[1])
-            (a_7^2+a_0^2)*p[2]
+            sage: (a[0] * p[2])(s[2])
+            a_0*s[2, 2] - a_0*s[3, 1] + a_0*s[4]
 
-        Tensor and infinite polynomial coefficients can be combined::
+        .. TODO::
 
-            sage: X = tensor([p[1], p[[]]])
-            sage: p[2](a[0] * X)
-            a_0^2*p[2] # p[]
-
-        .. NOTE::
-
-            :class:`sage.data_structures.stream.Stream_plethysm` computes
-            homogeneous components on demand.  Using it here would require
-            converting both finite inputs to exact streams and recombining
-            all components, so this method keeps its direct implementation.
+            The implementation of plethysm in
+            :class:`sage.data_structures.stream.Stream_plethysm` seems
+            to be faster.  This should be investigated.
         """
         from sage.structure.element import parent as get_parent
         Px = get_parent(x)
@@ -3574,8 +3577,6 @@ class SymmetricFunctionAlgebra_generic_Element(CombinatorialFreeModule.Element):
 
         p = parent.realization_of().power()
 
-        if exclude is not None:
-            exclude = tuple(exclude)
         degree_one = _variables_recursive(R, include=include, exclude=exclude)
 
         if tensorflag:
@@ -3583,7 +3584,7 @@ class SymmetricFunctionAlgebra_generic_Element(CombinatorialFreeModule.Element):
             lincomb = Px.linear_combination
             elt = lincomb((prod((lincomb((tensor([p[r].plethysm(base(la))
                                                  for base, la in zip(tparents, trm)]),
-                                         _raise_variables(c, r, degree_one, exclude))
+                                         _raise_variables(c, r, degree_one))
                                         for trm, c in x)
                                 for r in mu), tensor([base.one() for base in tparents])),
                            d)
@@ -3600,8 +3601,7 @@ class SymmetricFunctionAlgebra_generic_Element(CombinatorialFreeModule.Element):
         p_x = p(x)
 
         def f(part):
-            return p.prod(pn_pleth(p_x.map_coefficients(
-                lambda c: _raise_variables(c, i, degree_one, exclude)), i)
+            return p.prod(pn_pleth(p_x.map_coefficients(lambda c: _raise_variables(c, i, degree_one)), i)
                           for i in part)
         ret = p._apply_module_morphism(p(self), f, codomain=p)
         if Px is R:
@@ -6844,8 +6844,8 @@ def _variables_recursive(R, include=None, exclude=None):
     If ``include`` is specified, only these variables are returned
     as elements of ``R``.  Otherwise, all variables in ``R``
     (recursively) with the exception of those in ``exclude`` are
-    returned.  For an infinite polynomial ring, return ``None`` so that
-    the variables can be determined from each coefficient instead.
+    returned.  If ``R`` does not implement ``variable_names_recursive``,
+    return an empty list.
 
     EXAMPLES::
 
@@ -6862,8 +6862,8 @@ def _variables_recursive(R, include=None, exclude=None):
         [b]
 
         sage: A.<x> = InfinitePolynomialRing(QQ)
-        sage: _variables_recursive(A) is None
-        True
+        sage: _variables_recursive(A)
+        []
 
     TESTS::
 
@@ -6879,23 +6879,19 @@ def _variables_recursive(R, include=None, exclude=None):
     if include is not None:
         degree_one = [R(g) for g in include]
     else:
-        from sage.rings.polynomial.infinite_polynomial_ring import InfinitePolynomialRing_sparse
-        if isinstance(R, InfinitePolynomialRing_sparse):
-            return None
         try:
-            degree_one = [R(g) for g in R.variable_names_recursive()]
+            variable_names_recursive = R.variable_names_recursive
         except AttributeError:
-            try:
-                degree_one = R.gens()
-            except (NotImplementedError, AttributeError):
-                degree_one = []
+            degree_one = []
+        else:
+            degree_one = [R(g) for g in variable_names_recursive()]
         if exclude is not None:
             degree_one = [g for g in degree_one if g not in exclude]
 
     return [g for g in degree_one if g != R.one()]
 
 
-def _raise_variables(c, n, variables, exclude=None):
+def _raise_variables(c, n, variables):
     r"""
     Replace the given variables in the ring element ``c`` with their
     ``n``-th power.
@@ -6904,10 +6900,7 @@ def _raise_variables(c, n, variables, exclude=None):
 
     - ``c`` -- an element of a ring
     - ``n`` -- the power to raise the given variables to
-    - ``variables`` -- the variables to raise, or ``None`` to use the
-      variables occurring in ``c``
-    - ``exclude`` -- (optional) variables to omit when ``variables`` is
-      ``None``
+    - ``variables`` -- the variables to raise
 
     EXAMPLES::
 
@@ -6916,20 +6909,7 @@ def _raise_variables(c, n, variables, exclude=None):
         sage: S.<t> = R[]
         sage: _raise_variables(2*a + 3*b*t, 2, [a, t])
         3*b*t^2 + 2*a^2
-
-    The variables can be determined directly from ``c``::
-
-        sage: A.<a> = InfinitePolynomialRing(QQ)
-        sage: _raise_variables(a[0] + a[3], 2, None)
-        a_3^2 + a_0^2
-        sage: _raise_variables(a[0] + a[3], 2, None, exclude=[a[3]])
-        a_3 + a_0^2
     """
-    if variables is None:
-        variables = c.variables() if hasattr(c, 'variables') else ()
-        if exclude is not None:
-            variables = [g for g in variables if g not in exclude]
-
     try:
         return c.subs(**{str(g): g ** n for g in variables})
     except AttributeError:

--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -3611,6 +3611,26 @@ class Stream_plethysm(Stream_binary):
         sage: r2 = Stream_plethysm(f, g, True, p, include=[])                           # needs sage.modules
         sage: r_s - sum(r2[n] for n in range(2*(r_s.degree()+1)))                       # needs sage.modules
         (a2*b1^2-a2*b1)*p[2] + (a2*b111^2-a2*b111)*p[2, 2, 2] + (a2*b21^2-a2*b21)*p[4, 2]
+
+    Infinite polynomial variables are resolved one coefficient at a time,
+    which also works for lazy streams (:issue:`42687`)::
+
+        sage: # needs sage.modules
+        sage: R.<a> = InfinitePolynomialRing(QQ)
+        sage: p = SymmetricFunctions(R).p()
+        sage: L = LazySymmetricFunctions(p)
+        sage: f = L(lambda n: p[n])
+        sage: g = L((a[0] + a[2]) * p[1])
+        sage: f(g)[2]
+        (a_2^2+a_0^2)*p[2]
+        sage: excluded = [a[2]]
+        sage: f = Stream_exact([p[2]], order=2)
+        sage: g = Stream_exact([(a[0] + a[2]) * p[1]], order=1)
+        sage: h = Stream_plethysm(f, g, True, p, exclude=excluded)
+        sage: excluded.clear()
+        sage: h[2]
+        (a_2+a_0^2)*p[2]
+
     """
     def __init__(self, f, g, is_sparse, p, ring=None, include=None, exclude=None):
         r"""
@@ -3642,7 +3662,10 @@ class Stream_plethysm(Stream_binary):
         g = Stream_map_coefficients(g, lambda x: p(x), is_sparse)
         self._powers = [g]  # a cache for the powers of g in the powersum basis
         R = self._basis.base_ring()
+        if exclude is not None:
+            exclude = tuple(exclude)
         self._degree_one = _variables_recursive(R, include=include, exclude=exclude)
+        self._exclude = exclude
 
         if HopfAlgebrasWithBasis(R).TensorProducts() in p.categories():
             self._tensor_power = len(p._sets)
@@ -3837,15 +3860,15 @@ class Stream_plethysm(Stream_binary):
         # we have to check power_d for zero because it might be an
         # integer and not a symmetric function
         if power_d:
-            # _raise_variables(c, i, self._degree_one) cannot vanish
+            # _raise_variables(...) cannot vanish
             # because i is positive and c is nonzero
             if self._tensor_power is None:
                 terms = {mon.stretch(i):
-                         _raise_variables(c, i, self._degree_one)
+                         _raise_variables(c, i, self._degree_one, self._exclude)
                          for mon, c in power_d}
             else:
                 terms = {tuple(mu.stretch(i) for mu in mon):
-                         _raise_variables(c, i, self._degree_one)
+                         _raise_variables(c, i, self._degree_one, self._exclude)
                          for mon, c in power_d}
             return self._basis(self._p.element_class(self._p, terms))
 

--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -3611,26 +3611,6 @@ class Stream_plethysm(Stream_binary):
         sage: r2 = Stream_plethysm(f, g, True, p, include=[])                           # needs sage.modules
         sage: r_s - sum(r2[n] for n in range(2*(r_s.degree()+1)))                       # needs sage.modules
         (a2*b1^2-a2*b1)*p[2] + (a2*b111^2-a2*b111)*p[2, 2, 2] + (a2*b21^2-a2*b21)*p[4, 2]
-
-    Infinite polynomial variables are resolved one coefficient at a time,
-    which also works for lazy streams (:issue:`42687`)::
-
-        sage: # needs sage.modules
-        sage: R.<a> = InfinitePolynomialRing(QQ)
-        sage: p = SymmetricFunctions(R).p()
-        sage: L = LazySymmetricFunctions(p)
-        sage: f = L(lambda n: p[n])
-        sage: g = L((a[0] + a[2]) * p[1])
-        sage: f(g)[2]
-        (a_2^2+a_0^2)*p[2]
-        sage: excluded = [a[2]]
-        sage: f = Stream_exact([p[2]], order=2)
-        sage: g = Stream_exact([(a[0] + a[2]) * p[1]], order=1)
-        sage: h = Stream_plethysm(f, g, True, p, exclude=excluded)
-        sage: excluded.clear()
-        sage: h[2]
-        (a_2+a_0^2)*p[2]
-
     """
     def __init__(self, f, g, is_sparse, p, ring=None, include=None, exclude=None):
         r"""
@@ -3662,10 +3642,7 @@ class Stream_plethysm(Stream_binary):
         g = Stream_map_coefficients(g, lambda x: p(x), is_sparse)
         self._powers = [g]  # a cache for the powers of g in the powersum basis
         R = self._basis.base_ring()
-        if exclude is not None:
-            exclude = tuple(exclude)
         self._degree_one = _variables_recursive(R, include=include, exclude=exclude)
-        self._exclude = exclude
 
         if HopfAlgebrasWithBasis(R).TensorProducts() in p.categories():
             self._tensor_power = len(p._sets)
@@ -3860,15 +3837,15 @@ class Stream_plethysm(Stream_binary):
         # we have to check power_d for zero because it might be an
         # integer and not a symmetric function
         if power_d:
-            # _raise_variables(...) cannot vanish
+            # _raise_variables(c, i, self._degree_one) cannot vanish
             # because i is positive and c is nonzero
             if self._tensor_power is None:
                 terms = {mon.stretch(i):
-                         _raise_variables(c, i, self._degree_one, self._exclude)
+                         _raise_variables(c, i, self._degree_one)
                          for mon, c in power_d}
             else:
                 terms = {tuple(mu.stretch(i) for mu in mon):
-                         _raise_variables(c, i, self._degree_one, self._exclude)
+                         _raise_variables(c, i, self._degree_one)
                          for mon, c in power_d}
             return self._basis(self._p.element_class(self._p, terms))
 

--- a/src/sage/rings/fraction_field.py
+++ b/src/sage/rings/fraction_field.py
@@ -87,6 +87,7 @@ from sage.categories.rings import Rings
 from sage.misc import latex
 from sage.misc.cachefunc import cached_method
 from sage.rings import fraction_field_element, ring
+from sage.rings.infinity import infinity
 from sage.rings.integer_ring import ZZ
 from sage.structure.coerce import py_scalar_to_element
 from sage.structure.coerce_maps import CallableConvertMap, DefaultConvertMap_unique
@@ -526,6 +527,29 @@ class FractionField_generic(ring.Field):
             Multivariate Polynomial Ring in x, y over Rational Field
         """
         return self._R
+
+    def variable_names_recursive(self, depth=infinity):
+        r"""
+        Return the variable names of the underlying ring recursively.
+
+        INPUT:
+
+        - ``depth`` -- integer or :mod:`Infinity <sage.rings.infinity>`
+
+        EXAMPLES::
+
+            sage: R = QQ['x']['y']
+            sage: K = R.fraction_field()
+            sage: K.variable_names_recursive()
+            ('x', 'y')
+            sage: K.variable_names_recursive(1)
+            ('y',)
+        """
+        try:
+            variable_names_recursive = self.ring().variable_names_recursive
+        except AttributeError:
+            return ()
+        return variable_names_recursive(depth)
 
     @cached_method
     def is_exact(self):

--- a/src/sage/rings/laurent_series_ring.py
+++ b/src/sage/rings/laurent_series_ring.py
@@ -817,6 +817,34 @@ class LaurentSeriesRing(UniqueRepresentation, Parent):
         """
         return False
 
+    def variable_names_recursive(self, depth=infinity):
+        r"""
+        Return the variable names of this ring and its base rings.
+
+        INPUT:
+
+        - ``depth`` -- integer or :mod:`Infinity <sage.rings.infinity>`
+
+        EXAMPLES::
+
+            sage: R = QQ['x']
+            sage: L = LaurentSeriesRing(R, 'z')
+            sage: L.variable_names_recursive()
+            ('x', 'z')
+            sage: L.variable_names_recursive(1)
+            ('z',)
+        """
+        my_vars = self.variable_names()
+        if depth <= 0:
+            return ()
+        if depth == 1:
+            return my_vars
+        try:
+            base_vars = self.base_ring().variable_names_recursive(depth - len(my_vars))
+        except AttributeError:
+            return my_vars
+        return base_vars + my_vars
+
     @cached_method
     def gen(self, n=0):
         """

--- a/src/sage/rings/lazy_series_ring.py
+++ b/src/sage/rings/lazy_series_ring.py
@@ -1983,6 +1983,25 @@ class LazyLaurentSeriesRing(LazySeriesRing):
         from sage.misc.latex import latex
         return latex(self.base_ring()) + r"(\!({})\!)".format(self.variable_name())
 
+    def variable_names_recursive(self, depth=infinity):
+        r"""
+        Return the variable names of this ring and its base rings.
+
+        INPUT:
+
+        - ``depth`` -- integer or :mod:`Infinity <sage.rings.infinity>`
+
+        EXAMPLES::
+
+            sage: R = QQ['x']
+            sage: L = LazyLaurentSeriesRing(R, 'z')
+            sage: L.variable_names_recursive()
+            ('x', 'z')
+            sage: L.variable_names_recursive(1)
+            ('z',)
+        """
+        return self._laurent_poly_ring.variable_names_recursive(depth)
+
     @cached_method
     def gen(self, n=0):
         r"""
@@ -2913,6 +2932,25 @@ class LazyPowerSeriesRing(LazySeriesRing):
             return [R.one()]
         return [m.change_ring(R)
                 for m in self._internal_poly_ring.base_ring().monomials_of_degree(n)]
+
+    def variable_names_recursive(self, depth=infinity):
+        r"""
+        Return the variable names of this ring and its base rings.
+
+        INPUT:
+
+        - ``depth`` -- integer or :mod:`Infinity <sage.rings.infinity>`
+
+        EXAMPLES::
+
+            sage: R = QQ['q']
+            sage: L = LazyPowerSeriesRing(R, 'x, y')
+            sage: L.variable_names_recursive()
+            ('q', 'x', 'y')
+            sage: L.variable_names_recursive(2)
+            ('x', 'y')
+        """
+        return self._laurent_poly_ring.variable_names_recursive(depth)
 
     @cached_method
     def gen(self, n=0):

--- a/src/sage/rings/puiseux_series_ring.py
+++ b/src/sage/rings/puiseux_series_ring.py
@@ -422,6 +422,25 @@ class PuiseuxSeriesRing(UniqueRepresentation, Parent):
         #     P.variable_name() == self.variable_name()):
         #     return True
 
+    def variable_names_recursive(self, depth=infinity):
+        r"""
+        Return the variable names of this ring and its base rings.
+
+        INPUT:
+
+        - ``depth`` -- integer or :mod:`Infinity <sage.rings.infinity>`
+
+        EXAMPLES::
+
+            sage: R = QQ['x']
+            sage: P = PuiseuxSeriesRing(R, 'z')
+            sage: P.variable_names_recursive()
+            ('x', 'z')
+            sage: P.variable_names_recursive(1)
+            ('z',)
+        """
+        return self._laurent_series_ring.variable_names_recursive(depth)
+
     @cached_method
     def gen(self, n=0):
         r"""


### PR DESCRIPTION
Fixes #42687.

Plethysm previously fell back to `base_ring.gens()` when choosing the
coefficient-ring elements of degree one.  This is ambiguous for many rings and
fails for an `InfinitePolynomialRing`, whose generators represent entire
variable families rather than concrete variables.

This PR now uses `variable_names_recursive` as an explicit opt-in protocol:

- rings implementing `variable_names_recursive` keep their variables as the
  default degree-one elements;
- rings without that method have no default degree-one elements;
- `InfinitePolynomialRing` is no longer special-cased, and concrete variables
  can still be selected explicitly with `include=[...]`.

To preserve existing polynomial-like coefficient behavior, this also adds
`variable_names_recursive` to fraction fields (delegating to the underlying
ring), Laurent and Puiseux series rings, and lazy Laurent and power series
rings.  The fraction-field delegation is important for existing symmetric
function code such as Hall--Littlewood plethysm over `Frac(QQ[q])`.

Regression tests cover dense and sparse infinite polynomial rings, explicit
inclusions, the `QQbar` and symbolic-ring examples from the review discussion,
fraction fields, and the recursive-variable methods on the series rings.

Validation:

- full Cython build: 1361 targets completed;
- 4615 doctests passed across `sfa.py`, `hall_littlewood.py`, `stream.py`,
  `fraction_field.py`, `laurent_series_ring.py`, `lazy_series_ring.py`, and
  `puiseux_series_ring.py`;
- `git diff --check`.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and tested its doctests.

### :hourglass: Dependencies

None.
