### PR TITLE
graphs: use by_weight in matching

### DIFF
--- a/src/sage/combinat/permutation.py
+++ b/src/sage/combinat/permutation.py
@@ -8480,7 +8480,7 @@ def bistochastic_as_sum_of_permutations(M, check=True):
     P = Permutations()
 
     while G.size() > 0:
-        matching = G.matching(use_edge_labels=True)
+        matching = G.matching(by_weight=True)
         if len(matching) != n:
             if M.base_ring().is_exact():
                 raise ValueError("this cannot possibly happen")

--- a/src/sage/graphs/bipartite_graph.py
+++ b/src/sage/graphs/bipartite_graph.py
@@ -44,6 +44,7 @@ from collections.abc import Iterable
 from sage.graphs.generic_graph import GenericGraph
 from sage.graphs.graph import Graph
 from sage.misc.cachefunc import cached_method
+from sage.misc.decorators import rename_keyword
 from sage.misc.lazy_import import lazy_import
 from sage.rings.integer import Integer
 
@@ -2374,8 +2375,10 @@ class BipartiteGraph(Graph):
             return matrix(len(self.right), len(self.left), D, sparse=sparse, **kwds)
         return matrix(base_ring, len(self.right), len(self.left), D, sparse=sparse, **kwds)
 
