### PR TITLE
Fix misspelled indirect doctest annotations

### DIFF
--- a/src/sage/algebras/quatalg/quaternion_algebra_element.pyx
+++ b/src/sage/algebras/quatalg/quaternion_algebra_element.pyx
@@ -154,7 +154,7 @@ cdef to_quaternion(R, x):
     EXAMPLES::
 
         sage: Q.<i,j,kkkk> = QuaternionAlgebra(QQ,-7, 13)
-        sage: kkkk._repr_()   # implicit doctest
+        sage: kkkk._repr_()   # indirect doctest
         'kkkk'
     """
     if isinstance(x, (list, tuple)):
@@ -175,7 +175,7 @@ cdef inline print_coeff(y, i, bint atomic):
     EXAMPLES::
 
         sage: Q.<i,j,k> = QuaternionAlgebra(QQ,-7, 13)
-        sage: i._repr_()   # implicit doctest
+        sage: i._repr_()   # indirect doctest
         'i'
     """
     if not y:
@@ -907,7 +907,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
 
         EXAMPLES::
 
-            sage: QuaternionAlgebra(QQ,-5,-2)([1/2,-1/3,2/3,4/5])  # implicit doctest
+            sage: QuaternionAlgebra(QQ,-5,-2)([1/2,-1/3,2/3,4/5])  # indirect doctest
             1/2 - 1/3*i + 2/3*j + 4/5*k
         """
         mpz_init(self.x)
@@ -1035,7 +1035,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
             sage: type(A(2/3))
             <class 'sage.algebras.quatalg.quaternion_algebra_element.QuaternionAlgebraElement_rational_field'>
 
-            sage: A([-1/2,-10/3,-2/3,-4/5])     # implicit doctest
+            sage: A([-1/2,-10/3,-2/3,-4/5])     # indirect doctest
             -1/2 - 10/3*i - 2/3*j - 4/5*k
             sage: A(vector([1,2/3,3/4,4/5]))
             1 + 2/3*i + 3/4*j + 4/5*k
@@ -1459,7 +1459,7 @@ cdef class QuaternionAlgebraElement_rational_field(QuaternionAlgebraElement_abst
         TESTS::
 
             sage: K.<i,j,k> = QuaternionAlgebra(QQ, -10, -7)
-            sage: (1/4 + 1/2 * i + 1/7 * j + 1/28 * k)*14*i     # implicit doctest
+            sage: (1/4 + 1/2 * i + 1/7 * j + 1/28 * k)*14*i     # indirect doctest
             -70 + 7/2*i + 5*j - 2*k
         """
 
