### PR TITLE
Add runtime Python doctest discovery

### DIFF
--- a/src/sage/doctest/__main__.py
+++ b/src/sage/doctest/__main__.py
@@ -100,6 +100,8 @@ def _make_parser():
     parser.add_argument("-i", "--initial", action="store_true", default=False, help="only show the first failure in each file")
     parser.add_argument("--exitfirst", action="store_true", default=False, help="end the test run immediately after the first failure or unexpected exception")
     parser.add_argument("--force_lib", "--force-lib", action="store_true", default=False, help="do not import anything from the tested file(s)")
+    parser.add_argument("--runtime-docstrings", action="store_true", default=False,
+                        help="discover Python doctests from runtime docstrings")
     parser.add_argument("--if-installed", action="store_true", default=False, help="skip Python/Cython files that are not installed as modules")
     parser.add_argument("--abspath", action="store_true", default=False, help="print absolute paths rather than relative paths")
     parser.add_argument("--verbose", action="store_true", default=False, help="print debugging output during the test")

--- a/src/sage/doctest/control.py
+++ b/src/sage/doctest/control.py
@@ -142,6 +142,7 @@ class DocTestDefaults(SageObject):
         self.initial = False
         self.exitfirst = False
         self.force_lib = False
+        self.runtime_docstrings = False
         self.if_installed = False
         self.abspath = not runtest_default
         self.verbose = False
@@ -1028,7 +1029,11 @@ class DocTestController(SageObject):
                 raise ValueError(f"--all-except includes {paths_to_remove - set(paths)}, "
                                  f"which are not found in {paths}")
             paths = [path for path in paths if path not in paths_to_remove]  # keep duplicates
-        self.sources = [FileDocTestSource(path, self.options) for path in paths]
+        from sage.doctest.sources import RuntimePythonFileSource
+        self.sources = [RuntimePythonFileSource(path, self.options)
+                        if self.options.runtime_docstrings and path.endswith('.py')
+                        else FileDocTestSource(path, self.options)
+                        for path in paths]
 
     def filter_sources(self):
         """
@@ -1282,7 +1287,7 @@ class DocTestController(SageObject):
         opt = dict_difference(self.options.__dict__, DocTestDefaults(runtest_default=True).__dict__)
         # Options with no argument
         for o in ("all", "installed", "long", "initial", "exitfirst",
-                  "force_lib", "if_installed", "abspath", "verbose",
+                  "force_lib", "runtime_docstrings", "if_installed", "abspath", "verbose",
                   "debug", "only_errors", "failed", "new",
                   "show_skipped"):
             if o in opt:

--- a/src/sage/doctest/sources.py
+++ b/src/sage/doctest/sources.py
@@ -32,6 +32,7 @@ import sys
 import re
 import random
 import doctest
+import inspect
 from sage.cpython.string import bytes_to_str
 from sage.repl.load import load
 from sage.misc.lazy_attribute import lazy_attribute
@@ -1211,6 +1212,82 @@ class PythonSource(SourceLanguage):
                     in_docstring = True
                 neutralized.append(" "*reindent + line)
         return "".join(neutralized)
+
+
+class RuntimePythonFileSource(FileDocTestSource, PythonSource):
+    r"""
+    A Python doctest source that discovers docstrings after executing a file.
+
+    This source is useful for Python files that amend docstrings at runtime,
+    for example by decorators.  It is deliberately restricted to Python
+    files: Cython sources cannot be executed before they are compiled.
+    """
+    def __init__(self, path, options):
+        FileDocTestSource.__init__(self, path, options)
+        if not path.endswith('.py'):
+            raise ValueError("runtime doctest discovery requires a Python file")
+        self.__class__ = RuntimePythonFileSource
+
+    def create_doctests(self, namespace) -> tuple[list[doctest.DocTest], dict]:
+        r"""
+        Create doctests from the docstrings produced by executing this file.
+
+        TESTS::
+
+            sage: from sage.doctest.control import DocTestDefaults
+            sage: from sage.doctest.sources import RuntimePythonFileSource
+            sage: filename = tmp_filename(ext='.py')
+            sage: with open(filename, 'w') as f:
+            ....:     _ = f.write("def amend_docstring(obj):\n"
+            ....:                 "    obj.__doc__ += '\\n\\n    sage: Decorated.answer()\\n    42\\n'\n"
+            ....:                 "    return obj\n\n"
+            ....:                 "@amend_docstring\n"
+            ....:                 "class Decorated:\n"
+            ....:                 "    \\\"\\\"\\\"A decorated class.\\\"\\\"\\\"\n\n"
+            ....:                 "    @staticmethod\n"
+            ....:                 "    def answer():\n"
+            ....:                 "        return 42\n")
+            sage: source = RuntimePythonFileSource(filename, DocTestDefaults())
+            sage: doctests, _ = source.create_doctests({})
+            sage: any('Decorated.answer()' in example.sage_source
+            ....:     for test in doctests for example in test.examples)
+            True
+        """
+        if not os.path.exists(self.path):
+            import errno
+            raise OSError(errno.ENOENT, "File does not exist", self.path)
+
+        path = os.path.abspath(self.path)
+        base, filename = os.path.split(path)
+        cwd = os.getcwd()
+        if base:
+            os.chdir(base)
+        try:
+            load(path, namespace)
+        finally:
+            os.chdir(cwd)
+
+        self._init()
+        self.parser = SageDocTestParser(self.options.optional,
+                                        self.options.long,
+                                        probed_tags=self.options.probe,
+                                        file_optional_tags=self.file_optional_tags)
+        self.qualified_name = NestedName(self.basename)
+        doctests = []
+        for name, obj in namespace.items():
+            if name.startswith('__') or not inspect.isclass(obj) and not inspect.isfunction(obj):
+                continue
+            if inspect.getsourcefile(obj) != path:
+                continue
+            docstring = inspect.getdoc(obj)
+            if not docstring:
+                continue
+            self.qualified_name = NestedName(f'{self.basename}.{name}')
+            start = inspect.getsourcelines(obj)[1] - 1
+            self._process_doc(doctests, [docstring], namespace, start)
+        extras = {'tab': False, 'line_number': False,
+                  'optionals': self.parser.optionals}
+        return doctests, extras
 
 
 class TexSource(SourceLanguage):


### PR DESCRIPTION
Fixes #34828.

This draft adds an explicit `--runtime-docstrings` mode for Python files. In this mode, Sage executes a Python source file and discovers doctests from the resulting top-level class and function docstrings, so decorator-added examples are included. Cython and other source types retain the existing text-based discovery.

The initial implementation includes a regression doctest for a decorator that appends a `sage:` example to a class docstring.

Open design questions for review:
- Whether this opt-in mode should eventually become the Python default.
- How best to preserve precise line locations for dynamically generated text.
- How broadly runtime member discovery should recurse beyond top-level definitions.

Testing:
- `python3 -m py_compile src/sage/doctest/sources.py src/sage/doctest/control.py src/sage/doctest/__main__.py`
- `git diff --check`
- `./sage -t src/sage/doctest/sources.py src/
  sage/doctest/control.py`