### PR TITLE
Fix worker cleanup when RESetParallelIterator exits early

### DIFF
--- a/src/sage/parallel/map_reduce.py
+++ b/src/sage/parallel/map_reduce.py
@@ -1117,6 +1117,35 @@ class RESetMapReduce:
             <multiprocessing.queues.Queue object at 0x...>
             sage: len(S._workers)
             2
+
+        A worker construction failure releases the workers already created::
+
+            sage: from unittest.mock import patch
+            sage: from sage.parallel.map_reduce import RESetMapReduceWorker
+            sage: created = []
+            sage: def create_worker(*args):
+            ....:     if created:
+            ....:         raise RuntimeError('worker construction failed')
+            ....:     worker = RESetMapReduceWorker(*args)
+            ....:     created.append(worker)
+            ....:     return worker
+            sage: S.finish()
+            sage: with patch('sage.parallel.map_reduce.RESetMapReduceWorker', create_worker):
+            ....:     S.setup_workers(2)
+            Traceback (most recent call last):
+            ...
+            RuntimeError: worker construction failed
+            sage: created[0]._read_task.closed and created[0]._write_task.closed
+            True
+            sage: hasattr(S, '_workers')
+            False
+            sage: S.print_communication_statistics()
+            #proc:        0
+            reqs sent:    0
+            reqs rcvs:    0
+            - thefs:      0
+            + thefs:      0
+            sage: del created
         """
         self._nprocess = proc_number(max_proc)
         self._results = mp.Queue()
@@ -1127,8 +1156,14 @@ class RESetMapReduce:
         self._aborted = mp.Value(ctypes.c_bool, False, lock=False)
         sys.stdout.flush()
         sys.stderr.flush()
-        self._workers = [RESetMapReduceWorker(self, i, reduce_locally)
-                         for i in range(self._nprocess)]
+        self._workers = []
+        try:
+            for i in range(self._nprocess):
+                self._workers.append(RESetMapReduceWorker(self, i, reduce_locally))
+        except BaseException:
+            self._aborted.value = True
+            self.finish()
+            raise
 
     def start_workers(self):
         r"""
@@ -1238,21 +1273,31 @@ class RESetMapReduce:
 
         .. SEEALSO:: :meth:`print_communication_statistics`
         """
-        if not self._aborted.value:
-            logger.debug("Joining worker processes...")
-            for worker in self._workers:
-                logger.debug(f"Joining {worker.name}")
-                worker.join()
-            logger.debug("Joining done")
-        else:
+        if not hasattr(self, '_workers'):
+            return
+        if self._aborted.value:
             logger.debug("Killing worker processes...")
             for worker in self._workers:
-                logger.debug(f"Terminating {worker.name}")
-                worker.terminate()
+                if worker.pid is not None:
+                    logger.debug(f"Terminating {worker.name}")
+                    worker.terminate()
             logger.debug("Killing done")
 
-        del self._results, self._active_tasks, self._done
+        logger.debug("Joining worker processes...")
+        for worker in self._workers:
+            if worker.pid is not None:
+                worker.join()
+        logger.debug("Joining done")
+
         self._get_stats()
+        for worker in self._workers:
+            worker._request.close()
+            worker._read_task.close()
+            worker._write_task.close()
+        self._results.close()
+        del self._results, self._active_tasks, self._done
+        # Suspended iterators retain this list to identify their own run.
+        self._workers.clear()
         del self._workers
 
     def abort(self):
@@ -1490,8 +1535,7 @@ class RESetMapReduce:
             sage: S.run()  # indirect doctest
             720*x^6 + 120*x^5 + 24*x^4 + 6*x^3 + 2*x^2 + x + 1
         """
