### PR TITLE
Add change_ring to elements of modules with basis

### DIFF
--- a/src/sage/categories/modules_with_basis.py
+++ b/src/sage/categories/modules_with_basis.py
@@ -2415,6 +2415,46 @@ class ModulesWithBasis(CategoryWithAxiom_over_base_ring):
             """
             return self.parent().term(*self.trailing_item(*args, **kwds))
 
+        def change_ring(self, R):
+            r"""
+            Return this element with its coefficients converted to ``R``.
+
+            INPUT:
+
+            - ``R`` -- the new base ring
+
+            EXAMPLES::
+
+                sage: F = CombinatorialFreeModule(QQ, ['a', 'b'])
+                sage: B = F.basis()
+                sage: x = B['a'] + 2*B['b']
+                sage: y = x.change_ring(ZZ)
+                sage: y
+                B['a'] + 2*B['b']
+                sage: y.parent().base_ring()
+                Integer Ring
+
+            If the base ring is unchanged, return the same element::
+
+                sage: x.change_ring(QQ) is x
+                True
+
+            Coefficients that become zero are removed::
+
+                sage: (7*B['a'] + B['b']).change_ring(GF(7))                            # needs sage.rings.finite_rings
+                B['b']
+
+            The coefficients must be convertible to the new base ring::
+
+                sage: (1/2*B['a']).change_ring(ZZ)
+                Traceback (most recent call last):
+                ...
+                TypeError: no conversion of this rational to integer
+            """
+            if R is self.base_ring():
+                return self
+            return self.map_coefficients(lambda c: c, new_base_ring=R)
+
         def map_coefficients(self, f, new_base_ring=None):
             """
             Return the element obtained by applying ``f`` to the nonzero

--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -1390,9 +1390,9 @@ class DominatingAction(Action):
             sage: p = SymmetricFunctions(ZZ).p()
             sage: y = g * p[1]; y
             FESDUMMY_0*p[1]
-            sage: y.parent().base_ring()
+            sage: y.parent()
             Symmetric Functions over CoefficientRing over Integer Ring in the powersum basis
-            sage: (p[2] * g).parent().base_ring()
+            sage: y.parent().base_ring()
             CoefficientRing over Integer Ring
 
         This includes tensor products that appear in multisort plethysm ::

--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -1383,6 +1383,24 @@ class DominatingAction(Action):
             Univariate Polynomial Ring in a over
              Fraction Field of Infinite polynomial ring in FESDUMMY over
              Univariate Polynomial Ring in b over Univariate Polynomial Ring in t over Integer Ring
+
+        Elements of modules with basis are moved over to the larger coefficient ring so that undetermined
+        coefficients can be operated with symmetric functions::
+
+            sage: p = SymmetricFunctions(ZZ).p()
+            sage: y = g * p[1]; y
+            FESDUMMY_0*p[1]
+            sage: y.parent().base_ring()
+            Symmetric Functions over CoefficientRing over Integer Ring in the powersum basis
+            sage: (p[2] * g).parent().base_ring()
+            CoefficientRing over Integer Ring
+
+        This includes tensor products that appear in multisort plethysm ::
+
+            sage: p2 = tensor([p, p])
+            sage: y = g * tensor([p[1], p[2]])
+            sage: y.parent().base_ring()
+            CoefficientRing over Integer Ring
         """
         G = g.parent()
         if x in G.base_ring():


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

This pr adds a `change_ring` method to elements of modules with basis. It returns the corresponding element over a new base ring by coercing the coefficients while preserving the basis. This allows sage’s generic scalar operations to extend symmetric-function elements to `CoefficientRing` used by implicit solvers.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ x] The title is concise and informative.
- [ x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ x] I have created tests covering the changes.
- [x ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


