### PR TITLE
Add number_of_divisors, moebius, and euler_phi as Integer methods

### DIFF
--- a/src/sage/arith/misc.py
+++ b/src/sage/arith/misc.py
@@ -3072,7 +3072,7 @@ class Euler_Phi:
 
     .. SEEALSO:
 
-        :meth:`sage.rings.integer.Integer
+        :meth:`sage.rings.integer.Integer.euler_phi`
 
     INPUT:
 
@@ -4678,8 +4678,8 @@ class Moebius:
         F = factor(n)
         for _, e in F:
             if e >= 2:
-                return 0
-        return (-1)**len(F)
+                return ZZ.zero()
+        return ZZ((-1)**len(F))
 
     def __repr__(self) -> str:
         """
@@ -4871,7 +4871,7 @@ def number_of_divisors(n) -> Integer:
     This function just converts the input to a :class:`sage.rings.integer.Integer`
     and calls :meth:`sage.rings.integer.Integer.number_of_divisors`. If you
     already have an :class:`sage.rings.integer.Integer`, it is easier (and
-    slightly faster) to call :meth:`~sage.rings.Integer.number_of_divisors`
+    slightly faster) to call :meth:`sage.rings.Integer.number_of_divisors`
     directly.
 
     INPUT:

--- a/src/sage/arith/misc.py
+++ b/src/sage/arith/misc.py
@@ -1635,7 +1635,7 @@ class Sigma:
         sage: sigma(mpz(100), mpz(4))
         106811523
     """
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         A description of this class, which computes the sum of the
         `k`-th powers of the divisors of `n`.
@@ -1648,7 +1648,7 @@ class Sigma:
         """
         return "Function that adds up (k-th powers of) the divisors of n"
 
-    def __call__(self, n, k=1):
+    def __call__(self, n, k=1) -> Integer:
         """
         Compute the sum of (the `k`-th powers of) the divisors of `n`.
 
@@ -3070,6 +3070,10 @@ class Euler_Phi:
     relatively prime to `n`. Thus if `n \leq 0` then
     ``euler_phi(n)`` is defined and equals 0.
 
+    .. SEEALSO:
+
+        :meth:`sage.rings.integer.Integer
+
     INPUT:
 
     - ``n`` -- integer
@@ -3078,14 +3082,8 @@ class Euler_Phi:
 
         sage: euler_phi(1)
         1
-        sage: euler_phi(2)
-        1
         sage: euler_phi(3)                                                              # needs sage.libs.pari
         2
-        sage: euler_phi(12)                                                             # needs sage.libs.pari
-        4
-        sage: euler_phi(37)                                                             # needs sage.libs.pari
-        36
 
     Notice that ``euler_phi`` is defined to be 0 on negative numbers and 0::
 
@@ -3128,7 +3126,7 @@ class Euler_Phi:
 
     - Alex Clemesha (2006-01-10): some examples
     """
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Return a string describing this class.
 
@@ -3140,7 +3138,7 @@ class Euler_Phi:
         """
         return "Number of positive integers <=n but relatively prime to n"
 
-    def __call__(self, n):
+    def __call__(self, n) -> Integer:
         """
         Call the ``euler_phi`` function.
 
@@ -3152,12 +3150,7 @@ class Euler_Phi:
             sage: Euler_Phi()(720)                                                      # needs sage.libs.pari
             192
         """
-        if n <= 0:
-            return ZZ.zero()
-        if n <= 2:
-            return ZZ.one()
-        from sage.libs.pari import pari
-        return ZZ(pari(n).eulerphi())
+        return ZZ(n).euler_phi()
 
     def plot(self, xmin=1, xmax=50, pointsize=30, rgbcolor=(0, 0, 1),
              join=True, **kwds):
@@ -4665,7 +4658,7 @@ class Moebius:
         sage: moebius(mpz(-5))                                                          # needs sage.libs.pari
         -1
     """
-    def __call__(self, n):
+    def __call__(self, n) -> Integer:
         """
         EXAMPLES::
 
