### PR TITLE
Add type annotations to sage.misc.map_threaded and sage.misc.flatten

### DIFF
--- a/src/sage/misc/flatten.py
+++ b/src/sage/misc/flatten.py
@@ -1,5 +1,7 @@
 "Flatten nested lists"
 
+from __future__ import annotations
+
 import sys
 from typing import Any
 

--- a/src/sage/misc/flatten.py
+++ b/src/sage/misc/flatten.py
@@ -1,9 +1,11 @@
 "Flatten nested lists"
 
 import sys
+from typing import Any
 
 
-def flatten(in_list, ltypes=(list, tuple), max_level=sys.maxsize):
+def flatten(in_list: Any, ltypes: tuple[type, ...] = (list, tuple),
+            max_level: int = sys.maxsize) -> list[Any]:
     """
     Flatten a nested list.
 

--- a/src/sage/misc/map_threaded.py
+++ b/src/sage/misc/map_threaded.py
@@ -2,8 +2,12 @@
 Threaded map function
 """
 
-from collections.abc import Callable
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def map_threaded(function: Callable[[Any], Any], sequence: Any) -> Any:

--- a/src/sage/misc/map_threaded.py
+++ b/src/sage/misc/map_threaded.py
@@ -2,7 +2,8 @@
 Threaded map function
 """
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 
 def map_threaded(function: Callable[[Any], Any], sequence: Any) -> Any:

--- a/src/sage/misc/map_threaded.py
+++ b/src/sage/misc/map_threaded.py
@@ -2,8 +2,10 @@
 Threaded map function
 """
 
+from typing import Any, Callable
 
-def map_threaded(function, sequence):
+
+def map_threaded(function: Callable[[Any], Any], sequence: Any) -> Any:
     """
     Apply the function to the elements in the sequence by threading
     recursively through all sub-sequences in the sequence.


### PR DESCRIPTION
### Description

Adds type annotations to `map_threaded()` in `sage/misc/map_threaded.py`
and `flatten()` in `sage/misc/flatten.py`, as part of the ongoing effort
tracked in #41722 to improve static analysis (pyright/mypy/ty) coverage
across the Sage codebase.

Both are small, self-contained utility functions with no Sage-specific
types involved, so they're good small entry points per the maintainer's
guidance in that issue to keep such PRs small and focused.

### Checklist
- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes. (N/A — type-only change, verified with `ast.parse`; no runtime behavior change since Python does not enforce type hints)
- [ ] I have updated the documentation and checked the documentation preview.

### Dependencies
None.