### PR TITLE
new method "interval_as_poset" in finite posets

### DIFF
--- a/src/sage/combinat/posets/incidence_algebras.py
+++ b/src/sage/combinat/posets/incidence_algebras.py
@@ -454,7 +454,7 @@ class ReducedIncidenceAlgebra(CombinatorialFreeModule):
         if not P.is_finite():
             raise NotImplementedError("only implemented for finite posets")
         for i in self._ambient.basis().keys():
-            S = P.subposet(P.interval(*i))
+            S = P.interval_as_poset(*i)
             added = False
             for k, ECk in EC.items():
                 if S._hasse_diagram.is_isomorphic(k._hasse_diagram):

--- a/src/sage/combinat/posets/lattices.py
+++ b/src/sage/combinat/posets/lattices.py
@@ -1891,7 +1891,7 @@ class FiniteLatticePoset(FiniteMeetSemilattice, FiniteJoinSemilattice):
         for e1 in range(n - 1):
             C = Counter(flatten([H.neighbors_out(e2) for e2 in H.neighbor_out_iterator(e1)]))
             for e3, c in C.items():
-                if c == 1 and len(H.closed_interval(e1, e3)) == 3:
+                if c == 1 and len(H.interval(e1, e3)) == 3:
                     if not certificate:
                         return False
                     for e2 in H.neighbor_in_iterator(e3):

--- a/src/sage/combinat/posets/moebius_algebra.py
+++ b/src/sage/combinat/posets/moebius_algebra.py
@@ -508,7 +508,7 @@ class QuantumMoebiusAlgebra(Parent, UniqueRepresentation):
             j = L.join(x, y)
             return self.sum_of_terms((z, moebius(a, z) * q**(R - rank(a)))
                                      for z in L.order_filter([j])
-                                     for a in L.closed_interval(j, z))
+                                     for a in L.interval(j, z))
 
         @cached_method
         def one(self):
@@ -592,7 +592,8 @@ class QuantumMoebiusAlgebra(Parent, UniqueRepresentation):
             L = M._lattice
 
             def poly(x, y):
-                return L.subposet(L.closed_interval(x, y)).characteristic_polynomial()
+                return L.interval_as_poset(x, y).characteristic_polynomial()
+
             return N.sum_of_terms((y, poly(x, y)(q=q))
                                   for y in L.order_filter([x]))
 

--- a/src/sage/combinat/posets/posets.py
+++ b/src/sage/combinat/posets/posets.py
@@ -6497,12 +6497,24 @@ class FinitePoset(UniqueRepresentation, Parent):
             Traceback (most recent call last):
             ...
             TypeError: 'sage.rings.integer.Integer' object is not iterable
