### PR TITLE
Fix coercion and repr for one-fold tensor products

### DIFF
--- a/src/sage/categories/tensor.py
+++ b/src/sage/categories/tensor.py
@@ -42,6 +42,33 @@ class TensorProductFunctor(CovariantFunctorialConstruction):
     of ``Algebras(QQ)``. This nested class is itself a subclass of
     :class:`~sage.categories.tensor.TensorProductsCategory`.
 
+    A one-fold tensor product is deliberately kept distinct from its sole
+    factor.  In particular, its basis is indexed by singleton tuples.  This
+    lets code that constructs tensor products from lists treat every positive
+    arity uniformly::
+
+        sage: # needs sage.modules
+        sage: F = CombinatorialFreeModule(QQ, ['a', 'b'], prefix='F')
+        sage: F.rename('F')
+        sage: T = tensor([F]); T
+        tensor([F])
+        sage: T is F
+        False
+        sage: F.basis().keys().list()
+        ['a', 'b']
+        sage: T.basis().keys().list()
+        [('a',), ('b',)]
+
+    For modules with basis using the standard tensor product implementation,
+    there is a canonical coercion from a one-fold tensor product to its factor,
+    so elements can be used without manually removing the singleton tuples::
+
+        sage: # needs sage.modules
+        sage: x = F.monomial('a') + 2 * F.monomial('b')
+        sage: tx = tensor([x]); tx
+        tensor([F['a']]) + 2*tensor([F['b']])
+        sage: F(tx) == x
+        True
 
     TESTS::
 

--- a/src/sage/combinat/free_module.py
+++ b/src/sage/combinat/free_module.py
@@ -1384,18 +1384,90 @@ class CombinatorialFreeModule_Tensor(CombinatorialFreeModule):
 
             sage: F = CombinatorialFreeModule(ZZ, [1,2]); F
             F
+
+        A one-fold tensor product canonically coerces to its factor, while
+        remaining a distinct parent (:issue:`41704`)::
+
+            sage: F.rename('F')
+            sage: T = tensor([F])
+            sage: F.has_coerce_map_from(T)
+            True
+            sage: x = F.monomial(1) + 2 * F.monomial(2)
+            sage: F(tensor([x])) == x
+            True
+            sage: T.has_coerce_map_from(F)
+            False
+            sage: F(tensor([F.zero()]))
+            0
+
+        Tensor products with more than one factor do not coerce to a single
+        factor::
+
+            sage: F.has_coerce_map_from(tensor([F, F]))
+            False
+
+        Coercions from the factor compose with this one::
+
+            sage: # needs sage.combinat
+            sage: Sym = SymmetricFunctions(QQ)
+            sage: p = Sym.powersum()
+            sage: s = Sym.schur()
+            sage: t = tensor([p[2]])
+            sage: p(t)
+            p[2]
+            sage: s(t)
+            -s[1, 1] + s[2]
+            sage: p[2] * t, t * p[2]
+            (p[2, 2], p[2, 2])
+
+        Registration on construction also handles factors that override
+        coercion discovery::
+
+            sage: # needs sage.combinat
+            sage: A.<x, y> = FreeAlgebra(QQ)
+            sage: A(tensor([x + y])) == x + y
+            True
+
+        This includes parents for which ``tensor`` selects a signed tensor
+        product category::
+
+            sage: # needs sage.combinat
+            sage: A = SteenrodAlgebra(2)
+            sage: a = A.an_element()
+            sage: A(tensor([a])) == a
+            True
         """
         self._sets = modules
         indices = CartesianProduct_iters(*[module.basis().keys()
                                            for module in modules]).map(tuple, is_injective=True)
         CombinatorialFreeModule.__init__(self, modules[0].base_ring(), indices, **options)
+        if len(modules) == 1:
+            self.module_morphism(
+                on_basis=self._onefold_to_factor_on_basis,
+                codomain=modules[0],
+            ).register_as_coercion()
         # the following is not the best option, but it's better than nothing.
         if 'tensor_symbol' in options:
             self._print_options['tensor_symbol'] = options['tensor_symbol']
 
+    def _onefold_to_factor_on_basis(self, key):
+        """
+        Return the image of the basis element indexed by ``key`` under the
+        canonical map from a one-fold tensor product to its factor.
+
+        TESTS::
+
+            sage: F = CombinatorialFreeModule(ZZ, [1,2]); F.rename('F')
+            sage: T = tensor([F])
+            sage: loads(dumps(F.coerce_map_from(T)))(T.monomial((2,)))
+            B[2]
+        """
+        return self._sets[0].monomial(key[0])
+
     def _repr_(self):
         r"""
