### PR TITLE
gh-38632: Add as_ETuples option to polynomial degrees()

### DIFF
--- a/src/sage/rings/polynomial/multi_polynomial_element.py
+++ b/src/sage/rings/polynomial/multi_polynomial_element.py
@@ -537,7 +537,7 @@ class MPolynomial_polydict(Polynomial_singular_repr, MPolynomial_element):
         macaulay2.use(m2_parent)
         return macaulay2('substitute(%s,%s)' % (repr(self), m2_parent._name))
 
-    def degrees(self, as_ETuples=False):
+    def degrees(self, as_ETuples=True):
         r"""
         Return the maximal degree of each variable in this polynomial.
 
@@ -546,7 +546,7 @@ class MPolynomial_polydict(Polynomial_singular_repr, MPolynomial_element):
 
         INPUT:
 
-        - ``as_ETuples`` -- boolean (default: ``False``); if ``True``, return
+        - ``as_ETuples`` -- boolean (default: ``True``); if ``True``, return
           the result as an :class:`~sage.rings.polynomial.polydict.ETuple`,
           otherwise return a plain :class:`tuple`
 
@@ -555,27 +555,30 @@ class MPolynomial_polydict(Polynomial_singular_repr, MPolynomial_element):
 
         EXAMPLES::
 
-            sage: R.<x,y,z> = PolynomialRing(QQbar)                                     # needs sage.rings.number_field
-            sage: f = 3*x^2 - 2*y + 7*x^2*y^2 + 5                                      # needs sage.rings.number_field
-            sage: f.degrees()                                                            # needs sage.rings.number_field
+            sage: # needs sage.rings.number_field
+            sage: R.<x,y,z> = PolynomialRing(QQbar)
+            sage: f = 3*x^2 - 2*y + 7*x^2*y^2 + 5
+            sage: f.degrees()
             (2, 2, 0)
-            sage: type(f.degrees())                                                      # needs sage.rings.number_field
-            <class 'tuple'>
-            sage: f.degrees(as_ETuples=True)                                             # needs sage.rings.number_field
-            (2, 2, 0)
-            sage: type(f.degrees(as_ETuples=True))                                      # needs sage.rings.number_field
+            sage: type(f.degrees())
             <class 'sage.rings.polynomial.polydict.ETuple'>
-            sage: f = x^2 + z^2                                                          # needs sage.rings.number_field
-            sage: f.degrees()                                                            # needs sage.rings.number_field
+            sage: f.degrees(as_ETuples=False)
+            (2, 2, 0)
+            sage: type(f.degrees(as_ETuples=False))
+            <class 'tuple'>
+            sage: f = x^2 + z^2
+            sage: f.degrees()
             (2, 0, 2)
-            sage: f.total_degree()  # this simply illustrates that total degree is not the sum of the degrees  # needs sage.rings.number_field
+            sage: f.total_degree()  # total degree is not the sum of the degrees
             2
-            sage: R.<x,y,z,u> = PolynomialRing(QQbar)                                   # needs sage.rings.number_field
-            sage: f = (1-x) * (1+y+z+x^3)^5                                             # needs sage.rings.number_field
-            sage: f.degrees()                                                            # needs sage.rings.number_field
+            sage: R.<x,y,z,u> = PolynomialRing(QQbar)
+            sage: f = (1-x) * (1+y+z+x^3)^5
+            sage: f.degrees()
             (16, 5, 5, 0)
-            sage: R(0).degrees()                                                         # needs sage.rings.number_field
+            sage: R(0).degrees()
             (0, 0, 0, 0)
+            sage: type(R(0).degrees(as_ETuples=False))
+            <class 'tuple'>
         """
         if not self:
             e = polydict.ETuple({}, self.parent().ngens())

--- a/src/sage/rings/polynomial/multi_polynomial_element.py
+++ b/src/sage/rings/polynomial/multi_polynomial_element.py
@@ -537,7 +537,7 @@ class MPolynomial_polydict(Polynomial_singular_repr, MPolynomial_element):
         macaulay2.use(m2_parent)
         return macaulay2('substitute(%s,%s)' % (repr(self), m2_parent._name))
 
