### PR TITLE
Fix pushforward of ideals to not enforce full-rank check in codomain

### DIFF
--- a/src/sage/rings/morphism.pyx
+++ b/src/sage/rings/morphism.pyx
@@ -879,11 +879,24 @@ cdef class RingHomomorphism(RingMap):
             sage: f.pushforward(R.ideal([x, 3*x + x*y + y^2]))                          # needs sage.libs.singular
             Ideal (xx, xx*yy + 3*xx) of Quotient of Multivariate Polynomial Ring
              in x, y over Rational Field by the ideal (x^2, y^2)
+
+        Check that :issue:`38422` is fixed, i.e. that the pushforward of an
+        ideal that does not have full rank in the codomain (such as a
+        fractional ideal of a quadratic field embedded into a quaternion
+        algebra) no longer spuriously raises an error::
+
+            sage: B.<i,j,k> = QuaternionAlgebra(-1, -1)
+            sage: O = B.maximal_order()
+            sage: K = QuadraticField(-35)
+            sage: I = K.class_group()[1].ideal()
+            sage: f0 = K.hom([5*i + j + 3*k])
+            sage: O * f0(I)
+            Fractional ideal (3, 3*i, 2 + 2*i + j, 3/2 + 1/2*i + 1/2*j + 1/2*k)
         """
         if not isinstance(I, ideal.Ideal_generic):
             raise TypeError("I must be an ideal")
         R = self.codomain()
-        return R.ideal([self(y) for y in I.gens()])
+        return R.ideal([self(y) for y in I.gens()], check=False)
 
     def inverse_image(self, I):
         """


### PR DESCRIPTION
Fixes #38422
### 
### Problem

`RingHomomorphism.pushforward` constructs the pushed-forward ideal via
`R.ideal(gens)` with the default `check=True`. For some codomains — e.g.
`QuaternionAlgebra_ab` — `ideal()` validates that the given generators
span a full-rank (rank 4) lattice, raising `ValueError: fractional ideal
must have rank 4` otherwise.

This check is too strict for `pushforward`'s use case: `gens` here are
already valid elements of the codomain (produced by applying the
homomorphism to `I.gens()`), and a pushed-forward ideal need not itself
be full rank in the codomain — e.g. the image of a fractional ideal of a
quadratic field `K` under an embedding `K \to B` into a quaternion
algebra only has ℤ-rank 2 (since `[K:\mathbb{Q}] = 2`), and is intended
to be used as an intermediate object, e.g. multiplied against a maximal
order's basis, to produce a genuine rank-4 ideal.

### Fix

Pass `check=False` to `R.ideal(...)` in `pushforward`, since the inputs
are already known-valid ring elements and don't need re-validation.

### Example (from the issue)

```python
sage: B.<i,j,k> = QuaternionAlgebra(-1, -1)
sage: O = B.maximal_order()
sage: K = QuadraticField(-35)
sage: I = K.class_group()[1].ideal()
sage: f0 = K.hom([5*i + j + 3*k])
sage: O * f0(I)
Fractional ideal (3, 3*i, 2 + 2*i + j, 3/2 + 1/2*i + 1/2*j + 1/2*k)
```

### Checklist
- [x] The title is concise and informative
- [x] The description explains in detail what this PR is about
- [x] I have linked a relevant issue or discussion
- [x] I have created tests covering the changes (regression doctest added)
- [ ] I have updated the documentation accordingly (not applicable — internal fix)