+
+            sage: L = LatticePoset({0:[1,2],1:[3],2:[3]})
+            sage: S = L.subposet([], category=LatticePosets().Finite()); S
+            Finite lattice containing 0 elements
+            sage: S.category()
+            Category of facade finite enumerated lattice posets
         """
         H = self._hasse_diagram
         elms = sorted({self._element_to_vertex(e) for e in elements})
 
+        if category is not None and category.is_subcategory(LatticePosets()):
+            from sage.combinat.posets.lattices import LatticePoset
+            constructor = LatticePoset
+        else:
+            constructor = Poset
+
         if not elms:
-            return Poset(category=category)
+            return constructor(facade=self._is_facade, category=category)
 
         relations = []
         lt = [set() for _ in range(elms[-1] + 1)]
@@ -6520,12 +6532,6 @@ class FinitePoset(UniqueRepresentation, Parent):
         else:
             g.relabel(lambda v: self._vertex_to_element(v).element,
                       inplace=True)
-
-        if category is not None and category.is_subcategory(LatticePosets()):
-            from sage.combinat.posets.lattices import LatticePoset
-            constructor = LatticePoset
-        else:
-            constructor = Poset
 
         return constructor(g, cover_relations=False,
                            facade=self._is_facade, category=category)

--- a/src/sage/combinat/posets/posets.py
+++ b/src/sage/combinat/posets/posets.py
@@ -29,7 +29,8 @@ List of Poset methods
     :meth:`~FinitePoset.is_lequal` | Return ``True`` if `x` is less than or equal to `y` in the poset.
     :meth:`~FinitePoset.is_gequal` | Return ``True`` if `x` is greater than or equal to `y` in the poset.
     :meth:`~FinitePoset.compare_elements` | Compare two element of the poset.
-    :meth:`~FinitePoset.closed_interval` | Return the list of elements in a closed interval of the poset.
+    :meth:`~FinitePoset.interval` | Return the list of elements in a closed interval of the poset.
+    :meth:`~FinitePoset.interval_as_poset` | Return the subposet of elements in a closed interval of the poset.
     :meth:`~FinitePoset.open_interval` | Return the list of elements in an open interval of the poset.
     :meth:`~FinitePoset.relations` | Return the list of relations in the poset.
     :meth:`~FinitePoset.relations_iterator` | Return an iterator over relations in the poset.
@@ -297,6 +298,7 @@ from sage.categories.category import Category
 from sage.categories.sets_cat import Sets
 from sage.categories.finite_enumerated_sets import FiniteEnumeratedSets
 from sage.categories.posets import Posets
+from sage.categories.lattice_posets import LatticePosets
 from sage.categories.finite_posets import FinitePosets
 from sage.structure.unique_representation import UniqueRepresentation
 from sage.structure.parent import Parent
@@ -3541,7 +3543,7 @@ class FinitePoset(UniqueRepresentation, Parent):
         if return_raising_chains:
             raising_chains = {}
         for a, b in self.relations_iterator(strict=True):
-            P = self.subposet(self.interval(a, b))
+            P = self.interval_as_poset(a, b)
             max_chains = sorted([[label_dict[(chain[i], chain[i + 1])]
                                   for i in range(len(chain) - 1)]
                                  for chain in P.maximal_chains_iterator()])
@@ -6421,7 +6423,7 @@ class FinitePoset(UniqueRepresentation, Parent):
                            category=self.category(),
                            facade=self._is_facade)
 
-    def graphviz_string(self, graph_string='graph', edge_string='--'):
+    def graphviz_string(self, graph_string='graph', edge_string='--') -> str:
         r"""
         Return a representation in the DOT language, ready to render in
         graphviz.
@@ -6447,10 +6449,20 @@ class FinitePoset(UniqueRepresentation, Parent):
         s += "\n}"
         return s
 
-    def subposet(self, elements):
+    def subposet(self, elements, category=None):
         """
         Return the poset containing given elements with partial order
         induced by this poset.
+
+        INPUT:
+
+        - elements -- some elements
+
+        - category -- optional category
+
+        .. SEEALSO::
+
+            :meth:`interval_as_poset`
 
         EXAMPLES::
 
@@ -6473,6 +6485,8 @@ class FinitePoset(UniqueRepresentation, Parent):
             sage: P = Poset({'a': ['b'], 'b': ['c']})
             sage: P.subposet(('a', 'b', 'c'))
             Finite poset containing 3 elements
+            sage: P.subposet(('a', 'b', 'c'), category=LatticePosets().Finite())
+            Finite lattice containing 3 elements
             sage: P.subposet([])
             Finite poset containing 0 elements
             sage: P.subposet(["a","b","x"])
@@ -6488,7 +6502,7 @@ class FinitePoset(UniqueRepresentation, Parent):
         elms = sorted({self._element_to_vertex(e) for e in elements})
 
         if not elms:
-            return Poset()
+            return Poset(category=category)
 
         relations = []
         lt = [set() for _ in range(elms[-1] + 1)]
@@ -6504,8 +6518,17 @@ class FinitePoset(UniqueRepresentation, Parent):
         if self._is_facade:
             g.relabel(self._vertex_to_element, inplace=True)
         else:
-            g.relabel(lambda v: self._vertex_to_element(v).element, inplace=True)
-        return Poset(g, cover_relations=False, facade=self._is_facade)
+            g.relabel(lambda v: self._vertex_to_element(v).element,
+                      inplace=True)
+
+        if category is not None and category.is_subcategory(LatticePosets()):
+            from sage.combinat.posets.lattices import LatticePoset
+            constructor = LatticePoset
+        else:
+            constructor = Poset
+
+        return constructor(g, cover_relations=False,
+                           facade=self._is_facade, category=category)
 
     def random_subposet(self, p):
         """
