### PR TITLE
Validate the documented parameter domains of the generalized Tamari constructors

### DIFF
--- a/src/sage/combinat/tamari_lattices.py
+++ b/src/sage/combinat/tamari_lattices.py
@@ -222,7 +222,7 @@ def GeneralizedTamariLattice(a, b, m=1):
 
     TESTS:
 
-    The documented conditions on the parameters are checked::
+    The documented sign conditions on the parameters are checked::
 
         sage: GeneralizedTamariLattice(3, 2, -1)
         Traceback (most recent call last):
@@ -232,10 +232,6 @@ def GeneralizedTamariLattice(a, b, m=1):
         Traceback (most recent call last):
         ...
         ValueError: the condition b>=0 does not hold
-        sage: GeneralizedTamariLattice(2, 3)
-        Traceback (most recent call last):
-        ...
-        ValueError: the condition a>=b does not hold
 
     A zero slope is allowed and gives the generalized Dyck lattices::
 
@@ -244,8 +240,6 @@ def GeneralizedTamariLattice(a, b, m=1):
     """
     if b < 0:
         raise ValueError("the condition b>=0 does not hold")
-    if a < b:
-        raise ValueError("the condition a>=b does not hold")
     if m < 0:
         raise ValueError("the condition m>=0 does not hold")
     if a < b * m:
@@ -313,22 +307,16 @@ def TamariLattice(n, m=1):
         ...
         ValueError: the condition m>=0 does not hold
 
-    A zero slope only makes sense for `n \leq 1`; larger indices used to
-    return a one-element lattice for every `n`::
+    A zero slope leaves only the vertical path, so the lattice is a
+    singleton for every index::
 
-        sage: posets.TamariLattice(1, 0)
-        Finite lattice containing 1 elements
-        sage: posets.TamariLattice(3, 0)
-        Traceback (most recent call last):
-        ...
-        ValueError: the condition m*n+1>=n does not hold
+        sage: [posets.TamariLattice(n, 0).cardinality() for n in range(5)]
+        [1, 1, 1, 1, 1]
     """
     if n < 0:
         raise ValueError("the condition n>=0 does not hold")
     if m < 0:
         raise ValueError("the condition m>=0 does not hold")
-    if m * n + 1 < n:
-        raise ValueError("the condition m*n+1>=n does not hold")
     return GeneralizedTamariLattice(m * n + 1, n, m)
 
 

--- a/src/sage/combinat/tamari_lattices.py
+++ b/src/sage/combinat/tamari_lattices.py
@@ -312,11 +312,23 @@ def TamariLattice(n, m=1):
         Traceback (most recent call last):
         ...
         ValueError: the condition m>=0 does not hold
+
+    A zero slope only makes sense for `n \leq 1`; larger indices used to
+    return a one-element lattice for every `n`::
+
+        sage: posets.TamariLattice(1, 0)
+        Finite lattice containing 1 elements
+        sage: posets.TamariLattice(3, 0)
+        Traceback (most recent call last):
+        ...
+        ValueError: the condition m*n+1>=n does not hold
     """
     if n < 0:
         raise ValueError("the condition n>=0 does not hold")
     if m < 0:
         raise ValueError("the condition m>=0 does not hold")
+    if m * n + 1 < n:
+        raise ValueError("the condition m*n+1>=n does not hold")
     return GeneralizedTamariLattice(m * n + 1, n, m)
 
 

--- a/src/sage/combinat/tamari_lattices.py
+++ b/src/sage/combinat/tamari_lattices.py
@@ -219,7 +219,35 @@ def GeneralizedTamariLattice(a, b, m=1):
     - [PRV2017]_
 
     - [CC2023]_
+
+    TESTS:
+
+    The documented conditions on the parameters are checked::
+
+        sage: GeneralizedTamariLattice(3, 2, -1)
+        Traceback (most recent call last):
+        ...
+        ValueError: the condition m>=0 does not hold
+        sage: GeneralizedTamariLattice(0, -1)
+        Traceback (most recent call last):
+        ...
+        ValueError: the condition b>=0 does not hold
+        sage: GeneralizedTamariLattice(2, 3)
+        Traceback (most recent call last):
+        ...
+        ValueError: the condition a>=b does not hold
+
+    A zero slope is allowed and gives the generalized Dyck lattices::
+
+        sage: GeneralizedTamariLattice(3, 2, 0)
+        Finite lattice containing 2 elements
     """
