### PR TITLE
Update Weil polynomials package from upstream

### DIFF
--- a/src/sage/rings/polynomial/weil/flint-utils.c
+++ b/src/sage/rings/polynomial/weil/flint-utils.c
@@ -1,0 +1,307 @@
+/*
+  FLINT utility functions.
+
+#*****************************************************************************
+#       Copyright (C) 2019-2026 Kiran S. Kedlaya <kskedl@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#                  http://www.gnu.org/licenses/
+#*****************************************************************************
+
+*/
+
+#include <stdlib.h>
+#include "flint-utils.h"
+
+#define ROTATE(x, y, z) { x = y; y = z; z = x; }
+/*****
+  Arithmetic functions
+
+  As with FLINT library functions, aliasing is allowed unless specified.
+*****/
+
+inline int is_mpz(fmpz f) {
+  return(COEFF_IS_MPZ(f));
+}
+
+/* Set res to a*b, interpreting NULL for a as 1. */
+void fmpz_opt_mul(fmpz_t res, const fmpz_t a, const fmpz_t b) {
+  if (a) fmpz_mul(res, a, b); else fmpz_set(res, b);
+}
+
+/* Set res to a*b + c, interpreting NULL for a as 1.
+   Aliasing not allowed between res and c unless a == NULL. */
+void fmpz_opt_addmul(fmpz_t res, const fmpz_t a, const fmpz_t b, const fmpz_t c) {
+  if (a) {
+    fmpz_mul(res, a, b);
+    fmpz_add(res, res, c);
+  }
+  else fmpz_add(res, b, c);
+}
+
+/* Set res to floor((a+b)/2). */
+void fmpz_fmid(fmpz_t res, const fmpz_t a, const fmpz_t b) {
+  fmpz_add(res, a, b);
+  fmpz_fdiv_q_ui(res, res, 2);
+}
+
+/* Set res to ceil((a+b)/2). */
+void fmpz_cmid(fmpz_t res, const fmpz_t a, const fmpz_t b) {
+  fmpz_add(res, a, b);
+  fmpz_cdiv_q_ui(res, res, 2);
+}
+
+/* Set res to ceil(sqrt(a)). For the floor, use FLINT's built-in fmpz_sqrt instead. */
+void fmpz_sqrt_c(fmpz_t res, const fmpz_t a) {
+  int s = fmpz_root(res, a, 2);
+  if (!s) fmpz_add_ui(res, res, 1);
+}
+
+/* Set res to floor(a/b) if r == 0 and ceil(r/b) if r == 1. Aliasing allowed. */
+void fmpz_div_q(fmpz_t res, const fmpz_t a, const fmpz_t b, int r) {
+  if (r) fmpz_cdiv_q(res, a, b); else fmpz_fdiv_q(res, a, b);
+}
+
+/* Set res to the floor (if r==0) or ceiling (if r==1) of (a/b + c sqrt(q))/d).
+   No aliasing allowed. b and d must be positive.
+   If b is NULL we interpret it as 1. If c is NULL we interpret it as 0. */
+void fmpq_floor_ceil_quad(fmpz_t res, int r, const fmpz_t a, const fmpz_t b, const fmpz_t c, const fmpz_t d, const fmpz_t q) {
+  const fmpz *tmp;
+
+  if (c) {
+    int s = fmpz_sgn(c) > 0;
+    fmpz_mul(res, c, c);
+    fmpz_mul(res, res, q);
+    if (r ^ s) fmpz_sqrt(res, res); else fmpz_sqrt_c(res, res);
+    if (!s) fmpz_neg(res, res);
+    if (b) fmpz_mul(res, res, b);
+    fmpz_add(res, res, a);
+    tmp = res;
+  } else tmp = a;
+  if (b) { fmpz_div_q(res, tmp, b, r); tmp = res; }
+  fmpz_div_q(res, tmp, d, r);
+}
+
+/* Compute (a*b-c*d)/e assuming that division is exact.
+   Aliasing allowed except between res and e. */
+void fmpz_fmms_divexact(fmpz *res, const fmpz *a, const fmpz *b, const fmpz *c, const fmpz *d, const fmpz_t e) {
+  fmpz_fmms(res, a, b, c, d);
+  fmpz_divexact(res, res, e);
+}
+
+/* Compute the vector res with res[i] = a[i]*b[i].
+   Aliasing allowed except for *partial* overlap between res and a, b. */
+void _fmpz_vec_mul(fmpz *res, const fmpz *a, const fmpz *b, int n) {
+  for (int i=0; i<n; i++) fmpz_mul(res+i, a+i, b+i);
+}
+
+/* Compute the vector res with res[i] = a[i]*b[i] - c[i]*d[i].
+   Aliasing allowed except for *partial* overlap between res and a, b, c, or d. */
+void _fmpz_vec_fmms(fmpz *res, const fmpz *a, const fmpz *b, const fmpz *c, const fmpz *d, int n) {
+  for (int i=0; i<n; i++) fmpz_fmms(res+i, a+i, b+i, c+i, d+i);
+}
+
+/* Compute the vector res with res[i] = a[i]*b + c[i]*d.
+   No aliasing allowed between res and b or d.
+   No partial overlap allowed between res and a or c. */
+void _fmpz_vec_scalar_fmma(fmpz *res, const fmpz *a, const fmpz_t b, const fmpz *c, const fmpz_t d, int n) {
+  for (int i=0; i<n; i++) fmpz_fmma(res+i, a+i, b, c+i, d);
+}
+
+/* Compute the vector res with res[i] = a[i]*b - c[i]*d.
+   No aliasing allowed between res and b or d.
+   No partial overlap allowed between res and a or c. */
+void _fmpz_vec_scalar_fmms(fmpz *res, const fmpz *a, const fmpz_t b, const fmpz *c, const fmpz_t d, int n) {
+  for (int i=0; i<n; i++) fmpz_fmms(res+i, a+i, b, c+i, d);
+}
+
+/* Compute the vector res with res[i] = (a[i]*b - c[i]*d)/e assuming that division is exact.
+   No aliasing allowed between res and b, d, or e.
+   No partial overlap allowed between res and a or c. */
+void _fmpz_vec_scalar_fmms_divexact(fmpz *res, const fmpz *a, const fmpz *b, const fmpz *c, const fmpz *d, int n, const fmpz *e) {
+  _fmpz_vec_scalar_fmms(res, a, b, c, d, n);
+  _fmpz_vec_scalar_divexact_fmpz_wrapper(res, res, n, e);
+ }
+
+/* Compute the vector res with res[i] = (a[i]*b[i] - c[i]*d[i])/e[i] assuming that division is exact.
+   No partial overlap allowed between res and a, b, c, d, or e. */
+void _fmpz_vec_fmms_divexact(fmpz *res, const fmpz *a, const fmpz *b, const fmpz *c, const fmpz *d, const fmpz_t e, int n) {
+  for (int i=0; i<n; i++) fmpz_fmms_divexact(res+i, a+i, b+i, c+i, d+i, e+i);
+}
+
+/* Compute the vector res with res[i] = a[i]*b + c[i].
+   Aliasing not allowed between res and b. */
+void _fmpz_vec_scalar_fmma_one(fmpz *res, const fmpz *a, const fmpz_t b, const fmpz *c, int n) {
+  _fmpz_vec_scalar_mul_fmpz(res, a, n, b);
+  _fmpz_vec_add(res, res, c, n);
+}
+
+/* Compute the vector res with res[i] = a[i]*b - c[i].
+   Aliasing not allowed between res and b. */
+void _fmpz_vec_scalar_fmms_one(fmpz *res, const fmpz *a, const fmpz_t b, const fmpz *c, int n) {
+  _fmpz_vec_scalar_mul_fmpz(res, a, n, b);
+  _fmpz_vec_sub(res, res, c, n);
+}
+
+/*
+  Compute the Hankel determinant associated to the sequence seq of odd length n
+  by a direct application of FLINT's determinant function.
+*/
+
+void hankel_determinant_direct(fmpz_t res, const fmpz *seq, int n) {
+  fmpz_mat_t mat;
+  int s = n/2 + 1;
+  fmpz_mat_init(mat, s, s);
+  for (int i=0; i<s; i++)
+    for (int j=0; j<s; j++)
+      fmpz_set(fmpz_mat_entry(mat, i, j), seq+i+j);
+  fmpz_mat_det(res, mat);
+  fmpz_mat_clear(mat);
+  return;
+}
+
+/*
+  Attempt to compute the Hankel determinant associated to the sequence seq of odd length n
+  using Dodgson condensation. Returns 1 for success, 0 for failure.
+
+  This function assumes that {w, 2*n-5} is scratch space.
+*/
+
+int hankel_determinant_condensation(fmpz_t res, const fmpz *seq, int n, fmpz *w) {
+  if (n == 1) { fmpz_set(res, seq); return(1); }
+
+  int i, n1 = n-2;
+  fmpz *f0 = w; // Length n-2
+  fmpz *f1 = w+n1; // Length max(0,n-4)
+  fmpz *t = (fmpz *)seq;
+
+  _fmpz_vec_fmms(f0, t, t+2, t+1, t+1, n1);
+  while (n1 > 1) {
+    n1 -= 2;
+    for (i=0; i<n1; i++) if (fmpz_is_zero(t+i+2)) return(0); // Failure because of zero division
+    _fmpz_vec_fmms_divexact(f1, f0, f0+2, f0+1, f0+1, t+2, n1);
+    ROTATE(t, f0, f1)
+  }
+  fmpz_set(res, f0);
+  return(1);
+}
+
+/*
+    Use a subresultant sequence to test whether a given polynomial has
+    real roots. Note that this test has an early abort mechanism:
+    having real roots means that the sign sequence has the maximal number
+    of sign changes, so the test aborts if any sign change is missed.
+
+    This function assumes that:
+        - {poly, n} is a normalized vector with n >= 2 and positive leading coefficient;
+        - {f0, n-1} and {f1, n-1} are scratch space.
+
+    We add a (if b is NULL) or a*b (otherwise) to the constant term before testing.
+
+    Based on code by Sebastian Pancratz from the FLINT repository (plus the Ducos variation).
+*/
+
+#define sgn_criterion (sgn == 1 || (force_squarefree && sgn == 0))
+int _fmpz_poly_all_real_roots(const fmpz *poly, int n, fmpz *f0, fmpz *f1,
+                              int force_squarefree, const fmpz_t a, const fmpz_t b) {
+  if (n <= 2) return(1);  // Constant or linear polynomial
+
+  /* Put the updated constant term of poly in f1. */
+  fmpz_opt_addmul(f1, b, a, poly);
+
+  int sgn;
+  if (n == 3) { // Quadratic case, compute discriminant
+    fmpz_mul_ui(f1, f1, 4);
+    fmpz_fmms_wrapper(f1, f1, poly+2, poly+1, poly+1);
+    sgn = fmpz_sgn(f1);
+    return(!sgn_criterion);
+  }
+
+  /* Introduce some unallocated pointers.
+     To gloss these, imagine we are trying to set f0 to be the
+     pseudoremainder of f1 modulo f2. */
+  fmpz *t; // Receives the leading coefficient of f0
+  fmpz *lead1; // Holds the leading coefficient of f1
+  fmpz *lead11; // Holds the subleading coefficient of f1
+  fmpz *lead2; // Holds the leading coefficient of f2
+  fmpz *content; // Holds a value that will be divided (twice) out of f0
+
+  /* At this point deg(poly) = n-1, deg(f1) = n-2.
+     Compute the next leading coefficient; instead of the Ducos variation,
+     we remove one factor of the leading coefficient of poly. */
+
+  t = f1+n-3; lead1 = f0+n-2; lead11 = lead1-1; lead2 = (fmpz *)poly+n-1;
+  fmpz_mul_ui(lead1, lead2, n-1);
+  fmpz_mul_ui(t, lead1, 2);
+  fmpz_mul_ui(lead11, lead2-1, n-2);
+  fmpz_fmms_wrapper(t, t, lead2-2, lead11, lead2-1);
+
+  /* If we miss any one sign change, we cannot have enough. */
+  sgn = fmpz_sgn(t);
+  if (sgn_criterion) return(0);
+
+  /* Set f0 := deriv(poly). */
+  _fmpz_poly_derivative(f0, poly, n-2);
+
+  /* Set f1 to the pseudoremainder of poly modulo f0, again removing one factor of lead2.
+     We use t+1 = f1+n-2 as scratch. */
+
+  _fmpz_vec_scalar_fmms(f1+1, poly+1, lead1, f0, lead2, n-4);
+  fmpz_mul(f1, f1, lead1);
+  fmpz_set_ui(t+1, n-1);
+  _fmpz_vec_scalar_fmms(f1, f1, t+1, f0, lead2-1, n-3);
+
+  /* If not forcing squarefree but sgn == 0, we win iff f1 = 0. */
+  if (!sgn && !force_squarefree) return (_fmpz_vec_is_zero(f1, n-3));
+
+  /* At this point deg(f0) = n-2, deg(f1) = n-3.
+     Start computing the next leading coefficient (up to a positive factor). */
+
+  content = lead1; t = f0+n-4; lead1 = f1+n-3; lead11 = lead1-1;
+  fmpz_fmms_wrapper(t, t, lead1, t+1, lead11);
+  fmpz_divexact_ui(t, t, n-1);
+
+  _fmpz_vec_scalar_mul_fmpz(f1, f1, n-2, lead2); // Put back in a factor for later
+
+  for (n -= 3; n > 1; n--) {
+    /* At this point deg(f0) = n+1, deg(f1) = n.
+       Finish computing the next leading coefficient (up to a positive factor). */
+    fmpz_sub(t, t, lead1-2);
+    if (fmpz_sgn(t) * fmpz_sgn(lead1) > 0) return(0);
+    fmpz_fmma_wrapper(t, t, lead1, lead11, lead11);
+
+    /* If we miss any one sign change, we cannot have enough. */
+    sgn = fmpz_sgn(t);
+    if (sgn_criterion) return(0);
+
+    /* Replace f0 by its pseudoremainder modulo f1, 
+       leaving f0[n], f0[n+1] intact as well as f0[n-1] (except to remove content). */
+    _fmpz_vec_scalar_fmms_divexact(f0, f0, lead1, f1, t+1, n-1, content);
+    _fmpz_vec_sub_wrapper(f0+1, f0+1, f1, n-2);
+    _fmpz_vec_scalar_fmma(f0, f0, lead1, f1, lead11, n-1);
+
+    /* If not forcing squarefree but sgn == 0, we win iff f0 = 0. */
+    if (!sgn && !force_squarefree) return (_fmpz_vec_is_zero(f0, n-1));
+
+    /* Divide f0 by content. */
+    _fmpz_vec_scalar_divexact_fmpz_wrapper(f0, f0, n, content);
+
+    /* Swap f0 with f1 at the pointer level. */
+    ROTATE(t, f0, f1)
+
+    /* At this point deg(f0) = n, deg(f1) = n-1.
+       Start computing the next leading coefficient (up to a positive factor). */
+    content = lead1; t = f0+n-2; lead1 = f1+n-1; lead11 = lead1-1;
+    fmpz_fmms_divexact(t, t, lead1, lead11, t+1, content);
+  }
+
+  /* Handle the case where the pseudoremainder is a scalar. */
+  if (fmpz_sgn(t) * fmpz_sgn(lead1) > 0) return(0);
+  fmpz_fmma_wrapper(t, t, lead1, lead11, lead11);
+  sgn = fmpz_sgn(t);
+  return (!sgn_criterion);
+}
+

