### PR TITLE
Fix static sparse conversion for non-reflexive vertex labels

### DIFF
--- a/src/sage/graphs/base/static_sparse_graph.pyx
+++ b/src/sage/graphs/base/static_sparse_graph.pyx
@@ -263,6 +263,57 @@ cdef int init_short_digraph(short_digraph g, G, edge_labelled=False,
         sage: B = StaticSparseBackend(G, sort=False)
         sage: list(B.iterator_edges('a', True))
         [('a', 'b', 'ab'), ('a', 'd', 'ad'), ('a', 'e', 'ae'), ('a', 'c', 'ac')]
+
+    Non-reflexive vertex labels must preserve the graph when making it
+    immutable::
+
+        sage: nan = float('nan')
+        sage: G = graphs.CycleGraph(4)
+        sage: G.relabel({0: nan})
+        sage: H = G.copy(immutable=True)
+        sage: all(H.has_edge(u, v) == G.has_edge(u, v) for u in G for v in G)
+        True
+        sage: H.is_cartesian_product()
+        True
+
+    Rebuild from an immutable graph with a different vertex order. Its edge
+    iterator places the queried vertex at the other end of each edge::
+
+        sage: from sage.graphs.base.static_sparse_backend import StaticSparseCGraph
+        sage: vertices = list(reversed(list(H)))
+        sage: B = StaticSparseCGraph(H, vertex_list=vertices)
+        sage: all(B.has_arc(i, j) == H.has_edge(u, v)
+        ....:     for i, u in enumerate(vertices) for j, v in enumerate(vertices))
+        True
+
+    Directed edges retain their orientation and labels, including edges
+    between distinct NaN vertices::
+
+        sage: G = DiGraph([(0, 1, 'a'), (2, 1, 'b'), (1, 3, 'c')])
+        sage: G.relabel({1: nan, 3: float('nan')})
+        sage: H = G.copy(immutable=True)
+        sage: (H.order(), H.in_degree(nan), H.out_degree(nan))
+        (4, 2, 1)
+        sage: all(H.has_edge(u, v) == G.has_edge(u, v) for u in G for v in G)
+        True
+        sage: all(H.has_edge(u, v, label) for u, v, label in G.edge_iterator())
+        True
+
+    Loops and parallel edges also retain their degrees and labels::
+
+        sage: G = Graph([(0, 1, 'a'), (0, 1, 'b'),
+        ....:            (1, 1, 'loop'), (1, 2, 'c')],
+        ....:           loops=True, multiedges=True)
+        sage: G.relabel({1: nan})
+        sage: H = G.copy(immutable=True)
+        sage: (H.degree(nan), H.number_of_loops())
+        (5, 1)
+        sage: sorted(H.edge_label(0, nan))
+        ['a', 'b']
+        sage: H.edge_label(nan, nan)
+        ['loop']
+        sage: H.edge_label(nan, 2)
+        ['c']
     """
     from sage.graphs.graph import Graph
     from sage.graphs.digraph import DiGraph
@@ -320,9 +371,11 @@ cdef int init_short_digraph(short_digraph g, G, edge_labelled=False,
             edge_iterator = G.edge_iterator(v, labels=edge_labelled,
                                             sort_vertices=False)
         for e in edge_iterator:
-            u = e[0] if v == e[1] else e[1]
-            j = v_to_id[u]
-            # Handle the edge u -> v of G (= the edge j -> i of g)
+            # Compare vertex IDs: labels such as NaN need not equal themselves.
+            j = v_to_id[e[0]]
+            if j == i:
+                j = v_to_id[e[1]]
+            # Store the arc j -> i in g.
             g.neighbors[j][0] = i
             # Note: cannot use the dereference Cython operator here, do not
             # known why but the following line does not compile

--- a/src/sage/graphs/base/static_sparse_graph.pyx
+++ b/src/sage/graphs/base/static_sparse_graph.pyx
@@ -270,6 +270,8 @@ cdef int init_short_digraph(short_digraph g, G, edge_labelled=False,
         sage: nan = float('nan')
         sage: G = graphs.CycleGraph(4)
         sage: G.relabel({0: nan})
+        sage: G.is_cartesian_product()
+        True
         sage: H = G.copy(immutable=True)
         sage: all(H.has_edge(u, v) == G.has_edge(u, v) for u in G for v in G)
         True
@@ -290,14 +292,23 @@ cdef int init_short_digraph(short_digraph g, G, edge_labelled=False,
     between distinct NaN vertices::
 
         sage: G = DiGraph([(0, 1, 'a'), (2, 1, 'b'), (1, 3, 'c')])
-        sage: G.relabel({1: nan, 3: float('nan')})
+        sage: nan2 = float('nan')
+        sage: G.relabel({1: nan, 3: nan2})
         sage: H = G.copy(immutable=True)
         sage: (H.order(), H.in_degree(nan), H.out_degree(nan))
         (4, 2, 1)
+        sage: (H.in_degree(nan2), H.out_degree(nan2))
+        (1, 0)
         sage: all(H.has_edge(u, v) == G.has_edge(u, v) for u in G for v in G)
         True
         sage: all(H.has_edge(u, v, label) for u, v, label in G.edge_iterator())
         True
+
+    A newly created NaN is a different label and is not a vertex of ``H``.
+    Degree queries must use one of the original NaN objects::
+
+        sage: float('nan') in H
+        False
 
     Loops and parallel edges also retain their degrees and labels::
 


### PR DESCRIPTION
Converting a graph with a non-reflexive vertex label such as `float('nan')` to an immutable graph can corrupt its adjacency representation. This was reported in [the discussion on #42773](https://github.com/sagemath/sage/pull/42773#discussion_r3995707747). On 10.10.beta10, the following should return `True` for both graphs, but the immutable graph can give an incorrect result or raise an exception; a local run also encountered a segmentation fault:

```python
g = graphs.CycleGraph(4)
g.relabel({0: float('nan')})
g.is_cartesian_product()
h = g.copy(immutable=True)
h.is_cartesian_product()
```

`init_short_digraph` uses `v == e[1]` to select the opposite endpoint. For NaN this is false even when both references denote the same vertex, so adjacency entries are written into the wrong segment of a degree-sized allocation. Resolve the endpoints through the existing vertex-to-integer mapping and compare their integer IDs instead. This preserves the original labels and handles both endpoint orders, including when the source already has a static sparse backend.

The regression doctests cover the reported example and graph conversions with non-reflexive labels, directed edges, edge labels, loops, and parallel edges.

Validation on the rebuilt Sage 10.10.beta10 checkout: all 412 doctests passed
(142 in `static_sparse_graph.pyx`, 206 in `static_sparse_backend.pyx`, and 64 in
`graph_products.pyx`):

```sh
python -m sage.doctest --serial --timeout=180 \
    src/sage/graphs/base/static_sparse_graph.pyx \
    src/sage/graphs/base/static_sparse_backend.pyx \
    src/sage/graphs/graph_decompositions/graph_products.pyx
```

An additional local matrix of 132 graph cases passed, including custom
non-reflexive labels, different NaN positions, and reconstruction from both
mutable and immutable sources. `git diff --check` also passed.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

### :hourglass: Dependencies

None.