-    def degrees(self, as_ETuples=True):
+    def degrees(self, as_ETuples=False):
         r"""
         Return the maximal degree of each variable in this polynomial.
 
@@ -546,7 +546,7 @@ class MPolynomial_polydict(Polynomial_singular_repr, MPolynomial_element):
 
         INPUT:
 
-        - ``as_ETuples`` -- boolean (default: ``True``); if ``True``, return
+        - ``as_ETuples`` -- boolean (default: ``False``); if ``True``, return
           the result as an :class:`~sage.rings.polynomial.polydict.ETuple`,
           otherwise return a plain :class:`tuple`
 
@@ -560,11 +560,11 @@ class MPolynomial_polydict(Polynomial_singular_repr, MPolynomial_element):
             sage: f.degrees()                                                            # needs sage.rings.number_field
             (2, 2, 0)
             sage: type(f.degrees())                                                      # needs sage.rings.number_field
-            <class 'sage.rings.polynomial.polydict.ETuple'>
-            sage: f.degrees(as_ETuples=False)                                            # needs sage.rings.number_field
-            (2, 2, 0)
-            sage: type(f.degrees(as_ETuples=False))                                     # needs sage.rings.number_field
             <class 'tuple'>
+            sage: f.degrees(as_ETuples=True)                                             # needs sage.rings.number_field
+            (2, 2, 0)
+            sage: type(f.degrees(as_ETuples=True))                                      # needs sage.rings.number_field
+            <class 'sage.rings.polynomial.polydict.ETuple'>
             sage: f = x^2 + z^2                                                          # needs sage.rings.number_field
             sage: f.degrees()                                                            # needs sage.rings.number_field
             (2, 0, 2)

--- a/src/sage/rings/polynomial/multi_polynomial_element.py
+++ b/src/sage/rings/polynomial/multi_polynomial_element.py
@@ -537,33 +537,53 @@ class MPolynomial_polydict(Polynomial_singular_repr, MPolynomial_element):
         macaulay2.use(m2_parent)
         return macaulay2('substitute(%s,%s)' % (repr(self), m2_parent._name))
 
-    def degrees(self):
+    def degrees(self, as_ETuples=True):
         r"""
-        Return a tuple (precisely - an ``ETuple``) with the
-        degree of each variable in this polynomial. The list of degrees is,
-        of course, ordered by the order of the generators.
+        Return the maximal degree of each variable in this polynomial.
+
+        The degree of each variable is the maximum degree of that variable
+        appearing in any monomial of ``self``.
+
+        INPUT:
+
+        - ``as_ETuples`` -- boolean (default: ``True``); if ``True``, return
+          the result as an :class:`~sage.rings.polynomial.polydict.ETuple`,
+          otherwise return a plain :class:`tuple`
+
+        OUTPUT: an :class:`~sage.rings.polynomial.polydict.ETuple` or a
+        :class:`tuple` with the degree of each variable
 
         EXAMPLES::
 
-            sage: R.<x,y,z> = PolynomialRing(QQbar)
-            sage: f = 3*x^2 - 2*y + 7*x^2*y^2 + 5
-            sage: f.degrees()
+            sage: R.<x,y,z> = PolynomialRing(QQbar)                                     # needs sage.rings.number_field
+            sage: f = 3*x^2 - 2*y + 7*x^2*y^2 + 5                                      # needs sage.rings.number_field
+            sage: f.degrees()                                                            # needs sage.rings.number_field
             (2, 2, 0)
-            sage: f = x^2 + z^2
-            sage: f.degrees()
+            sage: type(f.degrees())                                                      # needs sage.rings.number_field
+            <class 'sage.rings.polynomial.polydict.ETuple'>
+            sage: f.degrees(as_ETuples=False)                                            # needs sage.rings.number_field
+            (2, 2, 0)
+            sage: type(f.degrees(as_ETuples=False))                                     # needs sage.rings.number_field
+            <class 'tuple'>
+            sage: f = x^2 + z^2                                                          # needs sage.rings.number_field
+            sage: f.degrees()                                                            # needs sage.rings.number_field
             (2, 0, 2)