--- a/src/sage/rings/polynomial/weil/flint-utils.h
+++ b/src/sage/rings/polynomial/weil/flint-utils.h
@@ -1,0 +1,61 @@
+#pragma once
+#include <flint/flint.h>
+#include <flint/fmpz.h>
+#include <flint/fmpz_vec.h>
+#include <flint/fmpz_poly.h>
+#include <flint/fmpz_mat.h>
+
+#define DEBUG 0
+
+#if DEBUG
+
+/* Wrapper functions for FLINT commands that don't show up in profiling data. */
+void fmpz_fmma_wrapper(fmpz_t f, const fmpz_t a, const fmpz_t b, const fmpz_t c, const fmpz_t d) {
+  fmpz_fmma(f, a, b, c, d);
+}
+
+void fmpz_fmms_wrapper(fmpz_t f, const fmpz_t a, const fmpz_t b, const fmpz_t c, const fmpz_t d) {
+  fmpz_fmms(f, a, b, c, d);
+}
+
+void _fmpz_vec_sub_wrapper(fmpz *res, const fmpz *vec1, const fmpz *vec2, slong len2) {
+  _fmpz_vec_sub(res, vec1, vec2, len2);
+}
+
+void _fmpz_vec_scalar_divexact_fmpz_wrapper(fmpz *vec1, const fmpz *vec2, slong len2, const fmpz_t x) {
+  _fmpz_vec_scalar_divexact_fmpz(vec1, vec2, len2, x);
+}
+
+#else
+  #define fmpz_fmma_wrapper(f, a, b, c, d) fmpz_fmma(f, a, b, c, d)
+  #define fmpz_fmms_wrapper(f, a, b, c, d) fmpz_fmms(f, a, b, c, d)
+  #define _fmpz_vec_sub_wrapper(res, vec1, vec2, len2) _fmpz_vec_sub(res, vec1, vec2, len2)
+  #define _fmpz_vec_scalar_divexact_fmpz_wrapper(vec1, vec2, len2, x) _fmpz_vec_scalar_divexact_fmpz(vec1, vec2, len2, x)
+#endif
+
+inline int is_mpz(fmpz f);
+
+void fmpz_opt_mul(fmpz_t res, const fmpz_t a, const fmpz_t b);
+void fmpz_opt_addmul(fmpz_t res, const fmpz_t a, const fmpz_t b, const fmpz_t c);
+void fmpz_fmid(fmpz_t res, const fmpz_t a, const fmpz_t b);
+void fmpz_cmid(fmpz_t res, const fmpz_t a, const fmpz_t b);
+void fmpz_sqrt_c(fmpz_t res, const fmpz_t a);
+void fmpz_div_q(fmpz_t res, const fmpz_t a, const fmpz_t b, int r);
+void fmpq_floor_ceil_quad(fmpz_t res, int r, const fmpz_t a, const fmpz_t b, const fmpz_t c, const fmpz_t d, const fmpz_t q);
+
+void fmpz_fmms_divexact(fmpz *res, const fmpz *a, const fmpz *b, const fmpz *c, const fmpz *d, const fmpz_t e);
+void _fmpz_vec_fmms(fmpz *res, const fmpz *a, const fmpz *b, const fmpz *c, const fmpz *d, int n);
+void _fmpz_vec_scalar_fmma(fmpz *res, const fmpz *a, const fmpz_t b, const fmpz *c, const fmpz_t d, int n);
+void _fmpz_vec_scalar_fmms(fmpz *res, const fmpz *a, const fmpz_t b, const fmpz *c, const fmpz_t d, int n);
+void _fmpz_vec_scalar_fmms_divexact(fmpz *res, const fmpz *a, const fmpz *b, const fmpz *c, const fmpz *d, int n, const fmpz *e);
+void _fmpz_vec_fmms_divexact(fmpz *res, const fmpz *a, const fmpz *b, const fmpz *c, const fmpz *d, const fmpz_t e, int n);
+void _fmpz_vec_scalar_fmma_one(fmpz *res, const fmpz *a, const fmpz_t b, const fmpz *c, int n);
+void _fmpz_vec_scalar_fmms_one(fmpz *res, const fmpz *a, const fmpz_t b, const fmpz *c, int n);
+
+void hankel_determinant_direct(fmpz_t res, const fmpz *seq, int n);
+int hankel_determinant_condensation(fmpz_t res, const fmpz *seq, int n, fmpz *w);
+
+int _fmpz_poly_all_real_roots(const fmpz *poly, int n, fmpz *f0, fmpz *f1,
+                              int force_squarefree, const fmpz_t a, const fmpz_t b);
+
+

--- a/src/sage/rings/polynomial/weil/power_sums.c
+++ b/src/sage/rings/polynomial/weil/power_sums.c
@@ -1,12 +1,9 @@
 /*
   Low-level code to exhaust over trees of Weil polynomials.
-  This code does not implement parallelism; see the Cython wrapper.
-
-  TODO: check for memory leaks.
-  TODO: try the Routh-Hurwitz criterion.
+  For examples of parallel execution, see the Cython, C, and Rust wrappers.
 
 #*****************************************************************************
-#       Copyright (C) 2019 Kiran S. Kedlaya <kskedl@gmail.com>
+#       Copyright (C) 2019-2026 Kiran S. Kedlaya <kskedl@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,489 +14,286 @@
 
 */
 
+#include <stdlib.h>
+#include "flint-utils.c"
 #include "power_sums.h"
 
