### PR TITLE
.github/workflows: raise the "slow doctest" limit on macOS

### DIFF
--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -172,11 +172,16 @@ jobs:
             # Ignore errors on Windows, for now
             pytest -n 4 --doctest-ignore-import-errors --doctest -rfEs -s src || true
           else
+            # Substitution is slow on macOS (issue 40825), so raise the
+            # "slow doctest" limit on that platform. We'll still get
+            # regular warnings from the other jobs.
             pytest -n 4 -rfEs -s src
             ./sage -t ${{
               matrix.tests == 'all' &&
               '--all-except="$SEPARATELY_TESTED_FLAKY_FILES"' ||
-              '--new --long' }} -p4 --format github
+              '--new --long' }} ${{
+              startsWith(matrix.os, 'macos') && '--warn-long=60'
+              }} -p4 --format github
           fi
 
       - name: Test flaky files

--- a/.github/workflows/ci-optional-packages.yml
+++ b/.github/workflows/ci-optional-packages.yml
@@ -88,5 +88,8 @@ jobs:
       - name: Run tests
         continue-on-error: true
         run: |
+          # Substitution is slow on macOS (issue 40825), so raise the
+          # "slow doctest" limit on that platform. We'll still get
+          # regular warnings from the other jobs.
           source ./.homebrew-build-env
-          ./sage -t --all -p4
+          ./sage -t --all --warn-long=60 -p4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,10 @@ jobs:
 
       - name: Test
         run: |
-          uv run --frozen ./sage -t --all -p4 || true
+          # Substitution is slow on macOS (issue 40825), so raise the
+          # "slow doctest" limit on that platform. We'll still get
+          # regular warnings from the other jobs.
+          uv run --frozen ./sage -t --warn-long=60 --all -p4 || true
 
       - name: Upload log
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
[Substitution is slow on macOS](https://github.com/sagemath/sage/issues/40825), causing several tests to raise "slow doctest" warnings on the CI. These aren't real problems (beyond the fact that substitution is slow), and warnings for actually-long tests will still be raised by other jobs, so let's set the warning limit to 60s on macOS.

The main goal here is to hide these warnings from Github's "changes" view, since they appear to indicate a new problem in that context. But it's also nice to just not have them show up (grep, etc.) in the list of tests that should be sped-up or marked `# long time`.

Example (scroll to the bottom): https://github.com/sagemath/sage/pull/42775/changes