### PR TITLE
gh-42712: Limit Singular polynomial ring variables

### DIFF
--- a/src/sage/libs/singular/ring.pyx
+++ b/src/sage/libs/singular/ring.pyx
@@ -545,7 +545,7 @@ cdef ring *singular_ring_new(base_ring, n, names, term_order) except NULL:
         else:
             modbase, cexponent = ch.perfect_power()
 
-            if modbase == 2 and 1 < cexponent <= 8*sizeof(unsigned long):  # see :issue:`40855`
+            if modbase == 2 and 1 < cexponent <= <long>(8 * sizeof(unsigned long)):  # see :issue:`40855`
                 _cf = nInitChar(n_Z2m, <void *>cexponent)
 
             elif modbase.is_prime() and cexponent > 1:

--- a/src/sage/libs/singular/ring.pyx
+++ b/src/sage/libs/singular/ring.pyx
@@ -16,6 +16,8 @@ AUTHORS:
 #                  https://www.gnu.org/licenses/
 # ****************************************************************************
 
+from libc.limits cimport SHRT_MAX
+
 from sage.cpython.string cimport str_to_bytes, bytes_to_str
 
 from sage.libs.gmp.types cimport __mpz_struct
@@ -88,7 +90,8 @@ cdef ring *singular_ring_new(base_ring, n, names, term_order) except NULL:
 
     - ``base_ring`` -- a Sage ring
 
-    - ``n`` -- the number of variables (> 0)
+    - ``n`` -- the number of variables (at least 1 and fitting in a signed C
+      ``short``)
 
     - ``names`` -- list of names of length ``n``
 
@@ -333,7 +336,8 @@ cdef ring *singular_ring_new(base_ring, n, names, term_order) except NULL:
     _ring  = NULL
 
     n = int(n)
-    if n < 1:
+    # Singular stores the number of variables in a signed short.
+    if n < 1 or n > SHRT_MAX:
         raise NotImplementedError(f"polynomials in {n} variables are not supported in Singular")
 
     nvars = n

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -292,7 +292,8 @@ cdef class MPolynomialRing_libsingular(MPolynomialRing_base):
         - ``base_ring`` -- base ring (must be either GF(q), ZZ, ZZ/nZZ,
                           QQ or absolute number field)
 
-        - ``n`` -- number of variables (must be at least 1)
+        - ``n`` -- number of variables (must be at least 1 and fit in a signed
+          C ``short``)
 
         - ``names`` -- names of ring variables, may be string of list/tuple
 
@@ -379,6 +380,14 @@ cdef class MPolynomialRing_libsingular(MPolynomialRing_base):
             Traceback (most recent call last):
             ...
             NotImplementedError: polynomials in -1 variables are not supported in Singular
+
+        Check that the number of variables fits into Singular's signed short
+        (:issue:`42712`)::
+
+            sage: MPolynomialRing_libsingular(QQ, 2**15, (), "lex")
+            Traceback (most recent call last):
+            ...
+            NotImplementedError: polynomials in 32768 variables are not supported in Singular
         """
         self._ngens = n
         self._ring = singular_ring_new(base_ring, n, names, order)

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -384,6 +384,9 @@ cdef class MPolynomialRing_libsingular(MPolynomialRing_base):
         Check that the number of variables fits into Singular's signed short
         (:issue:`42712`)::
 
+            sage: R = PolynomialRing(QQ, "x", 2**15)
+            sage: type(R)
+            <class 'sage.rings.polynomial.multi_polynomial_ring.MPolynomialRing_polydict_domain_with_category'>
             sage: MPolynomialRing_libsingular(QQ, 2**15, (), "lex")
             Traceback (most recent call last):
             ...

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -384,6 +384,7 @@ cdef class MPolynomialRing_libsingular(MPolynomialRing_base):
         Check that the number of variables fits into Singular's signed short
         (:issue:`42712`)::
 
+            sage: # long time
             sage: R = PolynomialRing(QQ, "x", 2**15)
             sage: type(R)
             <class 'sage.rings.polynomial.multi_polynomial_ring.MPolynomialRing_polydict_domain_with_category'>


### PR DESCRIPTION
### Description

Singular stores the number of polynomial ring variables in a signed C `short`. Check the requested count against `SHRT_MAX` before allocating or calling `rDefault`.

Raising `NotImplementedError` keeps the existing backend-selection behavior: the default `PolynomialRing` constructor can fall back to the generic implementation, while an explicit `implementation="singular"` request receives a clear exception instead of terminating the process.

A regression test covers the first unsupported variable count.

### Testing

- `./sage -t --warn-long 30 src/sage/libs/singular/ring.pyx src/sage/rings/polynomial/multi_polynomial_libsingular.pyx`
- Verified 32,767 variables still use libSingular.
- Verified 32,768 variables fall back to the generic backend by default.
- Verified an explicit Singular request for 32,768 variables raises `NotImplementedError`.

Fixes #42712