@@ -4675,23 +4668,20 @@ class Moebius:
         """
         n = py_scalar_to_element(n)
 
-        if not isinstance(n, Integer):
-            # Use a generic algorithm.
-            if n < 0:
-                n = -n
-            F = factor(n)
-            for _, e in F:
-                if e >= 2:
-                    return 0
-            return (-1)**len(F)
+        if isinstance(n, Integer):
+            # Use fast PARI algorithm
+            return n.moebius()
 
-        # Use fast PARI algorithm
-        if n == 0:
-            return ZZ.zero()
-        from sage.libs.pari import pari
-        return ZZ(pari(n).moebius())
+        # Fallback to a generic algorithm.
+        if n < 0:
+            n = -n
+        F = factor(n)
+        for _, e in F:
+            if e >= 2:
+                return 0
+        return (-1)**len(F)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Return a description of this function.
 
@@ -4874,9 +4864,13 @@ def continuant(v, n=None):
     return b
 
 
-def number_of_divisors(n):
+def number_of_divisors(n) -> Integer:
     r"""
     Return the number of divisors of the integer `n`.
+    This function just converts the input to a :class:`~sage.rings.Integer` and
+    calls :meth:`sage.rings.integer.Integer.number_of_divisors`. If you already
+    have an :class:`~sage.rings.integer.Integer`, it is easier (and slightly
+    faster) to call :meth:`~sage.rings.Integer.number_of_divisors` directly.
 
     INPUT:
 
@@ -4886,12 +4880,7 @@ def number_of_divisors(n):
 
     EXAMPLES::
 
-        sage: number_of_divisors(100)                                                   # needs sage.libs.pari
-        9
-        sage: number_of_divisors(-720)                                                  # needs sage.libs.pari
-        30
-
-    Tests with numpy and gmpy2 numbers::
+    Tests with numpy, gmpy2, and Python numbers::
 
         sage: from numpy import int8                                                    # needs numpy
         sage: number_of_divisors(int8(100))                                             # needs numpy sage.libs.pari
@@ -4899,12 +4888,11 @@ def number_of_divisors(n):
         sage: from gmpy2 import mpz
         sage: number_of_divisors(mpz(100))                                              # needs sage.libs.pari
         9
+        sage: number_of_divisors(100r)
+        9
     """
-    m = ZZ(n)
-    if m.is_zero():
-        raise ValueError("input must be nonzero")
-    from sage.libs.pari import pari
-    return ZZ(pari(m).numdiv())
+
+    return ZZ(n).number_of_divisors()
 
 
 def hilbert_symbol(a, b, p, algorithm='pari'):

--- a/src/sage/arith/misc.py
+++ b/src/sage/arith/misc.py
@@ -4869,9 +4869,9 @@ def number_of_divisors(n) -> Integer:
     Return the number of divisors of the integer `n`.
 
     This function just converts the input to a :class:`sage.rings.integer.Integer`
-    and calls :meth:`sage.rings.integer.Integer.number_of_divisors`. If you
+    and calls :meth:`~sage.rings.integer.Integer.number_of_divisors`. If you
     already have an :class:`sage.rings.integer.Integer`, it is easier (and
-    slightly faster) to call :meth:`sage.rings.integer.Integer.number_of_divisors`
+    slightly faster) to call :meth:`~sage.rings.integer.Integer.number_of_divisors`
     directly.
 
     INPUT:

--- a/src/sage/arith/misc.py
+++ b/src/sage/arith/misc.py
@@ -3070,7 +3070,7 @@ class Euler_Phi:
     relatively prime to `n`. Thus if `n \leq 0` then
     ``euler_phi(n)`` is defined and equals 0.
 
-    .. SEEALSO:
+    .. SEEALSO::
 
         :meth:`sage.rings.integer.Integer.euler_phi`
 
@@ -4890,7 +4890,7 @@ def number_of_divisors(n) -> Integer:
         sage: from gmpy2 import mpz
         sage: number_of_divisors(mpz(100))                                              # needs sage.libs.pari
         9
-        sage: number_of_divisors(100r)
+        sage: number_of_divisors(100r)                                                  # needs sage.libs.pari
         9
     """
 

