### PR TITLE
Update tests for maxima 5.50

### DIFF
--- a/src/sage/calculus/functional.py
+++ b/src/sage/calculus/functional.py
@@ -364,11 +364,10 @@ def limit(f, dir=None, taylor=False, **argv):
         sage: limit((tan(sin(x)) - sin(tan(x)))/x^7, taylor=True, x=0)
         1/30
 
-    Sage does not know how to do this limit (which is 0), so it returns
-    it unevaluated::
+    Sage does not know how to do this limit, so it returns it unevaluated::
 
-        sage: lim(exp(x^2)*(1-erf(x)), x=infinity)
-        -limit((erf(x) - 1)*e^(x^2), x, +Infinity)
+        sage: lim(zeta(x)-1/(x-1), x, 1)
+        limit(-1/(x - 1) + zeta(x), x, 1)
     """
     if not isinstance(f, Expression):
         from sage.symbolic.ring import SR

--- a/src/sage/calculus/tests.py
+++ b/src/sage/calculus/tests.py
@@ -118,8 +118,10 @@ No problems here::
 
     sage: integrate(exp(1-x^2),x)
     1/2*sqrt(pi)*erf(x)*e
-    sage: integrate(sin(x^2),x)
-    1/16*sqrt(pi)*((I + 1)*sqrt(2)*erf((1/2*I + 1/2)*sqrt(2)*x) - (I - 1)*sqrt(2)*erf(sqrt(-I)*x) - 2*sqrt(2)*imag_part(erf((-1)^(1/4)*x)) + 2*sqrt(2)*real_part(erf((-1)^(1/4)*x)))
+    sage: ans = integrate(sin(x^2),x); ans # random - depends on maxima version
+    -1/4*(-1)^(3/4)*sqrt(pi)*(I*sqrt(-I)*erf((-1)^(1/4)*x) - I*(-1)^(1/4)*erf(sqrt(-I)*x))/sqrt(-I)
+    sage: ans in [1/16*sqrt(pi)*((I + 1)*sqrt(2)*erf((1/2*I + 1/2)*sqrt(2)*x) - (I - 1)*sqrt(2)*erf(sqrt(-I)*x) - 2*sqrt(2)*imag_part(erf((-1)^(1/4)*x)) + 2*sqrt(2)*real_part(erf((-1)^(1/4)*x))), -1/4*(-1)^(3/4)*sqrt(pi)*(I*sqrt(-I)*erf((-1)^(1/4)*x) - I*(-1)^(1/4)*erf(sqrt(-I)*x))/sqrt(-I)]
+    True
 
     sage: integrate((1-x^2)^n,x)  # long time
     x*hypergeometric((1/2, -n), (3/2,), x^2*exp_polar(2*I*pi))

--- a/src/sage/functions/exp_integral.py
+++ b/src/sage/functions/exp_integral.py
@@ -106,10 +106,10 @@ class Function_exp_integral_e(BuiltinFunction):
         0.00354575823814662 - 0.00973200528288687*I
 
     Maxima returns the following improper integral as a multiple of
-    ``exp_integral_e(1,1)``::
+    ``exp_integral_e(1,1)`` (or, equivalently, of ``Ei(-1)``)::
 
-        sage: uu = integral(e^(-x)*log(x+1), x, 0, oo); uu                              # needs sage.symbolic
-        e*exp_integral_e(1, 1)
+        sage: uu = integral(e^(-x)*log(x+1), x, 0, oo); uu                              # needs sage.symbolic, random - depends on maxima version
+        -Ei(-1)*e
         sage: uu.n(digits=30)                                                           # needs sage.symbolic
         0.596347362323194074341078499369
 

--- a/src/sage/functions/other.py
+++ b/src/sage/functions/other.py
@@ -1906,8 +1906,8 @@ class Function_limit(BuiltinFunction):
     This function is called to create formal wrappers of limits that
     Maxima can't compute::
 
-        sage: a = lim(exp(x^2)*(1-erf(x)), x=infinity); a                               # needs sage.symbolic
-        -limit((erf(x) - 1)*e^(x^2), x, +Infinity)
+        sage: a = lim(zeta(x)-1/(x-1), x, 1); a                               # needs sage.symbolic
+        limit(-1/(x - 1) + zeta(x), x, 1)
 
     EXAMPLES::
 
@@ -1980,17 +1980,6 @@ class Function_limit(BuiltinFunction):
             \lim_{x \to a^-}\, f\left(x\right)
             sage: latex(limit(f(x),x=a,dir='left'))
             \lim_{x \to a^-}\, f\left(x\right)
-
-        Check if :issue:`13181` is fixed::
-
-            sage: # needs sage.symbolic
-            sage: t = var('t')
-            sage: latex(limit(exp_integral_e(1/2, I*t - I*x)*sqrt(-t + x), t=x, dir='-'))
-            \lim_{t \to x^-}\, \sqrt{-t + x} E_{\frac{1}{2}}\left(i \, t - i \, x\right)
-            sage: latex(limit(exp_integral_e(1/2, I*t - I*x)*sqrt(-t + x), t=x, dir='+'))
-            \lim_{t \to x^+}\, \sqrt{-t + x} E_{\frac{1}{2}}\left(i \, t - i \, x\right)
-            sage: latex(limit(exp_integral_e(1/2, I*t - I*x)*sqrt(-t + x), t=x))
-            \lim_{t \to x}\, \sqrt{-t + x} E_{\frac{1}{2}}\left(i \, t - i \, x\right)
         """
         if repr(direction) == 'minus':
             dir_str = '^-'