-/* Check for OpenMP at runtime.
-*/
-int has_openmp() {
+/* Check for OpenMP at runtime. */
+int num_threads() {
   #if defined(_OPENMP)
-  return(1);
+  return omp_get_max_threads();
   #endif
-  return(0);
+  return(1);
 }
 
-/*
-    Use a subresultant (Sturm-Habicht) sequence to test whether a given
-    polynomial has all real roots. Note that this test has an early abort
-    mechanism: having all real roots means that the sign sequence has
-    the maximal number of sign changes, so the test aborts as soon
-    as a sign change is missed.
+/*****
+  Memory allocation and deallocation
+*****/
 
-    This function assumes that:
-        - {poly, n} is a normalized vector with n >= 2
-        - {w, 2*n+1} is scratch space.
-    If a and b are not NULL, we add a*b to the constant term before testing.
+/* Static memory allocation and initialization. */
+ps_static_data_t *ps_static_init(int d, const fmpz_t q, const fmpz_t lead, const fmpz *modlist,
+                                 int num_constraints, const fmpz *constraints,
+                                 long node_limit, int force_squarefree) {
+  int i, j, k;
+  fmpz *k0, *pol;
 
-    Based on code by Sebastian Pancratz from the FLINT repository.
-    TODO: compare with floating-point interval arithmetic.
-*/
-
-int _fmpz_poly_all_real_roots(fmpz *poly, long n, fmpz *w, int force_squarefree,
-			      const fmpz_t a, const fmpz_t b) {
-  fmpz *f0     = w + 0*n;
-  fmpz *f1     = w + 1*n;
-  fmpz *c      = w + 2*n;
-  fmpz *d      = w + 2*n+1;
-  fmpz *t;
-
-  _fmpz_vec_set(f0, poly, n);
-  /* Sanitize input so that n = deg(f0). */
-  while ((n > 2) && fmpz_is_zero(f0+n-1))
-    n--;
-  if (n <= 2) return(1);
-  if (a != NULL && b != NULL) fmpz_addmul(f0, a, b);
-  _fmpz_poly_derivative(f1, f0, n);
-  n--;
-  int sgn0_l = fmpz_sgn(f0+n);
-
-  while (1) {
-    /* At this point deg(f0) = n, deg(f1) = n-1.
-       We explicitly compute the pseudoremainder of f0 modulo f1:
-       f0 := f1[n-1]*f0 - f0[n]*x*f1
-       f0 := f0[n-1]*f1 - f1[n-1]*f0
-    */
-    fmpz_set(c, f0+n);
-    _fmpz_vec_scalar_mul_fmpz(f0, f0, n, f1+n-1);
-    _fmpz_vec_scalar_submul_fmpz(f0+1, f1, n-1, c);
-    n--;
-    fmpz_set(c, f0+n);
-    fmpz_neg(d, f1+n);
-    _fmpz_vec_scalar_mul_fmpz(f0, f0, n, d);
-    _fmpz_vec_scalar_addmul_fmpz(f0, f1, n, c);
-
-    /* If f0 = 0, we win unless we are insisting on squarefree. */
-    if (!force_squarefree && _fmpz_vec_is_zero(f0, n)) return(1);
-
-    /* If we miss any one sign change, we cannot have enough. */
-    if (fmpz_sgn(f0+n-1) != sgn0_l) return(0);
-
-    if (n==1) return(1); /* If f0 is a scalar, it is nonzero and we win. */
-
-    /* Extract content from f0; in practice, this seems to do better than
-       an explicit subresultant computation. */
-    _fmpz_vec_content(c, f0, n);
-    _fmpz_vec_scalar_divexact_fmpz(f0, f0, n, c);
-
-    /* Swap f0 with f1. */
-    t = f0; f0 = f1; f1 = t;
-  }
-}
-
-
-
-/* Set res to floor(a). */
-void fmpq_floor(fmpz_t res, const fmpq_t a) {
-  fmpz_fdiv_q(res, fmpq_numref(a), fmpq_denref(a));
-};
-
-/* Set res to ceil(a). */
-void fmpq_ceil(fmpz_t res, const fmpq_t a) {
-  fmpz_cdiv_q(res, fmpq_numref(a), fmpq_denref(a));
-};
-
-void fmpz_sqrt_f(fmpz_t res, const fmpz_t a) {
-  fmpz_sqrt(res, a);
-}
-
-void fmpz_sqrt_c(fmpz_t res, const fmpz_t a) {
-  int s = fmpz_is_square(a);
-  fmpz_sqrt(res, a);
-  if (!s) fmpz_add_ui(res, res, 1);
-}
-
-/* Set res to floor(a + b sqrt(q)).
-   For efficiency, we do not assume a and b are canonical;
-   we must thus be careful about signs. */
-void fmpq_floor_quad(fmpz_t res, fmpq_t a,
-		     fmpq_t b, const fmpz_t q) {
-  if (b==NULL) fmpq_floor(res, a);
-  else {
-    fmpz *anum = fmpq_numref(a);
-    fmpz *aden = fmpq_denref(a);
-    int aden_s = fmpz_sgn(aden);
-    fmpz *bnum = fmpq_numref(b);
-    int bnum_s = fmpz_sgn(bnum);
-    fmpz *bden = fmpq_denref(b);
-    int bden_s = fmpz_sgn(bden);
-
-    fmpz_mul(res, aden, bnum);
-    fmpz_mul(res, res, res);
-    fmpz_mul(res, res, q);
-    if (bnum_s*bden_s >= 0) fmpz_sqrt_f(res, res);
-    else {
-      fmpz_sqrt_c(res, res);
-      fmpz_neg(res, res);
-    }
-    fmpz_mul_si(res, res, aden_s*bden_s);
-    fmpz_addmul(res, anum, bden);
-    if (bden_s > 0) fmpz_fdiv_q(res, res, aden);
-    else fmpz_cdiv_q(res, res, aden);
-    fmpz_fdiv_q(res, res, bden);
-  }
-}
-
-/* Set res to ceil(a + b sqrt(q)). */
-void fmpq_ceil_quad(fmpz_t res, fmpq_t a,
-		     fmpq_t b, const fmpz_t q) {
-  if (b==NULL) fmpq_ceil(res, a);
-  else {
-    fmpz *anum = fmpq_numref(a);
-    fmpz *aden = fmpq_denref(a);
-    int aden_s = fmpz_sgn(aden);
-    fmpz *bnum = fmpq_numref(b);
-    int bnum_s = fmpz_sgn(bnum);
-    fmpz *bden = fmpq_denref(b);
-    int bden_s = fmpz_sgn(bden);
-
-    fmpz_mul(res, aden, bnum);
-    fmpz_mul(res, res, res);
-    fmpz_mul(res, res, q);
-    if (bnum_s*bden_s >= 0) fmpz_sqrt_c(res, res);
-    else {
-      fmpz_sqrt_f(res, res);
-      fmpz_neg(res, res);
-    }
-    fmpz_mul_si(res, res, aden_s*bden_s);
-    fmpz_addmul(res, anum, bden);
-    if (bden_s > 0) fmpz_cdiv_q(res, res, aden);
-    else fmpz_fdiv_q(res, res, aden);
-    fmpz_cdiv_q(res, res, bden);
-  }
-}
-
-/* Memory allocation and initialization. */
-ps_static_data_t *ps_static_init(int d, fmpz_t q, int coeffsign, fmpz_t lead,
-				 int cofactor, fmpz *modlist, long node_limit,
-				 int force_squarefree) {
-  int i, j, k, l;
-  ps_static_data_t *st_data;
-  fmpz_poly_t pol;
-  fmpz_t m, const1;
-  fmpq *k1;
-
-  fmpz_poly_init(pol);
-  fmpz_init(m);
-  fmpz_init_set_ui(const1, 1);
-
-  st_data = (ps_static_data_t *)malloc(sizeof(ps_static_data_t));
-
+  ps_static_data_t *st_data = (ps_static_data_t *)malloc(sizeof(ps_static_data_t));
   st_data->d = d;
-  st_data->sign = coeffsign;
-  fmpz_init(st_data->q);
-  fmpz_set(st_data->q, q);
+  fmpz_init_set(st_data->q, q);
+  st_data->q_is_1 = fmpz_is_one(q);
+  st_data->q_is_square = fmpz_is_square(q);
+  st_data->lead_is_1 = fmpz_is_one(lead);
+  if (st_data->q_is_square) {
+    fmpz_init(st_data->q_sqrt);
+    fmpz_sqrt(st_data->q_sqrt, q);
+  }
   st_data->node_limit = node_limit;
   st_data->force_squarefree = force_squarefree;
 
-  fmpz_init(st_data->lead);
-  fmpz_set(st_data->lead, lead);
-
-  st_data->cofactor = _fmpz_vec_init(3);
-  switch (cofactor) {
-  case 0: /* Cofactor 1 */
-    fmpz_set_si(st_data->cofactor, 1);
-    fmpz_set_si(st_data->cofactor+1, 0);
-    fmpz_set_si(st_data->cofactor+2, 0);
-    break;
-
-  case 1: /* Cofactor x+sqrt(q) */
-    fmpz_set(st_data->cofactor, st_data->q);
-    fmpz_sqrt(st_data->cofactor, st_data->cofactor);
-    fmpz_set_si(st_data->cofactor+1, 1);
-    fmpz_set_si(st_data->cofactor+2, 0);
-    break;
-
-  case 2:  /* Cofactor x-sqrt(q) */
-    fmpz_set(st_data->cofactor, st_data->q);
-    fmpz_sqrt(st_data->cofactor, st_data->cofactor);
-    fmpz_neg(st_data->cofactor, st_data->cofactor);
-    fmpz_set_si(st_data->cofactor+1, 1);
-    fmpz_set_si(st_data->cofactor+2, 0);
-    break;
-
-  case 3: /* Cofactor x^2-q */
-    fmpz_neg(st_data->cofactor, st_data->q);
-    fmpz_set_si(st_data->cofactor+1, 0);
-    fmpz_set_si(st_data->cofactor+2, 1);
-    break;
-  }
-
   st_data->modlist = _fmpz_vec_init(d+1);
-  st_data->f = _fmpq_vec_init(d+1);
-  for (i=0; i<=d; i++) {
-    fmpz_set(st_data->modlist+i, modlist+d-i);
-    fmpq_set_si(st_data->f+i, d-i, 1);
-    fmpq_div_fmpz(st_data->f+i, st_data->f+i, st_data->lead);
-    /* In order to apply power sums and Descartes' rule of signs
-       when the modulus is 0, we must pretend that the modulus is 1. */
-    if (!fmpz_is_zero(st_data->modlist+i))
-      fmpq_mul_fmpz(st_data->f+i, st_data->f+i, st_data->modlist+i);
+  k0 = st_data->modlist; // Used as a temporary variable for now
+
+  fmpz_init(st_data->c0); // c0 = 4*lead^2*q
+  fmpz_mul(st_data->c0, lead, lead);
+  fmpz_mul(st_data->c0, st_data->c0, q);
+  fmpz_mul_ui(st_data->c0, st_data->c0, 4);
+  if (st_data->q_is_square) {
+    fmpz_init(st_data->c1);
+    fmpz_sqrt(st_data->c1, st_data->c0); // c1 = 2*lead*sqrt(q)
   }
 
-  fmpz_mat_init(st_data->binom_mat, d+1, d+1);
-  for (i=0; i<=d; i++)
-    for (j=0; j<=d; j++)
-      fmpz_bin_uiui(fmpz_mat_entry(st_data->binom_mat, i, j), i, j);
-
-  st_data->hausdorff_mats = (fmpq_mat_t *)malloc((d+1)*sizeof(fmpq_mat_t));
+  /* Matrix of cefficients of 2*(i-th Chebyshev polynomial)(x/2).
+     The coefficient of x^j is multiplied by c^{i-j} q^{(i-j)/2} where c is the leading coefficient. */
+  st_data->sum_mats = _fmpz_vec_init((d+1)*(d+1));
   for (i=0; i<=d; i++) {
-
-    fmpq_mat_init(st_data->hausdorff_mats[i], 2*d+2, d+1);
-    fmpq_mat_zero(st_data->hausdorff_mats[i]);
-
-    for (j=0; j<=i; j++)
-      for (k=0; k<=i; k++) {
-	// The coefficient of t^k in (t-2 sqrt(q))^j (t+2 sqrt(q))^{i-j}, rounding down the exponent of q.
-	if ((i-k)%2==0)
-	  k1 = fmpq_mat_entry(st_data->hausdorff_mats[i], 2*j, k);
-	else
-	  k1 = fmpq_mat_entry(st_data->hausdorff_mats[i], 2*j+1, k);
-	for (l=0; l<=j; l++) if (k-l >=0 && k-l<=i-j) {
-	    fmpz_mul(m, fmpz_mat_entry(st_data->binom_mat, j, l),
-		     fmpz_mat_entry(st_data->binom_mat, i-j, k-l));
-	    if ((j-l)%2==1) fmpz_neg(m, m);
-	    fmpq_add_fmpz(k1, k1, m);
-	  }
-	fmpq_mul_2exp(k1, k1, i-k);
-	for (l=0; l<(i-k)/2; l++) fmpq_mul_fmpz(k1, k1, q);
+    pol = st_data->sum_mats + (d+1)*i;
+    _fmpz_poly_chebyshev_t(pol, i);
+    _fmpz_poly_scale_2exp(pol, i+1, -1);
+    if (!st_data->q_is_1)
+      for (j=i%2; j<=i; j+=2) {
+        fmpz_pow_ui(k0, q, (i-j)/2);
+        fmpz_mul(pol+j, k0, pol+j);
+      }
+    if (!st_data->lead_is_1)
+      for (j=i%2; j<=i; j+=2) {
+        fmpz_pow_ui(k0, lead, i-j);
+        fmpz_mul(pol+j, k0, pol+j);
       }
   }
 
-  st_data->sum_mats = (fmpq_mat_t *)malloc((d+1)*sizeof(fmpq_mat_t));
-  for (i=0; i<=d; i++) {
-
-    fmpq_mat_init(st_data->sum_mats[i], 1, d+1);
-    fmpq_mat_zero(st_data->sum_mats[i]);
-
-    arith_chebyshev_t_polynomial(pol, i);
-    for (j=0; j<=d; j++) {
-
-      /* Coefficients of 2*(i-th Chebyshev polynomial)(x/2).
-         If q != 1, the coeff of x^j is multiplied by q^{floor(i-j)/2}. */
-      if (j <= i) {
-	k1 = fmpq_mat_entry(st_data->sum_mats[i], 0, j);
-	fmpq_set_fmpz_frac(k1, fmpz_poly_get_coeff_ptr(pol, j), const1);
-	fmpz_mul_2exp(m, const1, j);
-	fmpq_div_fmpz(k1, k1, m);
-	fmpz_set_ui(m, 2);
-	fmpq_mul_fmpz(k1, k1, m);
-	if (!fmpz_is_one(st_data->q) && i%2==j%2) {
-	  fmpz_set(m, st_data->q);
-	  fmpz_pow_ui(m, m, (i-j)/2);
-	  fmpq_mul_fmpz(k1, k1, m);
-	}
+  /* Linear conditions on asymmetrized coefficients.
+     Since these are provided in terms of symmetrized coefficients,
+     we convert them using the Chebyshev polynomial matrix. */
+  st_data->num_constraints = num_constraints;
+  if (num_constraints) {
+    st_data->constraints = _fmpz_vec_init((d+1) * num_constraints);
+    st_data->constraint_lens = malloc(sizeof(int *) * num_constraints);
+    for (i=0; i<num_constraints; i++) {
+      for (j=d; j>0 && fmpz_is_zero(constraints+(d+1)*i+j); j--);
+      if (j > 0) {
+        st_data->constraint_lens[i] = j;
+        pol = st_data->constraints+(d+1)*i;
+        for (k=1; k<=j; k++) {
+          fmpz_pow_ui(k0, lead, j-k);
+          fmpz_mul(k0, k0, constraints+(d+1)*i+k);
+          _fmpz_vec_scalar_addmul_fmpz(pol, st_data->sum_mats+(d+1)*k, j+1, k0);
+        }
+        _fmpz_vec_scalar_mul_ui(pol, pol, j+1, d);
+        fmpz_pow_ui(k0, lead, j);
+        fmpz_submul(pol, k0, constraints+(d+1)*i);
+        /* If force_squarefree is set, we must shift by one to avoid missing edge cases. */
+        if (force_squarefree) fmpz_sub_ui(pol, pol, 1);
       }
-
     }
   }
 
-  fmpz_poly_clear(pol);
-  fmpz_clear(m);
-  fmpz_clear(const1);
+  /* Moduli constraints. If not specified, fix the leading coefficient and impose no other constraints. */
+  if (modlist) for (i=0; i<=d; i++) fmpz_set(st_data->modlist+i, modlist+d-i);
+  else for (i=0; i<d; i++) fmpz_one(st_data->modlist+i);
+
+  /* Matrix of binomial coefficients. */
+  st_data->binom_mat = _fmpz_vec_init((d+1)*(d+1));
+  for (i=0; i<=d; i++)
+    for (j=0; j<=d; j++)
+      fmpz_bin_uiui(st_data->binom_mat+(d+1)*i+j, j, i);
+
+  /* Matrices to evaluate derivatives at +-2*sqrt(q). */
+  st_data->eval_pm2_mats = _fmpz_vec_init(2*(d+1)*(d+1));
+  for (i=0; i<=d; i++)
+    for (j=0; j<=i; j++) {
+      k0 = st_data->eval_pm2_mats + (d+1)*(2*i+j%2) + j;
+      if (st_data->q_is_1) fmpz_one(k0);
+      else if (st_data->q_is_square) fmpz_pow_ui(k0, st_data->q_sqrt, j);
+      else fmpz_pow_ui(k0, q, j/2);
+      fmpz_mul_2exp(k0, k0, j);
+      fmpz_mul_si(k0, k0, -i);
+      fmpz_mul(k0, k0, st_data->binom_mat + (d+2)*(d-i) + j);
+    }
+
+  st_data->ranges = _fmpz_vec_init(d+1);
+  for (i=1; i<=d; i++) {
+    k0 = st_data->ranges + i;
+    if (st_data->q_is_square) fmpz_pow_ui(k0, st_data->q_sqrt, i);
+    else fmpz_pow_ui(k0, q, i/2);
+    fmpz_mul_ui(k0, k0, 2*d);
+    for (j=0; j<i; j++) fmpz_mul(k0, k0, lead);
+  }
+
+  /* Matrix to compute reciprocal transform. */
+  fmpz_mat_init(st_data->pol_to_sym, 2*d+1, d+1);
+  fmpz_mat_zero(st_data->pol_to_sym);
+  for (i=0; i<=d; i++) {
+    k0 = fmpz_mat_entry(st_data->pol_to_sym, d-i, i);
+    fmpz_one(k0);
+    for (j=i; j>0; j--) {
+      pol = fmpz_mat_entry(st_data->pol_to_sym, d-i+2*j, i);
+      if (j==i) fmpz_set(pol, k0); else fmpz_add(pol, pol, k0);
+      if (!st_data->q_is_1) fmpz_mul(k0, k0, q);
+      fmpz_mul_ui(k0, k0, j);
+      fmpz_divexact_ui(k0, k0, i-j+1);
+    }
+  }
+
+  if (!st_data->lead_is_1) {
+    st_data->lead_pows = _fmpz_vec_init(d+1);
+    for (i=0; i<=d; i++) fmpz_pow_ui(st_data->lead_pows+i, lead, i);
+  }
 
   return(st_data);
 }
 
-ps_dynamic_data_t *ps_dynamic_init(int d, fmpz_t q, fmpz *coefflist) {
-  ps_dynamic_data_t *dy_data;
-  int i;
+/* Dynamic memory allocation and initialization.
+   Call with coefflist == NULL to prepare an inactive process. */
+ps_dynamic_data_t *ps_dynamic_init(int d, fmpz *coefflist) {
+  ps_dynamic_data_t *dy_data = (ps_dynamic_data_t *)malloc(sizeof(ps_dynamic_data_t));
 
-  dy_data = (ps_dynamic_data_t *)malloc(sizeof(ps_dynamic_data_t));
   dy_data->d = d;
-  dy_data->q_is_1 = fmpz_is_one(q);
-
-  /* Initialize mutable quantities */
   dy_data->n = d;
   dy_data->node_count = 0;
   dy_data->ascend = 0;
   dy_data->pol = _fmpz_vec_init(d+1);
-  dy_data->sympol = _fmpz_vec_init(2*d+3);
-  if (coefflist != NULL) {
-    dy_data->flag = 1; // Activate this process
-    for (i=0; i<=d; i++)
-      fmpz_set(dy_data->pol+i, coefflist+i);
-  } else dy_data->flag = 0;
-
-  fmpq_mat_init(dy_data->power_sums, d+1, 1);
-  fmpq_set_si(fmpq_mat_entry(dy_data->power_sums, 0, 0), d, 1);
-  fmpq_mat_init(dy_data->hankel_mat, d/2+1, d/2+1);
-  fmpq_mat_init(dy_data->hankel_dets, d/2+1, 1);
-  fmpq_set_si(fmpq_mat_entry(dy_data->hankel_dets, 0, 0), d, 1);
-  fmpq_mat_init(dy_data->hausdorff_prod, 2*d+2, 1);
-  fmpq_mat_init(dy_data->hausdorff_sums1, d+1, d+1);
-  fmpq_mat_init(dy_data->hausdorff_sums2, d+1, d+1);
-
+  dy_data->sympol = _fmpz_vec_init(2*d+1);
   dy_data->upper = _fmpz_vec_init(d+1);
+  dy_data->power_sums_num = _fmpz_vec_init(d+1);
+  fmpz_set_si(dy_data->power_sums_num, d);
+  _fmpz_vec_zero(dy_data->power_sums_num+1, d);
 
-  /* Allocate scratch space */
-  fmpq_mat_init(dy_data->sum_prod, 1, 1);
-  dy_data->wlen = 3*d+10;
+  dy_data->hankel_dets = _fmpz_vec_init(2*d+2);
+  fmpz_set_si(dy_data->hankel_dets, d);
+  fmpz_set_si(dy_data->hankel_dets+1, 1);
+
+  dy_data->wlen = 3*d+9;
   dy_data->w = _fmpz_vec_init(dy_data->wlen);
-  dy_data->w2len = 5;
-  dy_data->w2 = _fmpq_vec_init(dy_data->w2len);
+
+  if (coefflist) {
+    dy_data->flag = 1; // Activate this process
+    _fmpz_vec_set(dy_data->pol, coefflist, d+1);
+  } else dy_data->flag = 0; // Flag this process as inactive
   return(dy_data);
 }
 
-/* Split off a subtree.
-   The first process gives up on the current branch, up to the first coefficient that is not uniquely specified;
-   the remaining work is yielded to the second process, which may in turn be split immediately.
-*/
-void ps_dynamic_split(ps_dynamic_data_t *dy_data, ps_dynamic_data_t *dy_data2) {
-  if ((dy_data == NULL) || (dy_data->flag <= 0) || dy_data2->flag) return;
-
-  int i, d = dy_data->d, n = dy_data->n, ascend = dy_data->ascend;
-
-  for (i=d; i>n+ascend; i--)
-    if (fmpz_cmp(dy_data->pol+i, dy_data->upper+i) <0) {
-      dy_data2->n = n;
-      dy_data2->ascend = ascend;
-      _fmpz_vec_set(dy_data2->pol, dy_data->pol, d+1);
-      _fmpz_vec_set(dy_data2->upper, dy_data->upper, d+1);
-      fmpq_mat_set(dy_data2->power_sums, dy_data->power_sums);
-      fmpq_mat_set(dy_data2->hankel_dets, dy_data->hankel_dets);
-      if (dy_data->q_is_1) {
-	fmpq_mat_set(dy_data2->hausdorff_sums1, dy_data->hausdorff_sums1);
-	fmpq_mat_set(dy_data2->hausdorff_sums2, dy_data->hausdorff_sums2);
-      }
-      fmpz_set(dy_data2->upper+i, dy_data2->pol+i);
-      dy_data->ascend = i-n;
-      dy_data2->flag = 1; // This process can now itself be split.
-      return;
-  }
-  return;
-}
-
-/* Memory deallocation. */
+/* Static memory deallocation. */
 void ps_static_clear(ps_static_data_t *st_data) {
-  if (st_data == NULL) return;
-  int i, d = st_data->d;
-  fmpz_clear(st_data->lead);
+  if (!st_data) return;
+
+  int d = st_data->d;
+
+  if (fmpz_is_square(st_data->q)) fmpz_clear(st_data->q_sqrt);
   fmpz_clear(st_data->q);
-  _fmpz_vec_clear(st_data->cofactor, 3);
-  fmpz_mat_clear(st_data->binom_mat);
-  _fmpq_vec_clear(st_data->f, d+1);
+  fmpz_clear(st_data->c0);
+  if (st_data->q_is_square) fmpz_clear(st_data->c1);
   _fmpz_vec_clear(st_data->modlist, d+1);
-  for (i=0; i<=d; i++)  {
-    fmpq_mat_clear(st_data->hausdorff_mats[i]);
-    fmpq_mat_clear(st_data->sum_mats[i]);
+  _fmpz_vec_clear(st_data->binom_mat, (d+1)*(d+1));
+  _fmpz_vec_clear(st_data->sum_mats, (d+1)*(d+1));
+  _fmpz_vec_clear(st_data->eval_pm2_mats, 2*(d+1)*(d+1));
+  _fmpz_vec_clear(st_data->ranges, d+1);
+  fmpz_mat_clear(st_data->pol_to_sym);
+  if (!st_data->lead_is_1) _fmpz_vec_clear(st_data->lead_pows, d+1);
+  if (st_data->num_constraints) {
+    free(st_data->constraint_lens);
+    _fmpz_vec_clear(st_data->constraints, (d+1)*st_data->num_constraints);
   }
-  free(st_data->hausdorff_mats);
-  free(st_data->sum_mats);
   free(st_data);
 }
 
+/* Dynamic memory deallocation. */
 void ps_dynamic_clear(ps_dynamic_data_t *dy_data) {
-  if (dy_data == NULL) return;
+  if (!dy_data) return;
+
   int d = dy_data->d;
+
   _fmpz_vec_clear(dy_data->pol, d+1);
-  _fmpz_vec_clear(dy_data->sympol, 2*d+3);
+  _fmpz_vec_clear(dy_data->sympol, 2*d+1);
   _fmpz_vec_clear(dy_data->upper, d+1);
-  fmpq_mat_clear(dy_data->power_sums);
-  fmpq_mat_clear(dy_data->sum_prod);
-  fmpq_mat_clear(dy_data->hankel_mat);
-  fmpq_mat_clear(dy_data->hankel_dets);
-  fmpq_mat_clear(dy_data->hausdorff_prod);
-  fmpq_mat_clear(dy_data->hausdorff_sums1);
-  fmpq_mat_clear(dy_data->hausdorff_sums2);
+  _fmpz_vec_clear(dy_data->power_sums_num, d+1);
+  _fmpz_vec_clear(dy_data->hankel_dets, 2*d+2);
   _fmpz_vec_clear(dy_data->w, dy_data->wlen);
-  _fmpq_vec_clear(dy_data->w2, dy_data->w2len);
   free(dy_data);
 }
 
-/* Subroutines to adjust lower and upper bounds within set_range_from_power_sums.
-   These use t0z, t0q, t4q as persistent scratch space.
-   The pair (val1, val2) stands for val1 + val2*sqrt(q);
-   passing NULL for val2 is a faster variant of passing 0.
+/*****
+  Low-level flow control
+*****/
 
-  Usage: if g is a monic linear function of the k-th power sum, then
-  set_upper(g) or change_upper(g) imposes the condition g >= 0;
-  set_lower(g) or change_lower(g) imposes the condition g <= 0.
+/* Increment the current moving counter and update stored data to match.
+   If step is NULL it is interpreted as 1. */
 
-*/
+void step_forward(const ps_static_data_t *st_data, ps_dynamic_data_t *dy_data, int n, fmpz_t step) {
+  if (step && fmpz_is_zero(step)) return;
+  int d = st_data->d;
+  int k = d - n;
+  fmpz *pol = dy_data->pol;
+  fmpz *poln = pol+n;
+  fmpz *modulus = st_data->modlist + n;
+  int modulus_is_1 = fmpz_is_one(modulus);
+  fmpz *pow_num = dy_data->power_sums_num + k;
+  fmpz *det = dy_data->hankel_dets + 2*k;
+  fmpz *t0z = dy_data->w;
 
-#define STATE lower, upper, q, f, t0z, t0q, t4q
-#define STATE_DECLARE fmpz_t lower, fmpz_t upper, fmpz_t q, fmpq_t f, fmpz_t t0z, fmpq_t t0q, fmpq_t t4q
-
-void set_lower(const fmpq_t val1, const fmpq_t val2, STATE_DECLARE) {
-  fmpq_div(t0q, val1, f);
-  if (val2==NULL) fmpq_ceil(lower, t0q);
-  else {
-    fmpq_div(t4q, val2, f);
-    fmpq_ceil_quad(lower, t0q, t4q, q);
+  if (!st_data->lead_is_1) fmpz_mul_ui(t0z, st_data->lead_pows+k-1, k);
+  else fmpz_set_ui(t0z, k);
+  if (!modulus_is_1) fmpz_mul(t0z, t0z, modulus);
+  if (step) {
+    fmpz_mul(t0z, t0z, step);
+    if (modulus_is_1) fmpz_add(poln, poln, step);
+    else fmpz_addmul(poln, step, modulus);
+  } else {
+    if (modulus_is_1) fmpz_add_ui(poln, poln, 1);
+    else fmpz_add(poln, poln, modulus);
+  }
+  fmpz_sub(pow_num, pow_num, t0z);
+  if (k > 1) {
+    fmpz_submul(det, det-4, t0z);
+    fmpz_addmul(det+1, det-3, t0z);
+  } else {
+    fmpz_sub(det, det, t0z);
+    fmpz_add(det+1, det+1, t0z);
   }
 }
 
-void set_upper(const fmpq_t val1, const fmpq_t val2, STATE_DECLARE) {
-  fmpq_div(t0q, val1, f);
-  if (val2==NULL) fmpq_floor(upper, t0q);
-  else {
-    fmpq_div(t4q, val2, f);
-    fmpq_floor_quad(upper, t0q, t4q, q);
-  }
+int ascend_step_forward(const ps_static_data_t *st_data, ps_dynamic_data_t *dy_data, int n) {
+  int d = st_data->d;
+  fmpz *pol = dy_data->pol;
+  fmpz *upper = dy_data->upper;
+  do { n++; } while (n <= d && fmpz_cmp(pol+n, upper+n) >= 0);
+  if (n <= d) step_forward(st_data, dy_data, n, NULL);
+  return(n);
 }
 
-void change_lower(const fmpq_t val1, const fmpq_t val2, STATE_DECLARE) {
-  fmpq_div(t0q, val1, f);
-  if (val2==NULL) fmpq_ceil(t0z, t0q);
-  else {
-    fmpq_div(t4q, val2, f);
-    fmpq_ceil_quad(t0z, t0q, t4q, q);
-  }
-  if (fmpz_cmp(t0z, lower) > 0) fmpz_set(lower, t0z);
-}
+/* Update pow_num[k] using the Girard-Newton formula.
+   This is the k-th power sum times c^k where c is the leading coefficient. */
 
-void change_upper(const fmpq_t val1, const fmpq_t val2, STATE_DECLARE) {
-  fmpq_div(t0q, val1, f);
-  if (val2==NULL) fmpq_floor(t0z, t0q);
-  else {
-    fmpq_div(t4q, val2, f);
-    fmpq_floor_quad(t0z, t0q, t4q, q);
-  }
-  if (fmpz_cmp(t0z, upper) < 0) fmpz_set(upper, t0z);
-}
+void update_power_sums(fmpz *pow_num, fmpz *pol, int k) {
+  fmpz *tz = pow_num + k;
+  fmpz *lead = pol + k;
+  int i;
 
-void change_lower_strict(const fmpq_t val1, const fmpq_t val2, STATE_DECLARE) {
-  fmpq_div(t0q, val1, f);
-  if (val2==NULL) fmpq_floor(t0z, t0q);
-  else {
-    fmpq_div(t4q, val2, f);
-    fmpq_floor_quad(t0z, t0q, t4q, q);
-  }
-  fmpz_add_ui(t0z, t0z, 1);
-  if (fmpz_cmp(t0z, lower) > 0) fmpz_set(lower, t0z);
-}
-
-void change_upper_strict(const fmpq_t val1, const fmpq_t val2, STATE_DECLARE) {
-  fmpq_div(t0q, val1, f);
-  if (val2==NULL) fmpq_ceil(t0z, t0q);
-  else {
-    fmpq_div(t4q, val2, f);
-    fmpq_ceil_quad(t0z, t0q, t4q, q);
-  }
-  fmpz_sub_ui(t0z, t0z, 1);
-  if (fmpz_cmp(t0z, upper) < 0) fmpz_set(upper, t0z);
-}
-
-/* Impose the condition that val1*val3 >= val2, assuming that val1 is a linear 
-   monic function of the k-th power sum and val2, val3 do not depend on this sum. */
-void impose_quadratic_condition(const fmpq_t val1, const fmpq_t val2,
-				const fmpq_t val3, STATE_DECLARE) {
-  int s = fmpq_sgn(val3);
-  if (s) {
-    fmpq_mul(t0q, val2, val2);
-    fmpq_div(t0q, t0q, val3);
-    fmpq_sub(t0q, val1, t0q);
-    if (s>0) change_upper(t0q, NULL, STATE);
-    else change_lower(t0q, NULL, STATE);
+  if (fmpz_is_one(lead)) {
+    _fmpz_vec_dot_general(tz, NULL, 1, pol+1, pow_num+1, 0, k-1);
+    fmpz_submul_ui(tz, pol, k);
+  } else {
+    fmpz_mul_si(tz, pol, -k);
+    for (i=1; i<k; i++) fmpz_fmms_wrapper(tz, tz, lead, pol+i, pow_num+i);
   }
 }
 
@@ -507,321 +301,416 @@ void impose_quadratic_condition(const fmpq_t val1, const fmpq_t val2,
    a lower and upper bound for the next coefficient. Return 1 iff the resulting
    interval is nonempty.
 
+   The value of dy_data->pol+n is assumed to be correct modulo st_data->modlist+n.
 */
-int set_range_from_power_sums(ps_static_data_t *st_data,
-			      ps_dynamic_data_t *dy_data) {
-  int i, j, r;
+int set_range_from_power_sums(const ps_static_data_t *st_data, ps_dynamic_data_t *dy_data, int n) {
+  if (n < 0) return(1);
+
+  /* Static data */
+
   int d = st_data->d;
-  int n = dy_data->n;
-  int k = d+1-n;
-  int q_is_1 = dy_data->q_is_1;
-  fmpz *modulus = st_data->modlist+n-1;
-  fmpz *pol = dy_data->pol;
-  fmpz *q = st_data->q;
-  fmpq *f = (fmpq *)(st_data->f+n-1);
-  fmpq *t;
+  int k = d - n;
+  int k2 = k % 2;
+  int force_squarefree = st_data->force_squarefree;
+  fmpz *modulus = st_data->modlist + n;
+  int modulus_is_0 = fmpz_is_zero(modulus);
+  int modulus_is_1 = fmpz_is_one(modulus);
+  const fmpz *q = st_data->q;
+  int q_is_square = st_data->q_is_square;
+  fmpz *lead_pow = (st_data->lead_is_1) ? NULL : st_data->lead_pows+k-1;
 
-  /* Allocate temporary variables from persistent scratch space. */
-  fmpz *tpol = dy_data->w;
-  fmpz *tpol2 = dy_data->w+d+1;
+  /* Dynamic data */
 
-  fmpz *t0z = dy_data->w+3*d+5;
-  fmpz *t1z = dy_data->w+3*d+6;
-  fmpz *t2z = dy_data->w+3*d+7;
-  fmpz *lower = dy_data->w+3*d+8;
-  fmpz *upper = dy_data->w+3*d+9;
+  fmpz *pol = dy_data->pol + n;
+  fmpz *pow_num = dy_data->power_sums_num;
 
-  fmpq *t0q = dy_data->w2;
-  fmpq *t1q = dy_data->w2+1;
-  fmpq *t2q = dy_data->w2+2;
-  fmpq *t3q = dy_data->w2+3;
-  fmpq *t4q = dy_data->w2+4;
+  /* Integers allocated from working space, maintained throughout */
 
-  /* If k>d, no further coefficients to bound. */
-  if (k>d) return(1);
+  fmpz *f = dy_data->w;
+  fmpz *upper = f+1;
+  fmpz *lower = f+2;
 
-  /* Update power_sums[k]. */
-  t = fmpq_mat_entry(dy_data->power_sums, k, 0);
-  fmpq_set_si(t, -k, 1);
-  fmpq_mul_fmpz(t, t, pol+d-k);
-  for (i=1; i<k; i++) {
-    fmpq_set_si(t0q, -1, 1);
-    fmpq_mul_fmpz(t0q, t0q, pol+d-i);
-    fmpq_addmul(t, t0q, fmpq_mat_entry(dy_data->power_sums, k-i, 0));
-  }
-  fmpq_div_fmpz(t, t, pol+d);
+  /* Local working space, not maintained throughout */
 
-  /* Condition: the k-th symmetrized power sum must lie in [-2*sqrt(q), 2*sqrt(q)]. */
-  fmpq_mat_mul(dy_data->sum_prod, st_data->sum_mats[k], dy_data->power_sums);
-  t = fmpq_mat_entry(dy_data->sum_prod, 0, 0);
+  int i, j, s;
+  fmpz *w = f+3; // Length 3*k+3, passed to subroutines
 
-  fmpq_set_si(t1q, 2*d, 1);
-  if (!q_is_1) {
-    fmpz_pow_ui(t0z, q, k/2);
-    fmpq_mul_fmpz(t1q, t1q, t0z);
-  }
-  if (k%2==0) {
-    fmpq_sub(t0q, t, t1q);
-    set_lower(t0q, NULL, STATE);
-    fmpq_add(t0q, t, t1q);
-    set_upper(t0q, NULL, STATE);
-  } else {
-    set_upper(t, t1q, STATE);
-    fmpq_neg(t1q, t1q);
-    set_lower(t, t1q, STATE);
+  fmpz *t0z = w;
+  fmpz *t1z = w+1;
+  fmpz *t2z = w+2; // Affected by change_by_sign
+
+  /* Unallocated pointers */
+
+  fmpz *tz, *tza;
+
+  /* Adjust lower and upper bounds within set_range_from_power_sums (affects lower, upper, t2z).
+     The pair (val1, val2) stands for g = val1 + val2*sqrt(q).
+     The value in val1 is specified as a numerator-denominator pair which need not be canonicalized,
+     although the denominator must be positive (a denominator of NULL is interpreted as 1).
+     A value of NULL for val2_num is interpreted as 0. No aliasing allowed.
+
+     Given that g is a monic linear function of the k-th power sum, then:
+
+     -- passing r = 0 imposes the condition g >= 0 (or g > 0 if force_squarefree != 0);
+     -- passing r = 1 imposes the condition g <= 0 (or g < 0 if force_squarefree != 0);
+     -- passing update = 0 means we are setting the initial bounds;
+     -- passing update = 1 means we are updating previously set bounds.
+  */
+
+  inline void change_by_sign(int update, int r, const fmpz_t val1_num, const fmpz_t val1_den, const fmpz_t val2_num) {
+    fmpq_floor_ceil_quad(t2z, r ^ force_squarefree, val1_num, val1_den, val2_num, f, q);
+    if (!r) { // change_upper
+      if (force_squarefree) { if (!update || fmpz_cmp(t2z, upper) <= 0) fmpz_sub_ui(upper, t2z, 1); }
+      else if (!update || fmpz_cmp(t2z, upper) < 0) fmpz_set(upper, t2z);
+    } else { // change_lower
+      if (force_squarefree) { if (!update || fmpz_cmp(t2z, lower) >= 0) fmpz_add_ui(lower, t2z, 1); }
+      else if (!update || fmpz_cmp(t2z, lower) > 0) fmpz_set(lower, t2z);
     }
-
-  /* Compute the divided (n-1)-st derivative of pol, answer in tpol. */
-  for (i=0; i<=k; i++)
-    fmpz_mul(tpol+i, fmpz_mat_entry(st_data->binom_mat, n-1+i, n-1), pol+n-1+i);
-
-  /* Condition: Descartes' rule of signs applies at -2*sqrt(q), +2*sqrt(q).
-   This is only a new condition for the evaluations at these points. */
-
-  fmpq_set_si(t3q, -k, 1);
-  fmpq_div_fmpz(t3q, t3q, pol+d);
-
-  for (i=0; 2*i <= k; i++) fmpz_mul_2exp(tpol2+i, tpol+2*i, 2*i);
-  _fmpz_poly_evaluate_fmpz(t0z, tpol2, (k+2) / 2, q);
-  fmpq_mul_fmpz(t1q, t3q, t0z);
-
-  for (i=0; 2*i+1 <= k; i++) fmpz_mul_2exp(tpol2+i, tpol+2*i+1, 2*i+1);
-  _fmpz_poly_evaluate_fmpz(t0z, tpol2, (k+1) / 2, q);
-  fmpq_mul_fmpz(t2q, t3q, t0z);
-
-  /* If checking for squarefree, shear endpoints off the range. */
-  if (st_data->force_squarefree) {
-    change_lower_strict(t1q, t2q, STATE);
-    fmpq_neg(t2q, t2q);
-    if (k%2==1) change_upper_strict(t1q, t2q, STATE);
-    else change_lower_strict(t1q, t2q, STATE);
-  }
-  else {
-    change_lower(t1q, t2q, STATE);
-    fmpq_neg(t2q, t2q);
-    if (k%2==1) change_upper(t1q, t2q, STATE);
-    else change_lower(t1q, t2q, STATE);
-  }
-  if (fmpz_cmp(lower, upper) > 0) return(0);
-
-  /* Update Hankel matrices. */
-  if (k%2==0) {
-    fmpq_mat_one(dy_data->hankel_mat);
-    for (i=0; i<=k/2; i++)
-      for (j=0; j<=k/2; j++)
-	fmpq_set(fmpq_mat_entry(dy_data->hankel_mat, i, j),
-		 fmpq_mat_entry(dy_data->power_sums, i+j, 0));
-    fmpq_mat_det(t0q, dy_data->hankel_mat);
-    t = fmpq_mat_entry(dy_data->hankel_dets, k/2-1, 0);
-    fmpq_set(fmpq_mat_entry(dy_data->hankel_dets, k/2, 0), t0q);
   }
 
-  /* If modulus==0, then return 1 iff [lower, upper] contains 0
-     and Rolle's theorem is satisfied.
-   */
-  if (fmpz_is_zero(modulus)) {
-    if ((fmpz_sgn(lower) > 0) || (fmpz_sgn(upper) < 0) ||
-	!_fmpz_poly_all_real_roots(tpol, k+1, tpol2, st_data->force_squarefree,
-				   NULL, NULL)) return(0);
-    fmpz_zero(lower);
-    fmpz_zero(upper);
-    return(1);
-  } else
-    if (fmpz_cmp(lower, upper) > 0) return(0);
+  /* If modulus==0, reduce the interval to [0]. */
 
-  /* Condition: nonnegativity of the Hankel determinant.
-     TODO: reimplement this as a subresultant. */
-  if (k%2==0) {
-    if (fmpq_sgn(t) > 0) {
-      fmpq_div(t0q, t0q, t);
-      change_upper(t0q, NULL, STATE);
+  fmpz_set_ui(f, k);
+  if (modulus_is_0) { fmpz_zero(lower); fmpz_zero(upper); }
+  else if (!modulus_is_1) fmpz_mul(f, f, modulus);
+
+  /* Update the vector of power sums. */
+
+  update_power_sums(pow_num, pol, k);
+
+  /* Chebyshev criterion: the k-th symmetrized power sum must lie in [-2*d*q^(k/2), 2*d*q^(k/2)]. */
+
+  _fmpz_vec_dot(t0z, st_data->sum_mats+(d+1)*k, pow_num, k+1);
+  if (q_is_square || k2 == 0) { // q^{k/2} is rational
+    fmpz_add(t1z, t0z, st_data->ranges+k);
+    change_by_sign(modulus_is_0, 0, t1z, lead_pow, NULL);
+    fmpz_sub(t1z, t0z, st_data->ranges+k);
+    change_by_sign(modulus_is_0, 1, t1z, lead_pow, NULL);
+  } else { // q^{k/2} is irrational
+    change_by_sign(modulus_is_0, 0, t0z, lead_pow, st_data->ranges+k);
+    fmpz_neg(t1z, st_data->ranges+k);
+    change_by_sign(modulus_is_0, 1, t0z, lead_pow, t1z);
+  }
+
+  /* Impose optional linear constraints on power sums. */
+
+  for (i=0; i<st_data->num_constraints; i++)
+    if (st_data->constraint_lens[i] == k) {
+      tz = st_data->constraints + (d+1)*i;
+      _fmpz_vec_dot(t0z, tz, pow_num, k+1);
+      fmpz_opt_mul(t1z, lead_pow, tz+k);
+      if ((j = fmpz_sgn(t1z) < 0)) {
+        fmpz_neg(t0z, t0z);
+        fmpz_neg(t1z, t1z);
       }
-    else if (st_data->force_squarefree || fmpq_sgn(t0q)) return(0);
-    else change_upper(fmpq_mat_entry(dy_data->power_sums, k, 0), NULL, STATE);
-    if (fmpz_cmp(lower, upper) > 0) return(0);
-  }
+      change_by_sign(1, j, t0z, t1z, NULL);
+      if (fmpz_cmp(lower, upper) > 0) return(0);
+    }
 
-  /* Condition: the Hausdorff moment criterion for having roots in [-2, 2]. 
-     This might be redundant given the Hankel and Descartes criteria. */
-  fmpq_mat_mul(dy_data->hausdorff_prod, st_data->hausdorff_mats[k], dy_data->power_sums);
-  for (i=0; i<=k; i++) {
-    fmpq_set(t1q, fmpq_mat_entry(dy_data->hausdorff_prod, 2*i, 0));
-    fmpq_set(t2q, fmpq_mat_entry(dy_data->hausdorff_prod, 2*i+1, 0));
-    if (i%2==0) change_upper(t1q, t2q, STATE);
-    else change_lower(t1q, t2q, STATE);
-    if (q_is_1) {
-      fmpq_set(fmpq_mat_entry(dy_data->hausdorff_sums1, k, i), t1q);
-      fmpq_set(fmpq_mat_entry(dy_data->hausdorff_sums2, k, i), t2q);
+  /* Descartes criterion: the evaluations of the n-th derivative of pol at -2*sqrt(q), 2*sqrt(q)
+     have the correct signs. */
+
+  _fmpz_vec_dot(t0z, st_data->eval_pm2_mats+(d+1)*(2*k), pol, k+1);
+  _fmpz_vec_dot(t1z, st_data->eval_pm2_mats+(d+1)*(2*k+1), pol, k+1);
+  if (!k2) fmpz_abs(t1z, t1z);
+  if (q_is_square) {
+    fmpz_add(t0z, t0z, t1z);
+    change_by_sign(1, 1, t0z, NULL, NULL);
+    if (k2) {
+      fmpz_submul_ui(t0z, t1z, 2);
+      change_by_sign(1, 0, t0z, NULL, NULL);
+    }
+  } else {
+    change_by_sign(1, 1, t0z, NULL, t1z);
+    if (k2) {
+      fmpz_neg(t1z, t1z);
+      change_by_sign(1, 0, t0z, NULL, t1z);
     }
   }
   if (fmpz_cmp(lower, upper) > 0) return(0);
 
-  /* Condition: log convexity based on Cauchy-Schwarz. */
-  /* TODO: extend to q != 1 without losing too much efficiency. */
-  if (q_is_1) {
-    for (i=0; i<=k-2; i++) {
-      fmpq_add(t1q, fmpq_mat_entry(dy_data->hausdorff_sums1, k, i),
-	       fmpq_mat_entry(dy_data->hausdorff_sums2, k, i));
-      fmpq_add(t2q, fmpq_mat_entry(dy_data->hausdorff_sums1, k-1, i),
-	       fmpq_mat_entry(dy_data->hausdorff_sums2, k-1, i));
-      fmpq_add(t3q, fmpq_mat_entry(dy_data->hausdorff_sums1, k-2, i),
-	       fmpq_mat_entry(dy_data->hausdorff_sums2, k-2, i));
-      impose_quadratic_condition(t1q, t2q, t3q, STATE);
-    }
-    for (i=2; i<=k; i++) {
-      fmpq_add(t1q, fmpq_mat_entry(dy_data->hausdorff_sums1, k, i),
-	       fmpq_mat_entry(dy_data->hausdorff_sums2, k, i));
-      fmpq_add(t2q, fmpq_mat_entry(dy_data->hausdorff_sums1, k-1, i-1),
-	       fmpq_mat_entry(dy_data->hausdorff_sums2, k-1, i-1));
-      fmpq_add(t3q, fmpq_mat_entry(dy_data->hausdorff_sums1, k-2, i-2),
-	       fmpq_mat_entry(dy_data->hausdorff_sums2, k-2, i-2));
-      impose_quadratic_condition(t1q, t2q, t3q, STATE);
-    }
-  }
-  r = fmpz_cmp(lower, upper);
-  if (r>0) return(0);
+  /* Hausdorff criterion: the relevant Hankel matrices have nonnegative determinant.
+     In order to restrict to integer arithmetic, we skip this condition when
+     k is odd and q is not a perfect square. */
 
-  /* Check the Rolle condition at the midpoint. If it holds, perform a binary
-     search on the left endpoint; otherwise, do a linear search. */
-  if (r) {
-    fmpz_add(t0z, lower, upper);
-    fmpz_fdiv_q_2exp(t0z, t0z, 1);
-    r = _fmpz_poly_all_real_roots(tpol, k+1, tpol2, st_data->force_squarefree, t0z, modulus);
-  }
-  if (r) {
-    fmpz_set(t2z, t0z);
-    while (fmpz_cmp(lower, t0z)) {
-      fmpz_add(t1z, lower, t0z);
-      fmpz_fdiv_q_2exp(t1z, t1z, 1);
-      r = _fmpz_poly_all_real_roots(tpol, k+1, tpol2, st_data->force_squarefree, t1z, modulus);
-      if (r) fmpz_set(t0z, t1z);
-      else fmpz_add_ui(lower, t1z, 1);
+  if (q_is_square || !k2)
+    for (i=1; i>=0; i--) {
+      s = k2 ? k : i ? k-1 : k+1;
+      tz = dy_data->hankel_dets + 2*k + i;
+      j = k > 1 && (force_squarefree || fmpz_sgn(tz-4) > 0);
+      if (q_is_square && !i && k > 1 && (force_squarefree || fmpz_sgn(tz-3) > 0)) {
+        /* Use the recursive relationship between upper and lower Hankel determinants. */
+        if (k2) {
+          tza = t1z;
+          fmpz_mul_ui(tza, tz-2, 2);
+          fmpz_mul(tza, tza, st_data->c1);
+        } else tza = tz-2;
+        fmpz_fmms_divexact(tz, tz-1, tza, tz-4, tz+1, tz-3);
+        if (k2 && !j) { // Need the corner entry for a linear constraint
+          tza = w;
+          fmpz_mul(t0z, pow_num+s-1, st_data->c1);
+          fmpz_add(tza+s-1, t0z, pow_num+s);
+        } else tza = pow_num;
+      } else {
+        /* Compute the Hankel determinant by condensation (if possible) or directly.
+           Predefined: c1 == 2*lead*sqrt(q), c0 == 4*lead^2*q. */
+        if (i || k2) {
+          tza = (fmpz *)(k2 ? st_data->c1 : st_data->c0);
+          if (!i) _fmpz_vec_scalar_fmma_one(w, pow_num, tza, pow_num+1, s);
+          else _fmpz_vec_scalar_fmms_one(w, pow_num, tza, pow_num+2-k2, s);
+          tza = w;
+        } else tza = pow_num;
+        if (!hankel_determinant_condensation(tz, tza, s, w+k+1)) hankel_determinant_direct(tz, tza, s);
+      }
+
+      /* Deduce a linear constraint. */
+      if (j) {
+        if (lead_pow) fmpz_mul(tza = t1z, tz-4, lead_pow); else tza = tz-4;
+        if (i) { fmpz_neg(t0z, tz); tz = t0z; }
+      } else { // Argue that the corner entry is nonnegative
+        if (i) fmpz_neg(tz = t0z, tza+s-1); else tz = tza+s-1;
+        tza = lead_pow;
+      }
+      change_by_sign(1, i, tz, tza, NULL);
     }
-  } else {
-    r = _fmpz_poly_all_real_roots(tpol, k+1, tpol2, st_data->force_squarefree, lower, modulus);
-    while (!r) {
-      fmpz_add_ui(lower, lower, 1);
-      if (fmpz_cmp(lower, upper) > 0) return(0);
-      r = _fmpz_poly_all_real_roots(tpol, k+1, tpol2, st_data->force_squarefree, lower, modulus);
-    }
-    if (fmpz_cmp(lower, t0z)<0) fmpz_sub_ui(upper, t0z, 1);
-    fmpz_set(t2z, lower);
-  }
-  /* Now do a binary search on the right endpoint. */
-  while (fmpz_cmp(t2z, upper)) {
-      fmpz_add(t1z, t2z, upper);
-      fmpz_cdiv_q_2exp(t1z, t1z, 1);
-      r = _fmpz_poly_all_real_roots(tpol, k+1, tpol2, st_data->force_squarefree, t1z, modulus);
-      if (r) fmpz_set(t2z, t1z);
-      else fmpz_sub_ui(upper, t1z, 1);
-  }
+  if (fmpz_cmp(lower, upper) > 0) return(0);
 
   /* Set the new upper bound. */
-  fmpz_mul(upper, upper, modulus);
-  fmpz_add(dy_data->upper+n-1, pol+n-1, upper);
 
-  /* Set the new polynomial value. */
-  fmpz_addmul(pol+n-1, lower, modulus);
+  if (!modulus_is_1) fmpz_mul(upper, upper, modulus);
+  fmpz_add(dy_data->upper+n, pol, upper);
 
-  /* Correct the k-th power sum and related quantities. */
-  t1q = fmpq_mat_entry(dy_data->power_sums, k, 0);
-  fmpq_mul_fmpz(t0q, f, lower);
-  fmpq_sub(t1q, t1q, t0q);
-  if (q_is_1) for (i=0; i<=k; i++) {
-      t1q = fmpq_mat_entry(dy_data->hausdorff_sums1, k, i);
-      fmpq_sub(t1q, t1q, t0q);
-    }
-  if (k%2==0) {
-    t1q = fmpq_mat_entry(dy_data->hankel_dets, k/2, 0);
-    fmpq_submul(t1q, fmpq_mat_entry(dy_data->hankel_dets, k/2-1, 0), t0q);
+  /* Set the new polynomial value, then correct the k-th power sum and related quantities. */
+
+  step_forward(st_data, dy_data, n, lower);
+
+  return(1);
+}
+
+/* Given a polynomial pol of length k, shrink the interval [lower, upper] to the range of constant terms
+   which when added to pol give a polynomial with all real roots. Returns 0 if this range is empty (with
+   lower, upper now undefined) and 1 otherwise (with lower, upper now the endpoints of the new range).
+
+   This function assumes that {w, 2*k+2} is scratch space.
+*/
+
+int apply_rolle_condition(fmpz_t lower, fmpz_t upper, const fmpz *pol, int k,
+    int force_squarefree, const fmpz_t modulus, fmpz *w) {
+  int r, s;
+
+  /* Allocate from working space. */
+  fmpz *t0z = w;
+  fmpz *t1z = w+1;
+  fmpz *t2z = w+2;
+  fmpz *f0 = w+3; // Length k-1
+  fmpz *f1 = w+k+2; // Length k
+
+  #define TEST_ROOTS(x) _fmpz_poly_all_real_roots(pol, k, f0, f1, force_squarefree, x, modulus)
+
+  /* Handle the case upper == lower directly. */
+  fmpz_sub(t0z, upper, lower);
+  if (fmpz_is_zero(t0z)) return(TEST_ROOTS(lower));
+
+  /* Look for a single value where the Rolle criterion holds. */
+  fmpz_add_ui(t0z, t0z, 1);
+  r = fmpz_flog_ui(t0z, 2); // r = floor(log_2 (upper-lower+1)); forced to be positive
+  while (1) {
+    fmpz_one_2exp(t2z, r);
+    if (r) {
+      fmpz_add(t0z, lower, t2z);
+      fmpz_sub_ui(t0z, t0z, 1);
+    } else fmpz_set(t0z, lower);
+    do {
+      if ((s = TEST_ROOTS(t0z))) break;
+      fmpz_addmul_ui(t0z, t2z, 2);
+    } while (fmpz_cmp(t0z, upper) <= 0);
+    if (s) break; // Found a good value
+    if (!r--) return(0); // Found nothing
+  }
+
+  if (!r) { // In this case, enforce lower == upper and exit
+    fmpz_set(lower, t0z);
+    fmpz_set(upper, t0z);
+    return(1);
+  }
+
+  /* Shorten the interval based on tested values. */
+  fmpz_sub(t1z, t0z, t2z);
+  fmpz_add_ui(lower, t1z, 1); // Does not decrease lower
+  fmpz_add(t1z, t0z, t2z);
+  if (fmpz_cmp(t1z, upper) <= 0) fmpz_sub_ui(upper, t1z, 1);
+
+  /* Use binary searches to compute the interval on which the Rolle criterion is satisfied. */
+  fmpz_set(t1z, t0z);
+  while (!fmpz_equal(lower, t0z)) {
+    fmpz_fmid(t2z, lower, t0z);
+    if (TEST_ROOTS(t2z)) fmpz_set(t0z, t2z);
+    else fmpz_add_ui(lower, t2z, 1);
+  }
+  while (!fmpz_equal(t1z, upper)) {
+    fmpz_cmid(t0z, t1z, upper);
+    if (TEST_ROOTS(t0z)) fmpz_set(t1z, t0z);
+    else fmpz_sub_ui(upper, t0z, 1);
   }
   return(1);
 }
 
-/* Increment the current moving counter and update stored data to match. */
-void step_forward(ps_static_data_t *st_data, ps_dynamic_data_t *dy_data, int n) {
-  int d = st_data->d, k = d-n;
-  fmpz *pol = dy_data->pol;
-  fmpq *tq = fmpq_mat_entry(dy_data->power_sums, k, 0);
-  int j;
-
-  fmpz_add(pol+n, pol+n, st_data->modlist+n);
-  fmpq_sub(tq, tq, st_data->f+n);
-  if (dy_data->q_is_1) for (j=0; j<=k; j++) {
-      tq = fmpq_mat_entry(dy_data->hausdorff_sums1, k, j);
-      fmpq_sub(tq, tq, st_data->f+n);
-    }
-  if (k%2==0)
-    fmpq_submul(fmpq_mat_entry(dy_data->hankel_dets, k/2, 0),
-		st_data->f+n, fmpq_mat_entry(dy_data->hankel_dets, k/2-1, 0));
-}
-
-/* Return value sent back in dy_data->flag:
-   1: in process
-   2: found a solution
-   0: tree exhausted
-   -1: maximum number of nodes reached
+/* Use the Rolle condition to refine the range of a specific coefficient. Normally should be called after first
+   constructing a suitable range using set_range_from_power_sums. Returns 0 if the updated range would be empty
+   (in which case it is not actually updated).
 */
 
-void next_pol(ps_static_data_t *st_data, ps_dynamic_data_t *dy_data, int max_steps) {
+int reduce_range_from_rolle(const ps_static_data_t *st_data, ps_dynamic_data_t *dy_data, int n) {
+  if (n < 0) return(1);
   int d = st_data->d;
-  int node_limit = st_data->node_limit;
-  fmpz *modlist = st_data->modlist;
+  int k = d - n + 1;
+  fmpz *modulus = st_data->modlist + n;
+  int modulus_is_1 = fmpz_is_one(modulus) || fmpz_is_zero(modulus);
+
+  fmpz *pol = dy_data->pol + n;
+  fmpz *upper = dy_data->w;
+  fmpz *lower = dy_data->w+1;
+  fmpz *polderiv = dy_data->w+2;
+
+  fmpz_zero(lower);
+  fmpz_sub(upper, dy_data->upper+n, pol);
+  if (!modulus_is_1) fmpz_divexact(upper, upper, modulus);
+  _fmpz_vec_mul(polderiv, st_data->binom_mat + (d+2)*n, pol, k);
+
+  if (!apply_rolle_condition(lower, upper, polderiv, k, st_data->force_squarefree,
+    modulus_is_1 ? NULL : modulus, polderiv + k)) return(0);
+
+  /* Set the new upper bound. */
+
+  if (!modulus_is_1) fmpz_mul(upper, upper, modulus);
+  fmpz_add(dy_data->upper+n, pol, upper);
+
+  /* Set the new polynomial value, then correct the k-th power sum and related quantities. */
+
+  step_forward(st_data, dy_data, n, lower);
+
+  return(1);
+}
+
+/* Compute the reciprocal transform of pol and store it in sympol. */
+
+void reciprocal_transform(const ps_static_data_t *st_data, ps_dynamic_data_t *dy_data) {
+  fmpz_mat_mul_fmpz_vec(dy_data->sympol, st_data->pol_to_sym, dy_data->pol, st_data->d + 1);
+}
+
+/*****
+  High-level flow control
+*****/
+
+/* Split off a subtree (without allocating new memory).
+   The donor process yields its current branch at the first coefficient that is not uniquely specified.
+   The donee process may in turn be split immediately.
+   Return value is 1 if a split is executed and 0 otherwise.
+
+   It is safe to run this in parallel as long as the instances of dy_data are pairwise distinct
+   and the instances of dy_data2 are pairwise distinct.
+*/
+int ps_dynamic_split(const ps_static_data_t *st_data, ps_dynamic_data_t *dy_data, ps_dynamic_data_t *dy_data2) {
+  if (dy_data == NULL || dy_data2 == NULL || dy_data == dy_data2 || dy_data->flag <= 0 || dy_data2->flag) return(0);
+
+  int i;
+  int d = dy_data->d;
+  int k = dy_data->n + dy_data->ascend;
+
+  for (i=d; i>k; i--)
+    if (fmpz_cmp(dy_data->pol+i, dy_data->upper+i) < 0) {
+      int j = d - i + 1;
+      fmpz *lower = dy_data->pol+i;
+      fmpz *upper = dy_data->upper+i;
+      fmpz *modulus = st_data->modlist+i;
+      int modulus_is_1 = fmpz_is_one(modulus);
+      fmpz *t0z = dy_data->w; // Temporary variable
+
+      /* Copy the current state of the donor to the donee process. */
+      _fmpz_vec_set(dy_data2->pol+i, lower, j);
+      _fmpz_vec_set(dy_data2->upper+i, upper, j);
+      _fmpz_vec_set(dy_data2->power_sums_num, dy_data->power_sums_num, j);
+      _fmpz_vec_set(dy_data2->hankel_dets, dy_data->hankel_dets, 2*j);
+
+      /* Clear unused values to make sure large mpz's get deallocated promptly. */
+      _fmpz_vec_zero(dy_data2->power_sums_num+j, i);
+      _fmpz_vec_zero(dy_data2->hankel_dets+2*j, 2*i);
+      _fmpz_vec_zero(dy_data->w, dy_data->wlen);
+      _fmpz_vec_zero(dy_data2->w, dy_data2->wlen);
+
+      /* Restrict the donee process to the right half of the interval (rounding right). */
+      fmpz_sub(t0z, upper, lower);
+      if (!modulus_is_1) fmpz_divexact(t0z, t0z, modulus);
+      fmpz_cdiv_q_ui(t0z, t0z, 2);
+      step_forward(st_data, dy_data2, i, t0z);
+      dy_data2->ascend = 0;
+      dy_data2->n = i;
+      dy_data2->flag = 1;
+
+      /* Restrict the donor process to the left half of the interval. */
+      fmpz_sub_ui(t0z, t0z, 1);
+      if (!modulus_is_1) fmpz_mul(t0z, t0z, modulus);
+      fmpz_add(upper, lower, t0z);
+      return(1);
+    }
+  return(0);
+}
+
+/* Top-level flow control: allow one process to run for up to max_steps iterations,
+   or until it finds a polynomial to be returned, whichever comes first.
+
+   Return value also sent back in dy_data->flag:
+   1: in process
+   2: found a solution (returned in dy_data->sympol)
+   0: tree exhausted
+   -1: maximum number of nodes reached
+
+   It is threadsafe to run this in parallel with dynamic_split.
+*/
+
+int ps_next_pol(const ps_static_data_t *st_data, ps_dynamic_data_t *dy_data, int max_steps) {
+  if (dy_data==NULL || !dy_data->flag) return(0); // No work assigned to this process
+
+  int d = st_data->d;
+  int n = dy_data->n;
+  if (n>d) return(0); // This process is exhausted.
 
   int ascend = dy_data->ascend;
-  int n = dy_data->n;
-  int q_is_1 = dy_data->q_is_1;
+  long node_limit = st_data->node_limit;
   long node_count = dy_data->node_count;
-  fmpz *upper = dy_data->upper;
-  fmpz *pol = dy_data->pol;
-  fmpz *sympol = dy_data->sympol;
-  fmpz *temp = dy_data->w;
 
-  int i, j, flag = 1, count_steps = 0;
+  int flag = 1;
+  int count_steps = 0;
+  int i;
 
-  if (dy_data==NULL || !dy_data->flag) return; // No work assigned to this process
-  if (n>d) return;
-
-  dy_data->flag = 0; // Prevent work-stealing while this process is running
-
-  while ((flag==1) && (count_steps <= max_steps)) {
-    count_steps += 1;
+  while (1) {
     if (ascend) { // Ascend the tree and step forward as needed.
-      n += ascend;
-      if (n>d) flag = 0; // This process is complete.
-      else {
-	ascend = (fmpz_is_zero(modlist+n) || (fmpz_cmp(pol+n, upper+n) >= 0));
-	if (!ascend) step_forward(st_data, dy_data, n);
-      }
+      n = ascend_step_forward(st_data, dy_data, n);
+      if (n > d) { flag = 0; break; }
+      ascend = 0;
     } else if (n < 0) { // Return a solution.
-      _fmpz_vec_zero(sympol, 2*d+3);
-      for (i=0; i<=d; i++) {
-	fmpz_one(temp);
-	for (j=0; j<=i; j++) {
-	  fmpz_addmul(sympol+d+i-2*j, pol+i, temp);
-	  if (j<i) {
-	    fmpz_mul(temp, temp, st_data->q);
-	    fmpz_mul_si(temp, temp, i-j);
-	    fmpz_divexact_si(temp, temp, j+1);
-	  }
-	}
-      }
-      _fmpz_vec_scalar_mul_si(sympol, sympol, 2*d+1, st_data->sign);
-      _fmpz_poly_mul_KS(sympol, sympol, 2*d+1, st_data->cofactor, 3);
+      reciprocal_transform(st_data, dy_data);
       ascend = 1;
       flag = 2;
+      break;
     } else { // Compute children of the current node.
-      dy_data->n = n;
-      ascend = !set_range_from_power_sums(st_data, dy_data);
-      n -= 1;
-      if (ascend) {
-	node_count += 1;
-	if (node_limit != -1 && node_count >= node_limit) flag = -1;
-      }
+      n--;
+      if ((ascend = !(set_range_from_power_sums(st_data, dy_data, n) &&
+            reduce_range_from_rolle(st_data, dy_data, n)))) // Found a terminal node
+	if (node_limit != -1 && (++node_count) >= node_limit) { flag = -1; break; }
+      i = d-n+1; count_steps += i*i;
+      if (count_steps > max_steps) break;
     }
   }
+  /* Record the final working state. */
   dy_data->ascend = ascend;
   dy_data->n = n;
   dy_data->node_count = node_count;
   dy_data->flag = flag;
+  return(flag);
+}
+
+void ps_cleanup(int n) {
+  if (n == 0) flint_cleanup_master();
+  else if (n == 1) flint_cleanup();
 }

--- a/src/sage/rings/polynomial/weil/power_sums.h
+++ b/src/sage/rings/polynomial/weil/power_sums.h
@@ -1,44 +1,48 @@
 #pragma once
 #include <flint/flint.h>
+#include <flint/fmpz.h>
+#include <flint/fmpz_vec.h>
 #include <flint/fmpz_poly.h>
-#include <flint/fmpq.h>
-#include <flint/fmpq_mat.h>
-#include <flint/arith.h>
+#include <flint/fmpz_mat.h>
+
+#if defined(_OPENMP)
+  #include <omp.h>
+#endif
 
 typedef struct ps_static_data {
-  int d, sign, force_squarefree;
+  int d, force_squarefree;
   long node_limit;
-  fmpz_t a, b, lead, q;
-  fmpz_mat_t binom_mat;
-  fmpz *cofactor;
-  fmpz *modlist;
-  fmpq_mat_t *hausdorff_mats;
-  fmpq_mat_t *sum_mats;
-  fmpq *f;
+  fmpz_t q, q_sqrt, c0, c1;
+  int q_is_1, q_is_square, lead_is_1, num_constraints;
+  int *constraint_lens;
+  fmpz *modlist, *binom_mat, *sum_mats, *eval_pm2_mats, *ranges, *lead_pows, *constraints;
+  fmpz_mat_t pol_to_sym;
 } ps_static_data_t;
 
 typedef struct ps_dynamic_data {
-  int d, n, ascend, flag, q_is_1;
+  int d, n, ascend, flag;
   long node_count;
-  fmpq_mat_t power_sums, sum_prod, hankel_mat, hankel_dets,
-    hausdorff_prod, hausdorff_sums1, hausdorff_sums2;
-  fmpz *pol, *sympol, *upper;
+  fmpz *pol, *sympol, *upper, *power_sums_num, *hankel_dets;
 
   /* Scratch space */
   fmpz *w;
-  long wlen; /* = 4*d+10 */
-  fmpq *w2;
-  long w2len; /* = 5 */
+  long wlen; /* = 3*d+9 */
 } ps_dynamic_data_t;
 
-int has_openmp();
-ps_static_data_t *ps_static_init(int d, fmpz_t q, int coeffsign, fmpz_t lead,
-				 int cofactor, fmpz *modlist, long node_limit,
-				 int force_squarefree);
-ps_dynamic_data_t *ps_dynamic_init(int d, fmpz_t q, fmpz *coefflist);
+int num_threads();
+int is_mpz(fmpz f);
+
+ps_static_data_t *ps_static_init(int d, const fmpz_t q, const fmpz_t lead, const fmpz *modlist, int num_constraints, const fmpz *constraints, long node_limit, int force_squarefree);
+ps_dynamic_data_t *ps_dynamic_init(int d, fmpz *coefflist);
 void ps_static_clear(ps_static_data_t *st_data);
 void ps_dynamic_clear(ps_dynamic_data_t *dy_data);
-void extract_pol(int *Q, ps_dynamic_data_t *dy_data);
-void ps_dynamic_split(ps_dynamic_data_t *dy_data, ps_dynamic_data_t *dy_data2);
-void step_forward(ps_static_data_t *st_data, ps_dynamic_data_t *dy_data, int n);
-void next_pol(ps_static_data_t *st_data, ps_dynamic_data_t *dy_data, int max_steps);
+void ps_cleanup(int n);
+
+int ascend_step_forward(const ps_static_data_t *st_data, ps_dynamic_data_t *dy_data, int n);
+int reduce_range_from_rolle(const ps_static_data_t *st_data, ps_dynamic_data_t *dy_data, int n);
+int set_range_from_power_sums(const ps_static_data_t *st_data, ps_dynamic_data_t *dy_data, int n);
+void reciprocal_transform(const ps_static_data_t *st_data, ps_dynamic_data_t *dy_data);
+
+int ps_dynamic_split(const ps_static_data_t *st_data, ps_dynamic_data_t *dy_data, ps_dynamic_data_t *dy_data2);
+int ps_next_pol(const ps_static_data_t *st_data, ps_dynamic_data_t *dy_data, int max_steps);
+

--- a/src/sage/rings/polynomial/weil/weil_polynomials.pyx
+++ b/src/sage/rings/polynomial/weil/weil_polynomials.pyx
@@ -1,3 +1,8 @@
+## To enable OpenMP support, move the two lines starting with #distutils to the top.
+# For best results, you may need to set the environment variable OMP_NUM_THREADS to a
+# suitably large value (e.g., export OMP_NUM_THREADS=250).
+#distutils: libraries = gomp
+#distutils: extra_compile_args = -fopenmp
 r"""
 Iterator for Weil polynomials.
 
@@ -15,75 +20,83 @@ for smaller problem sizes. To enable support, ensure that your compiler supports
 OpenMP and remove the appropriate # characters in the distutils commands below.
 (You may also need to move those lines to the start of the file.)
 
-AUTHORS:
-
-- Kiran S. Kedlaya (2007-05-28): initial version
-
-- Kiran S. Kedlaya (2015-08-29): switch from NTL to FLINT
-
-- Kiran S. Kedlaya (2017-10-03): consolidate Sage layer into .pyx file;
-  define WeilPolynomials iterator; reverse convention for polynomials; pass
-  multiprecision integers to/from C
-
-- Kiran S. Kedlaya (2019-02-02): update for Python3; improve parallel mode
-
-- Kiran S. Kedlaya (2019-12-19): final packaging for Sage (with help from
-  David Roe)
+AUTHOR:
+  -- Kiran S. Kedlaya (2007-05-28): initial version
+  -- (2015-08-29): switch from NTL to FLINT
+  -- (2017-10-03): consolidate Sage layer into .pyx file
+                   define WeilPolynomials iterator
+                   reverse convention for polynomials
+                   pass multiprecision integers to/from C
+  -- (2019-02-02): update for Python3
+                   improve parallel mode
+  -- (2019-12-19): final packaging for Sage (with help from David Roe)
+  -- (2026-02-10): extensive low-level optimization and reorganization
+                   move some input sanitization out of C layer
+                   improved algorithm for computing ranges
+                     (using truncated Hausdorff moment condition)
+                   more efficient application of Rolle condition (binary search)
+                   choose number of processes based on available cores
+                   import fmpz's directly as longs when possible
+                   compute Hankel determinants via Dodgson condensation when possible
+                   compute subresultants via Ducos method
+                   more balanced work-splitting
+                   more direct conversion of output to Sage polynomials
+                   improved chunking in parallel mode
+  -- (2026-08-26): better answer conversion from FLINT to Sage
+                   compute some Hankel determinants recursively
+                   option to filter by linear constraints on Frobenius traces
 
 A standalone version of this code can be found at
-https://github.com/kedlaya/root-unitary.
+   https://github.com/kedlaya/root-unitary
 """
-# Remove second # from the next two lines to enable OpenMP support.
-##distutils: libraries = gomp
-##distutils: extra_compile_args = -fopenmp
 
-# ***************************************************************************
-#       Copyright (C) 2019 Kiran S. Kedlaya <kskedl@gmail.com>
+#*****************************************************************************
+#       Copyright (C) 2019-2026 Kiran S. Kedlaya <kskedl@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-#                  https://www.gnu.org/licenses/
-# ***************************************************************************
+#                  http://www.gnu.org/licenses/
+#*****************************************************************************
 
-cimport cython
-from cython.parallel import prange
-from libc.stdlib cimport malloc, free
-from cysignals.signals cimport sig_on, sig_off
+from cython.parallel cimport prange
+from cysignals.signals cimport sig_check
+from cpython.mem cimport PyMem_Malloc, PyMem_Free
 
-from sage.rings.rational_field import QQ
+from sage.arith.misc import next_prime, primitive_root
+from sage.rings.integer_ring import ZZ
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.functions.generalized import sgn
 
-from sage.rings.integer cimport Integer
-from sage.libs.gmp.types cimport mpz_t
 from sage.libs.gmp.mpz cimport mpz_set
 from sage.libs.flint.fmpz cimport *
 from sage.libs.flint.fmpz_vec cimport *
+from sage.libs.flint.fmpz_poly cimport *
+from sage.rings.integer cimport Integer
+from sage.rings.polynomial.polynomial_integer_dense_flint cimport Polynomial_integer_dense_flint
+from sage.structure.parent cimport Parent
 
-cdef extern from "sage/rings/polynomial/weil/power_sums.c":
+cdef extern from "power_sums.c":
     ctypedef struct ps_static_data_t:
         pass
 
     ctypedef struct ps_dynamic_data_t:
-        int flag
-        # State of the iterator (0 = inactive, 1 = running,
-        #                        2 = found a solution,
-        #                       -1 = too many nodes)
+        int flag        # State of the iterator (0 = inactive, 1 = running, 2 = found a solution, -1 = too many nodes)
+        long node_count # Number of terminal nodes encountered
+        fmpz *sympol    # Return value (a polynomial)
 
-        long node_count  # Number of terminal nodes encountered
-        fmpz *sympol     # Return value (a polynomial)
+    int num_threads()
+    int is_mpz(fmpz f)
 
-    int has_openmp()
-    ps_static_data_t *ps_static_init(int d, fmpz_t q, int coeffsign, fmpz_t lead,
-                                     int cofactor, fmpz *modlist, long node_limit,
-                                     int force_squarefree)
-    ps_dynamic_data_t *ps_dynamic_init(int d, fmpz_t q, fmpz *coefflist)
-    void ps_dynamic_split(ps_dynamic_data_t *dy_data, ps_dynamic_data_t *dy_data2) nogil
+    ps_static_data_t *ps_static_init(int d, const fmpz_t q, const fmpz_t lead, const fmpz *modlist, int num_constraints, const fmpz *constraints, long node_limit, int force_squarefree)
+    ps_dynamic_data_t *ps_dynamic_init(int d, fmpz *coefflist)
     void ps_static_clear(ps_static_data_t *st_data)
     void ps_dynamic_clear(ps_dynamic_data_t *dy_data)
-    void next_pol(ps_static_data_t *st_data, ps_dynamic_data_t *dy_data, int max_steps) nogil
+    void ps_cleanup(int n)
+
+    int ps_dynamic_split(ps_static_data_t *st_data, ps_dynamic_data_t *dy_data, ps_dynamic_data_t *dy_data2) nogil
+    int ps_next_pol(ps_static_data_t *st_data, ps_dynamic_data_t *dy_data, int max_steps) nogil
 
 cdef class dfs_manager:
     """
@@ -95,23 +108,23 @@ cdef class dfs_manager:
     cdef int d
     cdef int num_processes
     cdef long node_limit
-    cdef ps_static_data_t *ps_st_data
+    cdef ps_static_data_t *st_data
     cdef ps_dynamic_data_t **dy_data_buf
+    cdef Parent ring
 
-    def __cinit__(self, int d, q, coefflist, modlist, int sign, int cofactor,
-                  long node_limit, int parallel, int force_squarefree):
+    def __cinit__(self, int d, q, coefflist, modlist, constraints,
+                  long node_limit, int parallel, int force_squarefree, Parent ring):
         """
         Perform required C-level initialization (e.g., memory allocation).
 
-        This is called automatically at object creation. It should
-        never be called directly.
+        This is called automatically at object creation. It should never be called directly.
 
         TESTS:
 
         For some reason, Sage requires a dummy doctest to meet coverage requirements::
 
             sage: from sage.rings.polynomial.weil.weil_polynomials import WeilPolynomials
-            sage: w = WeilPolynomials(10,1,sign=1,lead=[3,1,1])
+            sage: w = WeilPolynomials(10, 1, sign=1, lead=[3,1,1])
             sage: it = iter(w)
             sage: it.process is not None # Verify object creation
             True
@@ -119,62 +132,79 @@ cdef class dfs_manager:
         cdef fmpz_t temp_lead
         cdef fmpz_t temp_q
         cdef fmpz *temp_array
-        cdef int i = 101 if parallel else 1
+        cdef fmpz *temp_constraints
+        cdef int i, j, num_constraints
+        cdef Integer np
 
         self.d = d
-        self.num_processes = i
-        self.dy_data_buf = <ps_dynamic_data_t **>malloc(i*cython.sizeof(cython.pointer(ps_dynamic_data_t)))
+        if parallel:
+            np = (Integer(num_threads())**2).next_prime()
+            while primitive_root(np) != 2:
+                np = np.next_prime()
+        else:
+            np = Integer(1)
+        self.num_processes = np
+        self.ring = ring
+        self.dy_data_buf = <ps_dynamic_data_t **>PyMem_Malloc(np * sizeof(ps_dynamic_data_t *))
+        if not self.dy_data_buf:
+            raise MemoryError()
         self.node_limit = node_limit
         fmpz_init(temp_lead)
         fmpz_set_mpz(temp_lead, Integer(coefflist[-1]).value)
         fmpz_init(temp_q)
         fmpz_set_mpz(temp_q, Integer(q).value)
-        temp_array = _fmpz_vec_init(d + 1)
-        for i in range(d + 1):
-            fmpz_set_mpz(temp_array + i, Integer(modlist[i]).value)
-        self.ps_st_data = ps_static_init(d, temp_q, sign, temp_lead, cofactor,
-                                         temp_array, node_limit, force_squarefree)
+        temp_array = _fmpz_vec_init(d+1)
+        for i in range(d+1):
+            fmpz_set_mpz(temp_array+i, Integer(modlist[i]).value)
+        num_constraints = len(constraints)
+        temp_constraints = _fmpz_vec_init((d+1) * num_constraints)
+        for i in range(num_constraints):
+            for j in range(min(d+1, len(constraints[i]))):
+                fmpz_set_mpz(temp_constraints+(d+1)*i+j, Integer(constraints[i][j]).value)
+        self.st_data = ps_static_init(d, temp_q, temp_lead,
+                                         temp_array, num_constraints, temp_constraints,
+                                         node_limit, force_squarefree)
 
         # Initialize processes, but assign work to only one process.
-        # In parallel mode, other processes will get initialized later via work-stealing.
+        # In parallel mode, other processes will get initialized later via work sharing.
         for i in range(d+1):
             fmpz_set_mpz(temp_array+i, Integer(coefflist[i]).value)
-        self.dy_data_buf[0] = ps_dynamic_init(d, temp_q, temp_array)
-        for i in range(1, self.num_processes):
-            self.dy_data_buf[i] = ps_dynamic_init(d, temp_q, NULL)
+        self.dy_data_buf[0] = ps_dynamic_init(d, temp_array)
+        for i in range(1, np):
+            self.dy_data_buf[i] = ps_dynamic_init(d, NULL)
 
         fmpz_clear(temp_lead)
         fmpz_clear(temp_q)
-        _fmpz_vec_clear(temp_array, d + 1)
+        _fmpz_vec_clear(temp_array, d+1)
+        _fmpz_vec_clear(temp_constraints, (d+1) * num_constraints)
 
     def __dealloc__(self):
         """
         Deallocate memory.
         """
-        ps_static_clear(self.ps_st_data)
-        self.ps_st_data = NULL
+        ps_static_clear(self.st_data)
+        self.st_data = NULL
         if self.dy_data_buf != NULL:
             for i in range(self.num_processes):
                 ps_dynamic_clear(self.dy_data_buf[i])
-            free(self.dy_data_buf)
+            PyMem_Free(self.dy_data_buf)
             self.dy_data_buf = NULL
 
     cpdef long node_count(self) noexcept:
         """
-        Count nodes.
+        Count nodes. This always gives 0 unless node_limit is specified.
 
-        This method should not be called directly. Instead, use the
-        ``node_count`` method of an instance of ``WeilPolynomials`` or
-        ``WeilPolynomials_iter``.
+        This method should not be called directly. Instead, use the ``node_count`` method
+        of an instance of ``WeilPolynomials`` or ``WeilPolynomials_iter``.
 
         TESTS::
 
             sage: from sage.rings.polynomial.weil.weil_polynomials import WeilPolynomials
-            sage: w = WeilPolynomials(10,1,sign=1,lead=[3,1,1])
+            sage: w = WeilPolynomials(10, 1, sign=1, lead=[3,1,1], node_limit=10000000)
             sage: it = iter(w)
             sage: _ = next(it)
             sage: it.process.node_count()
-            158
+            118
         """
         cdef long count = 0
         cdef int i
@@ -182,7 +212,21 @@ cdef class dfs_manager:
             count += self.dy_data_buf[i].node_count
         return count
 
-    cpdef object advance_exhaust(self):
+    cdef Polynomial_integer_dense_flint extract_poly(self, int i):
+        """
+        Extract a polynomial computed by process i.
+        """
+        cdef int j, n = 2*self.d + 1
+        cdef Polynomial_integer_dense_flint poly = self.ring.zero()
+        cdef fmpz *sympol = self.dy_data_buf[i].sympol
+
+        poly = poly._new() # Allocate a new polynomial in self.ring
+        fmpz_poly_realloc(poly._poly, n)
+        for j in range(n):
+           fmpz_poly_set_coeff_fmpz(poly._poly, j, sympol+j)
+        return poly
+
+    cpdef object advance_exhaust(self, list ans, long ans_max=10000):
         """
         Advance the tree exhaustion.
 
@@ -194,52 +238,39 @@ cdef class dfs_manager:
             sage: from sage.rings.polynomial.weil.weil_polynomials import WeilPolynomials
             sage: w = WeilPolynomials(10,1,sign=1,lead=[3,1,1])
             sage: it = iter(w)
-            sage: it.process.advance_exhaust()[0]
-            [3, 1, 1, -5, 1, -2, 1, -5, 1, 1, 3, 0, 0]
+            sage: ans = []
+            sage: ans = it.process.advance_exhaust(ans)
+            sage: ans[0]
+            3*x^10 + x^9 + x^8 - 5*x^7 + x^6 - 2*x^5 + x^4 - 5*x^3 + x^2 + x + 3
         """
-        cdef int i, j, k, d = self.d, t = 1, u = 0, np = self.num_processes, max_steps = 1000
-        cdef long ans_count = 0, ans_max = 10000
-        cdef mpz_t z
-        cdef Integer temp
-        ans = []
+        cdef int i, k = 1, flag
+        cdef int t = 1, u = 0, np = self.num_processes, max_steps = 10000
+        cdef long ans_count = 0
 
-        k = 1
-        while (t and not u and ans_count < ans_max):
-            if np == 1:  # Serial mode
-                next_pol(self.ps_st_data, self.dy_data_buf[0], max_steps)
-                t = self.dy_data_buf[0].flag
-            else:  # Parallel mode
-                t = 0
-                k = (k<<1) % np  # Note that 2 is a primitive root mod np.
-                with nogil:
-                    sig_on()
-                    for i in prange(np, schedule='dynamic'):  # Step each process forward
-                        next_pol(self.ps_st_data, self.dy_data_buf[i], max_steps)
-                        if self.dy_data_buf[i].flag:
-                            t += 1
-                        if self.dy_data_buf[i].flag == -1:
-                            u += 1
-                    for i in prange(np, schedule='dynamic'):  # Redistribute work to idle processes
-                        j = (i-k) % np
-                        ps_dynamic_split(self.dy_data_buf[j], self.dy_data_buf[i])
-                    sig_off()
-            for i in range(np):
-                if self.dy_data_buf[i].flag == 2:  # Extract a solution
-                    l = []
-                    # Convert a vector of fmpz's into mpz's, then Integers.
-                    for j in range(2 * d + 3):
-                        flint_mpz_init_set_readonly(z, &self.dy_data_buf[i].sympol[j])
-                        temp = Integer()
-                        mpz_set(temp.value, z)
-                        l.append(temp)
-                        flint_mpz_clear_readonly(z)
-                    ans.append(l)
+        if np == 1: # Serial mode
+            while (t and not u and ans_count < ans_max):
+                sig_check() # Check for interrupts
+                t = ps_next_pol(self.st_data, self.dy_data_buf[0], max_steps)
+                if t == 2: # Extract a solution
                     ans_count += 1
+                    ans.append(self.extract_poly(0))
+                elif t == -1: u = 1
+        else: # Parallel mode
+            while (t and not u and ans_count < ans_max):
+                sig_check() # Check for interrupts
+                t = 0
+                for i in prange(np, nogil=True): # Step each process forward in parallel
+                    t += ps_dynamic_split(self.st_data, self.dy_data_buf[i], self.dy_data_buf[(i+k) % np]) # Yield work
+                    flag = ps_next_pol(self.st_data, self.dy_data_buf[i], max_steps)
+                    t += flag
+                    if flag == 2:
+                        ans_count += 1
+                        with gil: ans.append(self.extract_poly(i))
+                    elif flag == -1: u += 1
+                k = (k<<1) % np # Note that 2 is a primitive root mod np.
         if u:
-            print(u)
             raise RuntimeError("Node limit ({0:%d}) exceeded".format(self.node_limit))
         return ans
-
 
 class WeilPolynomials_iter():
     r"""
@@ -248,52 +279,57 @@ class WeilPolynomials_iter():
     EXAMPLES::
 
         sage: from sage.rings.polynomial.weil.weil_polynomials import WeilPolynomials
-        sage: w = WeilPolynomials(10,1,sign=1,lead=[3,1,1])
+        sage: w = WeilPolynomials(10, 1, sign=1, lead=[3,1,1])
         sage: it = iter(w)
         sage: next(it)
         3*x^10 + x^9 + x^8 + 7*x^7 + 5*x^6 + 2*x^5 + 5*x^4 + 7*x^3 + x^2 + x + 3
-        sage: w = WeilPolynomials(10,1,sign=-1,lead=[3,1,1])
+        sage: w = WeilPolynomials(10, 1, sign=-1, lead=[3,1,1])
         sage: it = iter(w)
         sage: next(it)
         3*x^10 + x^9 + x^8 + 6*x^7 - 2*x^6 + 2*x^4 - 6*x^3 - x^2 - x - 3
     """
-    def __init__(self, d, q, sign, lead, node_limit,
-                 parallel, squarefree, polring=None):
+    def __init__(self, d, q, sign, lead, node_limit, parallel, squarefree, constraints=[], polring=None):
         r"""
         Create an iterator for Weil polynomials.
 
         EXAMPLES::
 
             sage: from sage.rings.polynomial.weil.weil_polynomials import WeilPolynomials
-            sage: w = WeilPolynomials(10,1,sign=1,lead=[3,1,1])
+            sage: w = WeilPolynomials(10, 1, sign=1, lead=[3,1,1])
             sage: it = iter(w)
             sage: next(it)
             3*x^10 + x^9 + x^8 + 7*x^7 + 5*x^6 + 2*x^5 + 5*x^4 + 7*x^3 + x^2 + x + 3
         """
-        if polring is None:
-            polring = PolynomialRing(QQ, name='x')
+        self.pol_internal = PolynomialRing(ZZ, name='x')
         self.pol = polring
-        x = self.pol.gen()
+        x = self.pol_internal.gen()
         d = Integer(d)
         if sign != 1 and sign != -1:
-            raise ValueError("invalid sign")
+            raise ValueError("Invalid sign")
         if not q.is_integer() or q <= 0:
             raise ValueError("q must be a positive integer")
+        if d == 0 and sign == -1: # No results
+            self.process = None
+            return
         if d % 2 == 0:
             if sign == 1:
                 d2 = d//2
                 num_cofactor = 0
+                self.cofactor = 1
             else:
                 d2 = d//2 - 1
                 num_cofactor = 3
+                self.cofactor = x**2 - q
         else:
             if not q.is_square():
-                raise ValueError("degree must be even if q is not a square")
+                raise ValueError("Degree must be even if q is not a square")
             d2 = d//2
             if sign == 1:
                 num_cofactor = 1
+                self.cofactor = x + q.sqrt()
             else:
                 num_cofactor = 2
+                self.cofactor = x - q.sqrt()
         try:
             leadlist = list(lead)
         except TypeError:
@@ -308,39 +344,40 @@ class WeilPolynomials_iter():
             j = Integer(j)
             k = Integer(k)
             if len(modlist) == 0 and k != 0:
-                raise ValueError("leading coefficient must be specified exactly")
-            if modlist and ((k != 0 and modlist[-1] % k != 0) or (k == 0 and modlist[-1] != 0)):
-                raise ValueError("invalid moduli")
+                raise ValueError("Leading coefficient must be specified exactly")
+            if len(modlist) > 0 and ((k != 0 and modlist[-1]%k != 0) or (k == 0 and modlist[-1] != 0)):
+                raise ValueError("Invalid moduli")
             coefflist.append(j)
             modlist.append(k)
         # Remove cofactor from initial coefficients
-        if num_cofactor == 1:  # cofactor x + sqrt(q)
+        if num_cofactor == 1: #cofactor x + sqrt(q)
             for i in range(1, len(coefflist)):
-                coefflist[i] -= coefflist[i-1]*q.sqrt()
-        elif num_cofactor == 2:  # cofactor x + sqrt(q)
+                coefflist[i] -= coefflist[i-1] * q.sqrt()
+        elif num_cofactor == 2: #cofactor x - sqrt(q)
             for i in range(1, len(coefflist)):
-                coefflist[i] += coefflist[i-1]*q.sqrt()
-        elif num_cofactor == 3:  # cofactor x^2 - q
+                coefflist[i] += coefflist[i-1] * q.sqrt()
+        elif num_cofactor == 3: #cofactor x^2 - q
             for i in range(2, len(coefflist)):
                 coefflist[i] += coefflist[i-2]*q
         # Asymmetrize initial coefficients
         for i in range(len(coefflist)):
             for j in range(1, (len(coefflist)-i+1)//2):
-                coefflist[i+2*j] -= (d2-i).binomial(j)*(q**j)*coefflist[i]
+                coefflist[i+2*j] -= (d2-i).binomial(j) * (q**j) * coefflist[i]
         for _ in range(d2+1-len(coefflist)):
             coefflist.append(0)
             modlist.append(1)
         coeffsign = sgn(coefflist[0])
+        self.cofactor *= coeffsign
         coefflist = [x*coeffsign for x in reversed(coefflist)]
         if node_limit is None:
             node_limit = -1
         force_squarefree = Integer(squarefree)
-        self.process = None if d2<0 else dfs_manager(
-            d2, q, coefflist, modlist, coeffsign, num_cofactor,
-            node_limit, parallel, force_squarefree)
+        self.process = dfs_manager(d2, q, coefflist, modlist, constraints, node_limit,
+                                   parallel, force_squarefree, self.pol_internal)
         self.q = q
         self.squarefree = squarefree
         self.ans = []
+        self.num_cofactor = num_cofactor
 
     def __iter__(self):
         r"""
@@ -349,7 +386,7 @@ class WeilPolynomials_iter():
         EXAMPLES::
 
             sage: from sage.rings.polynomial.weil.weil_polynomials import WeilPolynomials
-            sage: w = WeilPolynomials(10,1,sign=1,lead=[3,1,1])
+            sage: w = WeilPolynomials(10, 1, sign=1, lead=[3,1,1])
             sage: it = iter(w)
             sage: it.__iter__() is it
             True
@@ -363,34 +400,55 @@ class WeilPolynomials_iter():
         EXAMPLES::
 
             sage: from sage.rings.polynomial.weil.weil_polynomials import WeilPolynomials
-            sage: w = WeilPolynomials(10,1,sign=1,lead=[3,1,1])
+            sage: w = WeilPolynomials(10, 1, sign=1, lead=[3,1,1])
             sage: it = iter(w)
             sage: next(it)
             3*x^10 + x^9 + x^8 + 7*x^7 + 5*x^6 + 2*x^5 + 5*x^4 + 7*x^3 + x^2 + x + 3
         """
         if self.process is None:
             raise StopIteration
-        if not self.ans:
-            self.ans = self.process.advance_exhaust()
-            if not self.ans:
+        if len(self.ans) == 0:
+            self.process.advance_exhaust(self.ans)
+            if len(self.ans) == 0: # Iterator exhausted
                 self.count = self.process.node_count()
                 self.process = None
                 raise StopIteration
-        return self.pol(self.ans.pop())
+        res = self.ans.pop()
+        if self.pol is not None:
+            res = self.pol(res)
+        if self.num_cofactor: res *= self.cofactor
+        return res
 
-    def node_count(self):
+    def next(self): # For Python2 backward compatibility
         r"""
-        Return the number of terminal nodes found in the tree, excluding
-        actual solutions.
+        Step the iterator forward.
+
+        Included for Python2 backward compatibility.
 
         EXAMPLES::
 
             sage: from sage.rings.polynomial.weil.weil_polynomials import WeilPolynomials
-            sage: w = WeilPolynomials(10,1,sign=1,lead=[3,1,1])
+            sage: w = WeilPolynomials(10, 1, sign=1, lead=[3,1,1])
+            sage: it = iter(w)
+            sage: next(it)
+            3*x^10 + x^9 + x^8 + 7*x^7 + 5*x^6 + 2*x^5 + 5*x^4 + 7*x^3 + x^2 + x + 3
+        """
+        return self.__next__()
+
+    def node_count(self):
+        r"""
+        Return the number of terminal nodes found in the tree, excluding actual solutions.
+        
+        This always gives 0 unless node_limit is specified.
+
+        EXAMPLES::
+
+            sage: from sage.rings.polynomial.weil.weil_polynomials import WeilPolynomials
+            sage: w = WeilPolynomials(10, 1, sign=1, lead=[3,1,1], node_limit=10000000)
             sage: it = iter(w)
             sage: l = list(it)
             sage: it.node_count()
-            158
+            118
         """
         if self.process is None:
             return self.count
@@ -414,9 +472,9 @@ class WeilPolynomials():
     If parallel is False, then the order of values is descending lexicographical
     (i.e., polynomials with the largest coefficients of largest degrees sort first).
 
-    If parallel is True, then the order of values is not specified. (Beware that
+    If parallel is True, then the order of values is not specified. Beware that
     due to increased overhead, parallel execution may not yield a significant
-    speedup for small problem sizes.)
+    speedup for small problem sizes.
 
     INPUT:
 
@@ -445,18 +503,25 @@ class WeilPolynomials():
 
     - ``squarefree`` -- boolean (default: ``False``)
 
-        If set, only squarefree polynomials will be returned.
+        If set, only squarefree polynomials coprime to ``x^2 - q`` will be returned.
+
+    - ``constraints`` -- list (default: empty)
+
+        Each entry is a tuple expressing a lower bound constraint on the power sums `s_i`.
+        The tuple `(c0, c1, ..., cn)` represents ``c_0 \leq c_1 s_1 + \cdots + c_n t_n``.
 
     - ``polring`` -- (optional) a polynomial ring in which to construct the results
+
+        If not specified, answers are created in a polynomial ring over `ZZ` with variable `x`.
 
     EXAMPLES:
 
     Some simple cases::
 
         sage: from sage.rings.polynomial.weil.weil_polynomials import WeilPolynomials
-        sage: list(WeilPolynomials(2,2))
+        sage: list(WeilPolynomials(2, 2))
         [x^2 + 2*x + 2, x^2 + x + 2, x^2 + 2, x^2 - x + 2, x^2 - 2*x + 2]
-        sage: l = list(WeilPolynomials(4,2))
+        sage: l = list(WeilPolynomials(4, 2))
         sage: l[0], l[-1]
         (x^4 + 4*x^3 + 8*x^2 + 8*x + 4, x^4 - 4*x^3 + 8*x^2 - 8*x + 4)
         sage: l = list(WeilPolynomials(3, 1, sign=-1))
@@ -483,28 +548,46 @@ class WeilPolynomials():
 
     Generating Weil polynomials with prescribed initial coefficients::
 
-        sage: w = WeilPolynomials(10,1,sign=1,lead=[3,1,1])
+        sage: w = WeilPolynomials(10, 1, sign=1, lead=[3,1,1])
         sage: it = iter(w)
         sage: next(it)
         3*x^10 + x^9 + x^8 + 7*x^7 + 5*x^6 + 2*x^5 + 5*x^4 + 7*x^3 + x^2 + x + 3
-        sage: w = WeilPolynomials(10,1,sign=-1,lead=[3,1,1])
+        sage: w = WeilPolynomials(10, 1, sign=-1, lead=[3,1,1])
         sage: it = iter(w)
         sage: next(it)
         3*x^10 + x^9 + x^8 + 6*x^7 - 2*x^6 + 2*x^4 - 6*x^3 - x^2 - x - 3
+        sage: list(WeilPolynomials(10, 2, lead=[1, -3, 5, -5, 5, -5]))
+        [x^10 - 3*x^9 + 5*x^8 - 5*x^7 + 5*x^6 - 5*x^5 + 10*x^4 - 20*x^3 + 40*x^2 - 48*x + 32]
+
+    Generating Weil polynomials with linear constraints on power sums::
+
+        sage: w = WeilPolynomials(10, 1, sign=1, lead=[3,1])
+        sage: l = list(w)
+        sage: w2 = WeilPolynomials(10, 1, sign=1, lead=[3,1], constraints=[(3,1,0,1)])
+        sage: l2 = list(w2)
+        sage: l3 = [u for u in l if sum((i^3 + i) * j for i,j in u.roots(CC)) >= 2.99]
+        sage: l2 == l3
+        True
+        sage: w3 = WeilPolynomials(10, 1, sign=1, lead=[3,1], constraints=[(2,0,0,1), (-3,2,1,-1)])
+        sage: l4 = list(w3)
+        sage: l5 = [u for u in l if sum(i^3 * j for i,j in u.roots(CC)) >= 1.99]
+        sage: l6 = [u for u in l5 if sum((i^3 - i^2 - 2*i) * j for i,j in u.roots(CC)) <= 2.99 ]
+        sage: l4 == l6
+        True
 
     TESTS:
 
     Test restriction of initial coefficients::
 
-        sage: w1 = WeilPolynomials(10,1,sign=1,lead=3)
+        sage: w1 = WeilPolynomials(10, 1, sign=1, lead=3)
         sage: l1 = list(w1)
-        sage: w2 = WeilPolynomials(10,1,sign=1,lead=[3,1,1])
+        sage: w2 = WeilPolynomials(10, 1, sign=1, lead=[3,1,1])
         sage: l2 = list(w2)
         sage: l3 = [i for i in l1 if i[1] == 1 and i[2] == 1]
         sage: l2 == l3
         True
 
-        sage: w = WeilPolynomials(4,2,lead=[(1,0),(0,2)])
+        sage: w = WeilPolynomials(4, 2, lead=((1,0), (2,2)))
         sage: l = list(w)
         sage: l[0], l[-1]
         (x^4 + 4*x^3 + 8*x^2 + 8*x + 4, x^4 - 4*x^3 + 8*x^2 - 8*x + 4)
@@ -513,10 +596,10 @@ class WeilPolynomials():
 
     Test restriction to squarefree polynomials::
 
-        sage: for (d,q,sign) in ((6,2,1),(6,4,-1),(5,4,-1)):
-        ....:     w1 = WeilPolynomials(d,q,sign=sign)
+        sage: for (d,q,sign) in ((6,2,1), (6,4,-1), (5,4,-1)):
+        ....:     w1 = WeilPolynomials(d, q, sign=sign)
         ....:     l1 = list(w1)
-        ....:     w2 = WeilPolynomials(d,q,sign=sign,squarefree=True)
+        ....:     w2 = WeilPolynomials(d, q, sign=sign, squarefree=True)
         ....:     l2 = list(w2)
         ....:     l3 = [i for i in l1 if i.is_squarefree()]
         ....:     print(l2 == l3)
@@ -537,7 +620,6 @@ class WeilPolynomials():
 
     Test that :issue:`31809` is resolved::
 
-        sage: from sage.rings.polynomial.weil.weil_polynomials import WeilPolynomials
         sage: foo = list(WeilPolynomials(12, 3, lead=(1,0,9,2,46), squarefree=False))
         sage: bar = list(WeilPolynomials(12, 3, lead=(1,0,9,2,46), squarefree=True))
         sage: bar == [f for f in foo if f.is_squarefree()]
@@ -550,28 +632,25 @@ class WeilPolynomials():
 
     Test that :issue:`37860` is resolved::
 
-        sage: list(WeilPolynomials(-1, 1))
-        []
         sage: list(WeilPolynomials(0, 1, sign=-1))
         []
     """
-    def __init__(self, d, q, sign=1, lead=1, node_limit=None,
-                 parallel=False, squarefree=False, polring=None):
+    def __init__(self, d, q, sign=1, lead=1, node_limit=None, parallel=False, squarefree=False, constraints=[], polring=None):
         r"""
         Initialize this iterable.
 
         EXAMPLES::
 
             sage: from sage.rings.polynomial.weil.weil_polynomials import WeilPolynomials
-            sage: w = WeilPolynomials(10,1,sign=1,lead=[3,1,1])
-            sage: w.__init__(10,1,sign=1,lead=[3,1,-1]) # Change parameters before iterating
+            sage: w = WeilPolynomials(10, 1, sign=1, lead=[3,1,1])
+            sage: w.__init__(10, 1, sign=1, lead=[3,1,-1]) # Change parameters before iterating
             sage: it = iter(w)
             sage: next(it) # Results reflect the changed parameters
             3*x^10 + x^9 - x^8 + 7*x^7 + 5*x^6 - 2*x^5 + 5*x^4 + 7*x^3 - x^2 + x + 3
         """
-        if parallel and not has_openmp():
+        if parallel and num_threads() == 1:
             raise RuntimeError("Parallel execution not supported")
-        self.data = (d, q, sign, lead, node_limit, parallel, squarefree, polring)
+        self.data = (d, q, sign, lead, node_limit, parallel, squarefree, constraints, polring)
 
     def __iter__(self):
         r"""
@@ -580,7 +659,7 @@ class WeilPolynomials():
         EXAMPLES::
 
             sage: from sage.rings.polynomial.weil.weil_polynomials import WeilPolynomials
-            sage: w = WeilPolynomials(10,1,sign=1,lead=[3,1,1])
+            sage: w = WeilPolynomials(10, 1, sign=1, lead=[3,1,1])
             sage: it = w.__iter__()
             sage: next(it)
             3*x^10 + x^9 + x^8 + 7*x^7 + 5*x^6 + 2*x^5 + 5*x^4 + 7*x^3 + x^2 + x + 3
@@ -592,13 +671,16 @@ class WeilPolynomials():
     def node_count(self):
         r"""
         Return the number of terminal nodes found in the tree, excluding actual solutions.
+        
+        This always gives 0 unless node_limit is specified.
 
         EXAMPLES::
 
             sage: from sage.rings.polynomial.weil.weil_polynomials import WeilPolynomials
-            sage: w = WeilPolynomials(10,1,sign=1,lead=[3,1,1])
+            sage: w = WeilPolynomials(10, 1, sign=1, lead=[3,1,1], node_limit=10000000)
             sage: l = list(w)
             sage: w.node_count()
-            158
+            118
         """
         return self.w.node_count()
+

--- a/src/sage/rings/polynomial/weil/weil_polynomials.pyx
+++ b/src/sage/rings/polynomial/weil/weil_polynomials.pyx
@@ -7,58 +7,59 @@ r"""
 Iterator for Weil polynomials.
 
 For `q` a prime power, a `q`-Weil polynomial is a monic polynomial with integer
-coefficients whose complex roots all have absolute value `sqrt(q)`. The class
-WeilPolynomials provides an iterable over a space of polynomials of this type;
-it is possible to relax the monic condition by specifying one (or more) leading
-coefficients. One may also impose certain congruence conditions; this can be
+coefficients whose complex roots all have absolute value `\sqrt{q}`. The class
+``WeilPolynomials`` provides an iterable over a space of polynomials of this type.
+It is possible to relax the monic condition by specifying one (or more) leading
+coefficients. One may also impose certain congruence conditions. This can be
 used to limit the Newton polygons of the resulting polynomials, or to lift
 a polynomial specified by a congruence to a Weil polynomial.
 
-For large jobs, one can set parallel=True to use OpenMP (if support was
+For large jobs, one can set ``parallel=True`` to use ``OpenMP`` (if support was
 enabled at compile time). Due to increased overhead, this is not recommended
 for smaller problem sizes. To enable support, ensure that your compiler supports
-OpenMP and remove the appropriate # characters in the distutils commands below.
+``OpenMP`` and remove the appropriate ``#`` characters in the ``distutils`` commands below.
 (You may also need to move those lines to the start of the file.)
 
 AUTHOR:
-  -- Kiran S. Kedlaya (2007-05-28): initial version
-  -- (2015-08-29): switch from NTL to FLINT
-  -- (2017-10-03): consolidate Sage layer into .pyx file
-                   define WeilPolynomials iterator
-                   reverse convention for polynomials
-                   pass multiprecision integers to/from C
-  -- (2019-02-02): update for Python3
-                   improve parallel mode
-  -- (2019-12-19): final packaging for Sage (with help from David Roe)
-  -- (2026-02-10): extensive low-level optimization and reorganization
-                   move some input sanitization out of C layer
-                   improved algorithm for computing ranges
-                     (using truncated Hausdorff moment condition)
-                   more efficient application of Rolle condition (binary search)
-                   choose number of processes based on available cores
-                   import fmpz's directly as longs when possible
-                   compute Hankel determinants via Dodgson condensation when possible
-                   compute subresultants via Ducos method
-                   more balanced work-splitting
-                   more direct conversion of output to Sage polynomials
-                   improved chunking in parallel mode
-  -- (2026-08-26): better answer conversion from FLINT to Sage
-                   compute some Hankel determinants recursively
-                   option to filter by linear constraints on Frobenius traces
+
+-- Kiran S. Kedlaya (2007-05-28): initial version
+-- (2015-08-29): switch from NTL to FLINT
+-- (2017-10-03): consolidate Sage layer into .pyx file
+                 define WeilPolynomials iterator
+                 reverse convention for polynomials
+                 pass multiprecision integers to/from C
+-- (2019-02-02): update for Python3
+                 improve parallel mode
+-- (2019-12-19): final packaging for Sage (with help from David Roe)
+-- (2026-02-10): extensive low-level optimization and reorganization
+                 move some input sanitization out of C layer
+                 improved algorithm for computing ranges
+                 (using truncated Hausdorff moment condition)
+                 more efficient application of Rolle condition (binary search)
+                 choose number of processes based on available cores
+                 import fmpz's directly as longs when possible
+                 compute Hankel determinants via Dodgson condensation when possible
+                 compute subresultants via Ducos method
+                 more balanced work-splitting
+                 more direct conversion of output to Sage polynomials
+                 improved chunking in parallel mode
+-- (2026-08-26): better answer conversion from FLINT to Sage
+                 compute some Hankel determinants recursively
+                 option to filter by linear constraints on Frobenius traces
 
 A standalone version of this code can be found at
-   https://github.com/kedlaya/root-unitary
+https://github.com/kedlaya/root-unitary
 """
 
-#*****************************************************************************
+# ****************************************************************************
 #       Copyright (C) 2019-2026 Kiran S. Kedlaya <kskedl@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 2 of the License, or
 # (at your option) any later version.
-#                  http://www.gnu.org/licenses/
-#*****************************************************************************
+#                  https://www.gnu.org/licenses/
+# ****************************************************************************
 
 from cython.parallel cimport prange
 from cysignals.signals cimport sig_check


### PR DESCRIPTION
I recently updated my package for tabulating Weil polynomials:

https://github.com/kedlaya/root-unitary

so here is a PR to pull the upstream edits. There are improvements both in the underlying mathematics and the implementation, contributing to a 10x speedup in some cases. There is also some better functionality, e.g., the ability to filter efficiently by linear constraints on power sums (currently only available using the "hidden" iterator, not yet exposed in the polynomial ring method).