+    @rename_keyword(deprecation=99999, use_edge_labels='by_weight')
     def matching(self, value_only=False, algorithm=None,
-                 use_edge_labels=False, solver=None, verbose=0,
+                 by_weight=False, weight_function=None, check_weight=True,
+                 solver=None, verbose=0,
                  *, integrality_tolerance=1e-3):
         r"""
         Return a maximum matching of the graph represented by the list of its
@@ -2391,7 +2394,7 @@ class BipartiteGraph(Graph):
           only the cardinal (or the weight) of the matching is returned
 
         - ``algorithm`` -- string (default: ``'Hopcroft-Karp'`` if
-          ``use_edge_labels==False``, otherwise ``'Edmonds'``); algorithm to use
+          ``by_weight==False``, otherwise ``'Edmonds'``); algorithm to use
           among:
 
           - ``'Hopcroft-Karp'`` selects the default bipartite graph algorithm as
@@ -2404,13 +2407,20 @@ class BipartiteGraph(Graph):
 
           - ``'LP'`` uses a Linear Program formulation of the matching problem
 
-        - ``use_edge_labels`` -- boolean (default: ``False``)
+        - ``by_weight`` -- boolean (default: ``False``); if ``True``, computes a
+          weighted matching where each edge has the weight given by
+          ``weight_function``, or its label if ``weight_function`` is ``None``.
+          If ``False``, each edge has weight `1`. Only available when
+          ``algorithm`` is ``'Edmonds'`` or ``'LP'``.
 
-          - when set to ``True``, computes a weighted matching where each edge
-            is weighted by its label (if an edge has no label, `1` is assumed);
-            only if ``algorithm`` is ``'Edmonds'``, ``'LP'``
+        - ``weight_function`` -- function (default: ``None``); a function that
+          takes as input an edge ``(u, v, l)`` and outputs its weight. If not
+          ``None``, ``by_weight`` is automatically set to ``True``. If ``None``
+          and ``by_weight`` is ``True``, we use the edge label ``l``, if ``l``
+          is not ``None``, else `1` as a weight.
 
-          - when set to ``False``, each edge has weight `1`
+        - ``check_weight`` -- boolean (default: ``True``); whether to check that
+          the ``weight_function`` outputs a number for each edge
 
         - ``solver`` -- string (default: ``None``); specifies a Mixed
           Integer Linear Programming (MILP) solver to be used. If set
@@ -2463,31 +2473,31 @@ class BipartiteGraph(Graph):
 
             sage: G = graphs.CycleGraph(4)
             sage: B = BipartiteGraph([(u,v,2) for u,v in G.edges(sort=True, labels=0)])
-            sage: sorted(B.matching(use_edge_labels=True))                              # needs networkx
+            sage: sorted(B.matching(by_weight=True))                              # needs networkx
             [(0, 3, 2), (1, 2, 2)]
-            sage: B.matching(use_edge_labels=True, value_only=True)                     # needs networkx
+            sage: B.matching(by_weight=True, value_only=True)                     # needs networkx
             4
-            sage: B.matching(use_edge_labels=True, value_only=True, algorithm='Edmonds')            # needs networkx
+            sage: B.matching(by_weight=True, value_only=True, algorithm='Edmonds')            # needs networkx
             4
-            sage: B.matching(use_edge_labels=True, value_only=True, algorithm='LP')     # needs sage.numerical.mip
+            sage: B.matching(by_weight=True, value_only=True, algorithm='LP')     # needs sage.numerical.mip
             4
-            sage: B.matching(use_edge_labels=True, value_only=True, algorithm='Eppstein')
+            sage: B.matching(by_weight=True, value_only=True, algorithm='Eppstein')
             Traceback (most recent call last):
             ...
-            ValueError: use_edge_labels cannot be used with "Hopcroft-Karp" or "Eppstein"
-            sage: B.matching(use_edge_labels=True, value_only=True, algorithm='Hopcroft-Karp')
+            ValueError: by_weight cannot be used with "Hopcroft-Karp" or "Eppstein"
+            sage: B.matching(by_weight=True, value_only=True, algorithm='Hopcroft-Karp')
             Traceback (most recent call last):
             ...
-            ValueError: use_edge_labels cannot be used with "Hopcroft-Karp" or "Eppstein"
-            sage: B.matching(use_edge_labels=False, value_only=True,                    # needs networkx
+            ValueError: by_weight cannot be used with "Hopcroft-Karp" or "Eppstein"
+            sage: B.matching(by_weight=False, value_only=True,                    # needs networkx
             ....:            algorithm='Hopcroft-Karp')
             2
-            sage: B.matching(use_edge_labels=False, value_only=True,                    # needs networkx
+            sage: B.matching(by_weight=False, value_only=True,                    # needs networkx
             ....:            algorithm='Eppstein')
             2
-            sage: B.matching(use_edge_labels=False, value_only=True, algorithm='Edmonds')           # needs networkx
+            sage: B.matching(by_weight=False, value_only=True, algorithm='Edmonds')           # needs networkx
             2
-            sage: B.matching(use_edge_labels=False, value_only=True, algorithm='LP')    # needs sage.numerical.mip
+            sage: B.matching(by_weight=False, value_only=True, algorithm='LP')    # needs sage.numerical.mip
             2
 
         With multiedges enabled::
@@ -2496,7 +2506,7 @@ class BipartiteGraph(Graph):
             sage: for e in G.edges(sort=True):
             ....:     G.set_edge_label(e[0], e[1], int(e[0]) + int(e[1]))
             sage: G.allow_multiple_edges(True)
-            sage: G.matching(use_edge_labels=True, value_only=True)                     # needs networkx
+            sage: G.matching(by_weight=True, value_only=True)                     # needs networkx
             444
 
         Empty bipartite graph and bipartite graphs without edges::
@@ -2515,12 +2525,15 @@ class BipartiteGraph(Graph):
             sage: all(B.matching(algorithm=algo, value_only=True) == 0 for algo in algorithms)      # needs networkx
             True
         """
+        if weight_function is not None:
+            by_weight = True
+
         if algorithm is None:
-            algorithm = "Edmonds" if use_edge_labels else "Hopcroft-Karp"
+            algorithm = "Edmonds" if by_weight else "Hopcroft-Karp"
 
         if algorithm == "Hopcroft-Karp" or algorithm == "Eppstein":
