### PR TITLE
src/sage/matrix/matrix_double_dense.pyx: wrap numpy's matrix_rank()

### DIFF
--- a/src/sage/matrix/matrix_double_dense.pyx
+++ b/src/sage/matrix/matrix_double_dense.pyx
@@ -3860,3 +3860,128 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
             [     -3.0*I         2.0        -2.0]
         """
         return self.transpose()._normalize_columns().transpose()
+
+    def rank(self, tol=None, hermitian=False, rtol=None):
+        r"""
+        Compute the rank of this matrix.
+
+        This method wraps :func:`numpy.linalg.matrix_rank` and
+        determines the rank of the matrix by counting its nonzero
+        singular values subject to a tolerance.
+
+        INPUT:
+
+        - ``tol`` -- float (default: ``None``); absolute threshold
+          below which SVD values are considered zero. Leave
+          unspecified for the numpy default.
+
+        - ``hermitian`` -- bool (default: ``False``); whether or not
+          to assume that this matrix is Hermitian to improve
+          performance.
+
+        - ``rtol`` -- float (default: ``None``); relative (to the
+          largest singular value) threshold below which SVD values are
+          considered zero. Mutually exclusive to ``tol``. Leave
+          unspecified for the numpy default.
+
+        OUTPUT:
+
+        A nonnegative integer.
+
+        EXAMPLES::
+
+            sage: A = matrix.identity(RDF, 4)
+            sage: A.rank()
+            4
+            sage: A.change_ring(CDF).rank()
+            4
+            sage: A[3,3] = 0.0
+            sage: A.rank()
+            3
+            sage: A.change_ring(CDF).rank()
+            3
+
+        ::
+
+            sage: A = matrix.ones(RDF, 4)
+            sage: A.rank()
+            1
+            sage: B = A.change_ring(CDF)*I
+            sage: B.rank()
+            1
+
+        TESTS:
+
+        An example from the mailing list::
+
+            sage: A = matrix([[-3, 2, 1 ],
+            ....:             [ 2,-4, 4 ],
+            ....:             [ 1, 2,-5 ]])
+            sage: B = (2 * RDF(0.5) * A)
+            sage: A.rank() == B.rank()
+            True
+
+        The example from :issue:`7392`::
+
+            sage: A = matrix(RDF, [[1.5, 1.75],
+            ....:                  [1.5, 1.75]])
+            sage: A.rank()
+            1
+            sage: B = A.change_ring(CDF)*I
+            sage: B.rank()
+            1
+
+        Changing the ring of a random matrix over an exact field to
+        ``RDF`` or ``CDF`` should not affect its rank::
+
+            sage: A = matrix.random(QQ, 4)
+            sage: B = A.change_ring(RDF)
+            sage: A.rank() == B.rank()
+            True
+            sage: F = GaussianIntegers().fraction_field()
+            sage: A = matrix.random(F, 4)
+            sage: B = A.change_ring(CDF)
+            sage: A.rank() == B.rank()
+            True
+
+        A real, symmetric, positive-definite example::
+
+            sage: alpha = RDF._random_nonzero_element().abs()
+            sage: A = matrix.random(RDF, 4)
+            sage: A = A*A.T + alpha*matrix.identity(RDF, 4)
+            sage: A.is_positive_definite()
+            True
+            sage: A.rank(hermitian=True)
+            4
+
+        And a Hermitian, complex, positive-definite one::
+
+            sage: alpha = CDF._random_nonzero_element().abs()
+            sage: A = matrix.random(CDF, 4)
+            sage: A = A*A.H + alpha*matrix.identity(CDF, 4)
+            sage: A.is_positive_definite()
+            True
+            sage: A.rank(hermitian=True)
+            4
+        """
+        key = ("rank", tol, hermitian, rtol)
+        cached = self.fetch(key)
+        if cached is not None:
+            return cached
+
+        global numpy
+        if numpy is None:
+            import numpy
+
+        # numpy-2.4.5 and newer do not need the special case
+        # for empty matrices
+        if self._nrows == 0 or self._ncols == 0:
+            result = 0
+        else:
+            result = numpy.linalg.matrix_rank(self.numpy(),
+                                              tol=tol,
+                                              hermitian=hermitian,
+                                              rtol=rtol)
+        result = sage.rings.integer.Integer(result)
+        self.cache(key, result)
+        return result

--- a/src/sage/matrix/matrix_double_dense.pyx
+++ b/src/sage/matrix/matrix_double_dense.pyx
@@ -3931,18 +3931,20 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
             sage: B.rank()
             1
 
-        As long as its entries do not vary too widely in magnitude,
-        changing the ring of a random matrix over an exact field to
-        ``RDF`` or ``CDF`` should not affect its rank::
+        If its entries are nice enough, changing the ring of a small
+        random matrix over an exact field to ``RDF`` or ``CDF`` should
+        not affect its rank. This is not a theoretical guarantee and
+        depends on the implementation of the SVD, but it serves as an
+        easy smoke test::
 
-            sage: entries = [ QQ.random_element(2^16)
+            sage: entries = [ QQ.random_element(2^5)
             ....:             for _ in range(16) ]
             sage: A = matrix(QQ, 4, entries)
             sage: B = A.change_ring(RDF)
             sage: A.rank() == B.rank()
             True
             sage: F = GaussianIntegers().fraction_field()
-            sage: entries = [ F.random_element(2^16, 2^16)
+            sage: entries = [ F.random_element(2^5, 2^5)
             ....:             for _ in range(16) ]
             sage: A = matrix(F, 4, entries)
             sage: B = A.change_ring(CDF)

--- a/src/sage/matrix/matrix_double_dense.pyx
+++ b/src/sage/matrix/matrix_double_dense.pyx
@@ -3931,15 +3931,20 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
             sage: B.rank()
             1
 
-        Changing the ring of a random matrix over an exact field to
+        As long as its entries do not vary too widely in magnitude,
+        changing the ring of a random matrix over an exact field to
         ``RDF`` or ``CDF`` should not affect its rank::
 
-            sage: A = matrix.random(QQ, 4)
+            sage: entries = [ QQ.random_element(2^16)
+            ....:             for _ in range(16) ]
+            sage: A = matrix(QQ, 4, entries)
             sage: B = A.change_ring(RDF)
             sage: A.rank() == B.rank()
             True
             sage: F = GaussianIntegers().fraction_field()
-            sage: A = matrix.random(F, 4)
+            sage: entries = [ F.random_element(2^16, 2^16)
+            ....:             for _ in range(16) ]
+            sage: A = matrix(F, 4, entries)
             sage: B = A.change_ring(CDF)
             sage: A.rank() == B.rank()
             True
@@ -3963,6 +3968,7 @@ cdef class Matrix_double_dense(Matrix_numpy_dense):
             True
             sage: A.rank(hermitian=True)
             4
+
         """
         key = ("rank", tol, hermitian, rtol)
         cached = self.fetch(key)


### PR DESCRIPTION
We have several half-finished attempts at fixing `rank()` over inexact fields, but in the special cases of `RDF` and `CDF`, numpy has implemented it. Rather than begin another generic solution, this commit settles for the easy win: we wrap `numpy.linalg.matrix_rank()` directly.

This addresses the most egregious bug reports and should not stand in the way of a more general solution in the future.

Fixes: https://github.com/sagemath/sage/issues/7392
Fixes: https://github.com/sagemath/sage/issues/42704

**Doc shortcut**:
* https://doc-pr-42745--sagemath.netlify.app/html/en/reference/matrices/sage/matrix/matrix_double_dense#sage.matrix.matrix_double_dense.Matrix_double_dense.rank

**See also**:
* https://github.com/sagemath/sage/pull/39752
* https://github.com/sagemath/sage/pull/41824
* https://github.com/sagemath/sage/pull/42705