@@ -1674,7 +1674,7 @@ cdef class QuaternionAlgebraElement_number_field(QuaternionAlgebraElement_abstra
         EXAMPLES::
 
             sage: K.<a> = QQ[2^(1/5)]; Q.<i,j,k> = QuaternionAlgebra(K,-a,a*17/3)
-            sage: Q([a,-2/3,a^2-1/2,a*2])           # implicit doctest
+            sage: Q([a,-2/3,a^2-1/2,a*2])           # indirect doctest
             a + (-2/3)*i + (a^2 - 1/2)*j + 2*a*k
         """
         fmpz_poly_init(self.x)
@@ -1704,7 +1704,7 @@ cdef class QuaternionAlgebraElement_number_field(QuaternionAlgebraElement_abstra
         EXAMPLES::
 
             sage: K.<a> = QQ[2^(1/3)]; Q.<i,j,k> = QuaternionAlgebra(K,-a,a+1)
-            sage: Q([a,-2/3,a^2-1/2,a*2])           # implicit doctest
+            sage: Q([a,-2/3,a^2-1/2,a*2])           # indirect doctest
             a + (-2/3)*i + (a^2 - 1/2)*j + 2*a*k
         """
         self._parent = parent
@@ -2081,7 +2081,7 @@ cdef class QuaternionAlgebraElement_number_field(QuaternionAlgebraElement_abstra
             sage: F = QQ[3^(1/3)]
             sage: a = F.gen()
             sage: K.<i,j,k> = QuaternionAlgebra(F, -10 + a, -7 - a)
-            sage: ((1/4 + 1/2 * i + a^3/7 * j + a/28 * k)*14*i)^3   # implicit doctest
+            sage: ((1/4 + 1/2 * i + a^3/7 * j + a/28 * k)*14*i)^3   # indirect doctest
             34503/2*a^2 + 132195/2*a + 791399/4 + (203/8*a^2 - 10591*a + 169225/4)*i
              + (-84695/4*a^2 + 483413/8*a + 18591/4)*j + (-87/2*a^2 + 18156*a - 72525)*k
         """

--- a/src/sage/groups/perm_gps/partn_ref/refinement_python.pyx
+++ b/src/sage/groups/perm_gps/partn_ref/refinement_python.pyx
@@ -51,7 +51,7 @@ cdef class PythonPartitionStack:
         EXAMPLES::
 
             sage: from sage.groups.perm_gps.partn_ref.refinement_python import PythonPartitionStack
-            sage: P = PythonPartitionStack(7) # implicit doctest
+            sage: P = PythonPartitionStack(7) # indirect doctest
         """
         self.c_ps = PS_new(n, 1)
 
@@ -63,7 +63,7 @@ cdef class PythonPartitionStack:
 
             sage: from sage.groups.perm_gps.partn_ref.refinement_python import PythonPartitionStack
             sage: P = PythonPartitionStack(7)
-            sage: del(P) # implicit doctest
+            sage: del(P) # indirect doctest
         """
         PS_dealloc(self.c_ps)
 
@@ -75,7 +75,7 @@ cdef class PythonPartitionStack:
 
             sage: from sage.groups.perm_gps.partn_ref.refinement_python import PythonPartitionStack
             sage: P = PythonPartitionStack(7)
-            sage: P # implicit doctest
+            sage: P # indirect doctest
             PythonPartitionStack of degree 7 and depth 0.
         """
         return "PythonPartitionStack of degree %d and depth %d." % (self.c_ps.degree, self.c_ps.depth)
@@ -352,7 +352,7 @@ class PythonObjectWrapper:
             sage: def cs(a, b, c, d, e):
             ....:  return 0
             sage: from sage.groups.perm_gps.partn_ref.refinement_python import PythonObjectWrapper
-            sage: P = PythonObjectWrapper(None, acae, rari, cs, 7) # implicit doctest
+            sage: P = PythonObjectWrapper(None, acae, rari, cs, 7) # indirect doctest
             sage: P.obj
             sage: P.degree
             7

--- a/src/sage/modules/free_quadratic_module_integer_symmetric.py
+++ b/src/sage/modules/free_quadratic_module_integer_symmetric.py
@@ -1555,12 +1555,12 @@ class FreeQuadraticModule_integer_symmetric(FreeQuadraticModule_submodule_with_b
 
             sage: L = IntegralLattice('A4')
             sage: t = vector([1.2, -3/11, 5.5, -9.1])
-            sage: short = L.enumerate_short_vectors()   # implicit doctest
+            sage: short = L.enumerate_short_vectors()   # indirect doctest
             sage: vecs = [next(short) for _ in range(10)]
             sage: sorted(vecs, key=lambda v: (L(v).inner_product(L(v)), v))
             [(0, 0, 0, 1), (0, 0, 1, 0), (0, 0, 1, 1), (0, 1, 0, 0), (0, 1, 1, 0),
              (0, 1, 1, 1), (1, 0, 0, 0), (1, 1, 0, 0), (1, 1, 1, 0), (1, 1, 1, 1)]
-            sage: close = L.enumerate_close_vectors(t)  # implicit doctest
+            sage: close = L.enumerate_close_vectors(t)  # indirect doctest
             sage: vecs = [next(close) for _ in range(10)]
             sage: sorted(vecs, key=lambda v: (L(v).inner_product(L(v)), v))
             [(1, 0, 6, -8), (1, 0, 5, -9), (2, 0, 5, -9), (1, -1, 5, -9), (2, 1, 6, -9),

--- a/src/sage/rings/finite_rings/element_base.pyx
+++ b/src/sage/rings/finite_rings/element_base.pyx
@@ -441,14 +441,14 @@ cdef class FinitePolyExtElement(FiniteRingElement):
             Traceback (most recent call last):
             ...
             StopIteration
-            sage: list(a)   # implicit doctest
+            sage: list(a)   # indirect doctest
             [5, 7]
-            sage: tuple(a)  # implicit doctest
+            sage: tuple(a)  # indirect doctest
             (5, 7)
             sage: b = F(11)
-            sage: list(b)   # implicit doctest
+            sage: list(b)   # indirect doctest
             [11, 0]
-            sage: tuple(b)  # implicit doctest
+            sage: tuple(b)  # indirect doctest
             (11, 0)
             sage: list(b.polynomial())
             [11]
@@ -457,21 +457,21 @@ cdef class FinitePolyExtElement(FiniteRingElement):
 
             sage: F = GF(random_prime(333)^randrange(111,999),'t')
             sage: a = F.random_element()
-            sage: list(a) == a.list()  # implicit doctest
+            sage: list(a) == a.list()  # indirect doctest
             True
 
         ::
 
             sage: F.<t> = GF(17^60)
             sage: a = F.random_element()
-            sage: a == sum(c*t^i for i,c in enumerate(a))  # implicit doctest
+            sage: a == sum(c*t^i for i,c in enumerate(a))  # indirect doctest
             True
 
         ::
 
             sage: F.<t> = GF((2^127 - 1)^10, 't')
             sage: a = F.random_element()
-            sage: a == sum(c*t^i for i,c in enumerate(a))  # implicit doctest
+            sage: a == sum(c*t^i for i,c in enumerate(a))  # indirect doctest
             True
         """
         return iter(self.list())

--- a/src/sage/rings/finite_rings/finite_field_constructor.py
+++ b/src/sage/rings/finite_rings/finite_field_constructor.py
@@ -580,22 +580,22 @@ class FiniteFieldFactory(UniqueFactory):
 
         TESTS::
 
-            sage: GF((6, 1), 'a')       # implicit doctest
+            sage: GF((6, 1), 'a')       # indirect doctest
             Traceback (most recent call last):
             ...
             ValueError: the order of a finite field must be a prime power
 
-            sage: GF((9, 1), 'a')       # implicit doctest
+            sage: GF((9, 1), 'a')       # indirect doctest
             Traceback (most recent call last):
             ...
             ValueError: the order of a finite field must be a prime power
 
-            sage: GF((5, 0), 'a')       # implicit doctest
+            sage: GF((5, 0), 'a')       # indirect doctest
             Traceback (most recent call last):
             ...
             ValueError: the order of a finite field must be a prime power
 
-            sage: GF((3, 2, 1), 'a')    # implicit doctest
+            sage: GF((3, 2, 1), 'a')    # indirect doctest
             Traceback (most recent call last):
             ...
             ValueError: wrong input for finite field constructor

--- a/src/sage/rings/number_field/number_field_element.pyx
+++ b/src/sage/rings/number_field/number_field_element.pyx
@@ -3383,7 +3383,7 @@ cdef class NumberFieldElement(NumberFieldElement_base):
             +Infinity
             sage: K(0).additive_order()
             1
-            sage: K.ring_of_integers().characteristic()  # implicit doctest
+            sage: K.ring_of_integers().characteristic()  # indirect doctest
             0
         """
         return ZZ.one() if not self else infinity

--- a/src/sage/rings/real_mpfr.pyx
+++ b/src/sage/rings/real_mpfr.pyx
@@ -5740,7 +5740,7 @@ cdef class RealLiteral(RealNumber):
 
             sage: RealField(200)(float(1.3))
             1.3000000000000000444089209850062616169452667236328125000000
-            sage: RealField(200)(1.3)  # implicit doctest
+            sage: RealField(200)(1.3)  # indirect doctest
             1.3000000000000000000000000000000000000000000000000000000000
             sage: 1.3 + 1.2
             2.50000000000000

--- a/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
+++ b/src/sage/schemes/elliptic_curves/ell_curve_isogeny.py
@@ -1704,18 +1704,18 @@ class EllipticCurveIsogeny(EllipticCurveHom):
 
             sage: E = EllipticCurve(j=GF(7)(1728))
             sage: phi = EllipticCurveIsogeny(E, E((0,0)))
-            sage: phi.rational_maps()  # implicit doctest
+            sage: phi.rational_maps()  # indirect doctest
             ((x^2 + 1)/x, (x^2*y - y)/x^2)
 
             sage: R.<x> = GF(7)[]
             sage: phi = EllipticCurveIsogeny(E, x)
-            sage: phi.rational_maps()  # implicit doctest
+            sage: phi.rational_maps()  # indirect doctest
             ((x^2 + 1)/x, (x^2*y - y)/x^2)
 
             sage: E = EllipticCurve([1,2,3,4,5])
             sage: Eshort = E.short_weierstrass_model()
             sage: phi = E.isogeny(E(0), Eshort)
-            sage: phiX, phiY = phi.rational_maps()  # implicit doctest
+            sage: phiX, phiY = phi.rational_maps()  # indirect doctest
             sage: phiX(1,2), phiY(1,2)
             (63, 864)
         """
@@ -1755,7 +1755,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
 
             sage: E = EllipticCurve(j=GF(7)(1728))
             sage: phi = EllipticCurveIsogeny(E, E((0,0)))
-            sage: phi.kernel_polynomial()  # implicit doctest
+            sage: phi.kernel_polynomial()  # indirect doctest
             x
         """
         if self.__kernel_polynomial is None:
@@ -1955,7 +1955,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
 
             sage: E = EllipticCurve(GF(7), [0,0,0,-1,0])
             sage: P = E((4,2))
-            sage: phi = EllipticCurveIsogeny(E, [P,P]); phi  # implicit doctest
+            sage: phi = EllipticCurveIsogeny(E, [P,P]); phi  # indirect doctest
             Isogeny of degree 4
              from Elliptic Curve defined by y^2 = x^3 + 6*x over Finite Field of size 7
                to Elliptic Curve defined by y^2 = x^3 + 2*x over Finite Field of size 7
@@ -1989,7 +1989,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
 
             sage: E = EllipticCurve(GF(7), [0,0,0,-1,0])
             sage: P = E((4,2))
-            sage: phi = EllipticCurveIsogeny(E, P); phi  # implicit doctest
+            sage: phi = EllipticCurveIsogeny(E, P); phi  # indirect doctest
             Isogeny of degree 4
              from Elliptic Curve defined by y^2 = x^3 + 6*x over Finite Field of size 7
                to Elliptic Curve defined by y^2 = x^3 + 2*x over Finite Field of size 7
@@ -2030,7 +2030,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
 
             sage: E = EllipticCurve(GF(7), [0,0,0,-1,0])
             sage: P = E((4,2))
-            sage: phi = EllipticCurveIsogeny(E, [P,P]); phi  # implicit doctest
+            sage: phi = EllipticCurveIsogeny(E, [P,P]); phi  # indirect doctest
             Isogeny of degree 4
              from Elliptic Curve defined by y^2 = x^3 + 6*x over Finite Field of size 7
                to Elliptic Curve defined by y^2 = x^3 + 2*x over Finite Field of size 7
@@ -2243,7 +2243,7 @@ class EllipticCurveIsogeny(EllipticCurveHom):
             sage: E = EllipticCurve(GF(7), [0,0,0,-1,0])
             sage: P = E((4,2))
             sage: phi = EllipticCurveIsogeny(E, P)
-            sage: phi.kernel_polynomial()  # implicit doctest
+            sage: phi.kernel_polynomial()  # indirect doctest
             x^2 + 2*x + 4
         """
         poly_ring, x = self.__poly_ring.objgen()

--- a/src/sage/schemes/elliptic_curves/hom_composite.py
+++ b/src/sage/schemes/elliptic_curves/hom_composite.py
@@ -425,7 +425,7 @@ class EllipticCurveHom_composite(EllipticCurveHom):
 
             sage: from sage.schemes.elliptic_curves.hom_composite import EllipticCurveHom_composite
             sage: E = EllipticCurve([1,0])
-            sage: phi = EllipticCurveHom_composite(E, E(0,0))   # implicit doctest
+            sage: phi = EllipticCurveHom_composite(E, E(0,0))   # indirect doctest
             sage: from sage.schemes.elliptic_curves.hom import EllipticCurveHom
             sage: print(EllipticCurveHom._repr_(phi))
             Elliptic-curve morphism:

--- a/src/sage/schemes/elliptic_curves/hom_frobenius.py
+++ b/src/sage/schemes/elliptic_curves/hom_frobenius.py
@@ -248,7 +248,7 @@ class EllipticCurveHom_frobenius(EllipticCurveHom):
             sage: E = EllipticCurve(j=z2)
             sage: pi = EllipticCurveHom_frobenius(E)
             sage: P = E(7, 9*z2+4)
-            sage: pi(P)     # implicit doctest
+            sage: pi(P)     # indirect doctest
             (7 : 2*z2 + 7 : 1)
         """
         return self._codomain(*(c**self._degree for c in P))

--- a/src/sage/schemes/elliptic_curves/hom_scalar.py
+++ b/src/sage/schemes/elliptic_curves/hom_scalar.py
@@ -251,7 +251,7 @@ class EllipticCurveHom_scalar(EllipticCurveHom):
             sage: E = EllipticCurve([1,2,3,4,5])
             sage: phi = E.scalar_multiplication(5)
             sage: psi = E.scalar_multiplication(-7)
-            sage: phi * psi     # implicit doctest
+            sage: phi * psi     # indirect doctest
             Scalar-multiplication endomorphism [-35] of Elliptic Curve defined by y^2 + x*y + 3*y = x^3 + 2*x^2 + 4*x + 5 over Rational Field
 
         ::


### PR DESCRIPTION
Fixes #40451.

## Description

Replace 38 occurrences of `# implicit doctest` with the supported `# indirect doctest` annotation across 11 files. The coverage checker recognizes only `indirect doctest`, so the misspelled annotations could be reported as potentially wrong or go unnoticed.

## Testing

- `git diff --check`
- `python3 src/bin/sage-coverage --summary` on all 11 changed files; the corrected annotations no longer trigger coverage warnings

The full doctest run could not start in this checkout because Sage is not built (`ModuleNotFoundError: No module named sage`).