### PR TITLE
Avoid mutating vectors in immutable construction

### DIFF
--- a/src/sage/modules/free_module_element.pyx
+++ b/src/sage/modules/free_module_element.pyx
@@ -457,6 +457,24 @@ def vector(arg0, arg1=None, arg2=None, sparse=None, immutable=False):
         sage: v = vector(w, immutable=True)
         sage: v.is_immutable()
         True
+
+    Constructing an immutable vector from a vector does not change the input::
+
+        sage: v = vector([1, 2])
+        sage: w = vector(v, immutable=True)
+        sage: w is v
+        False
+        sage: w.is_immutable()
+        True
+        sage: v.is_immutable()
+        False
+
+    This also holds for sparse vectors and when a base ring is specified::
+
+        sage: v = vector(ZZ, [1, 2], sparse=True)
+        sage: w = vector(v, ZZ, immutable=True)
+        sage: w.is_immutable(), v.is_immutable(), w is v
+        (True, False, False)
         sage: w = np.array([i, 2, 3], complex)
         sage: v = vector(w, immutable=True)
         sage: v.is_immutable()
@@ -502,6 +520,8 @@ def vector(arg0, arg1=None, arg2=None, sparse=None, immutable=False):
     else:
         v = arg0_vector_(arg1)
         if immutable:
+            from copy import copy
+            v = copy(v)
             v.set_immutable()
         return v
 
@@ -512,6 +532,8 @@ def vector(arg0, arg1=None, arg2=None, sparse=None, immutable=False):
     else:
         v = arg1_vector_(arg0)
         if immutable:
+            from copy import copy
+            v = copy(v)
             v.set_immutable()
         return v
 

--- a/src/sage/modules/free_module_element.pyx
+++ b/src/sage/modules/free_module_element.pyx
@@ -457,6 +457,10 @@ def vector(arg0, arg1=None, arg2=None, sparse=None, immutable=False):
         sage: v = vector(w, immutable=True)
         sage: v.is_immutable()
         True
+        sage: w = np.array([i, 2, 3], complex)
+        sage: v = vector(w, immutable=True)
+        sage: v.is_immutable()
+        True
 
     Constructing an immutable vector from a vector does not change the input::
 
@@ -475,10 +479,18 @@ def vector(arg0, arg1=None, arg2=None, sparse=None, immutable=False):
         sage: w = vector(v, ZZ, immutable=True)
         sage: w.is_immutable(), v.is_immutable(), w is v
         (True, False, False)
-        sage: w = np.array([i, 2, 3], complex)
-        sage: v = vector(w, immutable=True)
-        sage: v.is_immutable()
-        True
+
+    This holds for empty vectors over the double fields too::
+
+        sage: # needs numpy
+        sage: v = vector(RDF, [])
+        sage: w = vector(v, immutable=True)
+        sage: w.is_immutable(), v.is_immutable(), w is v
+        (True, False, False)
+        sage: v = vector(CDF, [])
+        sage: w = vector(v, immutable=True)
+        sage: w.is_immutable(), v.is_immutable(), w is v
+        (True, False, False)
 
     TESTS:
 

--- a/src/sage/modules/vector_numpy_dense.pyx
+++ b/src/sage/modules/vector_numpy_dense.pyx
@@ -124,8 +124,6 @@ cdef class Vector_numpy_dense(FreeModuleElement):
             sage: a == copy(a)
             True
         """
-        if self._degree == 0:
-            return self
         from copy import copy
         return self._new(copy(self._vector_numpy))
 


### PR DESCRIPTION
Fixes #35693.

When `vector(..., immutable=True)` takes either `_vector_` fast path, copy the returned vector before making it immutable. This prevents `vector(v, immutable=True)` from mutating `v` while retaining the fast paths for the default mutable construction.

Add regression doctests for dense and sparse vector inputs.

Testing:
- `git diff --check`
- `./sage -t src/sage/modules/free_module_element.pyx` *(could not start: this checkout has no built Sage Python environment)*
- Cython syntax check unavailable: `cython` is not installed in this environment.