### PR TITLE
Accelerate dense matrix LU decomposition with native backends

### DIFF
--- a/src/sage/libs/linbox/fflas.pxd
+++ b/src/sage/libs/linbox/fflas.pxd
@@ -32,6 +32,14 @@ cdef extern from "fflas-ffpack/fflas-ffpack.h" namespace "FFLAS":
         FflasLeft
         FflasRight
 
+    ctypedef enum FFLAS_UPLO:
+        FflasUpper
+        FflasLower
+
+    ctypedef enum FFLAS_DIAG:
+        FflasNonUnit
+        FflasUnit
+
     # double
     Modular_double.Element* fgemv (Modular_double F, FFLAS_TRANSPOSE transA,
              size_t nrows, size_t ncols,
@@ -82,6 +90,7 @@ cdef extern from "fflas-ffpack/fflas-ffpack.h" namespace "FFLAS":
 
 cdef extern from "fflas-ffpack/fflas-ffpack.h" namespace "FFPACK":
     ctypedef enum FFPACK_LU_TAG:
+        FfpackSlabRecursive
         FfpackTileRecursive
 
     void RankProfileFromLU (size_t* P, size_t N, size_t R,
@@ -90,6 +99,8 @@ cdef extern from "fflas-ffpack/fflas-ffpack.h" namespace "FFPACK":
     void PLUQtoEchelonPermutation (size_t N, size_t R, size_t * P, size_t * outPerm)
 
     void MathPerm2LAPACKPerm (size_t * LapackP, size_t * MathP, size_t N)
+
+    void LAPACKPerm2MathPerm (size_t * MathP, const size_t * LapackP, size_t N)
 
     # double
     bint IsSingular (Modular_double F,
@@ -112,6 +123,21 @@ cdef extern from "fflas-ffpack/fflas-ffpack.h" namespace "FFPACK":
     int pRank (Modular_double,
               size_t nrows, size_t ncols,
               Modular_double.Element *A, size_t lda, size_t numthreads)
+
+    size_t LUdivine (Modular_double F, FFLAS_DIAG Diag, FFLAS_TRANSPOSE trans,
+                     size_t nrows, size_t ncols, Modular_double.Element* A,
+                     size_t lda, size_t* P, size_t* Q)
+
+    void getTriangular (Modular_double F, FFLAS_UPLO Uplo, FFLAS_DIAG Diag,
+                        size_t nrows, size_t ncols, size_t rank,
+                        const Modular_double.Element* A, size_t lda,
+                        Modular_double.Element* T, size_t ldt,
+                        bool only_nonzero)
+
+    void getEchelonForm (Modular_double F, FFLAS_UPLO Uplo, FFLAS_DIAG Diag,
+                         size_t nrows, size_t ncols, size_t rank,
+                         const size_t* Q, Modular_double.Element* A, size_t lda,
+                         FFPACK_LU_TAG LuTag)
 
     size_t ReducedRowEchelonForm (Modular_double F, size_t a, size_t b,
                                   Modular_double.Element* matrix,
@@ -169,6 +195,21 @@ cdef extern from "fflas-ffpack/fflas-ffpack.h" namespace "FFPACK":
     int pRank (Modular_float,
               size_t nrows, size_t ncols,
               Modular_float.Element *A, size_t lda, size_t numthreads)
+
+    size_t LUdivine (Modular_float F, FFLAS_DIAG Diag, FFLAS_TRANSPOSE trans,
+                     size_t nrows, size_t ncols, Modular_float.Element* A,
+                     size_t lda, size_t* P, size_t* Q)
+
+    void getTriangular (Modular_float F, FFLAS_UPLO Uplo, FFLAS_DIAG Diag,
+                        size_t nrows, size_t ncols, size_t rank,
+                        const Modular_float.Element* A, size_t lda,
+                        Modular_float.Element* T, size_t ldt,
+                        bool only_nonzero)
+
+    void getEchelonForm (Modular_float F, FFLAS_UPLO Uplo, FFLAS_DIAG Diag,
+                         size_t nrows, size_t ncols, size_t rank,
+                         const size_t* Q, Modular_float.Element* A, size_t lda,
+                         FFPACK_LU_TAG LuTag)
 
     size_t ReducedRowEchelonForm (Modular_float F, size_t a, size_t b,
                                   Modular_float.Element* matrix,

--- a/src/sage/libs/linbox/fflas.pxd
+++ b/src/sage/libs/linbox/fflas.pxd
@@ -32,12 +32,7 @@ cdef extern from "fflas-ffpack/fflas-ffpack.h" namespace "FFLAS":
         FflasLeft
         FflasRight
 
-    ctypedef enum FFLAS_UPLO:
-        FflasUpper
-        FflasLower
-
     ctypedef enum FFLAS_DIAG:
-        FflasNonUnit
         FflasUnit
 
     # double
@@ -90,7 +85,6 @@ cdef extern from "fflas-ffpack/fflas-ffpack.h" namespace "FFLAS":
 
 cdef extern from "fflas-ffpack/fflas-ffpack.h" namespace "FFPACK":
     ctypedef enum FFPACK_LU_TAG:
-        FfpackSlabRecursive
         FfpackTileRecursive
 
     void RankProfileFromLU (size_t* P, size_t N, size_t R,
@@ -127,17 +121,6 @@ cdef extern from "fflas-ffpack/fflas-ffpack.h" namespace "FFPACK":
     size_t LUdivine (Modular_double F, FFLAS_DIAG Diag, FFLAS_TRANSPOSE trans,
                      size_t nrows, size_t ncols, Modular_double.Element* A,
                      size_t lda, size_t* P, size_t* Q)
-
-    void getTriangular (Modular_double F, FFLAS_UPLO Uplo, FFLAS_DIAG Diag,
-                        size_t nrows, size_t ncols, size_t rank,
-                        const Modular_double.Element* A, size_t lda,
-                        Modular_double.Element* T, size_t ldt,
-                        bool only_nonzero)
-
-    void getEchelonForm (Modular_double F, FFLAS_UPLO Uplo, FFLAS_DIAG Diag,
-                         size_t nrows, size_t ncols, size_t rank,
-                         const size_t* Q, Modular_double.Element* A, size_t lda,
-                         FFPACK_LU_TAG LuTag)
 
     size_t ReducedRowEchelonForm (Modular_double F, size_t a, size_t b,
                                   Modular_double.Element* matrix,
@@ -199,17 +182,6 @@ cdef extern from "fflas-ffpack/fflas-ffpack.h" namespace "FFPACK":
     size_t LUdivine (Modular_float F, FFLAS_DIAG Diag, FFLAS_TRANSPOSE trans,
                      size_t nrows, size_t ncols, Modular_float.Element* A,
                      size_t lda, size_t* P, size_t* Q)
-
-    void getTriangular (Modular_float F, FFLAS_UPLO Uplo, FFLAS_DIAG Diag,
-                        size_t nrows, size_t ncols, size_t rank,
-                        const Modular_float.Element* A, size_t lda,
-                        Modular_float.Element* T, size_t ldt,
-                        bool only_nonzero)
-
-    void getEchelonForm (Modular_float F, FFLAS_UPLO Uplo, FFLAS_DIAG Diag,
-                         size_t nrows, size_t ncols, size_t rank,
-                         const size_t* Q, Modular_float.Element* A, size_t lda,
-                         FFPACK_LU_TAG LuTag)
 
     size_t ReducedRowEchelonForm (Modular_float F, size_t a, size_t b,
                                   Modular_float.Element* matrix,

--- a/src/sage/libs/m4rie.pxd
+++ b/src/sage/libs/m4rie.pxd
@@ -16,8 +16,8 @@ cdef extern from "m4rie/m4rie.h":
         m4ri_word *pow_gen
         m4ri_word *red
 
-        m4ri_word (*inv)(gf2e *ff, m4ri_word a)
-        m4ri_word (*mul)(gf2e *ff, m4ri_word a, m4ri_word b)
+        m4ri_word (*inv)(const gf2e *ff, m4ri_word a)
+        m4ri_word (*mul)(const gf2e *ff, m4ri_word a, m4ri_word b)
 
     gf2e *gf2e_init(m4ri_word minpoly)
     void gf2e_free(gf2e *ff)
@@ -25,7 +25,7 @@ cdef extern from "m4rie/m4rie.h":
 # cdef extern from "m4rie/mzed.h":
     ctypedef struct mzed_t:
         mzd_t *x
-        gf2e *finite_field
+        const gf2e *finite_field
         int nrows
         int ncols
         int w
@@ -34,7 +34,7 @@ cdef extern from "m4rie/m4rie.h":
     ctypedef size_t const_size_t "const size_t"
     ctypedef mzed_t const_mzed_t "const mzed_t"
 
-    mzed_t *mzed_init(gf2e *, size_t m, size_t n)
+    mzed_t *mzed_init(const gf2e *, size_t m, size_t n)
 
     void mzed_free(mzed_t *)
 

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -14102,6 +14102,18 @@ cdef class Matrix(Matrix1):
         # Take A = PLDL^{*}P^{T} and simply invert.
         return P*L_inv.conjugate_transpose()*D.inverse()*L_inv*P.transpose()
 
+    def _lu_nonzero_compact(self):
+        r"""
+        Return a backend-specific compact LU decomposition, if available.
+
+        Subclasses can override this method to return ``(perm, M)`` in the
+        same format as ``self.LU(pivot='nonzero', format='compact')``.  The
+        public :meth:`LU` method handles validation, caching, immutability,
+        and conversion to ``(P, L, U)``.  Returning ``None`` selects the
+        generic implementation.
+        """
+        return None
+
     def LU(self, pivot=None, format='plu'):
         r"""
         Finds a decomposition into a lower-triangular matrix and
@@ -14529,42 +14541,47 @@ cdef class Matrix(Matrix1):
         key = 'LU_' + pivot
         compact = self.fetch(key)
         if compact is None:
-            if F == R:
-                M = self.__copy__()
-            else:
-                M = self.change_ring(F)
-            m, n = M._nrows, M._ncols
-            d = min(m, n)
-            perm = list(range(m))
-            zero = F(0)
-            for k in range(d):
-                max_location = -1
-                if partial:
-                    # abs() necessary to convert zero to the
-                    # correct type for comparisons (Issue #12208)
-                    max_entry = abs(zero)
-                    for i in range(k, m):
-                        entry = abs(M.get_unsafe(i, k))
-                        if entry > max_entry:
-                            max_location = i
-                            max_entry = entry
+            if not partial and F == R:
+                compact = self._lu_nonzero_compact()
+            if compact is None:
+                if F == R:
+                    M = self.__copy__()
                 else:
-                    for i in range(k, m):
-                        if M.get_unsafe(i, k) != zero:
-                            max_location = i
-                            break
-                if max_location != -1:
-                    perm[k], perm[max_location] = perm[max_location], perm[k]
-                    M.swap_rows(k, max_location)
-                    inv = M.get_unsafe(k, k).inverse()
-                    for j in range(k+1, m):
-                        scale = -M.get_unsafe(j, k) * inv
-                        M.set_unsafe(j, k, -scale)
-                        for p in range(k+1, n):
-                            M.set_unsafe(j, p, M.get_unsafe(j, p) + scale*M.get_unsafe(k, p))
-            perm = tuple(perm)
+                    M = self.change_ring(F)
+                m, n = M._nrows, M._ncols
+                d = min(m, n)
+                perm = list(range(m))
+                zero = F(0)
+                for k in range(d):
+                    max_location = -1
+                    if partial:
+                        # abs() necessary to convert zero to the
+                        # correct type for comparisons (Issue #12208)
+                        max_entry = abs(zero)
+                        for i in range(k, m):
+                            entry = abs(M.get_unsafe(i, k))
+                            if entry > max_entry:
+                                max_location = i
+                                max_entry = entry
+                    else:
+                        for i in range(k, m):
+                            if M.get_unsafe(i, k) != zero:
+                                max_location = i
+                                break
+                    if max_location != -1:
+                        perm[k], perm[max_location] = perm[max_location], perm[k]
+                        M.swap_rows(k, max_location)
+                        inv = M.get_unsafe(k, k).inverse()
+                        for j in range(k+1, m):
+                            scale = -M.get_unsafe(j, k) * inv
+                            M.set_unsafe(j, k, -scale)
+                            for p in range(k+1, n):
+                                M.set_unsafe(j, p, M.get_unsafe(j, p) + scale*M.get_unsafe(k, p))
+                compact = (tuple(perm), M)
+            else:
+                perm, M = compact
+                compact = (tuple(perm), M)
             M.set_immutable()
-            compact = (perm, M)
             self.cache(key, compact)
 
         if format == 'compact':

--- a/src/sage/matrix/matrix2.pyx
+++ b/src/sage/matrix/matrix2.pyx
@@ -14497,6 +14497,24 @@ cdef class Matrix(Matrix1):
             sage: P, L, U = M.LU()
             sage: P.base_ring()
             Finite Field of size 11
+
+        Splitting the compact factors preserves the cache and works for
+        sparse matrices and rectangular, rank-deficient matrices::
+
+            sage: for R in (QQ, GF(2), GF(9, 'a'), GF(101)):
+            ....:     for sparse in (False, True):
+            ....:         A = matrix(R, [[0, 1, 0, 1], [0, 0, 0, 1],
+            ....:                        [0, 1, 0, 1]], sparse=sparse)
+            ....:         compact = A.LU(format='compact')
+            ....:         P, L, U = A.LU()
+            ....:         assert A == P * L * U
+            ....:         assert all(B.is_mutable() for B in (P, L, U))
+            ....:         assert compact[1].is_immutable()
+            ....:         L[2, 0] += 1
+            ....:         U[0, 1] += 1
+            ....:         assert A.LU(format='compact') is compact
+            ....:         P, L, U = A.LU()
+            ....:         assert A == P * L * U
         """
         if pivot not in [None, 'partial', 'nonzero']:
             msg = "pivot strategy must be None, 'partial' or 'nonzero', not {0}"
@@ -14534,7 +14552,7 @@ cdef class Matrix(Matrix1):
         partial = (pivot == 'partial')
 
         cdef Py_ssize_t m, n, d, i, j, k, p, max_location
-        cdef Matrix M
+        cdef Matrix M, L
 
         # can now access cache, else compute
         #   the compact version of LU decomposition
@@ -14599,9 +14617,10 @@ cdef class Matrix(Matrix1):
             P = P.change_ring(F)
             L = M.matrix_space(m, m).identity_matrix().__copy__()
             for i in range(1, m):
+                sig_check()
                 for k in range(min(i, d)):
-                    L[i, k] = M[i, k]
-                    M[i, k] = zero
+                    L.set_unsafe(i, k, M.get_unsafe(i, k))
+                    M.set_unsafe(i, k, zero)
             return P, L, M
 
     def _indefinite_factorization(self, algorithm, check=True):

--- a/src/sage/matrix/matrix_gf2e_dense.pyx
+++ b/src/sage/matrix/matrix_gf2e_dense.pyx
@@ -97,7 +97,7 @@ from sage.matrix.matrix_mod2_dense cimport Matrix_mod2_dense
 from sage.matrix.args cimport SparseEntry, MatrixArgs_init
 from sage.matrix.matrix_utils cimport check_matrix_multiplication_sizes
 
-from sage.libs.m4ri cimport m4ri_word, mzd_copy, mzp_t, mzp_init, mzp_free
+from sage.libs.m4ri cimport m4ri_word, mzd_copy, mzp_t, mzp_init, mzp_free, rci_t
 from sage.libs.m4rie cimport *
 from sage.libs.m4rie cimport mzed_t
 
@@ -139,8 +139,9 @@ cdef m4ri_word poly_to_word(f) except? -1:
     propagated::
 
         sage: from sage.doctest.util import ensure_interruptible_after
+        sage: A = MatrixSpace(GF(2^8), 2^10).random_element()
         sage: with ensure_interruptible_after(0.5):
-        ....:     MatrixSpace(GF(2^8), 2^9).random_element().LU()
+        ....:     A.echelonize(algorithm='builtin')
     """
     return f.to_integer()
 
@@ -800,6 +801,79 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
 
         return A
 
+    def _lu_nonzero_compact(self):
+        r"""
+        Return a compact PLE decomposition using M4RIE.
+
+        TESTS::
+
+            sage: K.<a> = GF(2^4)
+            sage: A = matrix(K, [[0, a, 1, a + 1], [0, a^2, a, 1],
+            ....:                [0, 0, 0, a], [1, a + 1, 0, 1]])
+            sage: P, L, U = A.LU()
+            sage: A == P * L * U
+            True
+            sage: L.is_triangular('lower') and U.is_triangular('upper')
+            True
+
+        The native factorization remains interruptible::
+
+            sage: from sage.doctest.util import ensure_interruptible_after
+            sage: A = MatrixSpace(GF(2^15), 2^10).random_element()
+            sage: with ensure_interruptible_after(0.5):
+            ....:     A.LU()
+        """
+        cdef rci_t i, j, pivot
+        cdef int rank
+        cdef rci_t nrows = self._nrows
+        cdef rci_t ncols = self._ncols
+        cdef m4ri_word diagonal, inverse, value
+        cdef const gf2e *ff
+        cdef Matrix_gf2e_dense B = self.__copy__()
+        cdef Matrix_gf2e_dense M = self.__copy__()
+        cdef mzp_t *P = NULL
+        cdef mzp_t *Q = NULL
+
+        if nrows == 0 or ncols == 0:
+            return tuple(range(nrows)), M
+
+        mzed_set_ui(M._entries, 0)
+        P = mzp_init(nrows)
+        Q = mzp_init(ncols)
+        try:
+            sig_on()
+            try:
+                rank = mzed_ple(B._entries, P, Q)
+            finally:
+                sig_off()
+
+            perm = list(range(nrows))
+            for i in range(nrows):
+                j = P.values[i]
+                perm[i], perm[j] = perm[j], perm[i]
+
+            ff = B._entries.finite_field
+            for j in range(rank):
+                diagonal = mzed_read_elem(B._entries, j, j)
+                inverse = ff.inv(ff, diagonal)
+                for i in range(j + 1, nrows):
+                    value = ff.mul(ff, mzed_read_elem(B._entries, i, j), inverse)
+                    if value:
+                        mzed_write_elem(M._entries, i, j, value)
+
+                pivot = Q.values[j]
+                mzed_write_elem(M._entries, j, pivot, diagonal)
+                for i in range(pivot + 1, ncols):
+                    value = ff.mul(ff, diagonal, mzed_read_elem(B._entries, j, i))
+                    if value:
+                        mzed_write_elem(M._entries, j, i, value)
+        finally:
+            mzp_free(P)
+            mzp_free(Q)
+
+        self.cache('rank', rank)
+        return tuple(perm), M
+
     def __bool__(self):
         """
         Return if ``self`` is a zero matrix or not.
@@ -1029,6 +1103,7 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
             return self
 
         cdef int full
+        cdef size_t r = 0
 
         full = int(reduced)
 
@@ -1060,7 +1135,7 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
             sig_off()
 
         elif algorithm == 'builtin':
-            self._echelon_in_place(algorithm='classical')
+            r = len(self._echelon_in_place(algorithm='classical'))
 
         else:
             raise ValueError("No algorithm '%s'." % algorithm)

--- a/src/sage/matrix/matrix_gf2e_dense.pyx
+++ b/src/sage/matrix/matrix_gf2e_dense.pyx
@@ -81,7 +81,7 @@ REFERENCES:
 #                  https://www.gnu.org/licenses/
 #*****************************************************************************
 
-from cysignals.signals cimport sig_on, sig_off
+from cysignals.signals cimport sig_on, sig_off, sig_check
 
 cimport sage.matrix.matrix_dense as matrix_dense
 from sage.structure.element cimport Matrix
@@ -97,7 +97,8 @@ from sage.matrix.matrix_mod2_dense cimport Matrix_mod2_dense
 from sage.matrix.args cimport SparseEntry, MatrixArgs_init
 from sage.matrix.matrix_utils cimport check_matrix_multiplication_sizes
 
-from sage.libs.m4ri cimport m4ri_word, mzd_copy, mzp_t, mzp_init, mzp_free, rci_t
+from sage.libs.m4ri cimport (m4ri_word, m4ri_radix, mzd_copy, mzd_clear_bits,
+                           mzp_t, mzp_init, mzp_free, rci_t)
 from sage.libs.m4rie cimport *
 from sage.libs.m4rie cimport mzed_t
 
@@ -816,6 +817,25 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
             sage: L.is_triangular('lower') and U.is_triangular('upper')
             True
 
+        Check diagonal normalization and skipped pivots across machine words
+        for several packed field widths, including rank-deficient tall and
+        wide matrices::
+
+            sage: for e in (2, 4, 8, 16):
+            ....:     K = GF(2^e, 'a')
+            ....:     a = K.gen()
+            ....:     A = matrix(K, 4, 67, {(0, 1): a, (0, 65): a + 1,
+            ....:                          (1, 65): a^2, (2, 1): a^2,
+            ....:                          (2, 65): a^2 + a}, sparse=False)
+            ....:     for B in (A, A.transpose(), matrix(K, 2, 1, [a, a]),
+            ....:               zero_matrix(K, 3, 4)):
+            ....:         P, L, U = B.LU()
+            ....:         assert B == P * L * U
+            ....:         assert L.is_triangular('lower')
+            ....:         assert all(U[i, j] == 0 for i in range(U.nrows())
+            ....:                    for j in range(min(i, U.ncols())))
+            ....:     assert A.rank() == 2
+
         The native factorization remains interruptible::
 
             sage: from sage.doctest.util import ensure_interruptible_after
@@ -825,19 +845,18 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
         """
         cdef rci_t i, j, pivot
         cdef int rank
+        cdef Py_ssize_t bit, start, stop
         cdef rci_t nrows = self._nrows
         cdef rci_t ncols = self._ncols
         cdef m4ri_word diagonal, inverse, value
         cdef const gf2e *ff
         cdef Matrix_gf2e_dense B = self.__copy__()
-        cdef Matrix_gf2e_dense M = self.__copy__()
         cdef mzp_t *P = NULL
         cdef mzp_t *Q = NULL
 
         if nrows == 0 or ncols == 0:
-            return tuple(range(nrows)), M
+            return tuple(range(nrows)), B
 
-        mzed_set_ui(M._entries, 0)
         P = mzp_init(nrows)
         Q = mzp_init(ncols)
         try:
@@ -849,30 +868,44 @@ cdef class Matrix_gf2e_dense(matrix_dense.Matrix_dense):
 
             perm = list(range(nrows))
             for i in range(nrows):
+                sig_check()
                 j = P.values[i]
                 perm[i], perm[j] = perm[j], perm[i]
 
+            # M4RIE stores the diagonal in L and normalizes the pivots of E.
+            # Move that diagonal into U and normalize L in place.
             ff = B._entries.finite_field
             for j in range(rank):
+                sig_check()
                 diagonal = mzed_read_elem(B._entries, j, j)
-                inverse = ff.inv(ff, diagonal)
-                for i in range(j + 1, nrows):
-                    value = ff.mul(ff, mzed_read_elem(B._entries, i, j), inverse)
-                    if value:
-                        mzed_write_elem(M._entries, i, j, value)
-
                 pivot = Q.values[j]
-                mzed_write_elem(M._entries, j, pivot, diagonal)
-                for i in range(pivot + 1, ncols):
-                    value = ff.mul(ff, diagonal, mzed_read_elem(B._entries, j, i))
-                    if value:
-                        mzed_write_elem(M._entries, j, i, value)
+                if diagonal != 1:
+                    inverse = ff.inv(ff, diagonal)
+                    for i in range(j + 1, nrows):
+                        value = mzed_read_elem(B._entries, i, j)
+                        if value:
+                            mzed_write_elem(B._entries, i, j, ff.mul(ff, value, inverse))
+                    if pivot + 1 < ncols:
+                        mzed_rescale_row(B._entries, j, pivot + 1, diagonal)
+
+                start = <Py_ssize_t>j * B._entries.w
+                stop = <Py_ssize_t>pivot * B._entries.w
+                for bit in range(start, stop, m4ri_radix):
+                    mzd_clear_bits(B._entries.x, j, bit, min(m4ri_radix, stop - bit))
+                mzed_write_elem(B._entries, j, pivot, diagonal)
+
+            start = <Py_ssize_t>rank * B._entries.w
+            stop = B._entries.x.ncols
+            for i in range(rank, nrows):
+                sig_check()
+                for bit in range(start, stop, m4ri_radix):
+                    mzd_clear_bits(B._entries.x, i, bit, min(m4ri_radix, stop - bit))
         finally:
             mzp_free(P)
             mzp_free(Q)
 
         self.cache('rank', rank)
-        return tuple(perm), M
+        return tuple(perm), B
 
     def __bool__(self):
         """

--- a/src/sage/matrix/matrix_mod2_dense.pyx
+++ b/src/sage/matrix/matrix_mod2_dense.pyx
@@ -1185,6 +1185,66 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
 
         return A
 
+    def _lu_nonzero_compact(self):
+        r"""
+        Return a compact PLE decomposition using M4RI.
+
+        TESTS::
+
+            sage: A = matrix(GF(2), [[0, 1, 0, 1], [0, 1, 1, 1],
+            ....:                    [0, 0, 0, 1], [0, 1, 1, 0]])
+            sage: P, L, U = A.LU()
+            sage: A == P * L * U
+            True
+            sage: L.is_triangular('lower') and U.is_triangular('upper')
+            True
+        """
+        cdef Py_ssize_t i, j
+        cdef long rank
+        cdef rci_t pivot
+        cdef Py_ssize_t nrows = self._nrows
+        cdef Py_ssize_t ncols = self._ncols
+        cdef Matrix_mod2_dense B = self.__copy__()
+        cdef Matrix_mod2_dense M = self.__copy__()
+        cdef mzp_t *P = NULL
+        cdef mzp_t *Q = NULL
+
+        if nrows == 0 or ncols == 0:
+            return tuple(range(nrows)), M
+
+        mzd_set_ui(M._entries, 0)
+        P = mzp_init(nrows)
+        Q = mzp_init(ncols)
+        try:
+            sig_on()
+            try:
+                rank = mzd_ple(B._entries, P, Q, 0)
+            finally:
+                sig_off()
+
+            perm = list(range(nrows))
+            for i in range(nrows):
+                j = P.values[i]
+                perm[i], perm[j] = perm[j], perm[i]
+
+            for j in range(rank):
+                for i in range(j + 1, nrows):
+                    if mzd_read_bit(B._entries, i, j):
+                        mzd_write_bit(M._entries, i, j, 1)
+
+            for i in range(rank):
+                pivot = Q.values[i]
+                mzd_write_bit(M._entries, i, pivot, 1)
+                for j in range(pivot + 1, ncols):
+                    if mzd_read_bit(B._entries, i, j):
+                        mzd_write_bit(M._entries, i, j, 1)
+        finally:
+            mzp_free(P)
+            mzp_free(Q)
+
+        self.cache('rank', rank)
+        return tuple(perm), M
+
     def _list(self):
         """
         Return list of the elements of ``self`` in row major

--- a/src/sage/matrix/matrix_mod2_dense.pyx
+++ b/src/sage/matrix/matrix_mod2_dense.pyx
@@ -105,7 +105,7 @@ TESTS::
 # ****************************************************************************
 
 from cysignals.memory cimport check_malloc, sig_free
-from cysignals.signals cimport sig_on, sig_str, sig_off
+from cysignals.signals cimport sig_on, sig_str, sig_off, sig_check
 
 cimport sage.matrix.matrix_dense as matrix_dense
 from sage.matrix.args cimport SparseEntry, MatrixArgs_init, MA_ENTRIES_NDARRAY
@@ -1209,6 +1209,23 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
             True
             sage: L.is_triangular('lower') and U.is_triangular('upper')
             True
+
+        Rank-deficient rectangular matrices can have pivots separated by
+        more than one machine word.  Preserve the lower factor when clearing
+        the remaining entries of the zero rows::
+
+            sage: A = matrix(GF(2), 4, 67,
+            ....:            {(0, 1): 1, (0, 65): 1, (1, 65): 1, (2, 1): 1},
+            ....:            sparse=False)
+            sage: for B in (A, A.transpose(), matrix(GF(2), 2, 1, [1, 1]),
+            ....:           zero_matrix(GF(2), 3, 4)):
+            ....:     P, L, U = B.LU()
+            ....:     assert B == P * L * U
+            ....:     assert L.is_triangular('lower')
+            ....:     assert all(U[i, j] == 0 for i in range(U.nrows())
+            ....:                for j in range(min(i, U.ncols())))
+            sage: A.rank()
+            2
         """
         cdef Py_ssize_t i, j
         cdef long rank
@@ -1216,14 +1233,12 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
         cdef Py_ssize_t nrows = self._nrows
         cdef Py_ssize_t ncols = self._ncols
         cdef Matrix_mod2_dense B = self.__copy__()
-        cdef Matrix_mod2_dense M = self.__copy__()
         cdef mzp_t *P = NULL
         cdef mzp_t *Q = NULL
 
         if nrows == 0 or ncols == 0:
-            return tuple(range(nrows)), M
+            return tuple(range(nrows)), B
 
-        mzd_set_ui(M._entries, 0)
         P = mzp_init(nrows)
         Q = mzp_init(ncols)
         try:
@@ -1235,26 +1250,30 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
 
             perm = list(range(nrows))
             for i in range(nrows):
+                sig_check()
                 j = P.values[i]
                 perm[i], perm[j] = perm[j], perm[i]
 
-            for j in range(rank):
-                for i in range(j + 1, nrows):
-                    if mzd_read_bit(B._entries, i, j):
-                        mzd_write_bit(M._entries, i, j, 1)
-
+            # PLE already stores the lower factor in its final position.
+            # Clear the displaced diagonal and restore each echelon pivot.
             for i in range(rank):
+                sig_check()
                 pivot = Q.values[i]
-                mzd_write_bit(M._entries, i, pivot, 1)
-                for j in range(pivot + 1, ncols):
-                    if mzd_read_bit(B._entries, i, j):
-                        mzd_write_bit(M._entries, i, j, 1)
+                for j in range(i, pivot, m4ri_radix):
+                    mzd_clear_bits(B._entries, i, j, min(m4ri_radix, pivot - j))
+                mzd_write_bit(B._entries, i, pivot, 1)
+
+            # Rows below the rank contain only the rank-column lower factor.
+            for i in range(rank, nrows):
+                sig_check()
+                for j in range(rank, ncols, m4ri_radix):
+                    mzd_clear_bits(B._entries, i, j, min(m4ri_radix, ncols - j))
         finally:
             mzp_free(P)
             mzp_free(Q)
 
         self.cache('rank', rank)
-        return tuple(perm), M
+        return tuple(perm), B
 
     def _list(self):
         """

--- a/src/sage/matrix/matrix_mod2_dense.pyx
+++ b/src/sage/matrix/matrix_mod2_dense.pyx
@@ -1196,6 +1196,66 @@ cdef class Matrix_mod2_dense(matrix_dense.Matrix_dense):   # dense or sparse
 
         return A
 
+    def _lu_nonzero_compact(self):
+        r"""
+        Return a compact PLE decomposition using M4RI.
+
+        TESTS::
+
+            sage: A = matrix(GF(2), [[0, 1, 0, 1], [0, 1, 1, 1],
+            ....:                    [0, 0, 0, 1], [0, 1, 1, 0]])
+            sage: P, L, U = A.LU()
+            sage: A == P * L * U
+            True
+            sage: L.is_triangular('lower') and U.is_triangular('upper')
+            True
+        """
+        cdef Py_ssize_t i, j
+        cdef long rank
+        cdef rci_t pivot
+        cdef Py_ssize_t nrows = self._nrows
+        cdef Py_ssize_t ncols = self._ncols
+        cdef Matrix_mod2_dense B = self.__copy__()
+        cdef Matrix_mod2_dense M = self.__copy__()
+        cdef mzp_t *P = NULL
+        cdef mzp_t *Q = NULL
+
+        if nrows == 0 or ncols == 0:
+            return tuple(range(nrows)), M
+
+        mzd_set_ui(M._entries, 0)
+        P = mzp_init(nrows)
+        Q = mzp_init(ncols)
+        try:
+            sig_on()
+            try:
+                rank = mzd_ple(B._entries, P, Q, 0)
+            finally:
+                sig_off()
+
+            perm = list(range(nrows))
+            for i in range(nrows):
+                j = P.values[i]
+                perm[i], perm[j] = perm[j], perm[i]
+
+            for j in range(rank):
+                for i in range(j + 1, nrows):
+                    if mzd_read_bit(B._entries, i, j):
+                        mzd_write_bit(M._entries, i, j, 1)
+
+            for i in range(rank):
+                pivot = Q.values[i]
+                mzd_write_bit(M._entries, i, pivot, 1)
+                for j in range(pivot + 1, ncols):
+                    if mzd_read_bit(B._entries, i, j):
+                        mzd_write_bit(M._entries, i, j, 1)
+        finally:
+            mzp_free(P)
+            mzp_free(Q)
+
+        self.cache('rank', rank)
+        return tuple(perm), M
+
     def _list(self):
         """
         Return list of the elements of ``self`` in row major

--- a/src/sage/matrix/matrix_modn_dense_flint.pyx
+++ b/src/sage/matrix/matrix_modn_dense_flint.pyx
@@ -27,6 +27,7 @@ AUTHORS:
 import sys
 
 from cpython.sequence cimport *
+from cysignals.memory cimport check_allocarray, sig_free
 from cysignals.signals cimport sig_on, sig_str, sig_off
 from libc.string cimport memcpy
 
@@ -346,6 +347,49 @@ cdef class Matrix_modn_dense_flint(Matrix_dense):
         nmod_mat_set(M._matrix, self._matrix)
         sig_off()
         return M
+
+    def _lu_nonzero_compact(self):
+        r"""
+        Return a compact LU decomposition using FLINT.
+
+        TESTS::
+
+            sage: A = matrix(GF(7), [[0, 1, 2], [1, 2, 3], [1, 2, 3]],
+            ....:            implementation='flint')
+            sage: P, L, U = A.LU()
+            sage: A == P * L * U
+            True
+            sage: L.is_triangular('lower') and all(L[i, i] == 1 for i in range(3))
+            True
+            sage: U.is_triangular('upper')
+            True
+        """
+        if not self._parent._base.is_field():
+            return None
+
+        cdef Py_ssize_t i
+        cdef slong rank
+        cdef slong *P
+        cdef Matrix_modn_dense_flint M = self.__copy__()
+        cdef Py_ssize_t nrows = self._nrows
+        cdef Py_ssize_t ncols = self._ncols
+
+        if nrows == 0 or ncols == 0:
+            return tuple(range(nrows)), M
+
+        P = <slong *>check_allocarray(nrows, sizeof(slong))
+        try:
+            sig_on()
+            try:
+                rank = nmod_mat_lu(P, M._matrix, 0)
+            finally:
+                sig_off()
+            perm = tuple(P[i] for i in range(nrows))
+        finally:
+            sig_free(P)
+
+        self.cache('rank', Integer(rank))
+        return perm, M
 
     def __neg__(self):
         r"""
@@ -944,7 +988,7 @@ cdef class Matrix_modn_dense_flint(Matrix_dense):
             [9223372036854775800]
         """
         cdef Py_ssize_t i, j, m = self._nrows, n = self._ncols
-        cdef mp_limb_t x, preN, preshift, N = modulus
+        cdef mp_limb_t x, preN, preshift = 0, N = modulus
         preN = n_preinvert_limb(N)
         if not mul:
             preshift = n_preinvert_limb(shift)

--- a/src/sage/matrix/matrix_modn_dense_flint.pyx
+++ b/src/sage/matrix/matrix_modn_dense_flint.pyx
@@ -27,6 +27,7 @@ AUTHORS:
 import sys
 
 from cpython.sequence cimport *
+from cysignals.memory cimport check_allocarray, sig_free
 from cysignals.signals cimport sig_on, sig_str, sig_off
 from libc.string cimport memcpy
 
@@ -346,6 +347,49 @@ cdef class Matrix_modn_dense_flint(Matrix_dense):
         nmod_mat_set(M._matrix, self._matrix)
         sig_off()
         return M
+
+    def _lu_nonzero_compact(self):
+        r"""
+        Return a compact LU decomposition using FLINT.
+
+        TESTS::
+
+            sage: A = matrix(GF(7), [[0, 1, 2], [1, 2, 3], [1, 2, 3]],
+            ....:            implementation='flint')
+            sage: P, L, U = A.LU()
+            sage: A == P * L * U
+            True
+            sage: L.is_triangular('lower') and all(L[i, i] == 1 for i in range(3))
+            True
+            sage: U.is_triangular('upper')
+            True
+        """
+        if not self._parent._base.is_field():
+            return None
+
+        cdef Py_ssize_t i
+        cdef slong rank
+        cdef slong *P
+        cdef Matrix_modn_dense_flint M = self.__copy__()
+        cdef Py_ssize_t nrows = self._nrows
+        cdef Py_ssize_t ncols = self._ncols
+
+        if nrows == 0 or ncols == 0:
+            return tuple(range(nrows)), M
+
+        P = <slong *>check_allocarray(nrows, sizeof(slong))
+        try:
+            sig_on()
+            try:
+                rank = nmod_mat_lu(P, M._matrix, 0)
+            finally:
+                sig_off()
+            perm = tuple(P[i] for i in range(nrows))
+        finally:
+            sig_free(P)
+
+        self.cache('rank', Integer(rank))
+        return perm, M
 
     def __neg__(self):
         r"""

--- a/src/sage/matrix/matrix_modn_dense_template.pxi
+++ b/src/sage/matrix/matrix_modn_dense_template.pxi
@@ -94,8 +94,11 @@ from cysignals.signals cimport sig_check, sig_on, sig_off
 
 from sage.libs.gmp.mpz cimport *
 from sage.libs.linbox.fflas cimport FFLAS_TRANSPOSE, FflasNoTrans, FflasTrans, \
-    FfpackTileRecursive, FflasLeft, FflasRight, vector, list as std_list, \
-    RankProfileFromLU, PLUQtoEchelonPermutation, MathPerm2LAPACKPerm
+    FFLAS_UPLO, FflasUpper, FflasLower, FFLAS_DIAG, FflasNonUnit, FflasUnit, \
+    FfpackSlabRecursive, FfpackTileRecursive, FflasLeft, FflasRight, vector, \
+    list as std_list, RankProfileFromLU, PLUQtoEchelonPermutation, \
+    MathPerm2LAPACKPerm, LAPACKPerm2MathPerm, LUdivine, getTriangular, \
+    getEchelonForm
 
 from libcpp cimport bool
 from sage.parallel.parallelism import Parallelism
@@ -404,7 +407,7 @@ cdef inline linbox_minpoly(celement modulus, Py_ssize_t nrows, celement* entries
     """
     Compute the minimal polynomial.
     """
-    cdef Py_ssize_t i
+    cdef size_t i
     cdef ModField *F = new ModField(<long>modulus)
     cdef vector[ModField.Element] *minP = new vector[ModField.Element]()
 
@@ -423,7 +426,7 @@ cdef inline linbox_charpoly(celement modulus, Py_ssize_t nrows, celement* entrie
     """
     Compute the characteristic  polynomial.
     """
-    cdef Py_ssize_t i
+    cdef size_t i
     cdef ModField *F = new ModField(<long>modulus)
     cdef ModDensePolyRing * R = new ModDensePolyRing(F[0])
     cdef ModDensePoly  P
@@ -949,6 +952,82 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
         if self._subdivisions is not None:
             A.subdivide(*self.subdivisions())
         return A
+
+    def _lu_nonzero_compact(self):
+        r"""
+        Return a compact PLE decomposition using FFLAS-FFPACK.
+
+        TESTS::
+
+            sage: for p in (7, 1048583):
+            ....:     A = matrix(GF(p), [[0, 1, 2], [1, 2, 3], [1, 2, 3]],
+            ....:                implementation='linbox')
+            ....:     P, L, U = A.LU()
+            ....:     assert A == P * L * U
+            ....:     assert all(L[i, i] == 1 for i in range(3))
+        """
+        if self.p <= 2 or not is_prime(self.p):
+            return None
+
+        cdef size_t i, j, rank
+        cdef size_t nrows = self._nrows
+        cdef size_t ncols = self._ncols
+        cdef vector[size_t] P
+        cdef vector[size_t] Q
+        cdef vector[size_t] math_perm
+        cdef vector[celement] lower
+        cdef ModField *F
+        cdef Matrix_modn_dense_template M = self.__copy__()
+
+        if nrows == 0 or ncols == 0:
+            return tuple(range(nrows)), M
+
+        P.resize(nrows)
+        Q.resize(ncols)
+        math_perm.resize(nrows)
+        for i in range(nrows):
+            P[i] = i
+            math_perm[i] = i
+        for j in range(ncols):
+            Q[j] = j
+
+        F = new ModField(<long>self.p)
+        try:
+            sig_on()
+            try:
+                rank = LUdivine(F[0], FflasUnit, FflasTrans,
+                                 nrows, ncols, <ModField.Element *>M._entries,
+                                 ncols, &P[0], &Q[0])
+            finally:
+                sig_off()
+
+            if rank:
+                lower.resize(nrows * rank)
+                sig_on()
+                try:
+                    getTriangular(F[0], FflasLower, FflasUnit,
+                                  nrows, ncols, rank,
+                                  <ModField.Element *>M._entries, ncols,
+                                  <ModField.Element *>&lower[0], rank, True)
+                    getEchelonForm(F[0], FflasUpper, FflasNonUnit,
+                                   nrows, ncols, rank, &Q[0],
+                                   <ModField.Element *>M._entries, ncols,
+                                   FfpackSlabRecursive)
+                finally:
+                    sig_off()
+        finally:
+            del F
+
+        for i in range(nrows):
+            for j in range(min(i, rank)):
+                M._entries[i * ncols + j] = lower[i * rank + j]
+
+        for i in range(rank, nrows):
+            P[i] = i
+        LAPACKPerm2MathPerm(&math_perm[0], &P[0], nrows)
+
+        self.cache('rank', Integer(rank))
+        return tuple(math_perm[i] for i in range(nrows)), M
 
     cpdef _add_(self, right):
         r"""
@@ -2068,7 +2147,7 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
                     start_row = start_row + 1
                     break
         self.cache('pivots', tuple(pivots))
-        self.cache('pivot_rows', tuple(range(r)))
+        self.cache('pivot_rows', tuple(range(start_row)))
         self.cache('in_echelon_form', True)
 
     def pivots(self) -> tuple:

--- a/src/sage/matrix/matrix_modn_dense_template.pxi
+++ b/src/sage/matrix/matrix_modn_dense_template.pxi
@@ -94,11 +94,9 @@ from cysignals.signals cimport sig_check, sig_on, sig_off
 
 from sage.libs.gmp.mpz cimport *
 from sage.libs.linbox.fflas cimport FFLAS_TRANSPOSE, FflasNoTrans, FflasTrans, \
-    FFLAS_UPLO, FflasUpper, FflasLower, FFLAS_DIAG, FflasNonUnit, FflasUnit, \
-    FfpackSlabRecursive, FfpackTileRecursive, FflasLeft, FflasRight, vector, \
+    FflasUnit, FfpackTileRecursive, FflasLeft, FflasRight, vector, \
     list as std_list, RankProfileFromLU, PLUQtoEchelonPermutation, \
-    MathPerm2LAPACKPerm, LAPACKPerm2MathPerm, LUdivine, getTriangular, \
-    getEchelonForm
+    MathPerm2LAPACKPerm, LAPACKPerm2MathPerm, LUdivine
 
 from libcpp cimport bool
 from sage.parallel.parallelism import Parallelism
@@ -965,6 +963,34 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
             ....:     P, L, U = A.LU()
             ....:     assert A == P * L * U
             ....:     assert all(L[i, i] == 1 for i in range(3))
+
+        Preserve the lower factor when the echelon form skips columns,
+        including rectangular matrices of deficient rank::
+
+            sage: examples = (
+            ....:     [[0, 0, 1, 2], [0, 0, 2, 4], [0, 0, 3, 6]],
+            ....:     [[0, 1, 2], [0, 2, 4], [0, 0, 1], [0, 0, 2]],
+            ....:     [[0, 1, 0, 2, 3], [0, 2, 0, 4, 6], [0, 0, 0, 1, 2]])
+            sage: for p in (7, 1048583):
+            ....:     for entries, rank in zip(examples, (1, 2, 2)):
+            ....:         A = matrix(GF(p), entries, implementation='linbox')
+            ....:         P, L, U = A.LU()
+            ....:         assert A == P * L * U
+            ....:         assert A.rank() == rank
+            ....:         assert all(L[i, i] == 1 for i in range(A.nrows()))
+            ....:         assert all(U[i, j] == 0
+            ....:                    for i in range(A.nrows())
+            ....:                    for j in range(min(i, A.ncols())))
+
+        Empty and zero matrices also have a compact decomposition::
+
+            sage: for p in (7, 1048583):
+            ....:     for m, n in ((0, 0), (0, 3), (3, 0), (3, 4)):
+            ....:         A = matrix(GF(p), m, n, implementation='linbox')
+            ....:         perm, M = A.LU(format='compact')
+            ....:         assert perm == tuple(range(m)) and M == A
+            ....:         P, L, U = A.LU()
+            ....:         assert A == P * L * U
         """
         if self.p <= 2 or not is_prime(self.p):
             return None
@@ -975,7 +1001,6 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
         cdef vector[size_t] P
         cdef vector[size_t] Q
         cdef vector[size_t] math_perm
-        cdef vector[celement] lower
         cdef ModField *F
         cdef Matrix_modn_dense_template M = self.__copy__()
 
@@ -987,7 +1012,6 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
         math_perm.resize(nrows)
         for i in range(nrows):
             P[i] = i
-            math_perm[i] = i
         for j in range(ncols):
             Q[j] = j
 
@@ -1000,29 +1024,26 @@ cdef class Matrix_modn_dense_template(Matrix_dense):
                                  ncols, &P[0], &Q[0])
             finally:
                 sig_off()
-
-            if rank:
-                lower.resize(nrows * rank)
-                sig_on()
-                try:
-                    getTriangular(F[0], FflasLower, FflasUnit,
-                                  nrows, ncols, rank,
-                                  <ModField.Element *>M._entries, ncols,
-                                  <ModField.Element *>&lower[0], rank, True)
-                    getEchelonForm(F[0], FflasUpper, FflasNonUnit,
-                                   nrows, ncols, rank, &Q[0],
-                                   <ModField.Element *>M._entries, ncols,
-                                   FfpackSlabRecursive)
-                finally:
-                    sig_off()
         finally:
             del F
 
-        for i in range(nrows):
-            for j in range(min(i, rank)):
-                M._entries[i * ncols + j] = lower[i * rank + j]
+        # LUdivine already stores L below the diagonal.  Keep those entries
+        # and clear only the gaps before the pivots and the trailing zero
+        # block of the echelon form.  A rank-zero matrix is already zero.
+        if rank:
+            for i in range(rank):
+                sig_check()
+                if Q[i] > i:
+                    memset(M._entries + i * ncols + i, 0,
+                           (Q[i] - i) * sizeof(celement))
+            if rank < ncols:
+                for i in range(rank, nrows):
+                    sig_check()
+                    memset(M._entries + i * ncols + rank, 0,
+                           (ncols - rank) * sizeof(celement))
 
         for i in range(rank, nrows):
+            sig_check()
             P[i] = i
         LAPACKPerm2MathPerm(&math_perm[0], &P[0], nrows)
 


### PR DESCRIPTION
### Description

Accelerate dense finite-field `Matrix.LU()` with native FLINT, FFLAS-FFPACK, M4RI, and M4RIE decompositions. The public API continues to return `A = P * L * U`, caches an immutable compact factorization, and returns fresh mutable `P`, `L`, and `U` matrices.

The implementation:

- adds a private backend hook while keeping validation, pivot-strategy options, and caching in the common `Matrix.LU()` implementation;
- uses `nmod_mat_lu` for FLINT matrices over prime fields;
- uses FFLAS-FFPACK `LUdivine` for float- and double-modulus matrices, retaining the lower factor in place and clearing only the required pivot gaps and trailing zero blocks;
- converts M4RI/M4RIE PLE results in place, reconstructs the row permutation, and normalizes M4RIE factors to Sage's unit-lower-triangular convention;
- uses typed Cython element access when expanding compact factors into `P`, `L`, and `U`, and checks for interrupts during conversion;
- preserves the existing generic implementation and validation paths for unsupported cases.

Fixes #40791.

### Benchmarks

Remeasured on 2026-09-12 at `96eccb363911`. The generic baseline is the pre-PR parent `7ea6fe54adc8`; the follow-up comparison uses the initial PR commit `0c2b2293f327`. All six affected Cython extensions were rebuilt from each revision with the same compiler and optimization flags, using the same installed dependencies.

Environment: Intel Core i7-14650HX, x86-64 Linux under WSL2, Python 3.12.13, GCC 14.3.0 (effective `-O2`), FLINT 3.5.0, FFLAS-FFPACK 2.5.0, M4RI/M4RIE 20250128, and OpenBLAS 0.3.33. Workers were pinned to the same logical CPU; BLAS, OpenMP, and LinBox parallelism were set to one.

Each entry is the median of **seven measured calls after two warm-up calls**, in **seconds**; speedup ratios use the unrounded medians. The revisions use identical saved matrix entries, with field polynomials, matrix implementations, SHA-256 hashes, and actual ranks checked before measurement. Version order rotates between rounds, and only one worker computes at a time. Before every call, the matrix cache is cleared and checked to be empty. Only `A.LU(format=...)` is timed; input construction, cache clearing, result release, full reconstruction, and input-integrity checks are outside the timer. All **414 calls** (92 warm-up and 322 measured) passed full reconstruction and input-integrity checks.

**Generic backend versus the current PR**

| Backend and input | Compact: generic → current | Speedup | PLU: generic → current | Speedup |
|---|---:|---:|---:|---:|
| FFLAS float, GF(7), random, 400 x 200 | 0.22569 → 0.00219411 | 102.86x | 0.238328 → 0.00393558 | 60.56x |
| FFLAS double, GF(1048583), random, 400 x 200 | 1.09269 → 0.0132688 | 82.35x | 1.09437 → 0.0171508 | 63.81x |
| FFLAS double, GF(1048583), rank 100, 400 x 200 | 0.868756 → 0.00906862 | 95.80x | 0.882169 → 0.0126357 | 69.82x |
| FLINT, GF(7), random, 400 x 200 | 0.750894 → 0.002704 | 277.70x | 0.770556 → 0.00745107 | 103.42x |
| M4RI, GF(2), random, 256 x 192 | 0.172885 → 0.000160455 | 1077.47x | 0.180271 → 0.00196555 | 91.72x |
| M4RIE, GF(2^8), random, 300 x 200 | 0.984833 → 0.00214608 | 458.90x | 1.00347 → 0.0122145 | 82.15x |
| M4RIE, GF(2^15), random, 240 x 180 | 1.15979 → 0.0962193 | 12.05x | 1.17506 → 0.102996 | 11.41x |

<details>
<summary>Follow-up optimization: initial PR versus current PR</summary>

The following isolates the additional factor-conversion optimizations. The two larger matrices were measured only in compact format and only for the native implementations; no generic-backend result is implied for those rows.

| Backend and input | Compact: initial → current | Speedup | PLU: initial → current | Speedup |
|---|---:|---:|---:|---:|
| FFLAS float, GF(7), random, 400 x 200 | 0.00217298 → 0.00219411 | 0.99x | 0.013962 → 0.00393558 | 3.55x |
| FFLAS double, GF(1048583), random, 400 x 200 | 0.0138442 → 0.0132688 | 1.04x | 0.0276068 → 0.0171508 | 1.61x |
| FFLAS double, GF(1048583), rank 100, 400 x 200 | 0.00888511 → 0.00906862 | 0.98x | 0.0231406 → 0.0126357 | 1.83x |
| FLINT, GF(7), random, 400 x 200 | 0.00263824 → 0.002704 | 0.98x | 0.0176316 → 0.00745107 | 2.37x |
| M4RI, GF(2), random, 256 x 192 | 0.000469504 → 0.000160455 | 2.93x | 0.00707775 → 0.00196555 | 3.60x |
| M4RIE, GF(2^8), random, 300 x 200 | 0.00229007 → 0.00214608 | 1.07x | 0.0197393 → 0.0122145 | 1.62x |
| M4RIE, GF(2^15), random, 240 x 180 | 0.0972336 → 0.0962193 | 1.01x | 0.107728 → 0.102996 | 1.05x |
| M4RI, GF(2), random, rank 4094, 4096 x 4096 | 0.142254 → 0.0236031 | 6.03x | not measured | — |
| FFLAS double, GF(1048583), random, 2048 x 2048 | 0.847905 → 0.787291 | 1.08x | not measured | — |

</details>

All samples, including occasional timing outliers, are retained. The small changes around 1x in the follow-up table should not be interpreted as established improvements or regressions.

These are measurements on one machine and fixed inputs, rather than guarantees for every shape, rank, field, or hardware configuration.

### Testing

- Recompiled all six affected Cython extensions with `-Werror`; the current implementation compiles without warnings.
- Passed **5,004 doctests** across `matrix2.pyx`, the five backend `.pyx` files, and `matrix_modn_dense_template.pxi`.
- Passed **540 API/property cases** covering reconstruction, rank, compact-cache reuse, mutable/immutable outputs, and cache invalidation after matrix mutation.
- Passed **11,431 independent adversarial cases**: exhaustive small GF(2)/GF(4) matrices, packed-word boundaries, extension degrees 2 through 16, prime-modulus boundaries, empty/tall/wide/rank-deficient matrices, generic and sparse fallbacks, and cached/subdivided inputs. The initial PR and current implementation agree on all checked permutations, compact entries, PLU entries, and subdivisions.
- Verified large-matrix interruption and recovery; the former GF(2) conversion stall is eliminated. An additional extreme single-row stress test hit the local process memory limit before conversion and is not counted as passed.
- Completed an independent code-simplification review with no remaining requested changes.

Local validation uses the rebuilt affected extensions with the installed Sage dependency environment; the full GitHub CI build remains a separate check.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview. (No rendered documentation is affected.)

### :hourglass: Dependencies

None.
