### PR TITLE
avoid using numpy in `graphs.RandomBipartite`

### DIFF
--- a/src/sage/graphs/bipartite_graph.py
+++ b/src/sage/graphs/bipartite_graph.py
@@ -1562,10 +1562,10 @@ class BipartiteGraph(Graph):
 
         EXAMPLES::
 
-            sage: g = BipartiteGraph(graphs.RandomBipartite(3, 3, .5))                  # needs numpy
-            sage: g.is_bipartite()                                                      # needs numpy
+            sage: g = BipartiteGraph(graphs.RandomBipartite(3, 3, .5))
+            sage: g.is_bipartite()
             True
-            sage: g.is_bipartite(certificate=True)  # random                            # needs numpy
+            sage: g.is_bipartite(certificate=True)  # random
             (True, {(0, 0): 0, (0, 1): 0, (0, 2): 0, (1, 0): 1, (1, 1): 1, (1, 2): 1})
 
         TESTS::
@@ -2646,7 +2646,6 @@ class BipartiteGraph(Graph):
 
         The two algorithms should return the same result::
 
-           sage: # needs networkx numpy
            sage: g = BipartiteGraph(graphs.RandomBipartite(10, 10, .5))
            sage: vc1 = g.vertex_cover(algorithm='Konig')
            sage: vc2 = g.vertex_cover(algorithm='Cliquer')

--- a/src/sage/graphs/generators/random.py
+++ b/src/sage/graphs/generators/random.py
@@ -215,29 +215,28 @@ def RandomBipartite(n1, n2, p, set_position=False, seed=None, immutable=False):
 
     EXAMPLES::
 
-        sage: g = graphs.RandomBipartite(5, 2, 0.5)                                     # needs numpy
-        sage: g.vertices(sort=True)                                                     # needs numpy
+        sage: g = graphs.RandomBipartite(5, 2, 0.5)
+        sage: g.vertices(sort=True)
         [(0, 0), (0, 1), (0, 2), (0, 3), (0, 4), (1, 0), (1, 1)]
 
     TESTS::
 
-        sage: g = graphs.RandomBipartite(5, -3, 0.5)                                    # needs numpy
+        sage: g = graphs.RandomBipartite(5, -3, 0.5)
         Traceback (most recent call last):
         ...
         ValueError: n1 and n2 should be integers strictly greater than 0
-        sage: g = graphs.RandomBipartite(5, 3, 1.5)                                     # needs numpy
+        sage: g = graphs.RandomBipartite(5, 3, 1.5)
         Traceback (most recent call last):
         ...
         ValueError: parameter p is a probability, and so should be a real value between 0 and 1
 
     :issue:`12155`::
 
-        sage: graphs.RandomBipartite(5, 6, .2).complement()                             # needs numpy
+        sage: graphs.RandomBipartite(5, 6, .2).complement()
         complement(Random bipartite graph of order 5+6 with edge probability 0.200000000000000): Graph on 11 vertices
 
     Test assigned positions::
 
-        sage: # needs numpy
         sage: graphs.RandomBipartite(1, 2, .1, set_position=True).get_pos()
         {(0, 0): (1, 1.0), (1, 0): (0, 0), (1, 1): (2.0, 0.0)}
         sage: graphs.RandomBipartite(2, 1, .1, set_position=True).get_pos()
@@ -254,12 +253,11 @@ def RandomBipartite(n1, n2, p, set_position=False, seed=None, immutable=False):
         set_random_seed(seed)
 
     from itertools import chain
-    from numpy.random import uniform
 
     name = f"Random bipartite graph of order {n1}+{n2} with edge probability {p}"
     S1 = [(0, i) for i in range(n1)]
     S2 = [(1, i) for i in range(n2)]
-    edges = ((v, w) for w in S2 for v in S1 if uniform() <= p)
+    edges = ((v, w) for w in S2 for v in S1 if random() <= p)
     g = Graph([chain(S1, S2), edges], format="vertices_and_edges",
               name=name, immutable=immutable)
 

--- a/src/sage/graphs/generators/smallgraphs.py
+++ b/src/sage/graphs/generators/smallgraphs.py
@@ -3612,7 +3612,7 @@ def HigmanSimsGraph(relabel=True, immutable=False):
     return HS
 
 