@@ -6850,6 +6873,10 @@ class FinitePoset(UniqueRepresentation, Parent):
 
         - ``y`` -- any element of the poset
 
+        .. SEEALSO::
+
+            :meth:`open_interval`
+
         EXAMPLES::
 
             sage: uc = [[1,3,2],[4],[4,5,6],[6],[7],[7],[7],[]]
@@ -6865,38 +6892,27 @@ class FinitePoset(UniqueRepresentation, Parent):
             sage: P = Poset(dg, facade = False)
             sage: P.interval("a","d")
             [a, b, c, d]
-        """
-        return [self._vertex_to_element(w)
-                for w in self._hasse_diagram.interval(
-                    self._element_to_vertex(x), self._element_to_vertex(y))]
 
-    def closed_interval(self, x, y):
-        r"""
-        Return the list of elements `z` such that `x \le z \le y` in the poset.
-
-        EXAMPLES::
+        TESTS::
 
             sage: P = Poset((divisors(1000), attrcall("divides")))
             sage: P.closed_interval(2, 100)
             [2, 4, 10, 20, 50, 100]
 
-        .. SEEALSO::
-
-            :meth:`open_interval`
-
-        TESTS::
-
             sage: C = posets.ChainPoset(10)
-            sage: C.closed_interval(3, 3)
+            sage: C.interval(3, 3)
             [3]
-            sage: C.closed_interval(8, 5)
+            sage: C.interval(8, 5)
             []
             sage: A = posets.AntichainPoset(10)
-            sage: A.closed_interval(3, 7)
+            sage: A.interval(3, 7)
             []
         """
-        return [self._vertex_to_element(_) for _ in self._hasse_diagram.interval(
-                self._element_to_vertex(x), self._element_to_vertex(y))]
+        return [self._vertex_to_element(w)
+                for w in self._hasse_diagram.interval(
+                    self._element_to_vertex(x), self._element_to_vertex(y))]
+
+    closed_interval = interval
 
     def open_interval(self, x, y):
         """
@@ -6910,7 +6926,7 @@ class FinitePoset(UniqueRepresentation, Parent):
 
         .. SEEALSO::
 
-            :meth:`closed_interval`
+            :meth:`interval`
 
         TESTS::
 
@@ -6925,8 +6941,67 @@ class FinitePoset(UniqueRepresentation, Parent):
             sage: A.open_interval(3, 7)
             []
         """
-        return [self._vertex_to_element(_) for _ in self._hasse_diagram.open_interval(
-                self._element_to_vertex(x), self._element_to_vertex(y))]
+        return [self._vertex_to_element(w)
+                for w in self._hasse_diagram.open_interval(
+                    self._element_to_vertex(x), self._element_to_vertex(y))]
+
+    def interval_as_poset(self, x, y):
+        r"""
+        Return the subposet of elements `z` such that `x \le z \le y`.
+
+        INPUT:
+
+        - ``x`` -- any element of the poset
+
+        - ``y`` -- any element of the poset
+
+        .. SEEALSO::
+
+            :meth:`interval`, :meth:`open_interval`, :meth:`subposet`
+
+        This tries to preserve the category if possible. In particular,
+        the output is a lattice when the poset is a lattice.
+
+        EXAMPLES::
+
+            sage: W = Permutations(4)
+            sage: P = W.weak_lattice()
+            sage: Q = P.interval_as_poset(Permutation([1,2,4,3]),P.top()); Q
+            Finite lattice containing 12 elements
+            sage: Q.category()
+            Category of finite enumerated chain graded lattice posets
+
+            sage: P = posets.TamariLattice(4)
+            sage: Q = P.interval_as_poset((1,0,1,1,0,0,1,0,0),P.top()); Q
+            Finite lattice containing 7 elements
+            sage: Q.category()
+            Category of facade finite enumerated trim congruence uniform
+            lattice posets
+
+            sage: P = posets.BooleanLattice(2).order_ideals_lattice()
+            sage: Q = P.interval_as_poset(Set([0]),P.top()); Q
+            Finite lattice containing 5 elements
+            sage: Q.category()
+            Category of facade finite enumerated distributive lattices
+        """
+        S = [self._vertex_to_element(w)
+             for w in self._hasse_diagram.interval(
+                 self._element_to_vertex(x), self._element_to_vertex(y))]
+        old_cat = self.category()
+        Latt = LatticePosets().Finite()
+        if old_cat.is_subcategory(Latt):
+            cat = Latt
+            if old_cat.is_subcategory(Latt.Trim()):
+                cat = cat.Trim()
+            if old_cat.is_subcategory(Latt.CongruenceUniform()):
+                cat = cat.CongruenceUniform()
+            if old_cat.is_subcategory(Latt.ChainGraded()):
+                cat = cat.ChainGraded()
+            if old_cat.is_subcategory(Latt.Distributive()):
+                cat = cat.Distributive()
+        else:
+            cat = FinitePosets()
+        return self.subposet(S, category=cat)
 
     def comparability_graph(self):
         r"""
