### PR TITLE
Fix extend handling in FiniteField_givaroElement.sqrt

### DIFF
--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -1116,13 +1116,32 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
             Traceback (most recent call last):
             ...
             ValueError: must be a perfect square
+
+        Square elements with ``extend=True`` do not require extension support::
+
+            sage: GF(9).one().sqrt(extend=True)
+            1
+            sage: GF(9).one().sqrt(extend=True, all=True)
+            [1, 2]
+            sage: K(2).sqrt(extend=True) in (2*a + 6, a + 3)
+            True
+            sage: set(K(2).sqrt(extend=True, all=True)) == {2*a + 6, a + 3}
+            True
+
+        Characteristic 2 where every element is a square::
+
+            sage: K2.<b> = GF(8)
+            sage: b.sqrt(extend=True) == b^4
+            True
+            sage: b.sqrt(extend=True, all=True) == [b^4]
+            True
         """
-        if extend:
-            raise NotImplementedError  # TODO: use RingExtension or GF(p^(2*e))
         if all:
             if self.is_square():
                 a = self.sqrt()
                 return [a, -a] if -a != a else [a]
+            if extend:
+                raise NotImplementedError  # TODO: use RingExtension or GF(p^(2*e))
             return []
         cdef Cache_givaro cache = <Cache_givaro>self._cache
         if self.element == cache.objectptr.one:
@@ -1131,6 +1150,8 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
             return make_FiniteField_givaroElement(cache, self.element // 2)
         elif cache.objectptr.characteristic() == 2:
             return make_FiniteField_givaroElement(cache, (cache.objectptr.cardinality() - 1 + self.element) / 2)
+        elif extend:
+            raise NotImplementedError  # TODO: use RingExtension or GF(p^(2*e))
         else:
             raise ValueError("must be a perfect square")
 

--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -1045,7 +1045,7 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
 
         INPUT:
 
-        - ``extend`` -- boolean (default: ``True``); if ``True``, return a
+        - ``extend`` -- boolean (default: ``False``); if ``True``, return a
           square root in an extension ring, if necessary. Otherwise,
           raise a :exc:`ValueError` if the root is not in the base ring.
 
@@ -1094,9 +1094,31 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
             sage: all(a.sqrt()*a.sqrt() == a for a in K if a.is_square())
             True
             sage: K.<a> = FiniteField(9)
-            sage: a.sqrt(extend = False, all = True)
+            sage: a.sqrt(extend=False, all=True)
             []
+
+        Check that :issue:`42719` is fixed::
+
+            sage: K.<a> = GF(9)
+            sage: a.is_square()
+            False
+            sage: a.sqrt(extend=True, all=True)
+            Traceback (most recent call last):
+            ...
+            NotImplementedError
+            sage: a.sqrt(extend=True, all=False)
+            Traceback (most recent call last):
+            ...
+            NotImplementedError
+            sage: a.sqrt(extend=False, all=True)
+            []
+            sage: a.sqrt(extend=False, all=False)
+            Traceback (most recent call last):
+            ...
+            ValueError: must be a perfect square
         """
+        if extend:
+            raise NotImplementedError  # TODO: use RingExtension or GF(p^(2*e))
         if all:
             if self.is_square():
                 a = self.sqrt()
@@ -1109,8 +1131,6 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
             return make_FiniteField_givaroElement(cache, self.element // 2)
         elif cache.objectptr.characteristic() == 2:
             return make_FiniteField_givaroElement(cache, (cache.objectptr.cardinality() - 1 + self.element) / 2)
-        elif extend:
-            raise NotImplementedError  # TODO: use RingExtension or GF(p^(2*e))
         else:
             raise ValueError("must be a perfect square")
 


### PR DESCRIPTION
### Description

Fixes #42719

In `src/sage/rings/finite_rings/element_givaro.pyx`, `FiniteField_givaroElement.sqrt(extend=True, all=True)` previously returned `[]` (empty list) on non-squares instead of raising `NotImplementedError`.

This occurred because the `if all:` check returned `[]` immediately when `self.is_square()` was `False`, completely bypassing the `elif extend: raise NotImplementedError` branch. As a result, `extend=True` was silently ignored whenever `all=True`, falsely claiming the element had no square roots in any extension field and violating the API contract.

### Proposed Solution

1. In `FiniteField_givaroElement.sqrt()`, check `if extend: raise NotImplementedError` upfront before checking `all` or evaluating base-field squareness (matching `element_pari_ffelt.pyx` and `element_base.pyx`).
2. Correct the docstring default parameter note for `extend` from `(default: True)` to `(default: False)` to match the method signature.
3. Add regression doctests for all combinations of `(extend, all)` for both squares and non-squares.

### Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation and checked the documentation preview.

### Dependencies

None.

Signed-off-by: bhuvan-somisetty <somisettybhuvan5@gmail.com>
