### PR TITLE
Remove circular dependency sphinx <-> sphinxcontrib_websupport

### DIFF
--- a/build/pkgs/sphinxcontrib_websupport/dependencies
+++ b/build/pkgs/sphinxcontrib_websupport/dependencies
@@ -1,4 +1,4 @@
- sphinxcontrib_serializinghtml jinja2 sphinx | $(PYTHON_TOOLCHAIN) $(PYTHON)
+ sphinxcontrib_serializinghtml jinja2 | $(PYTHON_TOOLCHAIN) $(PYTHON)
 
 ----------
 All lines of this file are ignored except the first.


### PR DESCRIPTION
During build, you will see:

make[3]: Circular /home/release/Sage/local/var/lib/sage/venv-python3.14/var/lib/sage/installed/sphinxcontrib_websupport-2.0.0 <- /home/release/Sage/local/var/lib/sage/venv-python3.14/var/lib/sage/installed/sphinx-9.1.0 dependency dropped.
make[1]: Circular /home/release/Sage/local/var/lib/sage/venv-python3.14/var/lib/sage/installed/sphinxcontrib_websupport-2.0.0 <- /home/release/Sage/local/var/lib/sage/venv-python3.14/var/lib/sage/installed/sphinx-9.1.0 dependency dropped.
make[1]: Circular /home/release/Sage/local/var/lib/sage/venv-python3.14/var/lib/sage/installed/sphinxcontrib_websupport-2.0.0 <- /home/release/Sage/local/var/lib/sage/venv-python3.14/var/lib/sage/installed/sphinx-9.1.0 dependency dropped.
