### PR TITLE
Guard power series square tests over unsupported rings

### DIFF
--- a/src/sage/rings/power_series_ring_element.pyx
+++ b/src/sage/rings/power_series_ring_element.pyx
@@ -1527,9 +1527,13 @@ cdef class PowerSeries(AlgebraElement):
         there is an element `y` in ``self.parent()``
         such that `y^2` equals ``self``.
 
-        ALGORITHM: If the base ring is a field, this is true whenever the
-        power series has even valuation and the leading coefficient is a
-        perfect square.
+        Apart from zero and constant series, this is only implemented when
+        the base ring is an integral domain of characteristic different
+        from `2`. Otherwise, a :exc:`NotImplementedError` is raised.
+
+        ALGORITHM: Over a field of characteristic different from `2`, this
+        is true whenever the power series has even valuation and the
+        leading coefficient is a perfect square.
 
         For an integral domain, it attempts the square root in the
         fraction field and tests whether or not the result lies in the
@@ -1552,13 +1556,69 @@ cdef class PowerSeries(AlgebraElement):
             sage: f = (1+t)^100
             sage: f.is_square()
             True
+
+        TESTS:
+
+        Over a ring with nilpotent elements, a square can have odd
+        valuation (:issue:`41220`)::
+
+            sage: R.<x> = PowerSeriesRing(Zmod(16))
+            sage: ((x + 4)^2).is_square()
+            Traceback (most recent call last):
+            ...
+            NotImplementedError: is_square() not implemented over a non-integral domain
+
+        Even valuation does not justify testing the leading coefficient::
+
+            sage: R.<x> = PowerSeriesRing(Zmod(9))
+            sage: ((3 + x^2)^2).is_square()
+            Traceback (most recent call last):
+            ...
+            NotImplementedError: is_square() not implemented over a non-integral domain
+
+        The restriction also applies to reduced rings with zero divisors::
+
+            sage: R.<x> = PowerSeriesRing(Zmod(15))
+            sage: ((3 + x)^2).is_square()
+            Traceback (most recent call last):
+            ...
+            NotImplementedError: is_square() not implemented over a non-integral domain
+
+        Zero and constant series can still be tested in the base ring::
+
+            sage: R(0).is_square(), O(x^5).is_square()
+            (True, True)
+            sage: R(4).is_square(), R(2).is_square()
+            (True, False)
+            sage: (4 + O(x^5)).is_square()
+            True
+
+        The field criterion does not apply in characteristic `2`::
+
+            sage: R.<x> = PowerSeriesRing(GF(2))
+            sage: (1 + x).is_square()
+            Traceback (most recent call last):
+            ...
+            NotImplementedError: is_square() not implemented in characteristic 2
         """
+        if self.is_zero():
+            return True
+        if self.degree() == 0:
+            return self[0].is_square()
+        base = self.base_ring()
+        if not base.is_integral_domain():
+            raise NotImplementedError(
+                "is_square() not implemented over a non-integral domain")
+        if base.characteristic() == 2:
+            raise NotImplementedError(
+                "is_square() not implemented in characteristic 2")
+
         val = self.valuation()
-        if val is not infinity and val % 2 == 1:
+        if val % 2 == 1:
             return False
         elif not self[val].is_square():
             return False
-        elif self.base_ring() in _Fields:
+        elif base in _Fields:
             return True
         else:
             try:


### PR DESCRIPTION
`((x + 4)^2).is_square()` over `Zmod(16)[[x]]` currently returns `False`. The valuation and leading-coefficient tests assume an integral domain; nilpotent coefficients can invalidate both tests.

Raise `NotImplementedError` for nonconstant series over non-integral domains before applying either test. Also reject nonconstant series in characteristic 2, where the existing field shortcut incorrectly accepts `1 + x`. Zero and constant series remain directly decidable through the base ring.

This is a conservative restriction of the generic algorithm, including over reduced rings with zero divisors. Regression doctests cover the original example, an even-valuation square with nonsquare leading coefficient over `Zmod(9)`, `Zmod(15)`, characteristic 2, zero, and constant series.

Fixes #41220.

### Validation

Rebuilt the Cython extension and passed 1,278 doctests:

- `src/sage/rings/power_series_ring_element.pyx`: 520 tests
- `src/sage/rings/power_series_poly.pyx`: 287 tests
- `src/sage/rings/laurent_series_ring_element.pyx`: 471 tests

`git diff --check` also passed.

### :memo: Checklist

- [x] The title is concise and informative.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [x] I have created tests covering the changes.
- [ ] I have updated the documentation and checked the documentation preview.

Docstrings are updated; the documentation preview is pending.

### :hourglass: Dependencies

None.