-        res = [tuple(self._workers[i]._stats) for i in range(self._nprocess)]
-        self._stats = res
+        self._stats = [tuple(worker._stats) for worker in self._workers]
 
     def print_communication_statistics(self, blocksize=16):
         r"""
@@ -1518,8 +1562,8 @@ class RESetMapReduce:
         def pstat(name, start, end, istat):
             res[0] += ("\n" + name + " ".join(
                 "%4i" % (self._stats[i][istat]) for i in range(start, end)))
-        for start in range(0, self._nprocess, blocksize):
-            end = min(start + blocksize, self._nprocess)
+        for start in range(0, len(self._stats), blocksize):
+            end = min(start + blocksize, len(self._stats))
             res[0] = ("#proc:     " +
                       " ".join("%4i" % (i) for i in range(start, end)))
             pstat("reqs sent: ", start, end, 0)
@@ -1969,6 +2013,13 @@ class RESetParallelIterator(RESetMapReduce):
     a recursively enumerated set for which the computations are done in
     parallel.
 
+    When stopping iteration early, use this object as a context manager or
+    explicitly close the generator returned by :func:`iter`. A ``break``
+    statement does not close a generator that is still referenced elsewhere.
+    Leaving the context or calling :meth:`close` terminates unfinished workers
+    and waits for them to exit; it does not wait for the current node's
+    computation to finish.
+
     EXAMPLES::
 
         sage: from sage.parallel.map_reduce import RESetParallelIterator
@@ -1976,7 +2027,101 @@ class RESetParallelIterator(RESetMapReduce):
         ....:     lambda l: [l + [0], l + [1]] if len(l) < 15 else [])
         sage: sum(1 for _ in S)
         65535
+
+    Stop iteration while another worker is still computing (:issue:`41015`)::
+
+        sage: from multiprocessing import Event
+        sage: from unittest.mock import patch
+        sage: started, blocked = Event(), Event()
+        sage: def children(n):
+        ....:     if n:
+        ....:         started.set()
+        ....:         blocked.wait()
+        ....:     return []
+        sage: with patch('sage.parallel.map_reduce.proc_number', return_value=2):
+        ....:     with RESetParallelIterator([0, 1], children) as S:
+        ....:         for n in S:
+        ....:             workers = list(S._workers)
+        ....:             assert started.wait(10)
+        ....:             break
+        sage: all(w.exitcode is not None for w in workers)
+        True
+        sage: hasattr(S, '_workers')
+        False
+        sage: del workers
     """
+    def __enter__(self):
+        r"""
+        Return this parallel iterable without starting any workers.
+
+        EXAMPLES::
+
+            sage: from sage.parallel.map_reduce import RESetParallelIterator
+            sage: S = RESetParallelIterator([], lambda n: [])
+            sage: with S as entered:
+            ....:     assert entered is S
+            sage: hasattr(S, '_workers')
+            False
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        r"""
+        Close the current computation without suppressing exceptions.
+
+        TESTS:
+
+        An exception before iteration must not be masked by cleanup::
+
+            sage: from sage.parallel.map_reduce import RESetParallelIterator
+            sage: with RESetParallelIterator([], lambda n: []):
+            ....:     raise ValueError('original error')
+            Traceback (most recent call last):
+            ...
+            ValueError: original error
+
+        Normal exhaustion has already released the workers::
+
+            sage: from unittest.mock import patch
+            sage: with patch('sage.parallel.map_reduce.proc_number', return_value=2):
+            ....:     with RESetParallelIterator([1, 2], lambda n: []) as S:
+            ....:         values = sorted(S)
+            sage: values
+            [1, 2]
+        """
+        self.close()
+
+    def close(self):
+        r"""
+        Terminate and join any workers belonging to the current iteration.
+
+        Calling this method before iteration starts or after it finishes has
+        no effect. The object can be iterated again after it is closed.
+
+        Termination uses :meth:`multiprocessing.Process.terminate`. Workers
+        that ignore the termination signal can prevent this method from
+        returning.
+
+        EXAMPLES::
+
+            sage: from sage.parallel.map_reduce import RESetParallelIterator
+            sage: S = RESetParallelIterator([0], lambda n: [n+1] if n < 10 else [])
+            sage: S.close()
+            sage: it = iter(S)
+            sage: next(it)
+            0
+            sage: S.close()
+            sage: S.close()
+            sage: list(it)
+            []
+        """
+        if hasattr(self, '_workers'):
+            # abort() sends shutdown messages synchronously, which can block
+            # on pipes no longer being consumed. We are terminating the
+            # workers, so there is no need to send those messages first.
+            self._aborted.value = True
+            self.finish()
+
     def map_function(self, z):
         r"""
         Return a singleton tuple.
@@ -2015,17 +2160,83 @@ class RESetParallelIterator(RESetMapReduce):
             [1, 1, 0, 1]
             sage: sum(1 for _ in it)
             65533
