### PR TITLE
base ring aware powersum conversion

### DIFF
--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -105,6 +105,7 @@ from sage.combinat.integer_vector_weighted import iterator_fast as wt_int_vec_it
 from sage.categories.action import Action
 from sage.categories.hopf_algebras_with_basis import HopfAlgebrasWithBasis
 from sage.categories.quotient_fields import QuotientFields
+from sage.categories.tensor import tensor
 from sage.structure.unique_representation import UniqueRepresentation
 from sage.rings.polynomial.infinite_polynomial_ring import InfinitePolynomialRing
 from sage.rings.polynomial.infinite_polynomial_element import InfinitePolynomial

--- a/src/sage/data_structures/stream.py
+++ b/src/sage/data_structures/stream.py
@@ -3670,18 +3670,28 @@ class Stream_plethysm(Stream_binary):
         else:
             self._basis = ring
         self._p = p
-        g = Stream_map_coefficients(g, lambda x: p(x), is_sparse)
-        self._powers = [g]  # a cache for the powers of g in the powersum basis
         R = self._basis.base_ring()
         self._degree_one = _variables_recursive(R, include=include, exclude=exclude)
 
+        def to_powersum(x):
+            P = x.parent()
+            return P.realization_of().p()(x)
+
+        f = Stream_map_coefficients(f, to_powersum, is_sparse)
+
+        def to_powersum_tensor(x):
+            P = x.parent()
+            powersum = tensor([factor.realization_of().p() for factor in P._sets])
+            return powersum(x)
+
         if HopfAlgebrasWithBasis(R).TensorProducts() in p.categories():
             self._tensor_power = len(p._sets)
-            p_f = p._sets[0]
-            f = Stream_map_coefficients(f, lambda x: p_f(x), is_sparse)
+            g = Stream_map_coefficients(g, to_powersum_tensor, is_sparse)
         else:
             self._tensor_power = None
-            f = Stream_map_coefficients(f, lambda x: p(x), is_sparse)
+            g = Stream_map_coefficients(g, to_powersum, is_sparse)
+
+        self._powers = [g]  # a cache for the powers of g in the powersum basis
         super().__init__(f, g, is_sparse)
 
     @lazy_attribute


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

This PR makes the powersum conversion used by Stream_plethysm preserve the base ring of each coefficient. This is especially important in context of implicitly defined streams since they are initially elements of larger base ring `CoefficientRing`.  `Stream_plethysm` now uses this conversion for both its inner and outer streams.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x ] The title is concise and informative.
- [x ] The description explains in detail what this PR is about.
- [x ] I have linked a relevant issue or discussion.
- [x ] I have created tests covering the changes.
- [x ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