-            if use_edge_labels:
-                raise ValueError('use_edge_labels cannot be used with '
+            if by_weight:
+                raise ValueError('by_weight cannot be used with '
                                  '"Hopcroft-Karp" or "Eppstein"')
             d = []
             if self.size():
@@ -2548,7 +2561,9 @@ class BipartiteGraph(Graph):
         if algorithm == "Edmonds" or algorithm == "LP":
             return Graph.matching(self, value_only=value_only,
                                   algorithm=algorithm,
-                                  use_edge_labels=use_edge_labels,
+                                  by_weight=by_weight,
+                                  weight_function=weight_function,
+                                  check_weight=check_weight,
                                   solver=solver, verbose=verbose,
                                   integrality_tolerance=integrality_tolerance)
         raise ValueError('algorithm must be "Hopcroft-Karp", '

--- a/src/sage/graphs/bipartite_graph.py
+++ b/src/sage/graphs/bipartite_graph.py
@@ -2375,7 +2375,7 @@ class BipartiteGraph(Graph):
             return matrix(len(self.right), len(self.left), D, sparse=sparse, **kwds)
         return matrix(base_ring, len(self.right), len(self.left), D, sparse=sparse, **kwds)
 
-    @rename_keyword(deprecation=99999, use_edge_labels='by_weight')
+    @rename_keyword(deprecation=42750, use_edge_labels='by_weight')
     def matching(self, value_only=False, algorithm=None,
                  by_weight=False, weight_function=None, check_weight=True,
                  solver=None, verbose=0,

--- a/src/sage/graphs/matching.py
+++ b/src/sage/graphs/matching.py
@@ -1074,7 +1074,7 @@ def is_matching_covered(G, matching=None, algorithm='Edmonds', coNP_certificate=
     return (True, None) if coNP_certificate else True
 
 
-@rename_keyword(deprecation=99999, use_edge_labels='by_weight')
+@rename_keyword(deprecation=42750, use_edge_labels='by_weight')
 def matching(G, value_only=False, algorithm='Edmonds',
              by_weight=False, weight_function=None, check_weight=True,
              solver=None, verbose=0,
@@ -1207,7 +1207,7 @@ def matching(G, value_only=False, algorithm='Edmonds',
         sage: g.matching(use_edge_labels=True)                                      # needs sage.networkx
         doctest:warning...
         DeprecationWarning: use the option 'by_weight' instead of 'use_edge_labels'
-        See https://github.com/sagemath/sage/issues/99999 for details.
+        See https://github.com/sagemath/sage/issues/42750 for details.
         [(1, 2, 999)]
 
     With loops and multiedges::

--- a/src/sage/graphs/matching.py
+++ b/src/sage/graphs/matching.py
@@ -49,6 +49,7 @@ Methods
 # ****************************************************************************
 import itertools
 
+from sage.misc.decorators import rename_keyword
 from sage.rings.integer import Integer
 from sage.graphs.views import EdgesView
 
@@ -134,11 +135,11 @@ def has_perfect_matching(G, algorithm='Edmonds', solver=None, verbose=0,
 
     if algorithm == "Edmonds":
         return len(G) == 2*G.matching(value_only=True,
-                                      use_edge_labels=False,
+                                      by_weight=False,
                                       algorithm='Edmonds')
     if algorithm == "LP_matching":
         return len(G) == 2*G.matching(value_only=True,
-                                      use_edge_labels=False,
+                                      by_weight=False,
                                       algorithm='LP',
                                       solver=solver,
                                       verbose=verbose,
@@ -1073,8 +1074,10 @@ def is_matching_covered(G, matching=None, algorithm='Edmonds', coNP_certificate=
     return (True, None) if coNP_certificate else True
 
 
+@rename_keyword(deprecation=99999, use_edge_labels='by_weight')
 def matching(G, value_only=False, algorithm='Edmonds',
-             use_edge_labels=False, solver=None, verbose=0,
+             by_weight=False, weight_function=None, check_weight=True,
+             solver=None, verbose=0,
              *, integrality_tolerance=1e-3):
     r"""
     Return a maximum weighted matching of the graph represented by the list
@@ -1106,12 +1109,19 @@ def matching(G, value_only=False, algorithm='Edmonds',
 
       - ``'LP'`` uses a Linear Program formulation of the matching problem
 
-    - ``use_edge_labels`` -- boolean (default: ``False``)
+    - ``by_weight`` -- boolean (default: ``False``); if ``True``, computes a
+      weighted matching where each edge has the weight given by
+      ``weight_function``, or its label if ``weight_function`` is ``None``. If
+      ``False``, each edge has weight `1`.
 
-      - when set to ``True``, computes a weighted matching where each edge
-        is weighted by its label (if an edge has no label, `1` is assumed)
+    - ``weight_function`` -- function (default: ``None``); a function that takes
+      as input an edge ``(u, v, l)`` and outputs its weight. If not ``None``,
+      ``by_weight`` is automatically set to ``True``. If ``None`` and
+      ``by_weight`` is ``True``, we use the edge label ``l``, if ``l`` is not
+      ``None``, else `1` as a weight.
 
-      - when set to ``False``, each edge has weight `1`
+    - ``check_weight`` -- boolean (default: ``True``); whether to check that the
+      ``weight_function`` outputs a number for each edge
 
     - ``solver`` -- string (default: ``None``); specifies a Mixed Integer
       Linear Programming (MILP) solver to be used. If set to ``None``, the
@@ -1165,7 +1175,7 @@ def matching(G, value_only=False, algorithm='Edmonds',
 
     TESTS:
 
-    When ``use_edge_labels`` is set to ``False``, with Edmonds' algorithm
+    When ``by_weight`` is set to ``False``, with Edmonds' algorithm
     and LP formulation::
 
         sage: g = Graph([(0,1,0), (1,2,999), (2,3,-5)])
@@ -1174,13 +1184,30 @@ def matching(G, value_only=False, algorithm='Edmonds',
         sage: sorted(g.matching(algorithm='LP'))                                    # needs sage.numerical.mip
         [(0, 1, 0), (2, 3, -5)]
 
-    When ``use_edge_labels`` is set to ``True``, with Edmonds' algorithm and
+    When ``by_weight`` is set to ``True``, with Edmonds' algorithm and
     LP formulation::
 
         sage: g = Graph([(0,1,0), (1,2,999), (2,3,-5)])
-        sage: g.matching(use_edge_labels=True)                                      # needs sage.networkx
+        sage: g.matching(by_weight=True)                                      # needs sage.networkx
         [(1, 2, 999)]
-        sage: g.matching(algorithm='LP', use_edge_labels=True)                      # needs sage.numerical.mip
+        sage: g.matching(algorithm='LP', by_weight=True)                      # needs sage.numerical.mip
+        [(1, 2, 999)]
+
+    A ``weight_function`` can read the weight from anywhere in the edge, and
+    setting it implies ``by_weight=True``::
+
+        sage: g = Graph([(0, 1, {'cost': 1}), (1, 2, {'cost': 9}),
+        ....:            (2, 3, {'cost': 2})])
+        sage: g.matching(weight_function=lambda e: e[2]['cost'])                    # needs sage.networkx
+        [(1, 2, {'cost': 9})]
+
+    The ``use_edge_labels`` keyword is deprecated in favour of ``by_weight``::
+
+        sage: g = Graph([(0,1,0), (1,2,999), (2,3,-5)])
+        sage: g.matching(use_edge_labels=True)                                      # needs sage.networkx
+        doctest:warning...
+        DeprecationWarning: use the option 'by_weight' instead of 'use_edge_labels'
+        See https://github.com/sagemath/sage/issues/99999 for details.
         [(1, 2, 999)]
 
     With loops and multiedges::
@@ -1188,7 +1215,7 @@ def matching(G, value_only=False, algorithm='Edmonds',
         sage: edge_list = [(0,0,5), (0,1,1), (0,2,2), (0,3,3), (1,2,6)
         ....: , (1,2,3), (1,3,3), (2,3,3)]
         sage: g = Graph(edge_list, loops=True, multiedges=True)
-        sage: m = g.matching(use_edge_labels=True)                                  # needs sage.networkx
+        sage: m = g.matching(by_weight=True)                                  # needs sage.networkx
         sage: type(m)                                                               # needs sage.networkx
         <class 'sage.graphs.views.EdgesView'>
         sage: sorted(m)                                                             # needs sage.networkx
@@ -1217,28 +1244,29 @@ def matching(G, value_only=False, algorithm='Edmonds',
         ...
         ValueError: algorithm must be set to either "Edmonds" or "LP"
     """
-    from sage.rings.real_mpfr import RR
-
-    def weight(x):
-        if x in RR:
-            return x
-        return 1
+    by_weight, weight_function = G._get_weight_function(by_weight=by_weight,
+                                                        weight_function=weight_function,
+                                                        check_weight=check_weight)
 
     W = {}
     L = {}
-    for u, v, l in G.edge_iterator():
+    for e in G.edge_iterator():
+        u, v, l = e
         if u == v:
             continue
         fuv = frozenset((u, v))
-        if fuv not in L or (use_edge_labels and W[fuv] < weight(l)):
+        if by_weight:
+            w = weight_function(e)
+            if fuv not in L or W[fuv] < w:
+                L[fuv] = l
+                W[fuv] = w
+        elif fuv not in L:
             L[fuv] = l
-            if use_edge_labels:
-                W[fuv] = weight(l)
 
     if algorithm == "Edmonds":
         import networkx
         g = networkx.Graph()
-        if use_edge_labels:
+        if by_weight:
             for (u, v), w in W.items():
                 g.add_edge(u, v, weight=w)
         else:
@@ -1246,7 +1274,7 @@ def matching(G, value_only=False, algorithm='Edmonds',
                 g.add_edge(u, v)
         d = networkx.max_weight_matching(g)
         if value_only:
-            if use_edge_labels:
+            if by_weight:
                 return sum(W[frozenset(e)] for e in d)
             return Integer(len(d))
 
@@ -1261,7 +1289,7 @@ def matching(G, value_only=False, algorithm='Edmonds',
         # weighted ...
         p = MixedIntegerLinearProgram(maximization=True, solver=solver)
         b = p.new_variable(binary=True)
-        if use_edge_labels:
+        if by_weight:
             p.set_objective(p.sum(w * b[fe] for fe, w in W.items()))
         else:
             p.set_objective(p.sum(b[fe] for fe in L))
@@ -1274,7 +1302,7 @@ def matching(G, value_only=False, algorithm='Edmonds',
         p.solve(log=verbose)
         b = p.get_values(b, convert=bool, tolerance=integrality_tolerance)
         if value_only:
-            if use_edge_labels:
+            if by_weight:
                 return sum(w for fe, w in W.items() if b[fe])
             return Integer(sum(1 for fe in L if b[fe]))
 


### PR DESCRIPTION
Part of #13112, following #42740.

`Graph.matching` and `BipartiteGraph.matching` now take `by_weight`, `weight_function` and `check_weight`, in the order used by the rest of the graph module. `use_edge_labels` is deprecated in their favour, and `by_weight` takes its position, so the arguments before it keep their positional meaning.

**The two files go together.** `BipartiteGraph.matching` delegates to `Graph.matching` for `'Edmonds'` and `'LP'`, so converting only one would make the library raise its own deprecation warning on that call.

A weight function can now be supplied, which was not expressible before:

```python
sage: g = Graph([(0, 1, {'cost': 1}), (1, 2, {'cost': 9}), (2, 3, {'cost': 2})])
sage: g.matching(weight_function=lambda e: e[2]['cost'])
[(1, 2, {'cost': 9})]
```

Two things worth flagging:

- As in #42740, the weight comes from `GenericGraph._get_weight_function`. The local helper it replaces returned `1` for any non-numeric label, so such a label was silently weighted 1; `check_weight` now rejects it. A behaviour change, not only a rename.
- `BipartiteGraph.matching` does not delegate for `'Hopcroft-Karp'` and `'Eppstein'`, so it sets `by_weight = True` itself when a `weight_function` is given, in order to reject that combination rather than ignore the weights. Its error message names `by_weight` accordingly.

### Tests

Doctests pass for `matching.py`, `graph.py`, `generic_graph.py` and `matching_covered_graph.py`, and all `matching` doctests pass in `bipartite_graph.py`. The `relabel` and `matching_polynomial` failures in my local run appear identically with an unmodified copy of the file — my build tree is one release behind.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [x] I have updated the documentation accordingly.

### :hourglass: Dependencies

None, though it follows the pattern settled in #42740.
