### PR TITLE
Fix sqrt(extend=True, all=True) silently returning [] for non-squares in Givaro finite fields

### DIFF
--- a/src/sage/rings/finite_rings/element_givaro.pyx
+++ b/src/sage/rings/finite_rings/element_givaro.pyx
@@ -1094,11 +1094,30 @@ cdef class FiniteField_givaroElement(FinitePolyExtElement):
             sage: K.<a> = FiniteField(9)
             sage: a.sqrt(extend = False, all = True)
             []
+
+        Check that :issue:`42719` is fixed, i.e. that ``extend=True``
+        together with ``all=True`` raises :exc:`NotImplementedError`
+        for a non-square element, instead of silently returning an
+        empty list::
+
+            sage: K.<a> = GF(3^2)
+            sage: a.is_square()
+            False
+            sage: a.sqrt(extend=True, all=False)
+            Traceback (most recent call last):
+            ...
+            NotImplementedError
+            sage: a.sqrt(extend=True, all=True)
+            Traceback (most recent call last):
+            ...
+            NotImplementedError
         """
         if all:
             if self.is_square():
                 a = self.sqrt()
                 return [a, -a] if -a != a else [a]
+            if extend:
+                raise NotImplementedError
             return []
         cdef Cache_givaro cache = <Cache_givaro>self._cache
         if self.element == cache.objectptr.one:


### PR DESCRIPTION
### Description
Fixes #42719.

`FiniteField_givaroElement.sqrt(extend=True, all=True)` silently
returned `[]` for a non-square element instead of raising
`NotImplementedError`, unlike `sqrt(extend=True, all=False)` (which
correctly raises) and unlike the PARI-backed finite field
implementation (`element_pari_ffelt.pyx`), which raises
`NotImplementedError` in both cases.

The `all` branch checked `self.is_square()` and returned `[]`
immediately on failure, without ever checking `extend`. This patch
adds that check, matching the existing `all=False` behavior.

The existing doctest for `extend=False, all=True` → `[]` is
preserved; a new doctest covers the previously-buggy
`extend=True, all=True` case.

### Checklist
- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes (regression doctest added).
- [ ] I have updated the documentation accordingly (not applicable — internal bugfix).

### Dependencies
None.