### PR TITLE
Remove junk variable names from finite (non-polynomial) rings

### DIFF
--- a/src/sage/rings/finite_rings/finite_field_base.pyx
+++ b/src/sage/rings/finite_rings/finite_field_base.pyx
@@ -1104,7 +1104,10 @@ cdef class FiniteField(Field):
             return self.__polynomial_ring
         else:
             if variable_name is None:
-                self.__polynomial_ring = PolynomialRing(GF(self.characteristic()), self.variable_name())
+                variable_name = "x"  # variable name of last resort
+                if self.variable_names():
+                    variable_name = self.variable_name()
+                self.__polynomial_ring = PolynomialRing(GF(self.characteristic()), variable_name)
                 return self.__polynomial_ring
             else:
                 return PolynomialRing(GF(self.characteristic()), variable_name)

--- a/src/sage/rings/finite_rings/finite_field_prime_modn.py
+++ b/src/sage/rings/finite_rings/finite_field_prime_modn.py
@@ -221,7 +221,9 @@ class FiniteField_prime_modn(FiniteField_generic, integer_mod_ring.IntegerModRin
             x
         """
         if name is None:
-            name = self.variable_name()
+            name = "x"
+            if self.variable_names():
+                name = self.variable_name()
         try:
             return self.__polynomial[name]
         except AttributeError:

--- a/src/sage/rings/finite_rings/hom_finite_field.pyx
+++ b/src/sage/rings/finite_rings/hom_finite_field.pyx
@@ -552,14 +552,15 @@ cdef class FrobeniusEndomorphism_finite_field(FrobeniusEndomorphism_generic):
             sage: Frob._repr_()
             'Frobenius endomorphism t |--> t^5 on Finite Field in t of size 5^3'
         """
-        name = self.domain().variable_name()
         if self._power == 0:
-            s = "Identity endomorphism of"
-        elif self._power == 1:
+            return f"Identity endomorphism of {self.domain()}"
+
+        name = self.domain().variable_name()
+        if self._power == 1:
             s = "Frobenius endomorphism %s |--> %s^%s on" % (name, name, self.domain().characteristic())
         else:
             s = "Frobenius endomorphism %s |--> %s^(%s^%s) on" % (name, name, self.domain().characteristic(), self._power)
-        s += " %s" % self.domain()
+        s += f" {self.domain()}"
         return s
 
     def _repr_short(self):

--- a/src/sage/rings/finite_rings/integer_mod_ring.py
+++ b/src/sage/rings/finite_rings/integer_mod_ring.py
@@ -505,12 +505,9 @@ class IntegerModRing_generic(quotient_ring.QuotientRing_generic, sage.rings.abc.
             # know that the result will also live in default_category.
             # Hence, we use the join of the default and the given category.
             category = category.join([category, default_category])
-        # Give the generator a 'name' to make quotients work.  The
-        # name 'x' is used because it's also used for the ring of
-        # integers: see the __init__ method for IntegerRing_class in
-        # sage/rings/integer_ring.pyx.
+
         quotient_ring.QuotientRing_generic.__init__(self, ZZ, ZZ.ideal(order),
-                                                    names=('x',),
+                                                    names=(),
                                                     category=category)
         # We want that the ring is its own base ring.
         self._base = self

--- a/src/sage/rings/finite_rings/residue_field.pyx
+++ b/src/sage/rings/finite_rings/residue_field.pyx
@@ -567,7 +567,12 @@ class ResidueField_generic(Field):
             sage: F(CyclotomicField(49))
             Residue field in zbar of Fractional ideal (17)
         """
-        return AlgebraicExtensionFunctor([self.polynomial()], [self.variable_name()], [None], residue=self.p), self.p.ring()
+        # The default name should agree with the choice of last resort
+        # in self.polynomial()
+        variable_name = "x"
+        if self.variable_names():
+            variable_name = self.variable_name()
+        return AlgebraicExtensionFunctor([self.polynomial()], [variable_name], [None], residue=self.p), self.p.ring()
 
     def ideal(self):
         r"""


### PR DESCRIPTION
Remove "x" from the list of variable names in rings like `GF(2)` and `Zmod(4)` that have no variables.

There's a lot of fallout from this... it looks like several finite rings are using "variable name" to mean "generator name" and are stuffing junk in the list to paper over the mismatch in expectations.