-            sage: f.total_degree()  # this simply illustrates that total degree is not the sum of the degrees
+            sage: f.total_degree()  # this simply illustrates that total degree is not the sum of the degrees  # needs sage.rings.number_field
             2
-            sage: R.<x,y,z,u> = PolynomialRing(QQbar)
-            sage: f = (1-x) * (1+y+z+x^3)^5
-            sage: f.degrees()
+            sage: R.<x,y,z,u> = PolynomialRing(QQbar)                                   # needs sage.rings.number_field
+            sage: f = (1-x) * (1+y+z+x^3)^5                                             # needs sage.rings.number_field
+            sage: f.degrees()                                                            # needs sage.rings.number_field
             (16, 5, 5, 0)
-            sage: R(0).degrees()
+            sage: R(0).degrees()                                                         # needs sage.rings.number_field
             (0, 0, 0, 0)
         """
         if not self:
-            return polydict.ETuple({}, self.parent().ngens())
-        return self._MPolynomial_element__element.max_exp()
+            e = polydict.ETuple({}, self.parent().ngens())
+        else:
+            e = self._MPolynomial_element__element.max_exp()
+        if as_ETuples:
+            return e
+        return tuple(e)
 
     def degree(self, x=None, std_grading=False):
         """

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -2910,11 +2910,22 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             return Integer(result)
         return Integer(singular_polynomial_deg(p, NULL, r))
 
-    def degrees(self):
-        """
-        Return a tuple with the maximal degree of each variable in
-        this polynomial.  The list of degrees is ordered by the order
-        of the generators.
+    def degrees(self, as_ETuples=True):
+        r"""
+        Return the maximal degree of each variable in this polynomial.
+
+        The degree of each variable is the maximum degree of that variable
+        appearing in any monomial of ``self``. The list of degrees is ordered
+        by the order of the generators.
+
+        INPUT:
+
+        - ``as_ETuples`` -- boolean (default: ``True``); if ``True``, return
+          the result as an :class:`~sage.rings.polynomial.polydict.ETuple`,
+          otherwise return a plain :class:`tuple`
+
+        OUTPUT: an :class:`~sage.rings.polynomial.polydict.ETuple` or a
+        :class:`tuple` with the degree of each variable
 
         EXAMPLES::
 
@@ -2923,6 +2934,12 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             3*y0*y1^2*y2
             sage: q.degrees()
             (1, 2, 1)
+            sage: type(q.degrees())
+            <class 'sage.rings.polynomial.polydict.ETuple'>
+            sage: q.degrees(as_ETuples=False)
+            (1, 2, 1)
+            sage: type(q.degrees(as_ETuples=False))
+            <class 'tuple'>
             sage: (q + y0^5).degrees()
             (5, 2, 1)
 
@@ -2937,6 +2954,7 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             sage: type(f.degrees()[0])
             <class 'sage.rings.integer.Integer'>
         """
+        from sage.rings.polynomial.polydict import ETuple
         cdef poly *p = self._poly
         cdef ring *r = self._parent_ring
         cdef int i
@@ -2945,7 +2963,11 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             for i from 0 <= i < r.N:
                 d[i] = max(d[i],p_GetExp(p, i+1, r))
             p = pNext(p)
-        return tuple(map(Integer, d))
+        d = list(map(Integer, d))
+        if as_ETuples:
+            return ETuple(d)
+        return tuple(d)
+
 
     def coefficient(self, degrees):
         """

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -2910,7 +2910,7 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             return Integer(result)
         return Integer(singular_polynomial_deg(p, NULL, r))
 
