### PR TITLE
matrix: exploit sparsity in is_symmetric

### DIFF
--- a/src/sage/matrix/matrix_sparse.pyx
+++ b/src/sage/matrix/matrix_sparse.pyx
@@ -1086,6 +1086,7 @@ cdef class Matrix_sparse(matrix.Matrix):
             return False
         cdef dict D = self._dict()
         zero = self.base_ring().zero()
+        cdef Py_ssize_t i, j
         for (i, j), v in D.items():
             if i != j and D.get((j, i), zero) != v:
                 return False

--- a/src/sage/matrix/matrix_sparse.pyx
+++ b/src/sage/matrix/matrix_sparse.pyx
@@ -1034,6 +1034,63 @@ cdef class Matrix_sparse(matrix.Matrix):
                    self._ncols, sparse=True)
         return M(v)
 
+    def is_symmetric(self) -> bool:
+        r"""
+        Return whether this matrix is symmetric.
+
+        The generic implementation compares the `n(n-1)/2` pairs of
+        off-diagonal entries and is therefore quadratic in the dimension of
+        the matrix, even when almost all of those entries are zero. Here only
+        the nonzero entries are visited, so the running time is linear in
+        their number.
+
+        EXAMPLES::
+
+            sage: M = matrix(ZZ, 3, 3, {(0, 1): 1, (1, 0): 1}, sparse=True)
+            sage: M.is_symmetric()
+            True
+            sage: M[0, 2] = 5
+            sage: M.is_symmetric()
+            False
+
+        A matrix that is not square is not symmetric::
+
+            sage: matrix(ZZ, 2, 3, sparse=True).is_symmetric()
+            False
+
+        TESTS:
+
+        An entry that is stored but zero is treated like any other zero::
+
+            sage: M = matrix(ZZ, 2, 2, sparse=True)
+            sage: M[0, 1] = 0
+            sage: M.is_symmetric()
+            True
+
+        Symmetry agrees with equality to the transpose (:issue:`18810`)::
+
+            sage: for _ in range(30):
+            ....:     M = random_matrix(ZZ, 8, 8, density=0.2, sparse=True)
+            ....:     assert M.is_symmetric() == (M == M.transpose())
+            ....:     N = M + M.transpose()
+            ....:     assert N.is_symmetric() == (N == N.transpose())
+
+        Entries need not come from an exact ring::
+
+            sage: R.<x> = QQ[]
+            sage: M = matrix(R, 2, 2, {(0, 1): x, (1, 0): x}, sparse=True)
+            sage: M.is_symmetric()
+            True
+        """
+        if self._nrows != self._ncols:
+            return False
+        cdef dict D = self._dict()
+        zero = self.base_ring().zero()
+        for (i, j), v in D.items():
+            if i != j and D.get((j, i), zero) != v:
+                return False
+        return True
+
     def density(self):
         """
         Return the density of the matrix.


### PR DESCRIPTION
Fixes #18810.

`Matrix.is_symmetric` in `matrix0.pyx` is generic: it compares the `n(n-1)/2` pairs of off-diagonal entries, which is quadratic in the dimension of the matrix regardless of how many entries are actually stored. On a sparse matrix each of those comparisons is a lookup into the sparse structure, so the sparse case ends up *slower* than the dense one — 253 ms against 104 ms for a 3000x3000 matrix holding 30000 nonzero entries.

This adds an override in `Matrix_sparse` that visits only the stored entries, so the cost is linear in their number. A missing entry is an implicit zero, so the comparison uses the ring's zero as the default; a matrix holding explicitly stored zeros is handled the same way as one that does not.

### Timings

`RandomGNM(n, 5n).adjacency_matrix()`, sparse over `ZZ`:

| n | nnz | before | after | |
|---|---|---|---|---|
| 1000 | 10000 | 28.5 ms | 0.77 ms | 37x |
| 3000 | 30000 | 253 ms | 3.45 ms | 73x |

Dense matrices are unaffected, and a matrix that is dense in practice gains nothing, as expected: on `CompleteGraph(200)` the timing is unchanged.

### Why I looked

I was measuring where `Graph.__init__` spends its time. `Graph.__init__` calls `is_symmetric` to tell an adjacency matrix from an incidence matrix, and that call turned out to be **95% of the total**. Building a graph from an adjacency matrix on the same instances:

| | before | after | |
|---|---|---|---|
| `RandomGNM(3000, 15000)` | 255 ms | 13.1 ms | 19x |
| `Grid2dGraph(40, 40)` | 61.3 ms | 2.1 ms | 30x |

### Tests

Doctests pass for `matrix_sparse.pyx`, `matrix0.pyx`, `matrix2.pyx`, the three sparse matrix types, `special.py`, and `graph.py` / `digraph.py` / `graph_input.py` — 7155 tests in total.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. -->

None.
