### PR TITLE
build/pkgs/gsl: Refresh config.guess and config.sub before configuring

### DIFF
--- a/build/pkgs/gsl/spkg-install.in
+++ b/build/pkgs/gsl/spkg-install.in
@@ -1,5 +1,8 @@
 cd src
 
+# Use newer versions of config.guess and config.sub (see Issue #42737)
+cp "$SAGE_ROOT"/config/config.* .
+
 sdh_configure LIBS="`pkg-config --libs-only-l cblas` -lm" \
               LDFLAGS="$LDFLAGS `pkg-config --libs-only-L cblas`" \
               CPPFLAGS="$CPPFLAGS `pkg-config --cflags-only-I cblas`" \


### PR DESCRIPTION
## Description

The GSL 2.7.1 release tarball contains config.guess and config.sub files dated 2013. Its config.sub rejects the build alias arm64-apple-darwin20.0.0 before any GSL source is compiled, while the current GNU config files canonicalize it to aarch64-apple-darwin20.0.0.

Copy the current config auxiliary files maintained by Sage into the unpacked GSL source tree before running sdh_configure. This follows the existing practice used by other bundled packages and restores a step that the Sage GSL package used historically. The change only affects the bundled-GSL build path.

The reporter later found that a reconfigured Conda environment detects the system GSL and no longer enters this path. This change addresses the separate case where bundled GSL is selected or explicitly requested.

Fixes #42737.

## Testing

- bash -n build/pkgs/gsl/spkg-install.in
- git diff --check
- Confirmed that the original GSL 2.7.1 config.sub rejects arm64-apple-darwin20.0.0 with exit status 1.
- Confirmed that the copied Sage config.sub canonicalizes the same input to aarch64-apple-darwin20.0.0.
- Confirmed that configure with build_alias=arm64-apple-darwin20.0.0 completes after copying the auxiliary files.
- Built GSL 2.7.1 from a clean source tree and ran make check -j2 successfully after copying the auxiliary files.

No documentation changes are needed.

## Checklist

- [x] The title is concise and informative.
- [x] The description explains the reason for the change.
- [x] A relevant issue is linked.
- [x] The change was covered by directed regression testing and the upstream GSL test suite.

## Dependencies

None.