### PR TITLE
Add type annotations to sage.misc.multireplace

### DIFF
--- a/src/sage/misc/multireplace.py
+++ b/src/sage/misc/multireplace.py
@@ -20,7 +20,7 @@ import re
 # The simplest, lambda-based implementation
 #
 
-def multiple_replace(dic, text):
+def multiple_replace(dic: dict[str, str], text: str) -> str:
     """
     Replace in 'text' all occurrences of any key in the given
     dictionary by its corresponding value.  Returns the new string.


### PR DESCRIPTION
### Description

Adds type annotations to `multiple_replace()` in `sage/misc/multireplace.py`, as a small contribution toward the ongoing effort tracked in #41748 to improve static analysis (pyright/mypy/ty) coverage across the Sage codebase.

This is a minimal, self-contained module (a single utility function with no Sage-specific types involved), so it's a good small entry point per the maintainer's guidance in that issue to keep such PRs small and focused.

### Checklist
- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes. (N/A — type-only change, verified with `ast.parse`; no runtime behavior change since Python does not enforce type hints)
- [ ] I have updated the documentation and checked the documentation preview.

### Dependencies
None.