-    def degrees(self, as_ETuples=True):
+    def degrees(self, as_ETuples=False):
         r"""
         Return the maximal degree of each variable in this polynomial.
 
@@ -2920,7 +2920,7 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
 
         INPUT:
 
-        - ``as_ETuples`` -- boolean (default: ``True``); if ``True``, return
+        - ``as_ETuples`` -- boolean (default: ``False``); if ``True``, return
           the result as an :class:`~sage.rings.polynomial.polydict.ETuple`,
           otherwise return a plain :class:`tuple`
 
@@ -2935,11 +2935,11 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             sage: q.degrees()
             (1, 2, 1)
             sage: type(q.degrees())
-            <class 'sage.rings.polynomial.polydict.ETuple'>
-            sage: q.degrees(as_ETuples=False)
-            (1, 2, 1)
-            sage: type(q.degrees(as_ETuples=False))
             <class 'tuple'>
+            sage: q.degrees(as_ETuples=True)
+            (1, 2, 1)
+            sage: type(q.degrees(as_ETuples=True))
+            <class 'sage.rings.polynomial.polydict.ETuple'>
             sage: (q + y0^5).degrees()
             (5, 2, 1)
 

--- a/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
+++ b/src/sage/rings/polynomial/multi_polynomial_libsingular.pyx
@@ -2942,6 +2942,10 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             <class 'sage.rings.polynomial.polydict.ETuple'>
             sage: (q + y0^5).degrees()
             (5, 2, 1)
+            sage: R(0).degrees(as_ETuples=True)
+            (0, 0, 0)
+            sage: type(R(0).degrees(as_ETuples=True))
+            <class 'sage.rings.polynomial.polydict.ETuple'>
 
         TESTS:
 
@@ -2954,7 +2958,6 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
             sage: type(f.degrees()[0])
             <class 'sage.rings.integer.Integer'>
         """
-        from sage.rings.polynomial.polydict import ETuple
         cdef poly *p = self._poly
         cdef ring *r = self._parent_ring
         cdef int i
@@ -2967,7 +2970,6 @@ cdef class MPolynomial_libsingular(MPolynomial_libsingular_base):
         if as_ETuples:
             return ETuple(d)
         return tuple(d)
-
 
     def coefficient(self, degrees):
         """

--- a/src/sage/rings/polynomial/plural.pyx
+++ b/src/sage/rings/polynomial/plural.pyx
@@ -2031,13 +2031,20 @@ cdef class NCPolynomial_plural(RingElement):
         cdef ring *r = (<NCPolynomialRing_plural>self._parent)._ring
         return singular_polynomial_deg(p, NULL, r)
 
-    def degrees(self):
-        """
-        Return a tuple with the maximal degree of each variable in
-        this polynomial.
+    def degrees(self, as_ETuples=True):
+        r"""
+        Return the maximal degree of each variable in this polynomial.
 
-        The list of degrees is ordered by the order
-        of the generators.
+        The list of degrees is ordered by the order of the generators.
+
+        INPUT:
+
+        - ``as_ETuples`` -- boolean (default: ``True``); if ``True``, return
+          the result as an :class:`~sage.rings.polynomial.polydict.ETuple`,
+          otherwise return a plain :class:`tuple`
+
+        OUTPUT: an :class:`~sage.rings.polynomial.polydict.ETuple` or a
+        :class:`tuple` with the degree of each variable
 
         EXAMPLES::
 
@@ -2049,9 +2056,16 @@ cdef class NCPolynomial_plural(RingElement):
             3*y0*y1^2*y2
             sage: q.degrees()
             (1, 2, 1)
+            sage: type(q.degrees())
+            <class 'sage.rings.polynomial.polydict.ETuple'>
+            sage: q.degrees(as_ETuples=False)
+            (1, 2, 1)
+            sage: type(q.degrees(as_ETuples=False))
+            <class 'tuple'>
             sage: (q + y0^5).degrees()
             (5, 2, 1)
         """
+        from sage.rings.polynomial.polydict import ETuple
         cdef poly *p = self._poly
         cdef ring *r = (<NCPolynomialRing_plural>self._parent)._ring
         cdef int i
@@ -2060,7 +2074,10 @@ cdef class NCPolynomial_plural(RingElement):
             for i from 0 <= i < r.N:
                 d[i] = max(d[i], p_GetExp(p, i+1, r))
             p = pNext(p)
+        if as_ETuples:
+            return ETuple(d)
         return tuple(d)
