### PR TITLE
Fix EllipticCurveHom_fractional.scaling_factor() ZeroDivisionError when characteristic divides denominator

### DIFF
--- a/src/sage/schemes/elliptic_curves/hom_fractional.py
+++ b/src/sage/schemes/elliptic_curves/hom_fractional.py
@@ -344,12 +344,23 @@ class EllipticCurveHom_fractional(EllipticCurveHom):
               To:   Elliptic Curve defined by y^2 = x^3 + x over Finite Field in z2 of size 419^2
             sage: endo.to_isogeny_chain() == endo
             True
+
+        Conversion works even when the characteristic divides the
+        denominator (:issue:`42576`)::
+
+            sage: p = 5
+            sage: E = EllipticCurve(GF(p), [1, 1])
+            sage: phi = E.scalar_multiplication(p) / p
+            sage: phi.to_isogeny_chain() == E.scalar_multiplication(1)
+            True
         """
         E = self._domain
 
         ker = []
         insep = 0
         for l, e in self._phi.degree().factor():
+            if not self._degree.valuation(l):
+                continue
             pts = E.torsion_gens(l**e, extend=True)
 
             assert len(pts) == 2 or l == E.base_field().characteristic()
@@ -392,12 +403,8 @@ class EllipticCurveHom_fractional(EllipticCurveHom):
             ker = [step._eval(T) for T in ker]
             E = chain.codomain()
 
-        for iso in E.isomorphisms(self._codomain):
-            if self.scaling_factor() == iso.scaling_factor() * chain.scaling_factor():
-                break
-        else:
-            assert False, 'bug in converting fractional isogeny to isogeny chain'
-
+        from sage.schemes.elliptic_curves.hom import find_post_isomorphism
+        iso = find_post_isomorphism(chain, self)
         return iso * chain
 
     # EllipticCurveHom methods
@@ -552,9 +559,25 @@ class EllipticCurveHom_fractional(EllipticCurveHom):
             sage: pi = E.frobenius_isogeny()
             sage: ((1 + pi) / 2).scaling_factor()
             210
+
+        The scaling factor can also be computed when the characteristic
+        divides the denominator (:issue:`42576`)::
+
+            sage: p = 5
+            sage: E = EllipticCurve(GF(p), [1, 1])
+            sage: phi = E.scalar_multiplication(p) / p
+            sage: phi.degree()
+            1
+            sage: phi == E.scalar_multiplication(1)
+            True
+            sage: phi.scaling_factor()
+            1
+            sage: phi.to_isogeny_chain()
+            Composite morphism of degree 1 = 1^2:
+              From: Elliptic Curve defined by y^2 = x^3 + x + 1 over Finite Field of size 5
+              To:   Elliptic Curve defined by y^2 = x^3 + x + 1 over Finite Field of size 5
         """
-        # FIXME this can crash when p | d
-        return self._phi.scaling_factor() / self._d
+        return self.formal()[1]
 
     def inseparable_degree(self):
         r"""


### PR DESCRIPTION
### Description
Fixes #42576.

In characteristic $p$, when $p$ divides the denominator $d$ of an `EllipticCurveHom_fractional`, the numerator's scaling factor and $d$ both evaluate to 0 in the base field, causing `scaling_factor()` to compute `0 / 0` and raise `ZeroDivisionError` (for instance on `E.scalar_multiplication(p) / p`).

Simply changing `scaling_factor()` to delegate to `self.formal()[1]` would introduce a circular dependency because `to_isogeny_chain()` selected the final post-isomorphism by comparing `self.scaling_factor() == iso.scaling_factor() * chain.scaling_factor()`.

To resolve this without circularity:
1. `to_isogeny_chain()` now determines the post-isomorphism via `find_post_isomorphism(chain, self)` by verifying agreement on sample points of the domain curve rather than comparing scaling factors.
2. In `to_isogeny_chain()`, primes $l$ that do not divide the degree of the fractional morphism $\psi = \phi / d$ are skipped (`if not self._degree.valuation(l): continue`), preventing spurious kernel points when $l \mid d$ but $l \nmid \deg(\psi)$ (such as $p$ for $[p]/p$).
3. `scaling_factor()` safely delegates to `self.formal()[1]`, and the `# FIXME this can crash when p | d` comment is removed.
4. Regression doctests covering the reproduction from #42576 have been added to both `scaling_factor()` and `to_isogeny_chain()`.

### Checklist
- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly (not applicable — bugfix).

### Dependencies
None.