### PR TITLE
Simplify float -> rational conversion

### DIFF
--- a/src/doc/en/thematic_tutorials/coercion_and_categories.rst
+++ b/src/doc/en/thematic_tutorials/coercion_and_categories.rst
@@ -1582,8 +1582,8 @@ that can be found in most algebraic structures.
 ::
 
     sage: P.an_element(); P.some_elements()
-    (2):(1)
-    [(2):(1)]
+    (6):(5)
+    [(6):(5)]
 
 .. end of output
 

--- a/src/sage/algebras/jordan_algebra.py
+++ b/src/sage/algebras/jordan_algebra.py
@@ -1476,9 +1476,9 @@ class ExceptionalJordanAlgebra(JordanAlgebra):
             sage: O = OctonionAlgebra(GF(3))
             sage: J = JordanAlgebra(O)
             sage: J.some_elements()
-            [[-1  0  0]
-             [ 0 -1  0]
-             [ 0  0 -1],
+            [[0 0 0]
+             [0 0 0]
+             [0 0 0],
              [1 0 0]
              [0 1 0]
              [0 0 1],

--- a/src/sage/combinat/ncsf_qsym/combinatorics.py
+++ b/src/sage/combinat/ncsf_qsym/combinatorics.py
@@ -207,7 +207,7 @@ def m_to_s_stat(R, I, K):
         if I.is_finer(J) and K.is_finer(J):
             pvec = [0] + Composition(I).refinement_splitting_lengths(J).partial_sums()
             pp = prod( R( len(I) - pvec[i] ) for i in range( len(pvec)-1 ) )
-            stat += R((-1)**(len(I)-len(K)) / pp * coeff_lp(K, J))
+            stat += R((-1)**(len(I)-len(K))) * coeff_lp(K, J) / pp
     return stat
 
 

--- a/src/sage/functions/hypergeometric_algebraic.py
+++ b/src/sage/functions/hypergeometric_algebraic.py
@@ -1357,7 +1357,7 @@ class HypergeometricAlgebraic_QQ(HypergeometricAlgebraic):
         classes = dict.fromkeys(range(1, len(self.top())+1), Primes(modulus=0))
         for c in range(d):
             if gcd(c, d) == 1:
-                Delta = QQ(1/c) % d
+                Delta = ~QQ(c) % d
                 j = self._parameters.interlacing_number(Delta)
                 classes[j] = classes[j].union(Primes(modulus=d, classes=[c]))
         for p in Primes():

--- a/src/sage/geometry/polyhedron/base0.py
+++ b/src/sage/geometry/polyhedron/base0.py
@@ -392,10 +392,10 @@ class Polyhedron_base0(Element, sage.geometry.abc.Polyhedron):
             sage: P.change_ring(ZZ) == P
             True
 
-            sage: P = Polyhedron(vertices=[(-1.3,0), (0,2.3)], base_ring=RDF); P.vertices()
-            (A vertex at (-1.3, 0.0), A vertex at (0.0, 2.3))
+            sage: P = Polyhedron(vertices=[(-1.5,0), (0,2.5)], base_ring=RDF); P.vertices()
+            (A vertex at (-1.5, 0.0), A vertex at (0.0, 2.5))
             sage: P.change_ring(QQ).vertices()
-            (A vertex at (-13/10, 0), A vertex at (0, 23/10))
+            (A vertex at (-3/2, 0), A vertex at (0, 5/2))
             sage: P == P.change_ring(QQ)
             True
             sage: P.change_ring(ZZ)

--- a/src/sage/manifolds/differentiable/characteristic_cohomology_class.py
+++ b/src/sage/manifolds/differentiable/characteristic_cohomology_class.py
@@ -921,7 +921,7 @@ class CharacteristicCohomologyClassRing(FiniteGCAlgebra):
                 if latex_name is None:
                     latex_name = r'\mathrm{ch}'
                 class_type = 'additive'
-                coeff = [1 / factorial(k) for k in
+                coeff = [base_ring.one() / factorial(k) for k in
                          range(dim // 2 + 1)]  # exp(x)
                 val = P(coeff)
             elif val == 'Todd':
@@ -934,8 +934,7 @@ class CharacteristicCohomologyClassRing(FiniteGCAlgebra):
                 class_type = 'multiplicative'
                 val = 1 + x / 2
                 for k in range(1, dim // 2 + 1):
-                    val += (-1) ** (k + 1) / factorial(2 * k) * bernoulli(
-                        2 * k) * x ** (2 * k)
+                    val += (-1)**(k + 1) * bernoulli(2*k) * x**(2*k) / factorial(2*k)
             elif val == 'Hirzebruch':
                 if vbundle._field_type != 'real':
                     raise ValueError(f'Hirzebruch class not defined on {vbundle}')
@@ -944,7 +943,7 @@ class CharacteristicCohomologyClassRing(FiniteGCAlgebra):
                 if latex_name is None:
                     latex_name = 'L'
                 class_type = 'multiplicative'
-                coeff = [2 ** (2 * k) * bernoulli(2 * k) / factorial(2 * k)
+                coeff = [2**(2*k) * bernoulli(2*k) / factorial(2*k)
                          for k in range(dim // 4 + 1)]
                 val = P(coeff)
             elif val == 'AHat':
@@ -955,8 +954,7 @@ class CharacteristicCohomologyClassRing(FiniteGCAlgebra):
                 if latex_name is None:
                     latex_name = r'\hat{A}'
                 class_type = 'multiplicative'
-                coeff = [- (2 ** (2 * k) - 2) / 2 ** (2 * k) * bernoulli(
-                    2 * k) / factorial(2 * k)
+                coeff = [- (2**(2*k) - 2) * bernoulli(2*k) / (factorial(2*k) * 2**(2*k))
                          for k in range(dim // 4 + 1)]
                 val = P(coeff)
             elif val == 'Euler':

--- a/src/sage/matrix/constructor.pyx
+++ b/src/sage/matrix/constructor.pyx
@@ -542,12 +542,12 @@ def matrix(*args, **kwds):
         [4 5 6]
         [7 8 9]
         Full MatrixSpace of 3 by 3 dense matrices over Integer Ring
-        sage: n = matrix(QQ, 2, 2, [1, 1/2, 1/3, 1/4]).numpy(); n
-        array([[1.        , 0.5       ],
-               [0.33333333, 0.25      ]])
+        sage: n = matrix(QQ, 2, 2, [1, 1/2, 1/4, 1/8]).numpy(); n
+        array([[1.   , 0.5  ],
+               [0.25 , 0.125]])
         sage: matrix(QQ, n)
         [  1 1/2]
-        [1/3 1/4]
+        [1/4 1/8]
 
     The dimensions of a matrix may be given as numpy types::
 

--- a/src/sage/rings/lazy_species.py
+++ b/src/sage/rings/lazy_species.py
@@ -2802,7 +2802,7 @@ class GraphSpecies(LazyCombinatorialSpeciesElementGeneratingSeriesMixin,
         P = self.parent()
         L = LazyPowerSeriesRing(P.base_ring().fraction_field(),
                                 P._laurent_poly_ring._indices._indices.variable_names())
-        s = L(lambda n: 2**binomial(n, 2) / factorial(n))
+        s = L(lambda n: 2**ZZ(n).binomial(2) / ZZ(n).factorial())
         if self._connected:
             return s.log()
         return s

--- a/src/sage/rings/padics/padic_generic_element.pyx
+++ b/src/sage/rings/padics/padic_generic_element.pyx
@@ -2143,7 +2143,8 @@ cdef class pAdicGenericElement(LocalGenericElement):
             ....:     for j in range(1,10):
             ....:         if j == 5:
             ....:             continue
-            ....:         assert i/j == R(i/j).rational_reconstruction()
+            ....:         q = QQ(i)/QQ(j)
+            ....:         assert q == R(q).rational_reconstruction()
         """
         if self.is_zero(self.precision_absolute()):
             return Rational(0)

--- a/src/sage/rings/rational.pyx
+++ b/src/sage/rings/rational.pyx
@@ -417,7 +417,7 @@ cdef class Rational(sage.structure.element.FieldElement):
         sage: QQ(float(1.5))
         3/2
         sage: QQ(RDF(1.2))
-        6/5
+        5404319552844595/4503599627370496
 
     Conversion from fractions::
 
@@ -653,7 +653,7 @@ cdef class Rational(sage.structure.element.FieldElement):
             mpq_set(self.value, temp_rational.value)
 
         elif isinstance(x, (float, sage.rings.real_double.RealDoubleElement)):
-            self.__set_value(sage.rings.real_mpfr.RealNumber(sage.rings.real_mpfr.RR, x), base)
+            self.__set_value(x.as_integer_ratio(), base)
 
         elif is_numpy_type(type(x)):
             import numpy

--- a/src/sage/rings/real_arb.pyx
+++ b/src/sage/rings/real_arb.pyx
@@ -355,7 +355,7 @@ class RealBallField(UniqueRepresentation, sage.rings.abc.RealBallField):
         sage: RBF.cardinality()
         +Infinity
         sage: RBF.cartesian_product(QQ).an_element()**2
-        ([1.440000000000000 +/- ...e-16], 1/4)
+        ([1.44000000000000 +/- ...e-15], 1/4)
         sage: RBF.coerce_embedding() is None
         True
         sage: RBF['x'].gens_dict_recursive()

--- a/src/sage/structure/parent.pyx
+++ b/src/sage/structure/parent.pyx
@@ -2836,12 +2836,15 @@ cdef class Parent(sage.structure.category_object.CategoryObject):
             pass
 
         from sage.rings.infinity import infinity
-        for x in ['_an_element_', 'pi', 1.2, 2, 1, 0, infinity]:
+        global _Integer
+        if _Integer is None:
+            from sage.rings.integer import Integer as _Integer
+        for x in ['_an_element_', 'pi', _Integer(6)/_Integer(5), 2, 1, 0, infinity]:
             # This weird looking list is to try to get an element
             # which does not coerce other places.
             try:
                 return self(x)
-            except (TypeError, NameError, NotImplementedError, AttributeError, ValueError):
+            except (TypeError, NameError, NotImplementedError, AttributeError, ValueError, ZeroDivisionError):
                 _record_exception()
 
         raise NotImplementedError(_LazyString("please implement _an_element_ for %s", (self,), {}))


### PR DESCRIPTION
When we are constructing a rational from a float (or from an element of RDF), we have access to the `as_integer_ratio()` method. This is much simpler (and more accurate) than a detour through `RealNumber()`. This came up while reviewing https://github.com/sagemath/sage/pull/42710, where `as_integer_ratio()` is used to obtain correct rounding because a direct float-to-rational conversion is lossy.

Afterwards, `QQ(1.2)` produces a more accurate but more gnarly fraction. To avoid this ugliness from creeping into examples,

* Two examples were updated to use nicer floats to demonstrate float->rational conversions.
* The parent `an_element()` was updated to try `base_ring(6/5)` rather than `base_ring(1.2)`.
  * Various `an_element()` output was updated to reflect that `QQ(6/5)` now works where previously `float(1.2)` did not.

The change  also uncovered several bugs where intermediate float values were used in what is often an exact computation, such as basis coefficients. These were all fixed by reorganizing the expression or by adding a well-timed `ZZ()`.