-        This is customizable by setting
+        For tensor products with at least two factors, the separator is
+        customizable by setting
         ``self.print_options('tensor_symbol'=...)``.
 
         TESTS::
@@ -1414,7 +1486,15 @@ class CombinatorialFreeModule_Tensor(CombinatorialFreeModule):
         To avoid a side\--effect on another doctest, we revert the change::
 
             sage: T.print_options(tensor_symbol=' # ')
+
+        A one-fold tensor product is displayed explicitly, rather than like
+        its sole factor (:issue:`18349`)::
+
+            sage: T = tensor([F]); T
+            tensor([F])
         """
+        if len(self._sets) == 1:
+            return f"tensor([{self._sets[0]}])"
         from sage.categories.tensor import tensor
         if hasattr(self, "_print_options"):
             symb = self._print_options['tensor_symbol']
@@ -1529,7 +1609,15 @@ class CombinatorialFreeModule_Tensor(CombinatorialFreeModule):
             sage: g = 2*G.monomial(3) +     G.monomial(4)
             sage: tensor([f, g]) # indirect doctest
             2*F[1] # G[3] + F[1] # G[4] + 4*F[2] # G[3] + 2*F[2] # G[4]
+
+        The representation of an element of a one-fold tensor product keeps
+        the tensor structure visible::
+
+            sage: tensor([f])
+            tensor([F[1]]) + 2*tensor([F[2]])
         """
+        if len(self._sets) == 1:
+            return f"tensor([{self._sets[0]._repr_term(term[0])}])"
         if hasattr(self, "_print_options"):
             symb = self._print_options['tensor_symbol']
             if symb is None:

--- a/src/sage/homology/hochschild_complex.py
+++ b/src/sage/homology/hochschild_complex.py
@@ -174,7 +174,7 @@ class HochschildComplex(UniqueRepresentation, Parent):
             sage: T = SGA.trivial_representation()
             sage: H = SGA.hochschild_complex(T)
             sage: H.module(0)
-            Trivial representation of Standard permutations of 3 over Rational Field
+            tensor([Trivial representation of Standard permutations of 3 over Rational Field])
             sage: H.module(1)
             Trivial representation of Standard permutations of 3 over Rational Field
              # Symmetric group algebra of order 3 over Rational Field
@@ -296,7 +296,7 @@ class HochschildComplex(UniqueRepresentation, Parent):
             sage: H = E.hochschild_complex(E)
             sage: del1 = H.coboundary(1)
             sage: z = del1.domain().an_element(); z
-            2 + 2*x + 3*y
+            2*tensor([1]) + 2*tensor([x]) + 3*tensor([y])
             sage: del1(z)
             0
             sage: del1.matrix()
@@ -468,11 +468,11 @@ class HochschildComplex(UniqueRepresentation, Parent):
             sage: H(0)
             Trivial chain
             sage: H(2)
-            Chain(0: 2)
+            Chain(0: 2*tensor([1]))
             sage: H(x+2*y)
-            Chain(0: x + 2*y)
+            Chain(0: tensor([x]) + 2*tensor([y]))
             sage: H({0: H.module(0).an_element()})