+    if b < 0:
+        raise ValueError("the condition b>=0 does not hold")
+    if a < b:
+        raise ValueError("the condition a>=b does not hold")
+    if m < 0:
+        raise ValueError("the condition m>=0 does not hold")
     if a < b * m:
         raise ValueError("the condition a>=b*m does not hold")
 
@@ -273,7 +301,22 @@ def TamariLattice(n, m=1):
     REFERENCES:
 
     - [BMFPR2011]_
+
+    TESTS::
+
+        sage: posets.TamariLattice(-1)
+        Traceback (most recent call last):
+        ...
+        ValueError: the condition n>=0 does not hold
+        sage: posets.TamariLattice(3, -1)
+        Traceback (most recent call last):
+        ...
+        ValueError: the condition m>=0 does not hold
     """
+    if n < 0:
+        raise ValueError("the condition n>=0 does not hold")
+    if m < 0:
+        raise ValueError("the condition m>=0 does not hold")
     return GeneralizedTamariLattice(m * n + 1, n, m)
 
 
@@ -382,7 +425,16 @@ def DexterSemilattice(n):
     REFERENCES:
 
     - [Cha18]_
+
+    TESTS::
+
+        sage: posets.DexterSemilattice(-1)
+        Traceback (most recent call last):
+        ...
+        ValueError: the condition n>=0 does not hold
     """
+    if n < 0:
+        raise ValueError("the condition n>=0 does not hold")
     a = n + 1
     b = n
 


### PR DESCRIPTION
Fixes #42502.

`GeneralizedTamariLattice` documents `a`, `b` as integers with `a >= b` and `m`
as a nonnegative rational with `a >= b*m`, but only checked the last condition.
A negative slope makes that check *easier* to satisfy rather than harder — for
`GeneralizedTamariLattice(3, 2, -1)` it reduces to `3 < -2`, which is false — so
the guard passed and a lattice was returned.

`TamariLattice` and `DexterSemilattice` performed no validation of their own
before delegating, so negative indices reached the lower-level constructor.

### Before

```
GeneralizedTamariLattice(3, 2, -1)  ->  lattice with 2 elements
GeneralizedTamariLattice(0, -1)     ->  lattice with 1 element
posets.TamariLattice(-1)            ->  lattice with 1 element
```

### After

```
GeneralizedTamariLattice(3, 2, -1)  ->  ValueError: the condition m>=0 does not hold
GeneralizedTamariLattice(0, -1)     ->  ValueError: the condition b>=0 does not hold
GeneralizedTamariLattice(2, 3)      ->  ValueError: the condition a>=b does not hold
posets.TamariLattice(-1)            ->  ValueError: the condition n>=0 does not hold
posets.TamariLattice(3, -1)         ->  ValueError: the condition m>=0 does not hold
posets.DexterSemilattice(-1)        ->  ValueError: the condition n>=0 does not hold
```

The new messages follow the wording of the existing `a>=b*m` check.

### One case deliberately left accepted

The issue also lists `GeneralizedTamariLattice(0, 0)` as invalid. I have left it
working, because `0 >= 0` satisfies the documented `a >= b`, and because
`posets.TamariLattice(0)` and `posets.DexterSemilattice(0)` already return valid
one-element lattices — rejecting `a = b = 0` would be inconsistent with those.
If maintainers would rather the documented domain were tightened to require
positive dimensions, I am happy to change both the code and the docstrings in
this PR; that seemed like a decision to confirm rather than assume.

### Cases that must keep working, and do

`m = 0` stays valid — the generalized Dyck branch (`if m == 0:`) depends on it.
Rational slopes, zero indices and `b = 0` are also unaffected:

```
posets.TamariLattice(3)      OK (5)     GeneralizedTamariLattice(3, 2, 0)    OK (2)
posets.TamariLattice(0)      OK (1)     GeneralizedTamariLattice(3, 2, 1/2)  OK (2)
posets.DexterSemilattice(0)  OK (1)     GeneralizedTamariLattice(4, 3)       OK (5)
```

### Verification

```
$ ./sage -t src/sage/combinat/tamari_lattices.py src/sage/combinat/nu_tamari_lattice.py \
          src/sage/combinat/posets/poset_examples.py src/sage/combinat/posets/lattices.py \
          src/sage/dynamics/finite_dynamical_system_catalog.py
All tests passed!
```

Those are the files that reference these constructors, checked so the new
validation does not reject an existing caller.

Tested on macOS 26 / arm64 against 10.10.beta0; `tamari_lattices.py` is
identical on `develop` and the patch applies there cleanly.
