### PR TITLE
Some tweaks to ruff config and ignoring false positives

### DIFF
--- a/.github/workflows/ruff.toml
+++ b/.github/workflows/ruff.toml
@@ -7,7 +7,6 @@ extend = "../../pyproject.toml"  # Start with the project configuration
 extend-ignore = [
   "E742",    # 2 failures
   "PLC3002", # 3 failures
-  "PLE0302", # 3 failures
   "PLW1508", # 8 failures
   "PLR5501", # 375 failures, should be easy to autofix
   "PLC0206", # 39

--- a/.github/workflows/ruff.toml
+++ b/.github/workflows/ruff.toml
@@ -5,7 +5,6 @@ extend = "../../pyproject.toml"  # Start with the project configuration
 # Remove rules that we do not yet follow across the whole codebase.
 # Roughly sorted by how easy these should be to fix.
 extend-ignore = [
-  "E742",    # 2 failures
   "PLC3002", # 3 failures
   "PLW1508", # 8 failures
   "PLR5501", # 375 failures, should be easy to autofix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -352,8 +352,9 @@ quote-style = "preserve"
 ignore = [
   "E501", # Line too long - hard to avoid in doctests, and better handled by black.
 
-  # Variable/function names I, O, l - common in math, and not an issue for most monospace fonts
+  # Variable/function/class names I, O, l - common in math, and not an issue for most monospace fonts
   "E741",
+  "E742",
   "E743",
 
   "PLC2401", # Non-ASCII variables - we deliberately use Greek letters (albeit sparingly)
@@ -567,6 +568,7 @@ select = [
   "UP034",
   "UP035",
   "UP036",
+  "UP040",
   "UP041",
   "UP042",
   "UP043",

--- a/src/sage/functions/piecewise.py
+++ b/src/sage/functions/piecewise.py
@@ -318,7 +318,7 @@ class PiecewiseFunction(BuiltinFunction):
 
     class EvaluationMethods:
 
-        def __pow__(self, parameters, variable, n):
+        def __pow__(self, parameters, variable, n):  # noqa: PLE0302
             """
             Return the `n`-th power of the piecewise function by applying the
             operation to each piece.
@@ -413,7 +413,7 @@ class PiecewiseFunction(BuiltinFunction):
                 intervals += list(domain)
             return RealSet(*intervals)
 
-        def __len__(self, parameters, variable):
+        def __len__(self, parameters, variable):  # noqa: PLE0302
             """
             Return the number of "pieces".
 

--- a/src/sage/symbolic/constants_c_impl.pyi
+++ b/src/sage/symbolic/constants_c_impl.pyi
@@ -6,5 +6,5 @@ class E(Expression):
     def __init__(self) -> None:
         ...
 
-    def __pow__(self, left: Any, right: Any, dummy: Any) -> Any:
+    def __pow__(self, left: Any, right: Any, dummy: Any) -> Any:  # noqa: PLE0302
         ...


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

This PR:
1. Ignores [E742](https://docs.astral.sh/ruff/rules/ambiguous-class-name/) in the main ruff config instead of the CI config. This rule is to not allow class names like `I` or `l` as they could potentially be hard to read, but I think that's a non-issue in most monospace fonts. We already had the variable and function name versions of this rule disabled.
2. Enforce [PLE0302](https://docs.astral.sh/ruff/rules/unexpected-special-method-signature/) after adding three noqa statements for it. This rule enforces that dunder methods have the correct number of parameters, but the `Expression` class does some weird things which make it not relevant to its subclasses.
3. Enable enforcement of [UP040](https://docs.astral.sh/ruff/rules/non-pep695-type-alias/), which was already followed throughout the codebase.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