--- a/src/sage/arith/misc.py
+++ b/src/sage/arith/misc.py
@@ -4868,9 +4868,9 @@ def number_of_divisors(n) -> Integer:
     r"""
     Return the number of divisors of the integer `n`.
 
-    This function just converts the input to a :class:`sage.rings.integer.Integer`
+    This function just converts the input to an :class:`~sage.rings.integer.Integer`
     and calls the :meth:`~sage.rings.integer.Integer.number_of_divisors` method
-    on it. If you already have an :class:`sage.rings.integer.Integer`, it is
+    on it. If you already have an :class:`~sage.rings.integer.Integer`, it is
     easier (and slightly faster) to call the
     :meth:`~sage.rings.integer.Integer.number_of_divisors` method directly.
 

--- a/src/sage/arith/misc.py
+++ b/src/sage/arith/misc.py
@@ -4869,10 +4869,10 @@ def number_of_divisors(n) -> Integer:
     Return the number of divisors of the integer `n`.
 
     This function just converts the input to a :class:`sage.rings.integer.Integer`
-    and calls :meth:`~sage.rings.integer.Integer.number_of_divisors`. If you
-    already have an :class:`sage.rings.integer.Integer`, it is easier (and
-    slightly faster) to call :meth:`~sage.rings.integer.Integer.number_of_divisors`
-    directly.
+    and calls the :meth:`~sage.rings.integer.Integer.number_of_divisors` method
+    on it. If you already have an :class:`sage.rings.integer.Integer`, it is
+    easier (and slightly faster) to call the
+    :meth:`~sage.rings.integer.Integer.number_of_divisors` method directly.
 
     INPUT:
 

--- a/src/sage/arith/misc.py
+++ b/src/sage/arith/misc.py
@@ -4867,10 +4867,12 @@ def continuant(v, n=None):
 def number_of_divisors(n) -> Integer:
     r"""
     Return the number of divisors of the integer `n`.
-    This function just converts the input to a :class:`~sage.rings.Integer` and
-    calls :meth:`sage.rings.integer.Integer.number_of_divisors`. If you already
-    have an :class:`~sage.rings.integer.Integer`, it is easier (and slightly
-    faster) to call :meth:`~sage.rings.Integer.number_of_divisors` directly.
+
+    This function just converts the input to a :class:`sage.rings.integer.Integer`
+    and calls :meth:`sage.rings.integer.Integer.number_of_divisors`. If you
+    already have an :class:`sage.rings.integer.Integer`, it is easier (and
+    slightly faster) to call :meth:`~sage.rings.Integer.number_of_divisors`
+    directly.
 
     INPUT:
 

--- a/src/sage/arith/misc.py
+++ b/src/sage/arith/misc.py
@@ -4878,7 +4878,7 @@ def number_of_divisors(n) -> Integer:
 
     OUTPUT: integer; the number of divisors of `n`
 
-    EXAMPLES::
+    EXAMPLES:
 
     Tests with numpy, gmpy2, and Python numbers::
 

--- a/src/sage/arith/misc.py
+++ b/src/sage/arith/misc.py
@@ -4871,7 +4871,7 @@ def number_of_divisors(n) -> Integer:
     This function just converts the input to a :class:`sage.rings.integer.Integer`
     and calls :meth:`sage.rings.integer.Integer.number_of_divisors`. If you
     already have an :class:`sage.rings.integer.Integer`, it is easier (and
-    slightly faster) to call :meth:`sage.rings.Integer.number_of_divisors`
+    slightly faster) to call :meth:`sage.rings.integer.Integer.number_of_divisors`
     directly.
 
     INPUT:

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -7444,11 +7444,11 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
 
         EXAMPLES::
 
-           sage: euler_phi(2)
+           sage: 2.euler_phi()                                                          # needs sage.libs.pari
             1
-            sage: euler_phi(12)                                                         # needs sage.libs.pari
+            sage: 12.euler_phi()                                                        # needs sage.libs.pari
             4
-            sage: euler_phi(37)                                                         # needs sage.libs.pari
+            sage: 37.euler_phi()                                                        # needs sage.libs.pari
             36
  
 

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -7397,9 +7397,9 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
 
             sage: 12.number_of_divisors()                                               # needs sage.libs.pari
             6
-            sage: 100.number_of_divisors()
+            sage: 100.number_of_divisors()                                              # needs sage.libs.pari
             9
-            sage: (-720).number_of_divisors()
+            sage: (-720).number_of_divisors()                                           # needs sage.libs.pari
             30
             sage: 0.number_of_divisors()
             Traceback (most recent call last):

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -7389,6 +7389,80 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
             return (self, one)
         return (-self, -one)
 