-def HoffmanSingletonGraph(immutable=False):
+def HoffmanSingletonGraph(immutable=False, seed=None):
     r"""
     Return the Hoffman-Singleton graph.
 
@@ -3636,6 +3636,9 @@ def HoffmanSingletonGraph(immutable=False):
 
     - ``immutable`` -- boolean (default: ``False``); whether to return an
       immutable or a mutable graph
+
+    - ``seed`` -- a ``random.Random`` seed or a Python ``int`` for the random
+      number generator (default: ``None``)
 
     EXAMPLES::
 
@@ -3676,6 +3679,10 @@ def HoffmanSingletonGraph(immutable=False):
     H.name('Hoffman-Singleton graph')
     from sage.combinat.permutation import Permutations
     from sage.misc.prandom import randint
+    if seed is not None:
+        from sage.misc.randstate import set_random_seed
+        set_random_seed(seed)
+
     P = Permutations([1, 2, 3, 4])
     qpp = [0] + list(P[randint(0, 23)])
     ppp = [0] + list(P[randint(0, 23)])
@@ -3702,7 +3709,7 @@ def HoffmanSingletonGraph(immutable=False):
             s = int(v[0])
         l += 1
     if immutable:
-        H, mymap = H.relabel(inplace=False, immutable=True, return_map=True)
+        H, mymap = H.relabel(range(50), inplace=False, immutable=True, return_map=True)
     else:
         mymap = H.relabel(range(50), return_map=True)
     H._circle_embedding([mymap[d] for d in D], angle=pi/2)
@@ -4863,7 +4870,7 @@ def ShrikhandeGraph(immutable=False):
                  name="Shrikhande graph", immutable=immutable)
 
 
-def SylvesterGraph(immutable=False):
+def SylvesterGraph(immutable=False, seed=None):
     """
     Return the Sylvester Graph.
 
@@ -4883,6 +4890,9 @@ def SylvesterGraph(immutable=False):
     - ``immutable`` -- boolean (default: ``False``); whether to return an
       immutable or a mutable graph
 
+    - ``seed`` -- a ``random.Random`` seed or a Python ``int`` for the random
+      number generator (default: ``None``)
+
     EXAMPLES::
 
         sage: g = graphs.SylvesterGraph(); g
@@ -4894,14 +4904,14 @@ def SylvesterGraph(immutable=False):
         sage: g.is_regular(k=5)
         True
     """
-    g = HoffmanSingletonGraph()
+    g = HoffmanSingletonGraph(seed=seed)
     e = next(g.edge_iterator(labels=False))
     g.delete_vertices(g.neighbors(e[0]) + g.neighbors(e[1]))
     g.name("Sylvester Graph")
     if immutable:
-        g = g.relabel(inplace=False, immutable=True)
+        g = g.relabel(range(g.order()), inplace=False, immutable=True)
     else:
-        g.relabel()
+        g.relabel(range(g.order()))
     ordering = [0, 1, 2, 4, 5, 9, 16, 35, 15, 18, 20, 30, 22, 6, 33, 32, 14,
                 10, 28, 29, 7, 24, 23, 26, 19, 12, 13, 21, 11, 31, 3, 27, 25,
                 17, 8, 34]
@@ -4947,9 +4957,9 @@ def SimsGewirtzGraph(immutable=False):
     g.delete_vertices(g.neighbors(e[0]) + g.neighbors(e[1]))
     g.name("Sims-Gewirtz Graph")
     if immutable:
-        g = g.relabel(inplace=False, immutable=True)
+        g = g.relabel(range(g.order()), inplace=False, immutable=True)
     else:
-        g.relabel()
+        g.relabel(range(g.order()))
     ordering = [0, 2, 3, 4, 6, 7, 8, 17, 1, 41, 49, 5, 22, 26, 11, 27, 15, 47,
                 53, 52, 38, 43, 44, 18, 20, 32, 19, 42, 54, 36, 51, 30, 33, 35,
                 37, 28, 34, 12, 29, 23, 55, 25, 40, 24, 9, 14, 48, 39, 45, 16,

--- a/src/sage/graphs/generic_graph.py
+++ b/src/sage/graphs/generic_graph.py
@@ -4590,7 +4590,7 @@ class GenericGraph(GenericGraph_pyx):
             True
             sage: graphs.CycleGraph(5).is_bipartite()
             False
-            sage: graphs.RandomBipartite(10, 10, 0.7).is_bipartite()                    # needs numpy
+            sage: graphs.RandomBipartite(10, 10, 0.7).is_bipartite()
             True
 
         A random graph is very rarely bipartite::
@@ -17166,8 +17166,8 @@ class GenericGraph(GenericGraph_pyx):
         Bipartite graphs have no odd cycle and consequently have
         infinite odd girth::
 
-            sage: G = graphs.RandomBipartite(6, 6, .5)                                  # needs numpy
-            sage: G.odd_girth()                                                         # needs numpy
+            sage: G = graphs.RandomBipartite(6, 6, .5)
+            sage: G.odd_girth()
             +Infinity
             sage: G = graphs.Grid2dGraph(3, 4)
             sage: G.odd_girth()

--- a/src/sage/graphs/graph.py
+++ b/src/sage/graphs/graph.py
@@ -1211,7 +1211,8 @@ class Graph(GenericGraph):
             if data.get_pos() is not None:
                 pos = data.get_pos()
             self.name(data.name())
-            self.set_vertices(data.get_vertices())
+            if hasattr(data, '_assoc'):
+                self.set_vertices(data.get_vertices())
             data._backend.subgraph_given_vertices(self._backend, data)
 
         elif format == 'NX':
@@ -2300,13 +2301,13 @@ class Graph(GenericGraph):
         It is clear, though, that a random Bipartite Graph which is not a forest
         has an even hole::
 
-            sage: g = graphs.RandomBipartite(10, 10, .5)                                # needs numpy
-            sage: g.is_even_hole_free() and not g.is_forest()                           # needs numpy sage.modules
+            sage: g = graphs.RandomBipartite(10, 10, .5)
+            sage: g.is_even_hole_free() and not g.is_forest()                           # needs sage.modules
             False
 
         We can check the certificate returned is indeed an even cycle::
 
-            sage: if not g.is_forest():                                                 # needs numpy sage.modules
+            sage: if not g.is_forest():                                                 # needs sage.modules
             ....:    cycle = g.is_even_hole_free(certificate=True)
             ....:    if cycle.order() % 2 == 1:
             ....:        print("Error !")
@@ -2332,7 +2333,7 @@ class Graph(GenericGraph):
 
             sage: t = lambda x: (Graph(x).is_forest() or
             ....:       isinstance(Graph(x).is_even_hole_free(certificate=True), Graph))
-            sage: all(t(graphs.RandomBipartite(10, 10, .5)) for i in range(100))        # needs numpy sage.modules
+            sage: all(t(graphs.RandomBipartite(10, 10, .5)) for i in range(100))        # needs sage.modules
             True
         """
         girth = self.girth()