+
+        TESTS:
+
+        Explicitly closing the generator releases its workers::
+
+            sage: it = iter(S)
+            sage: _ = next(it)
+            sage: workers = list(S._workers)
+            sage: it.close()
+            sage: all(w.exitcode is not None for w in workers)
+            True
+            sage: del workers
+
+        Closing an old generator must not close a subsequent iteration::
+
+            sage: old = iter(S)
+            sage: _ = next(old)
+            sage: S.close()
+            sage: new = iter(S)
+            sage: _ = next(new)
+            sage: old.close()
+            sage: hasattr(S, '_workers')
+            True
+            sage: new.close()
+
+        Two active iterations of the same object are not supported::
+
+            sage: it = iter(S)
+            sage: _ = next(it)
+            sage: next(iter(S))
+            Traceback (most recent call last):
+            ...
+            RuntimeError: parallel iteration is already running
+            sage: it.close()
+
+        A failure to start a worker also cleans up processes already started::
+
+            sage: from unittest.mock import patch
+            sage: from sage.parallel.map_reduce import RESetMapReduceWorker
+            sage: start = RESetMapReduceWorker.start
+            sage: processes = []
+            sage: def start_worker(worker):
+            ....:     processes.append(worker)
+            ....:     if len(processes) == 2:
+            ....:         raise RuntimeError('worker startup failed')
+            ....:     start(worker)
+            sage: with patch('sage.parallel.map_reduce.proc_number', return_value=2):
+            ....:     with patch.object(RESetMapReduceWorker, 'start', start_worker):
+            ....:         next(iter(S))
+            Traceback (most recent call last):
+            ...
+            RuntimeError: worker startup failed
+            sage: processes[0].exitcode is not None and processes[1].pid is None
+            True
+            sage: hasattr(S, '_workers')
+            False
+            sage: del processes
         """
+        if hasattr(self, '_workers'):
+            raise RuntimeError("parallel iteration is already running")
         self.setup_workers(reduce_locally=False)
-        self.start_workers()
-        active_proc = self._nprocess
-        while True:
-            newres = self._results.get()
-            if newres is not None:
-                logger.debug("Got some results")
-                yield from newres
-            else:
-                active_proc -= 1
-                if active_proc == 0:
-                    break
-        self.finish()
+        workers = self._workers
+        try:
+            self.start_workers()
+            active_proc = self._nprocess
+            while active_proc and getattr(self, '_workers', None) is workers:
+                newres = self._results.get()
+                if newres is not None:
+                    logger.debug("Got some results")
+                    for result in newres:
+                        if getattr(self, '_workers', None) is not workers:
+                            return
+                        yield result
+                else:
+                    active_proc -= 1
+            if active_proc == 0:
+                self.finish()
+        finally:
+            if getattr(self, '_workers', None) is workers:
+                self.close()


### PR DESCRIPTION
Stopping a `RESetParallelIterator` before exhaustion currently skips the `finish()` call at the end of its generator. Workers can continue computing after the caller has returned, and repeated early exits accumulate processes and file descriptors. Explicitly closing the generator or deleting it and running GC does not fix the missing cleanup path.

This change adds explicit and context-managed cleanup, and ensures generator finalization also releases the workers belonging to that iteration.

Fixes #41015.

### Behavior and implementation

```python
from sage.parallel.map_reduce import RESetParallelIterator

with RESetParallelIterator(forest=R) as parallel:
    for x in parallel:
        if wanted(x):
            break
```

- Add `RESetParallelIterator.close()`, `__enter__()`, and `__exit__()`. Closing a never-started or already-closed iterable is a no-op. The object can be reused after closing. Empty or fully exhausted contexts also exit cleanly, including when user code raises an exception.
- Protect iteration with `try/finally`, so closing a started generator (`it = iter(parallel); next(it); it.close()`), generator finalization, and exceptions raised into the generator clean up its workers. A retained generator still needs explicit closing or an enclosing context: Python's `break` does not itself call `close()`.
- Identify each run by its worker list. A suspended generator from a previous run cannot consume the new run's queue, yield stale buffered values after closing, or close the new workers. Reject two active iterations of the same object with `RuntimeError` instead of overwriting the first run's resources.
- On early cancellation, set the aborted state and enter `finish()` directly. Calling `abort()` first can block while synchronously sending shutdown messages through pipes that are no longer being consumed. Simply adding `finally: finish()` would also be insufficient: its non-aborted path waits for completion and can hang on workers flushing unconsumed results.
- In the shared `RESetMapReduce.finish()`, terminate all started workers when aborted, then join all started workers before closing their request queues and task pipes and releasing the result queue. Normal exhaustion still consumes all completion markers and uses the normal join path. Preserve `_aborted` for the existing `run()` timeout contract.
- Retain ownership of workers created before a constructor failure and clean up workers already started before a later start failure. Collect and display statistics using the actual worker list rather than assuming every requested worker was constructed. Clear the old list during cleanup so suspended generators do not retain its process objects.

The documentation explains the cleanup contract. Committed doctests include cancellation while another worker is demonstrably still computing, no-start/full-exhaustion contexts, exception preservation, explicit generator closing, stale generators, concurrent-iteration rejection, and partial worker construction/start failures, including statistics after a failed construction.

### Validation and review

Tested locally with Sage 10.10.beta10, Python 3.12.13, Linux/WSL2, using the conda Sage runtime and the modified checkout's Python module.

| Doctests, including `--long` | Passed |
| --- | ---: |
| `src/sage/parallel/map_reduce.py` | 366 |
| `src/sage/parallel/decorate.py` | 92 |
| `src/sage/sets/recursively_enumerated_set.pyx` | 374 |
| Other files in `src/sage/parallel` | 106 |
| **Total** | **938** |

The relevant test scope can be run in a working Sage environment with:

```sh
SAGE_NUM_THREADS=2 python -m sage.doctest --serial --long --timeout=180 \
    src/sage/parallel src/sage/sets/recursively_enumerated_set.pyx
ruff check src/sage/parallel/map_reduce.py
python -m py_compile src/sage/parallel/map_reduce.py
git diff --check
```

Ruff, Python compilation, and the whitespace check passed. Two files initially could not start because the local Maxima cache directory was read-only; both passed after redirecting `MAXIMA_USERDIR` to a writable temporary directory. The total above combines the successful original tests with those successful reruns.

Additional isolated local probes, separate from the committed doctests, passed **25/25** scenarios with process-group timeouts and cleanup. They covered break/return, retained generators, `close()`/`throw()`, exceptions before/during/after iteration, manual `abort()`/`finish()` mixed with closing, repeated use, stale generators, concurrent iteration, constructor/start/root-iterator failures, an active long branch, and a queued 2 MiB result after consumption stops.

Resource measurements:

- Before the fix, five early exits accumulated 20 active workers and increased the parent FD count from 6 to 136. Repeating that probe after the fix left zero active workers and 6 FDs after every iteration; the abandoned parent objects were released.
- In a separate 12-run probe retaining all public iterable and suspended-generator objects, each close left zero active workers and the FD count stayed at 6. Deliberately retained private `Process` handles were tested separately: their inspection handles remain until the caller releases/closes them, while their communication queues and pipes are closed by this patch.

Separate adversarial code review and code-simplification review found no remaining blocking issue within this scope. A review finding about statistics after partial construction was fixed and covered by the final doctests. The 25-case lifecycle suite preceded that final reporting-only correction; the final 366 module doctests include it. The simplification review retained the separate terminate-all/join-all phases and both iterator-identity checks because they protect different lifecycle transitions.

### Scope and related work

Related: #41611 proposes context-manager support for this issue. This is an independent implementation from `develop`, covering explicit/generator cleanup and process reaping as well. In particular, it handles never-started, fully exhausted, and manually cleaned-up contexts without unconditionally repeating `abort()`/`finish()`. It does not depend on #41611.

- Cancellation terminates unfinished workers; it does not promise to finish the current node's callback first. It uses `multiprocessing.Process.terminate()` followed by `join()`, with no timeout/kill escalation. A callback that ignores the termination signal can therefore prevent closing from returning; this limitation is documented.
- Cleanup covers worker construction/start and the iterator lifecycle. Pre-existing allocation failures earlier in setup, such as an `ActiveTaskCounter` allocation failure after the result queue is created but before `_workers` exists, remain outside this change. This PR does not claim cleanup for every possible allocation failure.
- Cross-platform behavior and other multiprocessing start methods were not tested locally. This is not a full Sage test-suite run, and the local results above are not a claim that the new PR's CI has passed.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

The docstrings and examples are updated; the hosted documentation preview has not yet been checked.

### :hourglass: Dependencies

None.