+    def number_of_divisors(self) -> Integer:
+        r"""
+        Return the number of positive divisors of this integer.
+
+        EXAMPLES::
+
+            sage: 12.number_of_divisors()                                               # needs sage.libs.pari
+            6
+            sage: 100.number_of_divisors()
+            9
+            sage: (-720).number_of_divisors()
+            30
+            sage: 0.number_of_divisors()
+            Traceback (most recent call last):
+            ...
+            ValueError: number_of_divisors is not defined for 0
+
+        .. SEEALSO::
+
+            :meth:`divisors`
+        """
+        if self == 0:
+            raise ValueError('number_of_divisors is not defined for 0')
+        return Integer(self.__pari__().numdiv())
+
+    def moebius(self) -> Integer:
+        r"""
+        Return the value of the Möbius function of the absolute value of this integer.
+
+        EXAMPLES::
+
+            sage: (-1).moebius()                                                        # needs sage.libs.pari
+            1
+            sage: 7.moebius()                                                           # needs sage.libs.pari
+            -1
+            sage: 0.moebius()   # potentially nonstandard!
+            0
+
+        .. SEEALSO::
+
+            :class:`sage.arith.misc.Moebius`
+        """
+        if self == 0:
+            return Integer(0)
+        return Integer(self.__pari__().moebius())
+
+    def euler_phi(self) -> Integer:
+        r"""
+        Return the value of the Euler phi function on this integer `n`.
+        We define this to be the number of positive integers less than or equal
+        to `n` that are relatively prime to `n`. Thus if `n \leq 0` then
+        ``n.euler_phi()`` is defined and equals 0.
+
+        EXAMPLES::
+
+           sage: euler_phi(2)
+            1
+            sage: euler_phi(12)                                                         # needs sage.libs.pari
+            4
+            sage: euler_phi(37)                                                         # needs sage.libs.pari
+            36
+ 
+
+        .. SEEALSO::
+
+            :class:`sage.arith.misc.Euler_Phi`
+        """
+        if self <= 0:
+            return Integer(0)
+        if self <= 2:
+            return Integer(1)
+        return Integer(self.__pari__().eulerphi())
+
+
 cdef int mpz_set_str_python(mpz_ptr z, char* s, int base) except -1:
     """
     Wrapper around ``mpz_set_str()`` which supports :pep:`3127`

--- a/src/sage/rings/integer.pyx
+++ b/src/sage/rings/integer.pyx
@@ -7444,7 +7444,7 @@ cdef class Integer(sage.structure.element.EuclideanDomainElement):
 
         EXAMPLES::
 
-           sage: 2.euler_phi()                                                          # needs sage.libs.pari
+            sage: 2.euler_phi()
             1
             sage: 12.euler_phi()                                                        # needs sage.libs.pari
             4


### PR DESCRIPTION
<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->

Closes #14401 (the original issue mentions a `partitions` function, I didn't implement that one because there doesn't seem to be a global `partitions` function in Sage anymore). After the changes, we see a reasonable speedup to the affected functions, and a greater speedup for the new method versions. I attribute this partly to the `moebius` and `euler_phi` functions actually being Cython classes, and partly to the new methods being written in Cython.

Also a small bit of code cleanup while I was at it (a few easy type annotation opportunities I saw while scrolling through the files).

Using the old functions (measured on 10.10.beta9):
```python
nums = list(srange(1, 10000))
%timeit [number_of_divisors(n) for n in nums]
%timeit [moebius(n) for n in nums]
%timeit [euler_phi(n) for n in nums]
```
```
16.6 ms ± 199 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
14.3 ms ± 430 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
21 ms ± 381 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Using the old functions (measured on this PR):
```python
nums = list(srange(1, 10000))
%timeit [number_of_divisors(n) for n in nums]
%timeit [moebius(n) for n in nums]
%timeit [euler_phi(n) for n in nums]
```
```
10.4 ms ± 334 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
8.95 ms ± 870 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
11.5 ms ± 966 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

Using the new Integer methods:
```python
nums = list(srange(1, 10000))
%timeit [n.number_of_divisors() for n in nums]
%timeit [n.moebius() for n in nums]
%timeit [n.euler_phi() for n in nums]
```
```
8.86 ms ± 1.18 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)
5.87 ms ± 137 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
9.25 ms ± 419 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