--- a/src/sage/manifolds/continuous_map.py
+++ b/src/sage/manifolds/continuous_map.py
@@ -1782,7 +1782,7 @@ class ContinuousMap(Morphism):
 
             sage: rot.display(c_spher, c_spher)
             R: U → U
-               (r, ph) ↦ (r, arctan2(1/2*sqrt(3)*cos(ph) + 1/2*sin(ph), -1/2*sqrt(3)*sin(ph) + 1/2*cos(ph)))
+               (r, ph) ↦ (r, arctan2(...sqrt(3)*cos(ph) + ...sin(ph), -...sqrt(3)*sin(ph) + ...cos(ph)))
 
         Therefore, we use the method :meth:`add_expr` to set the
         spherical-coordinate expression by hand::

--- a/src/sage/misc/functional.py
+++ b/src/sage/misc/functional.py
@@ -526,8 +526,10 @@ def symbolic_sum(expression, *args, **kwds):
     Another binomial identity (:issue:`7952`)::
 
         sage: t, k, i = var('t,k,i')                                                    # needs sage.symbolic
-        sage: sum(binomial(i + t, t), i, 0, k)                                          # needs sage.symbolic
-        binomial(k + t + 1, t + 1)
+        sage: s = sum(binomial(i + t, t), i, 0, k); s                                   # needs sage.symbolic, random - depends on maxima version
+        binomial(k + t + 1, k)
+        sage: bool(s == binomial(k + t + 1, k))                                         # needs sage.symbolic
+        True
 
     Summing a hypergeometric term::
 

--- a/src/sage/symbolic/integration/external.py
+++ b/src/sage/symbolic/integration/external.py
@@ -30,8 +30,8 @@ def maxima_integrator(expression, v, a=None, b=None):
 
     Check that :issue:`25817` is fixed::
 