@@ -8861,7 +8936,7 @@ class FinitePoset(UniqueRepresentation, Parent):
                 y = self.maximal_elements()[0]
             if not self.le(x, y):
                 return q.parent().zero()
-            P = self.subposet(self.interval(x, y))
+            P = self.interval_as_poset(x, y)
             return P.kazhdan_lusztig_polynomial(q=q, canonical_labels=canonical_labels)
 
         min_elt = self.minimal_elements()[0]

--- a/src/sage/tests/finite_poset.py
+++ b/src/sage/tests/finite_poset.py
@@ -13,55 +13,58 @@ from sage.misc.call import attrcall
 from functools import reduce
 
 implications = {
- 'doubling_convex': ['doubling_any'],
- 'doubling_interval': ['doubling_lower', 'doubling_upper'],
- 'doubling_lower': ['doubling_convex', 'meet_semidistributive'],
- 'doubling_upper': ['doubling_convex', 'join_semidistributive'],
- 'cosectionally_complemented': ['complemented', 'coatomic', 'regular'],
- 'distributive': ['modular', 'semidistributive', 'join_distributive', 'meet_distributive', 'subdirectly_reducible', 'doubling_interval', 'extremal'],
- 'geometric': ['upper_semimodular', 'relatively_complemented'],
- 'isoform': ['uniform'],
- 'join_distributive': ['meet_semidistributive', 'upper_semimodular'],
- 'join_semidistributive': ['join_pseudocomplemented', 'interval_dismantlable'],
- 'lower_semimodular': ['graded'],
- 'meet_distributive': ['join_semidistributive', 'lower_semimodular'],
- 'meet_semidistributive': ['pseudocomplemented', 'interval_dismantlable'],
- 'modular': ['upper_semimodular', 'lower_semimodular', 'supersolvable'],
- 'orthocomplemented': ['self_dual', 'complemented'],
- 'planar': ['dismantlable'],
- 'dismantlable': ['sublattice_dismantlable'],
- 'interval_dismantlable': ['sublattice_dismantlable'],
- 'relatively_complemented': ['sectionally_complemented', 'cosectionally_complemented', 'isoform'],
- 'sectionally_complemented': ['complemented', 'atomic', 'regular'],
- 'semidistributive': ['join_semidistributive', 'meet_semidistributive'],
- 'simple': ['isoform'],
- 'supersolvable': ['graded'],
- 'uniform': ['regular'],
- 'uniq_orthocomplemented': ['orthocomplemented'],
- 'upper_semimodular': ['graded'],
- 'vertically_decomposable': ['subdirectly_reducible'],
+    'doubling_convex': ['doubling_any'],
+    'doubling_interval': ['doubling_lower', 'doubling_upper'],
+    'doubling_lower': ['doubling_convex', 'meet_semidistributive'],
+    'doubling_upper': ['doubling_convex', 'join_semidistributive'],
+    'cosectionally_complemented': ['complemented', 'coatomic', 'regular'],
+    'distributive': ['modular', 'semidistributive', 'join_distributive',
+                     'meet_distributive', 'subdirectly_reducible',
+                     'doubling_interval', 'extremal'],
+    'geometric': ['upper_semimodular', 'relatively_complemented'],
+    'isoform': ['uniform'],
+    'join_distributive': ['meet_semidistributive', 'upper_semimodular'],
+    'join_semidistributive': ['join_pseudocomplemented', 'interval_dismantlable'],
+    'lower_semimodular': ['graded'],
+    'meet_distributive': ['join_semidistributive', 'lower_semimodular'],
+    'meet_semidistributive': ['pseudocomplemented', 'interval_dismantlable'],
+    'modular': ['upper_semimodular', 'lower_semimodular', 'supersolvable'],
+    'orthocomplemented': ['self_dual', 'complemented'],
+    'planar': ['dismantlable'],
+    'dismantlable': ['sublattice_dismantlable'],
+    'interval_dismantlable': ['sublattice_dismantlable'],
+    'relatively_complemented': ['sectionally_complemented', 'cosectionally_complemented', 'isoform'],
+    'sectionally_complemented': ['complemented', 'atomic', 'regular'],
+    'semidistributive': ['join_semidistributive', 'meet_semidistributive'],
+    'simple': ['isoform'],
+    'supersolvable': ['graded'],
+    'uniform': ['regular'],
+    'uniq_orthocomplemented': ['orthocomplemented'],
+    'upper_semimodular': ['graded'],
+    'vertically_decomposable': ['subdirectly_reducible'],
 }
 
 dual_properties = [
- ['atomic', 'coatomic'],
- ['upper_semimodular', 'lower_semimodular'],
- ['sectionally_complemented', 'cosectionally_complemented'],
- ['join_distributive', 'meet_distributive'],
- ['join_semidistributive', 'meet_semidistributive'],
- ['pseudocomplemented', 'join_pseudocomplemented'],
- ['doubling_lower', 'doubling_upper'],
+    ['atomic', 'coatomic'],
+    ['upper_semimodular', 'lower_semimodular'],
+    ['sectionally_complemented', 'cosectionally_complemented'],
+    ['join_distributive', 'meet_distributive'],
+    ['join_semidistributive', 'meet_semidistributive'],
+    ['pseudocomplemented', 'join_pseudocomplemented'],
+    ['doubling_lower', 'doubling_upper'],
 ]
 
 selfdual_properties = ['distributive', 'modular', 'semidistributive', 'complemented',
- 'relatively_complemented', 'orthocomplemented', 'uniq_orthocomplemented', 'supersolvable', 'planar',
- 'dismantlable', 'vertically_decomposable', 'simple', 'isoform', 'uniform', 'regular',
- 'subdirectly_reducible', 'doubling_any', 'doubling_convex', 'doubling_interval',
- 'interval_dismantlable', 'interval_dismantlable']
+                       'relatively_complemented', 'orthocomplemented', 'uniq_orthocomplemented',
+                       'supersolvable', 'planar', 'dismantlable', 'vertically_decomposable',
+                       'simple', 'isoform', 'uniform', 'regular', 'subdirectly_reducible',
+                       'doubling_any', 'doubling_convex', 'doubling_interval',
+                       'interval_dismantlable', 'interval_dismantlable']
 
 dual_elements = [
- ['atoms', 'coatoms'],
- ['meet_irreducibles', 'join_irreducibles'],
- ['meet_primes', 'join_primes']
+    ['atoms', 'coatoms'],
+    ['meet_irreducibles', 'join_irreducibles'],
+    ['meet_primes', 'join_primes']
 ]
 
 two_to_one = [
@@ -75,19 +78,19 @@ two_to_one = [
 ]
 
 mutually_exclusive = [
- ['doubling_any', 'simple'],
- ['vertically_decomposable', 'atomic'],
- ['vertically_decomposable', 'coatomic'],
- ['vertically_decomposable', 'regular'],
+    ['doubling_any', 'simple'],
+    ['vertically_decomposable', 'atomic'],
+    ['vertically_decomposable', 'coatomic'],
+    ['vertically_decomposable', 'regular'],
 ]
 
 set_inclusions = [
- ['atoms', 'join_irreducibles'],
- ['coatoms', 'meet_irreducibles'],
- ['double_irreducibles', 'join_irreducibles'],
- ['double_irreducibles', 'meet_irreducibles'],
- ['meet_primes', 'meet_irreducibles'],
- ['join_primes', 'join_irreducibles'],
+    ['atoms', 'join_irreducibles'],
+    ['coatoms', 'meet_irreducibles'],
+    ['double_irreducibles', 'join_irreducibles'],
+    ['double_irreducibles', 'meet_irreducibles'],
+    ['meet_primes', 'meet_irreducibles'],
+    ['join_primes', 'join_irreducibles'],
 ]
 
 sublattice_closed = ['distributive', 'modular', 'semidistributive', 'join_semidistributive', 'meet_semidistributive']
@@ -171,7 +174,7 @@ def check_finite_lattice(L):
     all_props = set(list(implications) + flatten(implications.values()))
     P = {x: check_attrcall('is_' + x, L) for x in all_props}
 
-    ### Relations between boolean-valued properties ###
+    # ### Relations between boolean-valued properties ###
 
     # Direct one-property implications
     for prop1 in implications:
@@ -203,7 +206,7 @@ def check_finite_lattice(L):
         if set(attrcall(e1)(L)) != set(attrcall(e2)(Ldual)):
             raise ValueError("dual elements error %s" % e1)
 
-    ### Certificates ###
+    # ### Certificates ###
 
     # Return value must be a pair with correct result as first element.
     for p_ in all_props:
@@ -257,14 +260,14 @@ def check_finite_lattice(L):
             raise ValueError("compl. error 1")
     if not P['sectionally_complemented']:
         a, b = L.is_sectionally_complemented(certificate=True)[1]
-        L_ = L.sublattice(L.interval(L.bottom(), a))
+        L_ = L.interval_as_poset(L.bottom(), a)
         if L_.is_complemented():
             raise ValueError("sec. compl. error 1")
         if len(L_.complements(b)) > 0:
             raise ValueError("sec. compl. error 2")
     if not P['cosectionally_complemented']:
         a, b = L.is_cosectionally_complemented(certificate=True)[1]
-        L_ = L.sublattice(L.interval(a, L.top()))
+        L_ = L.interval_as_poset(a, L.top())
         if L_.is_complemented():
             raise ValueError("cosec. compl. error 1")
         if L_.complements(b):
@@ -354,16 +357,16 @@ def check_finite_lattice(L):
 
     if not P['join_distributive']:
         a = L.is_join_distributive(certificate=True)[1]
-        L_ = L.sublattice(L.interval(a, L.join(L.upper_covers(a))))
+        L_ = L.interval_as_poset(a, L.join(L.upper_covers(a)))
         if L_.is_distributive():
             raise ValueError("certificate error in is_join_distributive")
     if not P['meet_distributive']:
         a = L.is_meet_distributive(certificate=True)[1]
-        L_ = L.sublattice(L.interval(L.meet(L.lower_covers(a)), a))
+        L_ = L.interval_as_poset(L.meet(L.lower_covers(a)), a)
         if L_.is_distributive():
             raise ValueError("certificate error in is_meet_distributive")
 
-    ### Other ###
+    # ### Other ###
 
     # Other ways to recognize some boolean property
     if P['distributive'] != (set(L.join_primes()) == set(L.join_irreducibles())):
@@ -514,11 +517,13 @@ def check_finite_poset(P):
         raise ValueError("error 1 in dimension")
     if dim1 != len(linexts):
         raise ValueError("error 2 in dimension")
-    P_ = Poset( (P.list(), lambda a, b: all(linext.index(a) < linext.index(b) for linext in linexts)) )
+    P_ = Poset((P.list(),
+                lambda a, b: all(linext.index(a) < linext.index(b) for linext in linexts)))
     if P_ != Poset(P.hasse_diagram()):
         raise ValueError("error 3 in dimension")
     x = [P.random_linear_extension() for _ in range(dim1-1)]
-    P_ = Poset( (P.list(), lambda a, b: all(linext.index(a) < linext.index(b) for linext in x)) )
+    P_ = Poset((P.list(),
+                lambda a, b: all(linext.index(a) < linext.index(b) for linext in x)))
     if P_ == Poset(P.hasse_diagram()):
         raise ValueError("error 4 in dimension")
     if dim1-P_one_less.dimension() < 0:


### PR DESCRIPTION
This is introducing the very convenient possibility to do `P.interval_as_poset(a,b)` for a poset P and two comparable elements.

The former way was `P.subposet(P.interval(a,b))`.

The new method has the advantage to be able to inherit at least partially the category.

I have also made `closed_interval` just an alias. 

I have used `interval_as_poset` in a few places in sage code base.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.