@@ -2655,14 +2656,14 @@ class Graph(GenericGraph):
 
         A Bipartite Graph is always perfect ::
 
-            sage: g = graphs.RandomBipartite(8,4,.5)                                    # needs numpy
-            sage: g.is_perfect()                                                        # needs numpy sage.modules
+            sage: g = graphs.RandomBipartite(8,4,.5)
+            sage: g.is_perfect()                                                        # needs sage.modules
             True
 
         So is the line graph of a bipartite graph::
 
-            sage: g = graphs.RandomBipartite(4,3,0.7)                                   # needs numpy
-            sage: g.line_graph().is_perfect()   # long time                             # needs numpy sage.modules
+            sage: g = graphs.RandomBipartite(4,3,0.7)
+            sage: g.line_graph().is_perfect()   # long time                             # needs sage.modules
             True
 
         As well as the Cartesian product of two complete graphs::
@@ -3530,7 +3531,7 @@ class Graph(GenericGraph):
 
         A bipartite graph has (by definition) chromatic number 2::
 
-            sage: graphs.RandomBipartite(50,50,0.7).chromatic_number()                  # needs numpy
+            sage: graphs.RandomBipartite(50,50,0.7).chromatic_number()
             2
 
         A complete multipartite graph with `k` parts has chromatic number `k`::

--- a/src/sage/graphs/matching.py
+++ b/src/sage/graphs/matching.py
@@ -563,8 +563,8 @@ def is_factor_critical(G, matching=None, algorithm='Edmonds', solver=None, verbo
 
     Bipartite graphs are not factor-critical::
 
-        sage: G = graphs.RandomBipartite(randint(1, 10), randint(1, 10), .5)        # needs numpy
-        sage: G.is_factor_critical()                                                # needs numpy
+        sage: G = graphs.RandomBipartite(randint(1, 10), randint(1, 10), .5)
+        sage: G.is_factor_critical()
         False
 
     Graphs with even order are not factor critical::


### PR DESCRIPTION
This PR replaces a the call to `numpy.uniform` by a call to `random` in `RandomBipartite`. This ease the setting of the random seed.  This way we avoid the need for several `# needs numpy`.

On the way we
- add parameter `seed` to methods `HoffmanSingletonGraph` and `SylvesterGraph`
- avoid instantiating parameter `_assoc` (with a dictionary associating `None` to each vertex)  in the `Graph` constructor when the input is a graph that does not include this parameter. 

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


