### PR TITLE
Document that PARI conversion loses the row count for matrices with zero columns

### DIFF
--- a/src/sage/matrix/matrix1.pyx
+++ b/src/sage/matrix/matrix1.pyx
@@ -85,6 +85,16 @@ cdef class Matrix(Matrix0):
             [3.0 1.0]
             sage: b = pari(a); b                                                        # needs sage.libs.pari
             [1.000000000..., 2.000000000...; 3.000000000..., 1.000000000...]
+
+        A PARI ``t_MAT`` is a vector of columns, so a matrix with no columns
+        has nowhere to record its number of rows.  The row count is therefore
+        lost for such a matrix, while the number of columns is preserved when
+        there are no rows::
+
+            sage: matrix(GF(5), 2, 0).__pari__()                                        # needs sage.libs.pari
+            [;]
+            sage: matrix(GF(5), 0, 3).__pari__()                                        # needs sage.libs.pari
+            matrix(0,3)
         """
         from sage.libs.pari import pari
         return pari.matrix(self._nrows, self._ncols, self._list())

--- a/src/sage/matrix/matrix_integer_dense.pyx
+++ b/src/sage/matrix/matrix_integer_dense.pyx
@@ -5946,7 +5946,7 @@ cdef class Matrix_integer_dense(Matrix_dense):
         return A
 
     def __pari__(self):
-        """
+        r"""
         Return PARI C-library version of this matrix.
 
         EXAMPLES::
@@ -5958,6 +5958,22 @@ cdef class Matrix_integer_dense(Matrix_dense):
             [1, 2; 3, 4]
             sage: type(pari(a))
             <class 'cypari2.gen.Gen'>
+
+        A PARI ``t_MAT`` is a vector of columns, so a matrix with no columns
+        has nowhere to record its number of rows.  The row count is therefore
+        lost for such a matrix::
+
+            sage: matrix(ZZ, 2, 0).__pari__()
+            [;]
+            sage: matrix(ZZ, 2, 0).__pari__().sage().dimensions()
+            (0, 0)
+
+        The number of columns is preserved when there are no rows::
+
+            sage: matrix(ZZ, 0, 3).__pari__()
+            matrix(0,3)
+            sage: matrix(ZZ, 0, 3).__pari__().sage().dimensions()
+            (0, 3)
         """
         return integer_matrix(self._matrix, 0)
 

--- a/src/sage/matrix/matrix_rational_dense.pyx
+++ b/src/sage/matrix/matrix_rational_dense.pyx
@@ -2909,13 +2909,27 @@ cdef class Matrix_rational_dense(Matrix_dense):
     # ###############################################
 
     def __pari__(self):
-        """
+        r"""
         Return pari version of this matrix.
 
         EXAMPLES::
 
             sage: matrix(QQ,2,[1/5,-2/3,3/4,4/9]).__pari__()
             [1/5, -2/3; 3/4, 4/9]
+
+        A PARI ``t_MAT`` is a vector of columns, so a matrix with no columns
+        has nowhere to record its number of rows.  The row count is therefore
+        lost for such a matrix, while the number of columns is preserved when
+        there are no rows::
+
+            sage: matrix(QQ, 2, 0).__pari__()
+            [;]
+            sage: matrix(QQ, 2, 0).__pari__().sage().dimensions()
+            (0, 0)
+            sage: matrix(QQ, 0, 3).__pari__()
+            matrix(0,3)
+            sage: matrix(QQ, 0, 3).__pari__().sage().dimensions()
+            (0, 3)
         """
         return rational_matrix(self._matrix, False)
 


### PR DESCRIPTION
Fixes #42743.

A PARI `t_MAT` is a vector of columns, so the number of rows is only
recoverable from the length of a column. A matrix with no columns has nowhere
to record it, and `gen_to_sage_matrix` makes that explicit:

```cython
nc = lg(g) - 1
nr = 0 if nc == 0 else lg(gel(g,1)) - 1
```

So `matrix(ZZ, 2, 0)` converts to a `0 x 0` PARI matrix and does not survive a
round trip, while the transposed case keeps its shape:

```
dims | pari repr   | matsize | round-trip dims
0x3  | matrix(0,3) | [0, 3]  | (0, 3)
2x0  | [;]         | [0, 0]  | (0, 0)
3x0  | [;]         | [0, 0]  | (0, 0)
```

`matrix(QQ, ...)` behaves identically.

This looks inherent to PARI's representation rather than something to fix in
the conversion, so this PR only records the behaviour: doctests for both the
preserved and the lost case, and a short note giving the reason. No code
changes, so there is nothing to regress.

If maintainers would rather `__pari__` reject the ambiguous case instead of
converting silently, that would be a behaviour change and I am happy to
redo it that way — see the discussion in #42743.

`Matrix_rational_dense.__pari__` has the same behaviour. I have left it alone
here to keep the change reviewable; happy to extend it in this PR if preferred.

### Verification

```
$ ./sage -t src/sage/matrix/matrix_integer_dense.pyx
[685 tests, 7.15s wall]
All tests passed!
```

Confirmed the new doctests actually execute rather than being skipped against a
stale build — the compiled docstring contains 8 `sage:` lines after the change,
up from 4.

Tested on macOS 26 / arm64 against 10.10.beta0. The `__pari__` method and
`gen_to_sage_matrix` are byte-identical on `develop`, and the patch applies
there cleanly.