+
 
     def coefficient(self, degrees):
         """

--- a/src/sage/rings/polynomial/plural.pyx
+++ b/src/sage/rings/polynomial/plural.pyx
@@ -2064,8 +2064,11 @@ cdef class NCPolynomial_plural(RingElement):
             <class 'sage.rings.polynomial.polydict.ETuple'>
             sage: (q + y0^5).degrees()
             (5, 2, 1)
+            sage: R(0).degrees(as_ETuples=True)
+            (0, 0, 0)
+            sage: type(R(0).degrees(as_ETuples=True))
+            <class 'sage.rings.polynomial.polydict.ETuple'>
         """
-        from sage.rings.polynomial.polydict import ETuple
         cdef poly *p = self._poly
         cdef ring *r = (<NCPolynomialRing_plural>self._parent)._ring
         cdef int i
@@ -2077,7 +2080,6 @@ cdef class NCPolynomial_plural(RingElement):
         if as_ETuples:
             return ETuple(d)
         return tuple(d)
-
 
     def coefficient(self, degrees):
         """

--- a/src/sage/rings/polynomial/plural.pyx
+++ b/src/sage/rings/polynomial/plural.pyx
@@ -2031,7 +2031,7 @@ cdef class NCPolynomial_plural(RingElement):
         cdef ring *r = (<NCPolynomialRing_plural>self._parent)._ring
         return singular_polynomial_deg(p, NULL, r)
 
-    def degrees(self, as_ETuples=True):
+    def degrees(self, as_ETuples=False):
         r"""
         Return the maximal degree of each variable in this polynomial.
 
@@ -2039,7 +2039,7 @@ cdef class NCPolynomial_plural(RingElement):
 
         INPUT:
 
-        - ``as_ETuples`` -- boolean (default: ``True``); if ``True``, return
+        - ``as_ETuples`` -- boolean (default: ``False``); if ``True``, return
           the result as an :class:`~sage.rings.polynomial.polydict.ETuple`,
           otherwise return a plain :class:`tuple`
 
@@ -2057,11 +2057,11 @@ cdef class NCPolynomial_plural(RingElement):
             sage: q.degrees()
             (1, 2, 1)
             sage: type(q.degrees())
-            <class 'sage.rings.polynomial.polydict.ETuple'>
-            sage: q.degrees(as_ETuples=False)
-            (1, 2, 1)
-            sage: type(q.degrees(as_ETuples=False))
             <class 'tuple'>
+            sage: q.degrees(as_ETuples=True)
+            (1, 2, 1)
+            sage: type(q.degrees(as_ETuples=True))
+            <class 'sage.rings.polynomial.polydict.ETuple'>
             sage: (q + y0^5).degrees()
             (5, 2, 1)
         """


### PR DESCRIPTION
This is a rebased and compatibility-corrected version of #42634 by
@Chaitanya140904.

## Problem

The `degrees()` return type differs between multivariate polynomial backends.
The generic `MPolynomial_polydict` backend historically returns `ETuple`, while
the libSingular and Plural backends return `tuple`.

#42634 added an `as_ETuples` option, but its compatibility follow-up changed
the default to `False` for every backend.  That changes the existing generic
backend API and breaks internal calls such as
`degrees().nonzero_positions()`.

Conversely, changing the libSingular and Plural defaults to `ETuple` would
break callers that rely on tuple operations such as negative indexing and
`.index()`.

## Solution

- Add `as_ETuples` to the generic, libSingular, and Plural implementations.
- Preserve each backend's historical default:
  - generic polydict: `as_ETuples=True`
  - libSingular and Plural: `as_ETuples=False`
- Allow callers to request either representation explicitly.
- Document and test both return types, including zero polynomials.
- Remove redundant `ETuple` imports.

This follows the compatibility strategy proposed in #42448 while also covering
the Plural backend.

## Testing

- Full Meson/Ninja build (1395 targets)
- Doctests for all three modified implementations (2587 tests)
- Regression doctests for the Drinfeld modular form and cluster seed callers
  (791 tests)
- Direct smoke tests for all three backends

All tests pass.

Closes #38632.