-            Chain(0: 2 + 2*x + 3*y)
+            Chain(0: 2*tensor([1]) + 2*tensor([x]) + 3*tensor([y]))
             sage: H({2: H.module(2).an_element()})
             Chain(2: 2*1 # 1 # 1 + 2*1 # 1 # x + 3*1 # 1 # y)
             sage: H({0:x-y, 2: H.module(2).an_element()})
@@ -522,7 +522,7 @@ class HochschildComplex(UniqueRepresentation, Parent):
             sage: H = F.hochschild_complex(F)
             sage: v = H.an_element()
             sage: [v.vector(i) for i in range(6)]
-            [2*F[1] + 2*F[x] + 3*F[y],
+            [2*tensor([F[1]]) + 2*tensor([F[x]]) + 3*tensor([F[y]]),
              2*F[1] # F[1] + 2*F[1] # F[x] + 3*F[1] # F[y],
              2*F[1] # F[1] # F[1] + 2*F[1] # F[1] # F[x] + 3*F[1] # F[1] # F[y],
              2*F[1] # F[1] # F[1] # F[1] + 2*F[1] # F[1] # F[1] # F[x]
@@ -551,9 +551,9 @@ class HochschildComplex(UniqueRepresentation, Parent):
             sage: T = SGA.trivial_representation()
             sage: H = SGA.hochschild_complex(T)
             sage: H(T.an_element())
-            Chain(0: 2*B['v'])
+            Chain(0: 2*tensor([B['v']]))
             sage: H({0: T.an_element()})
-            Chain(0: 2*B['v'])
+            Chain(0: 2*tensor([B['v']]))
             sage: H({1: H.module(1).an_element()})
             Chain(1: 2*B['v'] # [1, 2, 3] + 2*B['v'] # [1, 3, 2] + 3*B['v'] # [2, 1, 3])
             sage: H({0: H.module(0).an_element(), 3: H.module(3).an_element()})
@@ -562,11 +562,11 @@ class HochschildComplex(UniqueRepresentation, Parent):
             sage: F.<x,y> = FreeAlgebra(ZZ)
             sage: H = F.hochschild_complex(F)
             sage: H(x + 2*y^2)
-            Chain(0: F[x] + 2*F[y^2])
+            Chain(0: tensor([F[x]]) + 2*tensor([F[y^2]]))
             sage: H({0: x*y - x})
-            Chain(0: -F[x] + F[x*y])
+            Chain(0: -tensor([F[x]]) + tensor([F[x*y]]))
             sage: H(2)
-            Chain(0: 2*F[1])
+            Chain(0: 2*tensor([F[1]]))
             sage: H({0: x-y, 2: H.module(2).basis().an_element()})
             Chain with 2 nonzero terms over Integer Ring
         """
@@ -594,7 +594,7 @@ class HochschildComplex(UniqueRepresentation, Parent):
                 sage: H = F.hochschild_complex(F)
                 sage: a = H({0: x-y, 2: H.module(2).basis().an_element()})
                 sage: [a.vector(i) for i in range(3)]
-                [F[x] - F[y], 0, F[1] # F[1] # F[1]]
+                [tensor([F[x]]) - tensor([F[y]]), 0, F[1] # F[1] # F[1]]
             """
             try:
                 return self._vec[degree]
@@ -612,7 +612,7 @@ class HochschildComplex(UniqueRepresentation, Parent):
                 sage: H(0)
                 Trivial chain
                 sage: H(x+2*y)
-                Chain(0: x + 2*y)
+                Chain(0: tensor([x]) + 2*tensor([y]))
                 sage: H({2: H.module(2).an_element()})
                 Chain(2: 2*1 # 1 # 1 + 2*1 # 1 # x + 3*1 # 1 # y)
                 sage: H({0:x-y, 2: H.module(2).an_element()})
@@ -678,15 +678,15 @@ class HochschildComplex(UniqueRepresentation, Parent):
                 ....:        1: H.module(1).basis().an_element(),
                 ....:        2: H.module(2).basis().an_element()})
                 sage: [a.vector(i) for i in range(3)]
-                [F[x] - F[y], F[1] # F[1], F[1] # F[1] # F[1]]
+                [tensor([F[x]]) - tensor([F[y]]), F[1] # F[1], F[1] # F[1] # F[1]]
                 sage: [H.an_element().vector(i) for i in range(3)]
-                [2*F[1] + 2*F[x] + 3*F[y],
+                [2*tensor([F[1]]) + 2*tensor([F[x]]) + 3*tensor([F[y]]),
                  2*F[1] # F[1] + 2*F[1] # F[x] + 3*F[1] # F[y],
                  2*F[1] # F[1] # F[1] + 2*F[1] # F[1] # F[x] + 3*F[1] # F[1] # F[y]]
 
                 sage: v = a + H.an_element()
                 sage: [v.vector(i) for i in range(3)]
-                [2*F[1] + 3*F[x] + 2*F[y],
+                [2*tensor([F[1]]) + 3*tensor([F[x]]) + 2*tensor([F[y]]),
                  3*F[1] # F[1] + 2*F[1] # F[x] + 3*F[1] # F[y],
                  3*F[1] # F[1] # F[1] + 2*F[1] # F[1] # F[x] + 3*F[1] # F[1] # F[y]]
             """
@@ -714,7 +714,7 @@ class HochschildComplex(UniqueRepresentation, Parent):
                 ....:        2: H.module(2).basis().an_element()})
                 sage: v = 3*a
                 sage: [v.vector(i) for i in range(3)]
-                [3*F[x] - 3*F[y], 3*F[1] # F[1], 3*F[1] # F[1] # F[1]]
+                [3*tensor([F[x]]) - 3*tensor([F[y]]), 3*F[1] # F[1], 3*F[1] # F[1] # F[1]]
             """
             if scalar == 0:
                 return self.zero()


### PR DESCRIPTION
### Description

This fixes the conversion failure for one-fold tensor products and makes their structure visible in textual representations.

```python
sage: p = SymmetricFunctions(QQ).p()
sage: t = tensor([p[2]])
sage: t.parent()
tensor([Symmetric Functions over Rational Field in the powersum basis])
sage: p(t)
p[2]
```

The implementation registers the canonical one-way coercion

```text
tensor([M]) -> M,    (k,) |-> k
```

when a one-fold `CombinatorialFreeModule_Tensor` is constructed.  Registering the map on construction is important: it also covers factors that override `_coerce_map_from_`, as well as tensor products placed in a signed tensor product category.  The on-basis function is a named bound method so that the coercion map remains pickleable.

There is deliberately no coercion in the reverse direction, and tensor products with two or more factors are unchanged.  Existing coercions from `M` can compose with the new map, so a tensor over the powersum basis can, for example, coerce through `p` into the Schur basis without basis-specific tensor code.

### Why `tensor([M])` remains distinct from `M`

Mathematically, a one-fold tensor product is canonically isomorphic to its factor, but a chosen construction need not make the two objects definitionally equal:

```text
M^(tensor 1) ~= M.
```

For modules with basis, the uniform finite tensor-product construction indexes the basis by a Cartesian product of the factor bases.  With one factor, its indices are singleton tuples `(k,)`, whereas the indices of `M` are `k`.  The map `(k,) |-> k` is the canonical linear isomorphism between these two realizations.

Keeping the realizations distinct preserves the arity and construction metadata and lets generic code use tuple indices of a uniform length.  Collapsing `tensor([M])` to `M` would instead move the special case into every algorithm that constructs a tensor product from a variable-length list.

The parent and element representations now expose this distinction:

```python
sage: T = tensor([F]); T
tensor([F])
sage: tensor([F.monomial(1) + 2 * F.monomial(2)])
tensor([F[1]]) + 2*tensor([F[2]])
```

### Why the Hochschild complex is mathematically unchanged

The Hochschild chain modules are

```text
C_n(A, M) = M tensor A^(tensor n).
```

In degree zero, the existing implementation intentionally returns `tensor([M])`, with basis indices `(m,)`.  This PR preserves that parent and those indices.  This is precisely why the one-fold tensor product is not collapsed to `M`.

No executable code in `hochschild_complex.py` is changed; only doctest output is updated to reflect the explicit representation.  The boundary maps still construct their results directly from tuple keys.  When a degree-zero tensor is passed to the Hochschild element constructor, the new coercion may unwrap it to `M`, after which the existing constructor wraps its coefficients back as `(m,)`; this round trip is the identity on `C_0`.

The additional checks cover degree-zero round trips, the unchanged parent and singleton-tuple indices, and both `d^2 = 0` and `delta^2 = 0` for exterior-algebra and symmetric-group-algebra examples.


Fixes #41704.
Fixes #18349.