-        sage: maxima_integrator(log(e^x*log(x)*sin(x))/x^2, x)
-        -1/2*(2*x*integrate(sin(x)/(x*cos(x)^2 + x*sin(x)^2 + 2*x*cos(x) + x), x) - 2*x*integrate(sin(x)/(x*cos(x)^2 + x*sin(x)^2 - 2*x*cos(x) + x), x) - 2*x*log(x) - 2*x*real_part(Ei(-log(x))) - 2*log(2) + log(cos(x)^2 + sin(x)^2 + 2*cos(x) + 1) + log(cos(x)^2 + sin(x)^2 - 2*cos(x) + 1) + 2*log(log(x)))/x
+        sage: maxima_integrator(log(e^x*log(x)*sin(x))/x^2, x) # random - depends on maxima version
+        1/2*(-I*pi + 2*x*(Ei(-log(x)) - I*integrate(1/(x*(e^(I*x) + 1)), x) + I*integrate(1/(x*(e^(I*x) - 1)), x)) + (2*I + 2)*x*log(x) + 2*log(2) - 2*log(e^(I*x) + 1) - 2*log(-e^(I*x) + 1) - 2*log(log(x)))/x
     """
     from sage.calculus.calculus import maxima
     if not isinstance(expression, Expression):

--- a/src/sage/symbolic/integration/integral.py
+++ b/src/sage/symbolic/integration/integral.py
@@ -611,8 +611,10 @@ def integrate(expression, v=None, a=None, b=None, algorithm=None, hold=False):
                     z        Pi                2
                  x y  + Sqrt[--] FresnelS[Sqrt[--] x]
                              2                 Pi
-        sage: print(f.integral(x))
-        x*y^z + 1/16*sqrt(pi)*((I + 1)*sqrt(2)*erf((1/2*I + 1/2)*sqrt(2)*x) - (I - 1)*sqrt(2)*erf(sqrt(-I)*x) - 2*sqrt(2)*imag_part(erf((-1)^(1/4)*x)) + 2*sqrt(2)*real_part(erf((-1)^(1/4)*x)))
+        sage: ans = f.integral(x); ans  # random - depends on maxima version
+        x*y^z - 1/4*(-1)^(3/4)*sqrt(pi)*(I*sqrt(-I)*erf((-1)^(1/4)*x) - I*(-1)^(1/4)*erf(sqrt(-I)*x))/sqrt(-I)
+        sage: ans in [x*y^z - 1/4*(-1)^(3/4)*sqrt(pi)*(I*sqrt(-I)*erf((-1)^(1/4)*x) - I*(-1)^(1/4)*erf(sqrt(-I)*x))/sqrt(-I), x*y^z + 1/16*sqrt(pi)*((I + 1)*sqrt(2)*erf((1/2*I + 1/2)*sqrt(2)*x) - (I - 1)*sqrt(2)*erf(sqrt(-I)*x) - 2*sqrt(2)*imag_part(erf((-1)^(1/4)*x)) + 2*sqrt(2)*real_part(erf((-1)^(1/4)*x)))]
+        True
 
     Alternatively, just use algorithm='mathematica_free' to integrate via Mathematica
     over the internet (does NOT require a Mathematica license!)::
@@ -762,11 +764,6 @@ def integrate(expression, v=None, a=None, b=None, algorithm=None, hold=False):
 
         sage: _ = var('x,y')
         sage: f = log(x^2+y^2)
-        sage: res = integral(f,x,1414/10^7, 1); res
-        Traceback (most recent call last):
-        ...
-        ValueError: Computation failed since Maxima requested additional constraints; using the 'assume' command before evaluation *may* help ...
-        Is ... positive, negative or zero?
         sage: assume(y>1)
         sage: res = integral(f,x,1414/10^7, 1); res
         -2*y*arctan(707/5000000/y) + 2*y*arctan(1/y) + log(y^2 + 1) - 707/5000000*log(y^2 + 499849/25000000000000) - 4999293/2500000

--- a/src/sage/symbolic/relation.py
+++ b/src/sage/symbolic/relation.py
@@ -855,10 +855,10 @@ def solve(f, *args, explicit_solutions=None, multiplicities=None, to_poly_solve=
         [x == sin(x)]
         sage: solve(sin(x)==x,x,explicit_solutions=True)
         []
-        sage: solve(abs(1-abs(1-x)) == 10, x)
-        [abs(abs(x - 1) - 1) == 10]
-        sage: solve(abs(1-abs(1-x)) == 10, x, to_poly_solve=True)
-        [x == -10, x == 12]
+        sage: solve(sin(x)==cos(x), x)
+        [sin(x) == cos(x)]
+        sage: solve(sin(x)==cos(x), x, to_poly_solve=True)
+        [x == 1/4*pi + pi*z...]
 
         sage: from sage.symbolic.expression import Expression
         sage: Expression.solve(x^2==1,x)
@@ -981,10 +981,10 @@ def solve(f, *args, explicit_solutions=None, multiplicities=None, to_poly_solve=
 
     The following examples show the use of the keyword ``to_poly_solve``::
 
-        sage: solve(abs(1-abs(1-x)) == 10, x)
-        [abs(abs(x - 1) - 1) == 10]
-        sage: solve(abs(1-abs(1-x)) == 10, x, to_poly_solve=True)
-        [x == -10, x == 12]
+        sage: solve(sin(x)==cos(x), x)
+        [sin(x) == cos(x)]
+        sage: solve(sin(x)==cos(x), x, to_poly_solve=True)
+        [x == 1/4*pi + pi*z...]
 
         sage: var('Q')
         Q
@@ -1385,7 +1385,7 @@ def _solve_expression(f, x, explicit_solutions, multiplicities,
     Maxima 5.49 no longer raises an error for these inputs::
 
         sage: solve(acot(x), x)
-        [arccot(x) == 0]
+        [...]
         sage: solve(acot(x), x, to_poly_solve=True)
         []
 


### PR DESCRIPTION
Maxima 5.50 can solve some new limits and equations which make some tests invalid, update the tests accordingly

There are some other failures caused by upstream bugs, see [1,2], so upgrading to an unpatched 5.50 release is not recommended.

[1] https://sourceforge.net/p/maxima/bugs/4994/
[2] https://sourceforge.net/p/maxima/bugs/4995/

<!-- ^ Please provide a concise and informative title. -->
<!-- ^ Don't put issue numbers in the title, do this in the PR description below. -->
<!-- ^ For example, instead of "Fixes #12345" use "Introduce new method to calculate 1 + 2". -->
<!-- v Describe your changes below in detail. -->
<!-- v Why is this change required? What problem does it solve? -->
<!-- v If this PR resolves an open issue, please link to it here. For example, "Fixes #12345". -->



### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [ ] The title is concise and informative.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on. For example, -->
<!-- - #12345: short description why this is a dependency -->
<!-- - #34567: ... -->


